### PR TITLE
make transfer systems compatible with inventory

### DIFF
--- a/contracts/src/models/capacity.cairo
+++ b/contracts/src/models/capacity.cairo
@@ -9,12 +9,16 @@ struct Capacity {
 #[generate_trait]
 impl CapacityImpl of CapacityTrait {
     fn can_carry_weight(self: Capacity, entity_id: u128, quantity: u128, weight: u128) -> bool {
-        if self.weight_gram != 0 {
+        if self.is_capped() {
             let entity_total_weight_capacity = self.weight_gram * quantity;
             if entity_total_weight_capacity < weight {
                 return false;
             };
         };
         return true;
+    }
+
+    fn is_capped(self: Capacity) -> bool {
+        self.weight_gram != 0
     }
 }

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -24,8 +24,7 @@ mod combat_systems {
         ISoldierSystems, ICombatSystems
     };
     use eternum::systems::resources::contracts::resource_systems::{
-        InternalResourceChestSystemsImpl,
-        InternalInventorySystemsImpl 
+        InternalResourceSystemsImpl
     };
 
     use eternum::systems::transport::contracts::travel_systems::travel_systems::{
@@ -54,8 +53,8 @@ mod combat_systems {
         target_realm_entity_id: u128,
         attacking_entity_ids: Span<u128>,
         winner: Winner,
-        stolen_resource_types: Span<u8>,
-        stolen_resource_amounts: Span<u128>
+        stolen_resources: Span<(u8, u128)>,
+        
     }
 
     #[event]
@@ -727,8 +726,7 @@ mod combat_systems {
                     attacking_entity_ids: attacker_ids,
                     target_realm_entity_id,
                     winner,
-                    stolen_resource_types: array![].span(),
-                    stolen_resource_amounts: array![].span()
+                    stolen_resources: array![].span()
              });
 
         }
@@ -794,8 +792,7 @@ mod combat_systems {
             if attack_successful {
                 // attack was a success 
 
-                let mut stolen_resource_types: Array<u8> = array![];
-                let mut stolen_resource_amounts: Array<u128> = array![];
+                let mut stolen_resources: Array<(u8, u128)> = array![];
 
                 let attacker_capacity = get!(world, attacker_id, Capacity);
                 let attacker_quantity = get!(world, attacker_id, Quantity);
@@ -851,30 +848,24 @@ mod combat_systems {
                             attacker_remaining_weight
                                  -= stolen_resource_amount * resource_weight;
 
-                            stolen_resource_types.append(resource_type);
-                            stolen_resource_amounts.append(stolen_resource_amount);
+                            stolen_resources.append(
+                                (resource_type, stolen_resource_amount)
+                            );
                         }
                     }
                     index += 1;                
                 };
 
-                if stolen_resource_amounts.len() > 0 {
-                    // create a resource chest for the attacker 
-                    // and fill it with the stolen resources to it
-                    let (attacker_resource_chest, _) 
-                        = InternalResourceChestSystemsImpl::create(world, 
-                            stolen_resource_types.span(), stolen_resource_amounts.span()
-                        );
-                    InternalResourceChestSystemsImpl::fill(
-                        world, attacker_resource_chest.entity_id, target_realm_entity_id
-                    );
+                if stolen_resources.len() > 0 {
+                    // give stolen resources to attacker
 
-                    // add the resource chest to the attacker's inventory
-                    InternalInventorySystemsImpl::add(
-                        world, 
+                    InternalResourceSystemsImpl::transfer(
+                        world,
+                        target_realm_entity_id,
                         attacker_id,
-                        attacker_resource_chest.entity_id
+                        stolen_resources.span()
                     );
+                    
                 }
 
         
@@ -886,8 +877,7 @@ mod combat_systems {
                         attacking_entity_ids: array![attacker_id].span(),
                         target_realm_entity_id,
                         winner: Winner::Attacker,
-                        stolen_resource_types: stolen_resource_types.span(),
-                        stolen_resource_amounts: stolen_resource_amounts.span()
+                        stolen_resources: stolen_resources.span(),
                 });
 
             
@@ -913,8 +903,7 @@ mod combat_systems {
                         attacking_entity_ids: array![attacker_id].span(),
                         target_realm_entity_id,
                         winner: Winner::Target,
-                        stolen_resource_types: array![].span(),
-                        stolen_resource_amounts: array![].span()
+                        stolen_resources: array![].span(),
                 });
             }    
 

