### PR TITLE
feat: floating tooltips, popup width

### DIFF
--- a/client/src/components/cityview/realm/RealmLaborComponent.tsx
+++ b/client/src/components/cityview/realm/RealmLaborComponent.tsx
@@ -4,7 +4,6 @@ import { LaborPanel } from "./labor/LaborPanel";
 import useRealmStore from "../../../hooks/store/useRealmStore";
 import useUIStore from "../../../hooks/store/useUIStore";
 import { useRoute, useLocation } from "wouter";
-import { Tooltip } from "../../../elements/Tooltip";
 
 type RealmLaborComponentProps = {};
 

--- a/client/src/components/cityview/realm/RealmLaborComponent.tsx
+++ b/client/src/components/cityview/realm/RealmLaborComponent.tsx
@@ -14,6 +14,7 @@ export const RealmLaborComponent = ({}: RealmLaborComponentProps) => {
 
   const moveCameraToLaborView = useUIStore((state) => state.moveCameraToLaborView);
   const moveCameraToFoodView = useUIStore((state) => state.moveCameraToFoodView);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   // @ts-ignore
   const [location, setLocation] = useLocation();
@@ -40,13 +41,23 @@ export const RealmLaborComponent = ({}: RealmLaborComponentProps) => {
       {
         key: "labor",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Look at your current production,</p>
+                    <p className="whitespace-nowrap">or increase it by buying labour or buildings.</p>
+                    <p className="whitespace-nowrap">Don't forget to harvest your resources.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>All</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Look at your current production,</p>
-              <p className="whitespace-nowrap">or increase it by buying labour or buildings.</p>
-              <p className="whitespace-nowrap">Don't forget to harvest your resources.</p>
-            </Tooltip>
           </div>
         ),
         component: <LaborPanel />,

--- a/client/src/components/cityview/realm/RealmManagementComponent.tsx
+++ b/client/src/components/cityview/realm/RealmManagementComponent.tsx
@@ -12,7 +12,6 @@ import useUIStore from "../../../hooks/store/useUIStore";
 import useRealmStore from "../../../hooks/store/useRealmStore";
 import RealmStatusComponent from "./RealmStatusComponent";
 import { useGetRealm } from "../../../hooks/helpers/useRealm";
-import { Tooltip } from "../../../elements/Tooltip";
 import { LaborAuction } from "./labor/LaborAuction";
 
 const RealmManagementComponent = () => {

--- a/client/src/components/cityview/realm/RealmManagementComponent.tsx
+++ b/client/src/components/cityview/realm/RealmManagementComponent.tsx
@@ -31,6 +31,7 @@ const RealmManagementComponent = () => {
   const moveCameraToRealm = useUIStore((state) => state.moveCameraToRealm);
   const moveCameraToWorldMapView = useUIStore((state) => state.moveCameraToWorldMapView);
   const setIsLoadingScreenEnabled = useUIStore((state) => state.setIsLoadingScreenEnabled);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   useEffect(() => {
     if (selectedTab == 0) {
@@ -54,13 +55,23 @@ const RealmManagementComponent = () => {
       {
         key: "labor",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className=" whitespace-nowrap">Manage all of your Realm</p>
+                    <p className=" whitespace-nowrap"> resource production here.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <PickAxeSecond className="mb-2 fill-gold" />
             <div>Labor</div>
-            <Tooltip position="bottom">
-              <p className=" whitespace-nowrap">Manage all of your Realm</p>
-              <p className=" whitespace-nowrap"> resource production here.</p>
-            </Tooltip>
           </div>
         ),
         component: <RealmLaborComponent />,
@@ -68,13 +79,23 @@ const RealmManagementComponent = () => {
       {
         key: "open-offers",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">No Realm is self-sufficient.</p>
+                    <p className="whitespace-nowrap">Trade with other Lords</p>
+                    <p className="whitespace-nowrap">to get the resources you need.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <Coin className="mb-2 fill-gold" /> <div>Trade</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">No Realm is self-sufficient.</p>
-              <p className="whitespace-nowrap">Trade with other Lords</p>
-              <p className="whitespace-nowrap">to get the resources you need.</p>
-            </Tooltip>
           </div>
         ),
         component: <RealmTradeComponent />,

--- a/client/src/components/cityview/realm/RealmResourcesComponent.tsx
+++ b/client/src/components/cityview/realm/RealmResourcesComponent.tsx
@@ -13,7 +13,6 @@ import { SmallResource } from "./SmallResource";
 import { useComponentValue } from "@dojoengine/react";
 import { useDojo } from "../../../DojoContext";
 import { useGetRealm } from "../../../hooks/helpers/useRealm";
-import { Tooltip } from "../../../elements/Tooltip";
 import { LABOR_CONFIG } from "../../../constants/labor";
 import useUIStore from "../../../hooks/store/useUIStore";
 

--- a/client/src/components/cityview/realm/RealmResourcesComponent.tsx
+++ b/client/src/components/cityview/realm/RealmResourcesComponent.tsx
@@ -15,6 +15,7 @@ import { useDojo } from "../../../DojoContext";
 import { useGetRealm } from "../../../hooks/helpers/useRealm";
 import { Tooltip } from "../../../elements/Tooltip";
 import { LABOR_CONFIG } from "../../../constants/labor";
+import useUIStore from "../../../hooks/store/useUIStore";
 
 type RealmResourcesComponentProps = {} & React.ComponentPropsWithRef<"div">;
 
@@ -93,6 +94,7 @@ const ResourceComponent: React.FC<ResourceComponentProps> = ({ resourceId }) => 
   } = useDojo();
 
   let { realmEntityId } = useRealmStore();
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const nextBlockTimestamp = useBlockchainStore((state) => state.nextBlockTimestamp);
   const [productivity, setProductivity] = useState<number>(0);
@@ -123,7 +125,16 @@ const ResourceComponent: React.FC<ResourceComponentProps> = ({ resourceId }) => 
   return (
     <>
       <div className="flex flex-col">
-        <div className="flex relative group items-center p-3 text-xs font-bold text-white bg-black/60 rounded-xl h-11">
+        <div
+          onMouseEnter={() =>
+            setTooltip({
+              position: "bottom",
+              content: <>{findResourceById(resourceId)?.trait}</>,
+            })
+          }
+          onMouseLeave={() => setTooltip(null)}
+          className="flex relative group items-center p-3 text-xs font-bold text-white bg-black/60 rounded-xl h-11"
+        >
           <ResourceIcon
             withTooltip={false}
             resource={findResourceById(resourceId)?.trait as string}
@@ -131,7 +142,6 @@ const ResourceComponent: React.FC<ResourceComponentProps> = ({ resourceId }) => 
             className="mr-2"
           />
           <div className="text-xs">{currencyFormat(resource ? resource.balance : 0, 2)}</div>
-          <Tooltip>{findResourceById(resourceId)?.trait}</Tooltip>
         </div>
         {resourceId !== 253 && (
           <div

--- a/client/src/components/cityview/realm/RealmTradeComponent.tsx
+++ b/client/src/components/cityview/realm/RealmTradeComponent.tsx
@@ -23,6 +23,7 @@ export const RealmTradeComponent = ({}: RealmTradeComponentProps) => {
 
   const moveCameraToMarketView = useUIStore((state) => state.moveCameraToMarketView);
   const moveCameraToCaravansView = useUIStore((state) => state.moveCameraToCaravansView);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   // @ts-ignore
   const [location, setLocation] = useLocation();
@@ -49,14 +50,24 @@ export const RealmTradeComponent = ({}: RealmTradeComponentProps) => {
       {
         key: "my-offers",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Check offers made by you,</p>
+                    <p className="whitespace-nowrap">watch incoming caravans,</p>
+                    <p className="whitespace-nowrap">claim arrived resources,</p>
+                    <p className="whitespace-nowrap">or create new offers.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>My Offers</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Check offers made by you,</p>
-              <p className="whitespace-nowrap">watch incoming caravans,</p>
-              <p className="whitespace-nowrap">claim arrived resources,</p>
-              <p className="whitespace-nowrap">or create new offers.</p>
-            </Tooltip>
           </div>
         ),
         component: <MyOffersPanel />,
@@ -64,12 +75,22 @@ export const RealmTradeComponent = ({}: RealmTradeComponentProps) => {
       {
         key: "open-offers",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Offers from all over the world are found here.</p>
+                    <p className="whitespace-nowrap">Trade with your fellow Lords</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>Open Offers</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Offers from all over the world are found here.</p>
-              <p className="whitespace-nowrap">Trade with your fellow Lords</p>
-            </Tooltip>
           </div>
         ),
         component: <MarketPanel directOffers={false} />,
@@ -77,11 +98,21 @@ export const RealmTradeComponent = ({}: RealmTradeComponentProps) => {
       {
         key: "direct-offers",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Offers made specifically for you are found here.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>Direct Offers</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Offers made specifically for you are found here.</p>
-            </Tooltip>
           </div>
         ),
         component: <MarketPanel directOffers={true} />,
@@ -89,12 +120,24 @@ export const RealmTradeComponent = ({}: RealmTradeComponentProps) => {
       {
         key: "caravans",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">
+                      You can only trade resources if there are Caravans to carry them.
+                    </p>
+                    <p className="whitespace-nowrap">Manage your Caravans here</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>Caravans</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">You can only trade resources if there are Caravans to carry them.</p>
-              <p className="whitespace-nowrap">Manage your Caravans here</p>
-            </Tooltip>
           </div>
         ),
         component: <CaravansPanel />,
@@ -102,12 +145,22 @@ export const RealmTradeComponent = ({}: RealmTradeComponentProps) => {
       {
         key: "roads",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Build roads to other Realms to</p>
+                    <p className="whitespace-nowrap">get faster travel time for orders.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>Roads</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Build roads to other Realms to</p>
-              <p className="whitespace-nowrap">get faster travel time for orders.</p>
-            </Tooltip>
           </div>
         ),
         component: <RoadsPanel />,

--- a/client/src/components/cityview/realm/RealmTradeComponent.tsx
+++ b/client/src/components/cityview/realm/RealmTradeComponent.tsx
@@ -6,7 +6,6 @@ import { MyOffersPanel } from "./trade/MyOffers/MyOffersPanel";
 import useUIStore from "../../../hooks/store/useUIStore";
 import { useRoute, useLocation } from "wouter";
 import useRealmStore from "../../../hooks/store/useRealmStore";
-import { Tooltip } from "../../../elements/Tooltip";
 import { RoadsPanel } from "./trade/Roads/RoadsPanel";
 
 export type Order = {

--- a/client/src/components/cityview/realm/SmallResource.tsx
+++ b/client/src/components/cityview/realm/SmallResource.tsx
@@ -4,7 +4,6 @@ import { currencyFormat, getEntityIdFromKeys } from "../../../utils/utils";
 import { useComponentValue } from "@dojoengine/react";
 import { useDojo } from "../../../DojoContext";
 import useRealmStore from "../../../hooks/store/useRealmStore";
-import { Tooltip } from "../../../elements/Tooltip";
 import useUIStore from "../../../hooks/store/useUIStore";
 
 export const SmallResource = ({ resourceId }: { resourceId: number }) => {

--- a/client/src/components/cityview/realm/SmallResource.tsx
+++ b/client/src/components/cityview/realm/SmallResource.tsx
@@ -5,6 +5,7 @@ import { useComponentValue } from "@dojoengine/react";
 import { useDojo } from "../../../DojoContext";
 import useRealmStore from "../../../hooks/store/useRealmStore";
 import { Tooltip } from "../../../elements/Tooltip";
+import useUIStore from "../../../hooks/store/useUIStore";
 
 export const SmallResource = ({ resourceId }: { resourceId: number }) => {
   const {
@@ -14,11 +15,21 @@ export const SmallResource = ({ resourceId }: { resourceId: number }) => {
   } = useDojo();
 
   const { realmEntityId } = useRealmStore();
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const resource = useComponentValue(Resource, getEntityIdFromKeys([BigInt(realmEntityId ?? 0), BigInt(resourceId)]));
 
   return (
-    <div className="flex relative group items-center">
+    <div
+      onMouseEnter={() =>
+        setTooltip({
+          position: "bottom",
+          content: <>{findResourceById(resourceId)?.trait}</>,
+        })
+      }
+      onMouseLeave={() => setTooltip(null)}
+      className="flex relative group items-center"
+    >
       <ResourceIcon
         withTooltip={false}
         resource={findResourceById(resourceId)?.trait || ""}
@@ -26,7 +37,6 @@ export const SmallResource = ({ resourceId }: { resourceId: number }) => {
         className="mr-1"
       />
       <div className="text-xxs">{currencyFormat(resource?.balance || 0, 2)}</div>
-      <Tooltip>{findResourceById(resourceId)?.trait}</Tooltip>
     </div>
   );
 };

--- a/client/src/components/cityview/realm/trade/AcceptOffer.tsx
+++ b/client/src/components/cityview/realm/trade/AcceptOffer.tsx
@@ -125,7 +125,7 @@ export const AcceptOfferPopup = ({ onClose, selectedTrade }: AcceptOfferPopupPro
           <div className="mr-0.5">Accept Offer:</div>
         </div>
       </SecondaryPopup.Head>
-      <SecondaryPopup.Body>
+      <SecondaryPopup.Body width={"476px"}>
         <div className="flex flex-col items-center pt-2">
           <SelectCaravanPanel
             donkeysCount={donkeysCount}

--- a/client/src/components/cityview/realm/trade/Market/MarketOffer.tsx
+++ b/client/src/components/cityview/realm/trade/Market/MarketOffer.tsx
@@ -12,6 +12,7 @@ import { ResourcesOffer } from "../../../../../types";
 import { MarketInterface } from "../../../../../hooks/helpers/useTrade";
 import { Tooltip } from "../../../../../elements/Tooltip";
 import { currencyFormat } from "../../../../../utils/utils";
+import useUIStore from "../../../../../hooks/store/useUIStore";
 
 type TradeOfferProps = {
   marketOffer: MarketInterface;
@@ -23,6 +24,7 @@ export const MarketOffer = ({ marketOffer, onAccept, onBuildRoad }: TradeOfferPr
   const { hasRoad, distance, resourcesGet, resourcesGive, canAccept, ratio } = marketOffer;
 
   let { realm: makerRealm } = useGetRealm(marketOffer.makerId);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const [isLoading, setIsLoading] = useState(false);
 
@@ -43,20 +45,41 @@ export const MarketOffer = ({ marketOffer, onAccept, onBuildRoad }: TradeOfferPr
         <div className=" text-gold flex">
           <div className=" text-right">{`${distance.toFixed(0)} km`}</div>
           {hasRoad ? (
-            <div className="text-order-brilliance relative group ml-2">
+            <div
+              onMouseEnter={() =>
+                setTooltip({
+                  position: "bottom",
+                  content: (
+                    <>
+                      <p className="whitespace-nowrap">This Realm has built road</p>
+                      <p className="whitespace-nowrap">to your Realm.</p>
+                    </>
+                  ),
+                })
+              }
+              onMouseLeave={() => setTooltip(null)}
+              className="text-order-brilliance relative group ml-2"
+            >
               (x2 speed)
-              <Tooltip position="left">
-                <p className="whitespace-nowrap">This Realm has built road</p>
-                <p className="whitespace-nowrap">to your Realm.</p>
-              </Tooltip>
             </div>
           ) : (
-            <div className="text-gold/50 decoration-dotted underline relative group ml-2" onClick={onBuildRoad}>
+            <div
+              onMouseEnter={() =>
+                setTooltip({
+                  position: "bottom",
+                  content: (
+                    <>
+                      <p className="whitespace-nowrap">Click to build road and</p>
+                      <p className="whitespace-nowrap">speed up trades with this Realm.</p>
+                    </>
+                  ),
+                })
+              }
+              onMouseLeave={() => setTooltip(null)}
+              className="text-gold/50 decoration-dotted underline relative group ml-2"
+              onClick={onBuildRoad}
+            >
               (Normal speed)
-              <Tooltip position="left">
-                <p className="whitespace-nowrap">Click to build road and</p>
-                <p className="whitespace-nowrap">speed up trades with this Realm.</p>
-              </Tooltip>
             </div>
           )}
         </div>

--- a/client/src/components/cityview/realm/trade/Market/MarketOffer.tsx
+++ b/client/src/components/cityview/realm/trade/Market/MarketOffer.tsx
@@ -10,7 +10,6 @@ import { useGetRealm } from "../../../../../hooks/helpers/useRealm";
 import clsx from "clsx";
 import { ResourcesOffer } from "../../../../../types";
 import { MarketInterface } from "../../../../../hooks/helpers/useTrade";
-import { Tooltip } from "../../../../../elements/Tooltip";
 import { currencyFormat } from "../../../../../utils/utils";
 import useUIStore from "../../../../../hooks/store/useUIStore";
 

--- a/client/src/components/cityview/realm/trade/MyOffers/MyOffer.tsx
+++ b/client/src/components/cityview/realm/trade/MyOffers/MyOffer.tsx
@@ -9,7 +9,6 @@ import { orderNameDict } from "../../../../../constants/orders";
 import * as realmsData from "../../../../../geodata/realms.json";
 import { MarketInterface } from "../../../../../hooks/helpers/useTrade";
 import { useGetRealm } from "../../../../../hooks/helpers/useRealm";
-import { Tooltip } from "../../../../../elements/Tooltip";
 import { currencyFormat } from "../../../../../utils/utils";
 import useUIStore from "../../../../../hooks/store/useUIStore";
 

--- a/client/src/components/cityview/realm/trade/MyOffers/MyOffer.tsx
+++ b/client/src/components/cityview/realm/trade/MyOffers/MyOffer.tsx
@@ -11,6 +11,7 @@ import { MarketInterface } from "../../../../../hooks/helpers/useTrade";
 import { useGetRealm } from "../../../../../hooks/helpers/useRealm";
 import { Tooltip } from "../../../../../elements/Tooltip";
 import { currencyFormat } from "../../../../../utils/utils";
+import useUIStore from "../../../../../hooks/store/useUIStore";
 
 type TradeOfferProps = {
   myOffer: MarketInterface;
@@ -21,6 +22,7 @@ export const MyOffer = ({ myOffer, onBuildRoad }: TradeOfferProps) => {
   const { takerId, hasRoad, distance, resourcesGet, resourcesGive, ratio } = myOffer;
 
   const [isLoading, setIsLoading] = useState(false);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   useEffect(() => {
     setIsLoading(false);
@@ -68,20 +70,41 @@ export const MyOffer = ({ myOffer, onBuildRoad }: TradeOfferProps) => {
           <div className=" text-gold flex">
             <div className=" text-right">{`${distance.toFixed(0)} km`}</div>
             {hasRoad ? (
-              <div className="text-order-brilliance relative group ml-2">
+              <div
+                onMouseEnter={() =>
+                  setTooltip({
+                    position: "bottom",
+                    content: (
+                      <>
+                        <p className="whitespace-nowrap">This Realm has built road</p>
+                        <p className="whitespace-nowrap">to your Realm.</p>
+                      </>
+                    ),
+                  })
+                }
+                onMouseLeave={() => setTooltip(null)}
+                className="text-order-brilliance relative group ml-2"
+              >
                 (x2 speed)
-                <Tooltip position="left">
-                  <p className="whitespace-nowrap">This Realm has built road</p>
-                  <p className="whitespace-nowrap">to your Realm.</p>
-                </Tooltip>
               </div>
             ) : (
-              <div className="text-gold/50 decoration-dotted underline relative group ml-2" onClick={onBuildRoad}>
+              <div
+                onMouseEnter={() =>
+                  setTooltip({
+                    position: "bottom",
+                    content: (
+                      <>
+                        <p className="whitespace-nowrap">Click to build road and</p>
+                        <p className="whitespace-nowrap">speed up trades with this Realm.</p>
+                      </>
+                    ),
+                  })
+                }
+                onMouseLeave={() => setTooltip(null)}
+                className="text-gold/50 decoration-dotted underline relative group ml-2"
+                onClick={onBuildRoad}
+              >
                 (Normal speed)
-                <Tooltip position="left">
-                  <p className="whitespace-nowrap">Click to build road and</p>
-                  <p className="whitespace-nowrap">speed up trades with this Realm.</p>
-                </Tooltip>
               </div>
             )}
           </div>

--- a/client/src/components/worldmap/RealmsListPanel.tsx
+++ b/client/src/components/worldmap/RealmsListPanel.tsx
@@ -2,22 +2,34 @@ import { useMemo, useState } from "react";
 import { Tabs } from "../../elements/tab";
 import { Tooltip } from "../../elements/Tooltip";
 import { RealmsListComponent } from "./RealmsListComponent";
+import useUIStore from "../../hooks/store/useUIStore";
 
 type RealmsListPanelProps = {};
 
 export const RealmsListPanel = ({}: RealmsListPanelProps) => {
   const [selectedTab, setSelectedTab] = useState(0);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const tabs = useMemo(
     () => [
       {
         key: "all",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Browse all settled realms.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>All Realms</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Browse all settled realms.</p>
-            </Tooltip>
           </div>
         ),
         component: <RealmsListComponent />,
@@ -25,11 +37,21 @@ export const RealmsListPanel = ({}: RealmsListPanelProps) => {
       {
         key: "my",
         label: (
-          <div className="flex group relative flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Browse your realms.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex group relative flex-col items-center"
+          >
             <div>My Realms</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Browse your realms.</p>
-            </Tooltip>
           </div>
         ),
         component: <RealmsListComponent onlyMyRealms />,

--- a/client/src/components/worldmap/RealmsListPanel.tsx
+++ b/client/src/components/worldmap/RealmsListPanel.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { Tabs } from "../../elements/tab";
-import { Tooltip } from "../../elements/Tooltip";
 import { RealmsListComponent } from "./RealmsListComponent";
 import useUIStore from "../../hooks/store/useUIStore";
 

--- a/client/src/components/worldmap/WorldMapMenuComponent.tsx
+++ b/client/src/components/worldmap/WorldMapMenuComponent.tsx
@@ -4,7 +4,6 @@ import { ReactComponent as City } from "../../assets/icons/common/city.svg";
 import { ReactComponent as World } from "../../assets/icons/common/world.svg";
 import { useLocation } from "wouter";
 import { Tabs } from "../../elements/tab";
-import { Tooltip } from "../../elements/Tooltip";
 import RealmsListPanel from "./RealmsListPanel";
 import { HyperstructuresPanel } from "./hyperstructures/HyperstructuresPanel";
 import useUIStore from "../../hooks/store/useUIStore";

--- a/client/src/components/worldmap/WorldMapMenuComponent.tsx
+++ b/client/src/components/worldmap/WorldMapMenuComponent.tsx
@@ -7,9 +7,11 @@ import { Tabs } from "../../elements/tab";
 import { Tooltip } from "../../elements/Tooltip";
 import RealmsListPanel from "./RealmsListPanel";
 import { HyperstructuresPanel } from "./hyperstructures/HyperstructuresPanel";
+import useUIStore from "../../hooks/store/useUIStore";
 
 const WorldMapMenuComponent = () => {
   const [selectedTab, setSelectedTab] = useState(0);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   // @ts-ignore
   const [_location, setLocation] = useLocation();
@@ -19,13 +21,23 @@ const WorldMapMenuComponent = () => {
       {
         key: "realms",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className=" whitespace-nowrap">Search for all existing</p>
+                    <p className=" whitespace-nowrap">Realms here.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <City className="mb-2 fill-gold" />
             <div>Realms</div>
-            <Tooltip position="bottom">
-              <p className=" whitespace-nowrap">Search for all existing</p>
-              <p className=" whitespace-nowrap">Realms here.</p>
-            </Tooltip>
           </div>
         ),
         component: <RealmsListPanel />,
@@ -33,12 +45,22 @@ const WorldMapMenuComponent = () => {
       {
         key: "hyperstructures",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">See, build or feed</p>
+                    <p className="whitespace-nowrap">Hyperstructures.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <Relic className="mb-2 fill-gold" /> <div>Hyperstructures</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">See, build or feed</p>
-              <p className="whitespace-nowrap">Hyperstructures.</p>
-            </Tooltip>
           </div>
         ),
         component: <HyperstructuresPanel />,

--- a/client/src/components/worldmap/hyperstructures/FeedHyperstructure.tsx
+++ b/client/src/components/worldmap/hyperstructures/FeedHyperstructure.tsx
@@ -20,7 +20,6 @@ import { ResourceCost } from "../../../elements/ResourceCost";
 import clsx from "clsx";
 import { HyperStructureInterface, useHyperstructure } from "../../../hooks/helpers/useHyperstructure";
 import { Tabs } from "../../../elements/tab";
-import { Tooltip } from "../../../elements/Tooltip";
 import ProgressBar from "../../../elements/ProgressBar";
 import { HyperStructureCaravansPanel } from "./HyperStructureCaravans/HyperStructureCaravansPanel";
 import hyperStructures from "../../../data/hyperstructures.json";

--- a/client/src/components/worldmap/hyperstructures/FeedHyperstructure.tsx
+++ b/client/src/components/worldmap/hyperstructures/FeedHyperstructure.tsx
@@ -29,6 +29,7 @@ import { NumberInput } from "../../../elements/NumberInput";
 import { ReactComponent as ArrowSeparator } from "../../../assets/icons/common/arrow-separator.svg";
 import { WEIGHT_PER_DONKEY_KG } from "../../../constants/travel";
 import { ReactComponent as CloseIcon } from "../../../assets/icons/common/cross-circle.svg";
+import useUIStore from "../../../hooks/store/useUIStore";
 
 type FeedHyperstructurePopupProps = {
   onClose: () => void;
@@ -37,6 +38,7 @@ type FeedHyperstructurePopupProps = {
 
 export const FeedHyperstructurePopup = ({ onClose, order }: FeedHyperstructurePopupProps) => {
   const [selectedTab, setSelectedTab] = useState(0);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const hyperStructurePosition = useMemo(() => {
     const { x, z } = hyperStructures[order - 1];
@@ -57,11 +59,21 @@ export const FeedHyperstructurePopup = ({ onClose, order }: FeedHyperstructurePo
       {
         key: "all",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Initialize or feed Hyperstructure with resources.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>Build</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Initialize or feed Hyperstructure with resources.</p>
-            </Tooltip>
           </div>
         ),
         component: (
@@ -77,12 +89,22 @@ export const FeedHyperstructurePopup = ({ onClose, order }: FeedHyperstructurePo
         key: "my",
         label: (
           // TODO: implement incoming caravans here
-          <div className="flex group relative flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Watch incoming caravans.</p>
+                    <p className="whitespace-nowrap">Pass resources to Hyperstructure on arriving.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex group relative flex-col items-center"
+          >
             <div>{`Caravans (${caravans.length})`}</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Watch incoming caravans.</p>
-              <p className="whitespace-nowrap">Pass resources to Hyperstructure on arriving.</p>
-            </Tooltip>
           </div>
         ),
         component: hyperstructureData ? (

--- a/client/src/components/worldmap/hyperstructures/HyperstructuresPanel.tsx
+++ b/client/src/components/worldmap/hyperstructures/HyperstructuresPanel.tsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { Tooltip } from "../../../elements/Tooltip";
 import { Tabs } from "../../../elements/tab";
 import { HyperstructuresListComponent } from "./HyperstructuresListComponent";
 import useUIStore from "../../../hooks/store/useUIStore";

--- a/client/src/components/worldmap/hyperstructures/HyperstructuresPanel.tsx
+++ b/client/src/components/worldmap/hyperstructures/HyperstructuresPanel.tsx
@@ -2,22 +2,34 @@ import { useMemo, useState } from "react";
 import { Tooltip } from "../../../elements/Tooltip";
 import { Tabs } from "../../../elements/tab";
 import { HyperstructuresListComponent } from "./HyperstructuresListComponent";
+import useUIStore from "../../../hooks/store/useUIStore";
 
 type HyperstructuresPanelProps = {};
 
 export const HyperstructuresPanel = ({}: HyperstructuresPanelProps) => {
   const [selectedTab, setSelectedTab] = useState(0);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const tabs = useMemo(
     () => [
       {
         key: "all",
         label: (
-          <div className="flex relative group flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Browse all Hyperstructures.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex relative group flex-col items-center"
+          >
             <div>All Hyperstructures</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Browse all Hyperstructures.</p>
-            </Tooltip>
           </div>
         ),
         component: <HyperstructuresListComponent />,
@@ -25,12 +37,22 @@ export const HyperstructuresPanel = ({}: HyperstructuresPanelProps) => {
       {
         key: "my",
         label: (
-          <div className="flex group relative flex-col items-center">
+          <div
+            onMouseEnter={() =>
+              setTooltip({
+                position: "bottom",
+                content: (
+                  <>
+                    <p className="whitespace-nowrap">Look at Hyperstructure of your order.</p>
+                    <p className="whitespace-nowrap">Initialize or feed it with resources.</p>
+                  </>
+                ),
+              })
+            }
+            onMouseLeave={() => setTooltip(null)}
+            className="flex group relative flex-col items-center"
+          >
             <div>My Order</div>
-            <Tooltip position="bottom">
-              <p className="whitespace-nowrap">Look at Hyperstructure of your order.</p>
-              <p className="whitespace-nowrap">Initialize or feed it with resources.</p>
-            </Tooltip>
           </div>
         ),
         component: <></>,

--- a/client/src/elements/SelectableResource.tsx
+++ b/client/src/elements/SelectableResource.tsx
@@ -5,6 +5,7 @@ import { ResourceIcon } from "./ResourceIcon";
 import { Tooltip } from "./Tooltip";
 import { soundSelector, useUiSounds } from "../hooks/useUISound";
 import { currencyFormat } from "../utils/utils";
+import useUIStore from "../hooks/store/useUIStore";
 
 type SelectableResourceProps = {
   resourceId: number;
@@ -14,8 +15,8 @@ type SelectableResourceProps = {
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export const SelectableResource = ({ resourceId, amount, selected, disabled, onClick }: SelectableResourceProps) => {
-  const [showTooltip, setShowTooltip] = React.useState(false);
   const resource = findResourceById(resourceId);
+  const setTooltip = useUIStore((state) => state.setTooltip);
 
   const { play: playAddWood } = useUiSounds(soundSelector.addWood);
   const { play: playAddStone } = useUiSounds(soundSelector.addStone);
@@ -125,8 +126,20 @@ export const SelectableResource = ({ resourceId, amount, selected, disabled, onC
 
   return (
     <div
-      onMouseOver={() => setShowTooltip(true)}
-      onMouseLeave={() => setShowTooltip(false)}
+      onMouseEnter={() =>
+        setTooltip({
+          position: "bottom",
+          content: (
+            <>
+              <div className="relative z-50 flex flex-col items-center justify-center mb-1 text-xs text-center text-lightest">
+                {resource?.trait}
+                <div className="mt-0.5 font-bold">{currencyFormat(amount || 0, 0)}</div>
+              </div>
+            </>
+          ),
+        })
+      }
+      onMouseLeave={() => setTooltip(null)}
       onClick={(e) => {
         if (!disabled && onClick) {
           onClick(e);
@@ -140,14 +153,6 @@ export const SelectableResource = ({ resourceId, amount, selected, disabled, onC
       )}
     >
       <ResourceIcon withTooltip={false} resource={resource?.trait || ""} size="xs" />
-      {showTooltip && (
-        <Tooltip>
-          <div className="relative z-50 flex flex-col items-center justify-center mb-1 text-xs text-center text-lightest">
-            {resource?.trait}
-            <div className="mt-0.5 font-bold">{currencyFormat(amount || 0, 0)}</div>
-          </div>
-        </Tooltip>
-      )}
     </div>
   );
 };

--- a/client/src/elements/SelectableResource.tsx
+++ b/client/src/elements/SelectableResource.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { ResourcesIds, findResourceById } from "../constants/resources";
 import clsx from "clsx";
 import { ResourceIcon } from "./ResourceIcon";
-import { Tooltip } from "./Tooltip";
 import { soundSelector, useUiSounds } from "../hooks/useUISound";
 import { currencyFormat } from "../utils/utils";
 import useUIStore from "../hooks/store/useUIStore";

--- a/client/src/elements/Tooltip.tsx
+++ b/client/src/elements/Tooltip.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 import useUIStore from "../hooks/store/useUIStore";
-import { useEffect } from "react";
 
 type TooltipProps = {
   className?: string;

--- a/client/src/elements/Tooltip.tsx
+++ b/client/src/elements/Tooltip.tsx
@@ -1,40 +1,53 @@
 import clsx from "clsx";
-import React from "react";
+import useUIStore from "../hooks/store/useUIStore";
+import { useEffect } from "react";
 
 type TooltipProps = {
-  children: React.ReactNode;
-  position?: "top" | "bottom" | "left";
   className?: string;
 };
 
-export const Tooltip = ({ position = "top", className, children }: TooltipProps) => (
-  <div
-    className={clsx(
-      "absolute z-[100] opacity-80 text-xxs hidden left-1/2 -translate-x-1/2 p-2 bg-black rounded-md flex-col justify-start items-center text-white group-hover:inline-flex",
-      position == "top" && "top-0 -translate-y-full",
-      position == "bottom" && "bottom-0 translate-y-[120%]",
-      position == "left" && "!left-0 !top-1/2 -translate-x-[110%] -translate-y-1/2",
-      className,
-    )}
-  >
-    {children}
-    <svg
-      className={clsx(
-        "absolute z-0",
-        position == "top" && "bottom-0 translate-y-1/2 -translate-x-1/2 left-1/2 bottom-0",
-        position == "bottom" && "top-0 -translate-y-1/2 rotate-180 -translate-x-1/2 left-1/2 bottom-0",
-        position == "left" && "right-0 top-1/2 -translate-y-1/2 translate-x-1/2 -rotate-90",
+export const Tooltip = ({ className }: TooltipProps) => {
+  const mouseCoords = useUIStore((state) => state.mouseCoords);
+  const tooltip = useUIStore((state) => state.tooltip);
+  const position = tooltip?.position ? tooltip.position : "top";
+
+  return (
+    <>
+      {tooltip && tooltip.content && (
+        <div
+          className={clsx(
+            "fixed z-[100] inline-flex opacity-80 text-xxs -translate-x-1/2 p-2 bg-black rounded-md flex-col justify-start items-center text-white",
+            position == "top" && "-translate-y-full",
+            position == "bottom" && "translate-y-1/2",
+            position == "left" && "-translate-x-[110%] -translate-y-1/2",
+            className,
+          )}
+          style={{
+            left: `${mouseCoords.x || -500}px`,
+            top: `${mouseCoords.y || -500}px`,
+          }}
+        >
+          {tooltip.content}
+          <svg
+            className={clsx(
+              "absolute z-0",
+              position == "top" && "bottom-0 translate-y-1/2 -translate-x-1/2 left-1/2 bottom-0",
+              position == "bottom" && "top-0 -translate-y-1/2 rotate-180 -translate-x-1/2 left-1/2 bottom-0",
+              position == "left" && "right-0 top-1/2 -translate-y-1/2 translate-x-1/2 -rotate-90",
+            )}
+            width="26"
+            height="18"
+            viewBox="0 0 26 18"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10.6931 16.2253C11.8927 17.6681 14.1074 17.6681 15.3069 16.2253L24.4998 5.1679C26.1248 3.21329 24.7348 0.25 22.1929 0.25H3.80708C1.26518 0.25 -0.124826 3.21329 1.50021 5.1679L10.6931 16.2253Z"
+              fill="#000"
+            />
+          </svg>
+        </div>
       )}
-      width="26"
-      height="18"
-      viewBox="0 0 26 18"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M10.6931 16.2253C11.8927 17.6681 14.1074 17.6681 15.3069 16.2253L24.4998 5.1679C26.1248 3.21329 24.7348 0.25 22.1929 0.25H3.80708C1.26518 0.25 -0.124826 3.21329 1.50021 5.1679L10.6931 16.2253Z"
-        fill="#000"
-      />
-    </svg>
-  </div>
-);
+    </>
+  );
+};

--- a/client/src/hooks/store/useUIStore.tsx
+++ b/client/src/hooks/store/useUIStore.tsx
@@ -3,6 +3,7 @@ import { createPopupsSlice, PopupsStore } from "./_popups";
 import realmsJson from "../../geodata/realms.json";
 import { Vector3 } from "three";
 import { createDataStoreSlice, DataStore } from "./_dataStore";
+import React from "react";
 export type Background = "map" | "realmView" | "combat" | "bastion";
 
 interface UIStore {
@@ -19,6 +20,13 @@ interface UIStore {
   cameraPosition: any;
   setCameraPosition: (position: any) => void;
   cameraTarget: any;
+  tooltip: {
+    content: React.ReactNode;
+    position: "top" | "left" | "right" | "bottom";
+  } | null;
+  setTooltip: (tooltip: { content: React.ReactNode; position: "top" | "left" | "right" | "bottom" } | null) => void;
+  mouseCoords: { x: number; y: number };
+  setMouseCoords: (coords: { x: number; y: number }) => void;
   setCameraTarget: (target: any) => void;
   moveCameraToRealm: (realmId: number) => void;
   moveCameraToTarget: (target: { x: number; y: number; z: number }, distance?: number) => void;
@@ -59,6 +67,10 @@ const useUIStore = create<UIStore & PopupsStore & DataStore>((set) => ({
   setCameraPosition: (position) => set({ cameraPosition: position }),
   cameraTarget: { x: 0, y: 0, z: 0 },
   setCameraTarget: (target) => set({ cameraTarget: target }),
+  tooltip: null,
+  setTooltip: (tooltip) => set({ tooltip }),
+  mouseCoords: { x: 0, y: 0 },
+  setMouseCoords: (coords) => set({ mouseCoords: coords }),
   moveCameraToRealm: (realmId) => {
     const x = realmsJson.features[realmId - 1].xy[0] * -1;
     const y = realmsJson.features[realmId - 1].xy[1] * -1;

--- a/client/src/layouts/World.tsx
+++ b/client/src/layouts/World.tsx
@@ -25,6 +25,7 @@ import { useSyncWorld } from "../hooks/graphql/useGraphQLQueries";
 import WorldMapMenuModule from "../modules/WorldMapMenuModule";
 import hyperStructures from "../data/hyperstructures.json";
 import { useHyperstructure } from "../hooks/helpers/useHyperstructure";
+import { Tooltip } from "../elements/Tooltip";
 
 export const World = () => {
   const { loading: worldLoading } = useSyncWorld();
@@ -39,6 +40,7 @@ export const World = () => {
   const isLoadingScreenEnabled = useUIStore((state) => state.isLoadingScreenEnabled);
   const setIsLoadingScreenEnabled = useUIStore((state) => state.setIsLoadingScreenEnabled);
   const setHyperstructures = useUIStore((state) => state.setHyperstructures);
+  const setMouseCoords = useUIStore((state) => state.setMouseCoords);
 
   const [playBackground, { stop }] = useSound("/sound/music/happy_realm.mp3", {
     soundEnabled: isSoundOn,
@@ -75,7 +77,15 @@ export const World = () => {
   }, [progress, worldLoading]);
 
   return (
-    <div className="fixed top-0 left-0 z-0 w-screen h-screen p-2 overflow-hidden">
+    <div
+      onMouseMove={(e) =>
+        setMouseCoords({
+          x: e.clientX,
+          y: e.clientY,
+        })
+      }
+      className="fixed antialiased top-0 left-0 z-0 w-screen h-screen p-2 overflow-hidden"
+    >
       <BackgroundContainer className="border-2 border-[#E0AF65] rounded-xl relative">
         <div className="absolute top-0 left-0 z-10 w-full pointer-events-none rounded-xl h-44 bg-gradient-to-b from-black to-transparent opacity-90" />
         <MainScene />
@@ -112,6 +122,7 @@ export const World = () => {
         <SignUpComponent worldLoading={worldLoading} />
       </BlurOverlayContainer>
       <Leva hidden={import.meta.env.PROD} />
+      <Tooltip />
       <Redirect to="/map" />
     </div>
   );


### PR DESCRIPTION
few ui fixes:

1.  Now tooltips don't causing scrolls and aren't cropped by parent container, also they will follow player's cursor position
Now we can easily add more help tooltips with detailed explanations of UI in any place.
3. Fixed width of "Accept offer" popup