### PR TITLE
fix combat success chance bug

### DIFF
--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -658,11 +658,11 @@ mod combat_systems {
 
             // need to divide by 100**2 because level_bonus in precision 100
             attackers_total_attack = (attackers_total_attack * attacker_level_bonus * attacker_order_level_bonus)/10000;
-            attackers_total_defence = (attackers_total_defence + attacker_level_bonus * attacker_order_level_bonus)/10000;
+            attackers_total_defence = (attackers_total_defence * attacker_level_bonus * attacker_order_level_bonus)/10000;
 
             // need to divide by 100**2 because level_bonus in precision 100
             let target_total_attack = (target_town_watch_attack.value * target_level_bonus * target_order_level_bonus)/10000;
-            let target_total_defence = (target_town_watch_defense.value + target_level_bonus * target_order_level_bonus)/10000;
+            let target_total_defence = (target_town_watch_defense.value * target_level_bonus * target_order_level_bonus)/10000;
 
             let mut damage: u128 = 0; 
 
@@ -821,11 +821,11 @@ mod combat_systems {
 
             // need to divide by 100**2 because level_bonus in precision 100
             let attackers_total_attack = (attacker_attack.value * attacker_level_bonus * attacker_order_level_bonus)/10000;
-            let attackers_total_defence = (attacker_defence.value + attacker_level_bonus * attacker_order_level_bonus)/10000;
+            let attackers_total_defence = (attacker_defence.value * attacker_level_bonus * attacker_order_level_bonus)/10000;
 
             // need to divide by 100**2 because level_bonus in precision 100
             let target_total_attack = (target_town_watch_attack.value * target_level_bonus * target_order_level_bonus)/10000;
-            let target_total_defence = (target_town_watch_defense.value + target_level_bonus * target_order_level_bonus)/10000;
+            let target_total_defence = (target_town_watch_defense.value * target_level_bonus * target_order_level_bonus)/10000;
 
             let attack_successful: bool = *random::choices(
                 array![true, false].span(), 


### PR DESCRIPTION
- fix bug that makes total defence of the target or attacker =~1
- the issue is that we used a `+` sign where we were supposed to use a `*` sign