--- a/contracts/src/systems/resources/contracts.cairo
+++ b/contracts/src/systems/resources/contracts.cairo
@@ -393,20 +393,8 @@ mod resource_systems {
             assert(resource_chest_weight.value != 0, 'chest is empty');
             
             // ensure that receiver has enough weight capacity
-            let receiver_weight = get!(world, receiving_entity_id, Weight);
-
             let receiver_capacity = get!(world, receiving_entity_id, Capacity);
-            let receiver_quantity = get!(world, receiving_entity_id, Quantity);
-
-            assert(
-                receiver_capacity
-                    .can_carry_weight(
-                            receiving_entity_id, 
-                            receiver_quantity.get_value(), 
-                            receiver_weight.value + resource_chest_weight.value
-                        ),
-                'not enough capacity'
-            );
+            assert(receiver_capacity.is_capped() == false, 'invalid recepient');
 
             // return resources to the entity
             let mut index = 0;

--- a/contracts/src/systems/resources/contracts.cairo
+++ b/contracts/src/systems/resources/contracts.cairo
@@ -21,10 +21,12 @@ mod resource_systems {
 
     use eternum::constants::{WORLD_CONFIG_ID};
 
-    use eternum::systems::resources::interface::{IResourceSystems, IResourceChestSystems};
+    use eternum::systems::resources::interface::{IResourceSystems, IInventorySystems};
 
     use core::integer::BoundedInt;
     use core::poseidon::poseidon_hash_span;
+
+    use debug::PrintTrait;
 
     #[derive(Drop, starknet::Event)]
     struct Transfer {
@@ -114,6 +116,10 @@ mod resource_systems {
 
             emit!(world, Transfer { receiving_entity_id, sending_realm_id, sending_entity_id, resources });
 
+            // check that recepient and sender are at the same position
+            caravan::check_position(world, receiving_entity_id, sending_entity_id);
+            caravan::check_arrival_time(world, receiving_entity_id);
+
             InternalResourceSystemsImpl::transfer(
                 world, sending_entity_id, receiving_entity_id, resources
             )
@@ -168,6 +174,9 @@ mod resource_systems {
                 };
             };
 
+            // check that recepient and sender are at the same position
+            caravan::check_position(world, receiving_entity_id, owner_entity_id);
+            caravan::check_arrival_time(world, receiving_entity_id);
 
             InternalResourceSystemsImpl::transfer(
                 world, owner_entity_id, receiving_entity_id, resources
@@ -179,69 +188,22 @@ mod resource_systems {
     impl InternalResourceSystemsImpl of InternalResourceSystemsTrait {
 
         fn transfer(
-            world: IWorldDispatcher, sending_entity_id: ID, 
-            receiving_entity_id: ID, resources: Span<(u8, u128)>
+            world: IWorldDispatcher, sender_id: ID,  receiver_id: ID, resources: Span<(u8, u128)>
         ) {
 
-            // compare positions
-            let sending_entity_position = get!(world, sending_entity_id, Position);
-            let receiving_entity_position = get!(world, receiving_entity_id, Position);
+            // create resource chest
+            let resource_chest
+                = InternalResourceChestSystemsImpl::create_and_fill(
+                    world, sender_id, resources
+                    );
 
-            assert(receiving_entity_position.x !=  0, 'entity position mismatch');
-            assert(receiving_entity_position.y != 0, 'entity position mismatch');
-
-            assert(receiving_entity_position.x == sending_entity_position.x, 'entity position mismatch');
-            assert(receiving_entity_position.y == sending_entity_position.y, 'entity position mismatch');
-        
-            // // get receiving entity's total capacity
-            let receiving_entity_capacity = get!(world, receiving_entity_id, Capacity);
-            let mut receiving_entity_total_capacity = 0;
-            if receiving_entity_capacity.weight_gram != 0 {
-                let receiving_entity_quantity = get!(world, receiving_entity_id, Quantity );
-                receiving_entity_total_capacity = receiving_entity_capacity.weight_gram * receiving_entity_quantity.get_value();
-            }
-
-
-            let mut total_weight = 0;
-            let mut resources = resources;
-            loop {
-                match resources.pop_front() {
-                    Option::Some((resource_type, resource_amount)) => {
-                        let (resource_type, resource_amount) = (*resource_type, *resource_amount);
-                        assert(resource_amount != 0, 'resource transfer amount is 0');
-
-                        let sending_entity_resource = get!(world, (sending_entity_id, resource_type) , Resource);  
-                        assert(sending_entity_resource.balance >= resource_amount, 'insufficient balance');
-
-                        let receiving_entity_resource = get!(world, (receiving_entity_id, resource_type) , Resource);
-                        set!(world, (
-                            Resource { 
-                                entity_id: sending_entity_id, 
-                                resource_type: resource_type, 
-                                balance: sending_entity_resource.balance - resource_amount
-                            },
-                            Resource { 
-                                entity_id: receiving_entity_id, 
-                                resource_type: resource_type, 
-                                balance: receiving_entity_resource.balance + resource_amount
-                            }
-                        ));
-                        
-                        total_weight += WeightConfigImpl::get_weight(
-                            world, resource_type, resource_amount
-                        );
-                    },
-                    Option::None(_) => {break;}
-                };
-            };
-
-            // ensure receiving entity has adequate capacity
-            if receiving_entity_total_capacity != 0 {
-                assert(
-                    receiving_entity_total_capacity >= total_weight, 
-                        'capacity not enough'
-                );
-            }
+            // give resource chest to receiver
+            InternalInventorySystemsImpl::add(
+                world, 
+                receiver_id,
+                resource_chest.entity_id
+            );
+     
         }
     }
 
@@ -249,23 +211,24 @@ mod resource_systems {
 
 
     #[external(v0)]
-    impl ResourceChestSystemsImpl of IResourceChestSystems<ContractState> {
+    impl InventorySystemsImpl of IInventorySystems<ContractState> {
 
-        /// Offload resources in a resource_chest from a caravan
-        fn offload_chest(
+
+        /// Transfer item from inventory
+        fn transfer_item(
             self: @ContractState, world: IWorldDispatcher, 
-            entity_id: ID, entity_index_in_inventory: u128, 
-            receiving_entity_id: ID, transport_id: ID
-            ) {
+            sender_id: ID, index: u128, receiver_id: ID
+        ) {
 
-            caravan::check_owner(world, transport_id, starknet::get_caller_address());
-            caravan::check_position(world, transport_id, receiving_entity_id);
-            caravan::check_arrival_time(world, transport_id);
+            caravan::check_owner(world, sender_id, starknet::get_caller_address());
+            caravan::check_position(world, sender_id, receiver_id);
+            caravan::check_arrival_time(world, sender_id);
 
-            InternalInventorySystemsImpl::remove(
-                world, transport_id, entity_index_in_inventory, entity_id
-                );
-            InternalResourceChestSystemsImpl::offload(world, entity_id, receiving_entity_id);
+            // remove resource chest from sender's inventory
+            let item_id = InternalInventorySystemsImpl::remove(world, sender_id, index);
+
+            // remove resources from resource chest and give receiver
+            InternalResourceChestSystemsImpl::offload(world, item_id, receiver_id);
             
         }
     }
@@ -275,11 +238,7 @@ mod resource_systems {
     #[generate_trait]
     impl InternalResourceChestSystemsImpl of InternalResourceChestTrait {
 
-        fn create( 
-                world: IWorldDispatcher, resource_types: Span<u8>, resource_amounts: Span<u128>
-            ) -> (ResourceChest, u128) {
-
-            assert(resource_types.len() == resource_amounts.len(), 'length not equal');
+        fn create( world: IWorldDispatcher, resources: Span<(u8, u128)> ) -> (ResourceChest, u128) {
             
             let resource_chest_id = world.uuid().into();
 
@@ -287,11 +246,12 @@ mod resource_systems {
             let mut index = 0;
             let mut resources_weight = 0;
             loop {
-                if index == resource_types.len() {
-                    break ();
+                if index == resources.len(){
+                    break;
                 }
-                let resource_type = *resource_types[index];
-                let resource_amount = *resource_amounts[index];
+                
+                let (resource_type, resource_amount) = *resources.at(index);
+
                 set!(world,(
                     DetachedResource {
                         entity_id: resource_chest_id,
@@ -313,7 +273,7 @@ mod resource_systems {
                 = ResourceChest {
                     entity_id:resource_chest_id,
                     locked_until: 0,
-                    resources_count: resource_types.len(),
+                    resources_count: resources.len(),
                 };
 
             set!(world,(resource_chest));
@@ -356,6 +316,67 @@ mod resource_systems {
         }
 
 
+
+        fn create_and_fill(
+            world: IWorldDispatcher, donor_id: u128, resources: Span<(u8, u128)>
+        ) -> ResourceChest {
+
+            let resource_chest_id = world.uuid().into();
+
+            // create the chest
+            let mut index = 0;
+            let mut resources_weight = 0;
+            loop {
+                if index == resources.len(){
+                    break;
+                }
+                
+                let (resource_type, resource_amount) = *resources.at(index);
+
+                let mut donor_resource = get!(world, (donor_id, resource_type), Resource);
+                assert(donor_resource.balance >= resource_amount, 'insufficient balance');
+                
+                // remove resources from donor's balance
+                donor_resource.balance -= resource_amount;
+                set!(world, (donor_resource));
+
+                // create detached resource
+                set!(world,(
+                    DetachedResource {
+                        entity_id: resource_chest_id,
+                        index,
+                        resource_type,
+                        resource_amount
+                    }
+                ));
+              
+                // update resources total weight
+                let resource_type_weight 
+                    = get!(world, (WORLD_CONFIG_ID, resource_type), WeightConfig);
+                resources_weight += resource_type_weight.weight_gram * resource_amount;
+                index += 1;
+            };
+
+            // create resource chest
+            let resource_chest 
+                = ResourceChest {
+                    entity_id:resource_chest_id,
+                    locked_until: 0,
+                    resources_count: resources.len(),
+                };
+            set!(world,(
+                resource_chest, 
+                Weight {
+                    entity_id: resource_chest_id,
+                    value: resources_weight
+                }
+            ));
+            
+            resource_chest
+
+        }
+
+
         fn lock_until(world: IWorldDispatcher, entity_id: u128, ts: u64) {
 
             let mut resource_chest = get!(world, entity_id, ResourceChest);
@@ -389,6 +410,7 @@ mod resource_systems {
 
             // return resources to the entity
             let mut index = 0;
+            let mut resources: Array<(u8, u128)> = array![];
             loop {
                 if index == resource_chest.resources_count {
                     break ();
@@ -404,6 +426,11 @@ mod resource_systems {
                 receiving_entity_resource.balance += resource_chest_resource.resource_amount;
                 set!(world,( receiving_entity_resource ));
 
+                resources.append((
+                    resource_chest_resource.resource_type,
+                    resource_chest_resource.resource_amount
+                ));
+
                 index += 1;
             };
 
@@ -415,6 +442,20 @@ mod resource_systems {
             // reset resource chest weight
             resource_chest_weight.value = 0;
             set!(world,(resource_chest_weight));
+
+
+            // emit transfer event 
+
+            let entity_owner = get!(world, entity_id, EntityOwner);
+            let realm_id = entity_owner.get_realm_id(world);
+
+            emit!(world, Transfer { 
+                receiving_entity_id, 
+                sending_realm_id: realm_id, 
+                sending_entity_id: entity_id,
+                resources: resources.span()
+            });
+
 
         }
 
@@ -437,10 +478,13 @@ mod resource_systems {
 
         fn add(world: IWorldDispatcher, entity_id: ID, item_id: ID) {
 
-                // ensure entity can carry the weight
+                let mut inventory = get!(world, entity_id, Inventory);
+                assert(inventory.items_key != 0, 'entity has no inventory');
+
                 let item_weight = get!(world, item_id, Weight);
                 assert(item_weight.value > 0, 'item is empty');
 
+                // ensure entity can carry the weight
                 let mut entity_weight = get!(world, entity_id, Weight);
                 entity_weight.value += item_weight.value;
 
@@ -454,10 +498,11 @@ mod resource_systems {
                             'capacity is not enough'
                     );
                 }  
+
                 set!(world, (entity_weight));
 
                 // add item to inventory
-                let mut inventory = get!(world, entity_id, Inventory);
+
                 let foreign_key 
                     = InternalInventorySystemsImpl::get_foreign_key(inventory, inventory.items_count);
                 set!(world, (
@@ -474,8 +519,8 @@ mod resource_systems {
 
         /// Remove an item from an inventory
         fn remove(
-            world: IWorldDispatcher, entity_id: ID, index: u128, item_id: ID
-        ) {
+            world: IWorldDispatcher, entity_id: ID, index: u128
+        ) -> u128 {
             let mut inventory = get!(world, entity_id, Inventory);
             assert(inventory.items_count > 0, 'inventory is empty');
 
@@ -488,8 +533,16 @@ mod resource_systems {
                 = InternalInventorySystemsImpl::get_foreign_key(inventory, index);
             let mut current_inventory_item 
                 = get!(world, current_inventory_item_foreign_key, ForeignKey);
-            // ensure that the index maps to the item id 
-            assert(current_inventory_item.entity_id == item_id, 'inventory: wrong index');
+
+            let item_id = current_inventory_item.entity_id;
+
+
+            // remove weight from entity
+            let mut entity_weight = get!(world, entity_id, Weight);
+            let mut item_weight = get!(world, item_id, Weight);
+            entity_weight.value -= item_weight.value;
+            set!(world, (entity_weight));
+
 
             current_inventory_item.entity_id = last_inventory_item.entity_id;
             inventory.items_count -= 1;
@@ -497,11 +550,7 @@ mod resource_systems {
             set!(world, (current_inventory_item));
             set!(world, (inventory));
 
-            // remove weight from entity
-            let mut entity_weight = get!(world, entity_id, Weight);
-            let mut item_weight = get!(world, item_id, Weight);
-            entity_weight.value -= item_weight.value;
-            set!(world, (entity_weight));
+            item_id
         }
     }
     

--- a/contracts/src/systems/resources/interface.cairo
+++ b/contracts/src/systems/resources/interface.cairo
@@ -21,10 +21,9 @@ trait IResourceSystems<TContractState> {
 }
 
 #[starknet::interface]
-trait IResourceChestSystems<TContractState> {
-    fn offload_chest(
+trait IInventorySystems<TContractState> {
+    fn transfer_item(
         self: @TContractState, world: IWorldDispatcher, 
-        entity_id: ID, entity_index_in_inventory: u128, 
-        receiving_entity_id: ID, transport_id: ID
+        sender_id: ID, index: u128, receiver_id: ID
     );
 }

--- a/contracts/src/systems/resources/tests.cairo
+++ b/contracts/src/systems/resources/tests.cairo
@@ -1,4 +1,4 @@
 mod resource_approval_system_tests;
 mod resource_transfer_system_tests;
 
-mod resource_chest_offload_system_tests;
+mod inventory_transfer_item_system_tests;

--- a/contracts/src/systems/trade/contracts/trade_systems.cairo
+++ b/contracts/src/systems/trade/contracts/trade_systems.cairo
@@ -42,12 +42,10 @@ mod trade_systems {
             self: @ContractState,
             world: IWorldDispatcher,
             maker_id: u128,
-            maker_gives_resource_types: Span<u8>,
-            maker_gives_resource_amounts: Span<u128>,
+            maker_gives_resources: Span<(u8, u128)>,
             maker_transport_id: ID,
             taker_id: u128,
-            taker_gives_resource_types: Span<u8>,
-            taker_gives_resource_amounts: Span<u128>,
+            taker_gives_resources: Span<(u8, u128)>,
             expires_at: u64
         ) -> ID {
             let caller = starknet::get_caller_address();
@@ -66,7 +64,7 @@ mod trade_systems {
             // create resource chest that maker will collect
             let (maker_resource_chest, maker_resources_weight) 
                 = resource_chest::create(
-                    world, taker_gives_resource_types, taker_gives_resource_amounts
+                    world, taker_gives_resources
                 );
 
             // check that maker's transport can carry 
@@ -79,7 +77,7 @@ mod trade_systems {
             // create resource chest that taker will collect
             let (taker_resource_chest, _) 
                 = resource_chest::create(
-                    world, maker_gives_resource_types, maker_gives_resource_amounts
+                    world, maker_gives_resources
                 );
 
             // fill the taker's chest with the maker's resources

--- a/contracts/src/systems/trade/interface/trade_systems_interface.cairo
+++ b/contracts/src/systems/trade/interface/trade_systems_interface.cairo
@@ -7,18 +7,16 @@ trait ITradeSystems<TContractState> {
     /// Create an offer to sell resources.
     ///
     /// The offer may be open or direct. To make an open offer, set
-    /// `buyer_id` to 0 and to make a direct offer, set `buyer_id` to the
-    /// ID of the buyer.
+    /// `taker_id` to 0 and to make a direct offer, set `taker_id` to the
+    /// ID of the taker.
     ///
     /// # Arguments
     /// - `world`: Dojo world.
-    /// - `seller_id`: seller entity id.
-    /// - `seller_resource_types`: an array containing the types of resources to be sold.
-    /// - `seller_resource_amounts`: an array containing the quantities of resources to be sold.
-    /// - `seller_caravan_id`: The unique identifier of the seller's caravan.
-    /// - `buyer_id`: The unique identifier of the buyer.
-    /// - `buyer_resource_types`: an array containing the types of resources to be bought.
-    /// - `buyer_resource_amounts`: an array containing the quantities of resources to be bought.
+    /// - `maker_id`: maker entity id.
+    /// - `maker_gives_resources`: an array containing the types of resources to be sold and amount.
+    /// - `maker_caravan_id`: The unique identifier of the maker's caravan.
+    /// - `taker_id`: The unique identifier of the taker.
+    /// - `taker_gives_resources`: an array containing the types of resources to be bought and amount.
     /// - `expires_at`: The expiration time after which offer is no longer valid.
     ///
     /// # Returns
@@ -28,12 +26,10 @@ trait ITradeSystems<TContractState> {
         self: @TContractState,
         world: IWorldDispatcher,
         maker_id: u128,
-        maker_gives_resource_types: Span<u8>,
-        maker_gives_resource_amounts: Span<u128>,
+        maker_gives_resources: Span<(u8, u128)>,
         maker_transport_id: ID,
         taker_id: u128,
-        taker_gives_resource_types: Span<u8>,
-        taker_gives_resource_amounts: Span<u128>,
+        taker_gives_resources: Span<(u8, u128)>,
         expires_at: u64
     ) -> ID;
 

--- a/contracts/src/systems/trade/tests/trade_systems_tests/accept_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/accept_order.cairo
@@ -209,12 +209,16 @@ fn setup(direct_trade: bool) -> (IWorldDispatcher, u128, u128, u128, u128, ITrad
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
-            trade_taker_id,
-            array![ResourceTypes::WOOD, ResourceTypes::SILVER].span(),
-            array![200, 200].span(),
+            taker_id,
+            array![
+                (ResourceTypes::WOOD, 200), 
+                (ResourceTypes::SILVER, 200), 
+            ].span(),
             100
     );
 

--- a/contracts/src/systems/trade/tests/trade_systems_tests/cancel_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/cancel_order.cairo
@@ -198,12 +198,16 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::WOOD, ResourceTypes::SILVER].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::WOOD, 200), 
+                (ResourceTypes::SILVER, 200), 
+            ].span(),
             100
     );
 

--- a/contracts/src/systems/trade/tests/trade_systems_tests/create_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/create_order.cairo
@@ -176,12 +176,16 @@ fn test_create_order() {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::STONE, 200), 
+                (ResourceTypes::GOLD, 200), 
+            ].span(),
             100
     );
 
@@ -256,12 +260,16 @@ fn test_caller_not_maker() {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::STONE, 200), 
+                (ResourceTypes::GOLD, 200), 
+            ].span(),
             100
     );
 }
@@ -282,12 +290,16 @@ fn test_caller_not_owner_of_transport_id() {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::STONE, 200), 
+                (ResourceTypes::GOLD, 200), 
+            ].span(),
             100
     );
 }
@@ -315,12 +327,16 @@ fn test_different_transport_position() {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::STONE, 200), 
+                (ResourceTypes::GOLD, 200), 
+            ].span(),
             100
     );
 }
@@ -348,12 +364,16 @@ fn test_transport_in_transit() {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::STONE, 200), 
+                (ResourceTypes::GOLD, 200), 
+            ].span(),
             100
     );
 }
@@ -419,12 +439,16 @@ fn test_transport_not_enough_capacity() {
     let trade_id = trade_systems_dispatcher.create_order(
             world,
             maker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![100, 100].span(),
+            array![
+                (ResourceTypes::STONE, 100), 
+                (ResourceTypes::GOLD, 100), 
+            ].span(),
             maker_transport_id,
             taker_id,
-            array![ResourceTypes::STONE, ResourceTypes::GOLD].span(),
-            array![200, 200].span(),
+            array![
+                (ResourceTypes::STONE, 200), 
+                (ResourceTypes::GOLD, 200), 
+            ].span(),
             100
     );
 }


### PR DESCRIPTION
- resources transferred from realm to any other entity goes to the entity's inventory
- the entities(e.g caravans) now offload resources by calling the `transfer_item` function instead of `offload_chest`. they work very similarly
- minor update to `trade.create_order` API
