### PR TITLE
feat: draggable popups

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
     "react": "^18.2.0",
     "react-custom-scroll": "^5.0.0",
     "react-dom": "^18.2.0",
+    "react-draggable": "^4.4.5",
     "react-popper": "^2.3.0",
     "rxjs": "^7.8.1",
     "starknet": "^5.19.5",

--- a/client/src/components/SettingsComponent.tsx
+++ b/client/src/components/SettingsComponent.tsx
@@ -49,7 +49,7 @@ export const SettingsComponent = ({}: SettingsComponentProps) => {
         <Muted onClick={() => toggleSound()} className="ml-[6px] cursor-pointer fill-gold" />
       )}
       {showSettings && (
-        <SecondaryPopup className="top-1/3">
+        <SecondaryPopup className="top-1/3" name="settings">
           <SecondaryPopup.Head>
             <div className="flex items-center">
               <div className="mr-0.5">Settings</div>

--- a/client/src/components/SignUpComponent.tsx
+++ b/client/src/components/SignUpComponent.tsx
@@ -29,7 +29,7 @@ export const SignUpComponent = ({}: SignUpComponentProps) => {
 
   return (
     <SecondaryPopup className="!translate-x-0 !left-auto !top-1/2 !-translate-y-1/2">
-      <SecondaryPopup.Head>
+      <SecondaryPopup.Head className="!cursor-default">
         <div className="mr-0.5">Sign Up</div>
       </SecondaryPopup.Head>
       <SecondaryPopup.Body width="400px">

--- a/client/src/components/cityview/realm/labor/LaborBuild.tsx
+++ b/client/src/components/cityview/realm/labor/LaborBuild.tsx
@@ -206,7 +206,7 @@ export const LaborBuildPopup = ({ resourceId, setBuildLoadingStates, onClose }: 
   };
 
   return (
-    <SecondaryPopup>
+    <SecondaryPopup name="labor">
       <SecondaryPopup.Head>
         <div className="flex items-center space-x-1">
           <div className="mr-0.5">Build Labor:</div>

--- a/client/src/components/cityview/realm/trade/CreateOffer.tsx
+++ b/client/src/components/cityview/realm/trade/CreateOffer.tsx
@@ -121,7 +121,7 @@ export const CreateOfferPopup = ({ onClose }: CreateOfferPopupProps) => {
   }, [donkeysCount, resourceWeight]);
 
   return (
-    <SecondaryPopup>
+    <SecondaryPopup name="create-offer">
       <SecondaryPopup.Head>
         <div className="flex items-center space-x-1">
           <div className="mr-0.5">Create Offer:</div>

--- a/client/src/containers/TopContainer.tsx
+++ b/client/src/containers/TopContainer.tsx
@@ -1,9 +1,5 @@
 export const TopContainer = ({ children }: { children: React.ReactNode }) => {
-    return (
-        <div className="absolute z-10 w-auto h-32 top-8 left-8 right-8">
-            {children}
-        </div>
-    );
+  return <div className="absolute z-20 w-auto h-32 top-8 left-8 right-8">{children}</div>;
 };
 
 export default TopContainer;

--- a/client/src/elements/SecondaryPopup.tsx
+++ b/client/src/elements/SecondaryPopup.tsx
@@ -10,7 +10,7 @@ type FilterPopupProps = {
 export const SecondaryPopup = ({ children, className }: FilterPopupProps) => {
   const nodeRef = React.useRef(null);
   return (
-    <Draggable nodeRef={nodeRef} onStop={(e) => console.log(e)}>
+    <Draggable nodeRef={nodeRef}>
       <div ref={nodeRef} className={clsx("fixed z-50 flex flex-col translate-x-6 top-[200px] left-[450px]", className)}>
         {children}
       </div>

--- a/client/src/elements/SecondaryPopup.tsx
+++ b/client/src/elements/SecondaryPopup.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React from "react";
+import Draggable from "react-draggable";
 
 type FilterPopupProps = {
   children: React.ReactNode;
@@ -7,8 +8,13 @@ type FilterPopupProps = {
 };
 
 export const SecondaryPopup = ({ children, className }: FilterPopupProps) => {
+  const nodeRef = React.useRef(null);
   return (
-    <div className={clsx("fixed flex flex-col translate-x-6 top-[200px] left-[432px] z-50", className)}>{children}</div>
+    <Draggable nodeRef={nodeRef} onStop={(e) => console.log(e)}>
+      <div ref={nodeRef} className={clsx("fixed z-50 flex flex-col translate-x-6 top-[200px] left-[450px]", className)}>
+        {children}
+      </div>
+    </Draggable>
   );
 };
 

--- a/client/src/elements/SecondaryPopup.tsx
+++ b/client/src/elements/SecondaryPopup.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import Draggable from "react-draggable";
 
 type FilterPopupProps = {
@@ -9,7 +9,7 @@ type FilterPopupProps = {
 };
 
 export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) => {
-  const nodeRef = React.useRef(null);
+  const nodeRef = useRef<any>(null);
 
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [loaded, setLoaded] = useState(false);
@@ -17,6 +17,31 @@ export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) 
   const handleStop = (e: any, data: any) => {
     if (name) {
       localStorage.setItem(name, JSON.stringify({ x: data.x, y: data.y }));
+    }
+  };
+
+  const handleClick = () => {
+    let maxZIndex = 50;
+    document.querySelectorAll(".popup").forEach((popup) => {
+      const zIndex = parseInt(window.getComputedStyle(popup).zIndex);
+      if (zIndex > maxZIndex) {
+        maxZIndex = zIndex;
+      }
+    });
+    if (nodeRef && nodeRef.current) {
+      nodeRef.current.style.zIndex = `${maxZIndex + 1}`;
+      document.querySelectorAll("[data-old-z-index]").forEach((popup: any) => {
+        popup.style.zIndex = popup.getAttribute("data-old-z-index");
+        popup.removeAttribute("data-old-z-index");
+      });
+      let parent = nodeRef.current.parentElement;
+      while (parent && getComputedStyle(parent).position !== "absolute") {
+        parent = parent.parentElement;
+      }
+      if (parent) {
+        parent.setAttribute("data-old-z-index", parent.style.zIndex);
+        parent.style.zIndex = `${maxZIndex + 1}`;
+      }
     }
   };
 
@@ -35,8 +60,9 @@ export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) 
       {loaded && (
         <Draggable handle=".handle" defaultPosition={position} nodeRef={nodeRef} onStop={handleStop}>
           <div
+            onClick={handleClick}
             ref={nodeRef}
-            className={clsx("fixed z-50 flex flex-col translate-x-6 top-[200px] left-[450px]", className)}
+            className={clsx("popup fixed z-50 flex flex-col translate-x-6 top-[200px] left-[450px]", className)}
           >
             {children}
           </div>

--- a/client/src/elements/SecondaryPopup.tsx
+++ b/client/src/elements/SecondaryPopup.tsx
@@ -1,27 +1,59 @@
 import clsx from "clsx";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import Draggable from "react-draggable";
 
 type FilterPopupProps = {
   children: React.ReactNode;
   className?: string;
+  name?: string;
 };
 
-export const SecondaryPopup = ({ children, className }: FilterPopupProps) => {
+export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) => {
   const nodeRef = React.useRef(null);
+
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [loaded, setLoaded] = useState(false);
+
+  const handleStop = (e: any, data: any) => {
+    if (name) {
+      localStorage.setItem(name, JSON.stringify({ x: data.x, y: data.y }));
+    }
+  };
+
+  useEffect(() => {
+    if (name) {
+      const pos = localStorage.getItem(name);
+      if (pos) {
+        setPosition(JSON.parse(pos));
+      }
+    }
+    setLoaded(true);
+  }, []);
+
   return (
-    <Draggable nodeRef={nodeRef}>
-      <div ref={nodeRef} className={clsx("fixed z-50 flex flex-col translate-x-6 top-[200px] left-[450px]", className)}>
-        {children}
-      </div>
-    </Draggable>
+    <>
+      {loaded && (
+        <Draggable handle=".handle" defaultPosition={position} nodeRef={nodeRef} onStop={handleStop}>
+          <div
+            ref={nodeRef}
+            className={clsx("fixed z-50 flex flex-col translate-x-6 top-[200px] left-[450px]", className)}
+          >
+            {children}
+          </div>
+        </Draggable>
+      )}
+    </>
   );
 };
 
-SecondaryPopup.Head = ({ children }: { children: React.ReactNode }) => (
-  <div className="text-xxs relative -mb-[1px] z-10 bg-brown px-1 py-0.5 rounded-t-[4px] border-t border-x border-white text-white w-min whitespace-nowrap">
-    {" "}
-    {children}{" "}
+SecondaryPopup.Head = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <div
+    className={clsx(
+      "text-xxs relative cursor-move -mb-[1px] z-30 bg-brown px-1 py-0.5 rounded-t-[4px] border-t border-x border-white text-white w-min whitespace-nowrap handle",
+      className,
+    )}
+  >
+    {children}
   </div>
 );
 
@@ -29,7 +61,7 @@ SecondaryPopup.Body = ({ width = null, children }: { width?: string | null; chil
   <div
     className={`${
       width ? "" : "min-w-[438px]"
-    } relative z-0 bg-gray border flex flex-col border-white rounded-tr-[4px] rounded-b-[4px]`}
+    } relative z-10 bg-gray border flex flex-col border-white rounded-tr-[4px] rounded-b-[4px]`}
     style={{ width: width ? width : "" }}
   >
     {children}

--- a/client/src/elements/SecondaryPopup.tsx
+++ b/client/src/elements/SecondaryPopup.tsx
@@ -20,7 +20,7 @@ export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) 
     }
   };
 
-  const handleClick = () => {
+  const moveToTopZIndex = () => {
     let maxZIndex = 50;
     document.querySelectorAll(".popup").forEach((popup) => {
       const zIndex = parseInt(window.getComputedStyle(popup).zIndex);
@@ -45,6 +45,10 @@ export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) 
     }
   };
 
+  const handleClick = () => {
+    moveToTopZIndex();
+  };
+
   useEffect(() => {
     if (name) {
       const pos = localStorage.getItem(name);
@@ -54,6 +58,10 @@ export const SecondaryPopup = ({ children, className, name }: FilterPopupProps) 
     }
     setLoaded(true);
   }, []);
+
+  useEffect(() => {
+    moveToTopZIndex();
+  }, [loaded]);
 
   return (
     <>

--- a/client/src/elements/Steps.tsx
+++ b/client/src/elements/Steps.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React, { useMemo } from "react";
+import React, { Fragment, useMemo } from "react";
 
 type StepsProps = {
   step: number;
@@ -12,9 +12,8 @@ export const Steps = ({ step, maxStep, className }: StepsProps) => {
   return (
     <div className={clsx("flex justify-center items-center", className)}>
       {Array.from(Array(maxStep).keys()).map((i, index) => (
-        <>
+        <Fragment key={index}>
           <div
-            key={`dot-${index}`}
             className={clsx(
               "w-2 h-2 rounded-full",
               i == _step ? "bg-gold" : "bg-dark-brown",
@@ -23,7 +22,6 @@ export const Steps = ({ step, maxStep, className }: StepsProps) => {
           />
           {i < maxStep - 1 && (
             <div
-              key={`delimeter-${index}`}
               className={clsx(
                 "w-6 h-[1px] mx-1",
                 i < _step ? "bg-gold" : "bg-dark-brown",
@@ -31,7 +29,7 @@ export const Steps = ({ step, maxStep, className }: StepsProps) => {
               )}
             />
           )}
-        </>
+        </Fragment>
       ))}
     </div>
   );


### PR DESCRIPTION
- Labor, Settings and Create offer popups are now draggable.
- After dragging popup position is saved to localStorage, and this position will be used as default after reopening the popup between game sessions.
- Clicking on popup now moves it to top level z-index
- Last opened popup appears on top level z-index