### PR TITLE
feat: caravan disassembly and free transport unit return

### DIFF
--- a/contracts/src/systems/transport/contracts/caravan_systems.cairo
+++ b/contracts/src/systems/transport/contracts/caravan_systems.cairo
@@ -166,6 +166,124 @@ mod caravan_systems {
             );
             caravan_id
         }
+
+
+
+        /// Disassemble a caravan entity
+        ///
+        /// # Arguments
+        ///
+        /// * `caravan_id` - The caravan entity id
+        ///
+        /// # Returns
+        ///
+        /// * `transport_ids` - The id of transport units used to form the caravan
+        ///
+        fn disassemble(self: @ContractState, world: IWorldDispatcher, caravan_id: ID) -> Span<ID> {
+            // ensure that caller is the owner
+            let caravan_owner = get!(world, caravan_id, Owner);
+            let caller = starknet::get_caller_address();
+            assert(caravan_owner.address == caller, 'caller not owner');
+
+            // ensure that it is a caravan
+            let caravan_members = get!(world, caravan_id, CaravanMembers);
+            assert(caravan_members.count > 0, 'not a caravan');
+
+            // ensure that its inventory is empty
+            let caravan_inventory = get!(world, caravan_id, Inventory);
+            assert(caravan_inventory.items_count == 0, 'inventory not empty');
+
+            // ensure that it is not blocked
+            let caravan_movable = get!(world, caravan_id, Movable);
+            assert(caravan_movable.blocked == false, 'caravan is blocked');
+
+            // ensure that it is not in transit
+            let caravan_arrival_time = get!(world, caravan_id, ArrivalTime);
+            assert(caravan_arrival_time.arrives_at <= starknet::get_block_timestamp(),
+                         'caravan in transit'
+            );
+
+            // ensure that caravan is at home position
+            let caravan_position = get!(world, caravan_id, Position);
+            let owner_entity = get!(world, caravan_id, EntityOwner);
+            let owner_position = get!(world, owner_entity.entity_owner_id, Position);
+            assert(caravan_position.x == owner_position.x, 'mismatched positions');
+            assert(caravan_position.y == owner_position.y, 'mismatched positions');
+
+
+            let mut index = 0;
+            let mut transport_ids = array![];
+            loop {
+                if index == caravan_members.count {
+                    break;
+                }
+
+                // get transport id
+                let foreign_key_arr = array![
+                    caravan_id.into(), caravan_members.key.into(), index.into()
+                ];
+                let foreign_key = poseidon_hash_span(foreign_key_arr.span());
+                let mut foreign_key = get!(world, foreign_key, ForeignKey);
+                let transport_id = foreign_key.entity_id;
+
+                // unblock the transport
+                let mut transport_movable = get!(world, transport_id, Movable);
+                transport_movable.blocked = false;
+                set!(world, (transport_movable));
+
+                // delete foreign key
+                foreign_key.entity_id = 0; 
+                set!(world, (foreign_key));
+
+                // add transport id to array
+                transport_ids.append(transport_id);
+
+                index += 1;
+            };
+
+
+            // reset all caravan components
+            set!(world, (
+                    Owner {
+                        entity_id: caravan_id, 
+                        address: Zeroable::zero(), 
+                    }, 
+                    EntityOwner {
+                        entity_id: caravan_id,
+                        entity_owner_id: 0,
+                    },
+                    Movable {
+                        entity_id: caravan_id, 
+                        sec_per_km: 0, 
+                        blocked: false, 
+                        round_trip: false,
+                        intermediate_coord_x: 0,  
+                        intermediate_coord_y: 0,  
+                    }, 
+                    Capacity {
+                        entity_id: caravan_id, 
+                        weight_gram: 0, 
+                    }, 
+                    CaravanMembers {
+                        entity_id: caravan_id, 
+                        key: 0, 
+                        count: 0
+                    }, 
+                    Inventory {
+                        entity_id: caravan_id, 
+                        items_key: 0, 
+                        items_count: 0
+                    }, 
+                    Position {
+                        entity_id: caravan_id, 
+                        x: 0, 
+                        y: 0
+                    }
+                )
+            );            
+
+            return transport_ids.span();
+        }
     }
 
 

--- a/contracts/src/systems/transport/contracts/travel_systems.cairo
+++ b/contracts/src/systems/transport/contracts/travel_systems.cairo
@@ -55,6 +55,8 @@ mod travel_systems {
             self: @ContractState, world: IWorldDispatcher, 
             travelling_entity_id: ID, destination_coord: Coord
         ) {
+            // todo@security prevent free transport units from travelling
+            // only caravans should be able to travel
 
             let travelling_entity_owner = get!(world, travelling_entity_id, Owner);
             assert(

--- a/contracts/src/systems/transport/interface/caravan_systems_interface.cairo
+++ b/contracts/src/systems/transport/interface/caravan_systems_interface.cairo
@@ -5,4 +5,5 @@ use dojo::world::IWorldDispatcher;
 #[starknet::interface]
 trait ICaravanSystems<TContractState> {
     fn create(self: @TContractState, world: IWorldDispatcher, entity_ids: Array<ID>) -> ID;
+    fn disassemble(self: @TContractState, world: IWorldDispatcher, caravan_id: ID) -> Span<ID>;
 }

--- a/contracts/src/systems/transport/interface/transport_unit_systems_interface.cairo
+++ b/contracts/src/systems/transport/interface/transport_unit_systems_interface.cairo
@@ -8,4 +8,6 @@ trait ITransportUnitSystems<TContractState> {
         self: @TContractState, world: IWorldDispatcher, 
         entity_id: u128, quantity: u128
     ) -> ID;
+    fn return_free_units(self: @TContractState, world: IWorldDispatcher, unit_ids: Span<u128>);
+
 }

--- a/contracts/src/systems/transport/tests/caravan_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/caravan_systems_tests.cairo
@@ -4,9 +4,10 @@ use eternum::constants::FREE_TRANSPORT_ENTITY_TYPE;
 use eternum::models::position::Position;
 use eternum::models::caravan::CaravanMembers;
 use eternum::models::metadata::ForeignKey;
-use eternum::models::movable::Movable;
+use eternum::models::movable::{Movable, ArrivalTime};
 use eternum::models::capacity::Capacity;
 use eternum::models::owner::{Owner, EntityOwner};
+use eternum::models::inventory::Inventory;
 
 use eternum::systems::realm::contracts::realm_systems;
 use eternum::systems::realm::interface::{
@@ -45,6 +46,7 @@ use core::poseidon::poseidon_hash_span;
 use core::traits::Into;
 use core::array::ArrayTrait;
 use core::clone::Clone;
+use core::zeroable::Zeroable;
 
 
 
@@ -180,7 +182,7 @@ fn test_create_caravan() {
 #[test]
 #[available_gas(300000000000)]
 #[should_panic(expected: ('entity is not owned by caller','ENTRYPOINT_FAILED' ))]
-fn test_not_owner() {
+fn test_create_caravan__not_owner() {
 
     let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
         = setup();
@@ -194,7 +196,7 @@ fn test_not_owner() {
 #[test]
 #[available_gas(300000000000)]
 #[should_panic(expected: ('entity is blocked','ENTRYPOINT_FAILED' ))]
-fn test_blocked_entity() {
+fn test_create_caravan__blocked_entity() {
     let (world, mut transport_units, caravan_systems_dispatcher, realm_entity_id) 
         = setup();
     
@@ -209,3 +211,214 @@ fn test_blocked_entity() {
 
 
 
+
+
+
+//////////////////////////////////////////
+//
+//          Test disassemble caravan
+//
+//////////////////////////////////////////
+
+
+
+
+
+
+#[test]
+#[available_gas(300000000000)]
+fn test_disassemble_caravan() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    // create caravan
+    let caravan_id 
+        = caravan_systems_dispatcher.create(world, transport_units.clone());
+    let original_caravan_members = get!(world, caravan_id, CaravanMembers);
+
+
+    // disassemble caravan
+    let disassembled_transport_ids 
+        = caravan_systems_dispatcher.disassemble(world, caravan_id);
+
+    // check that disassembled transport units are the same as the original ones
+    assert(disassembled_transport_ids.len() == transport_units.len(), 'not the same length');
+    let mut index = 0;
+    loop {
+        if index == transport_units.len() {
+            break;
+        }
+        assert(
+            *transport_units.at(index) == *disassembled_transport_ids.at(index), 
+                'not same transport id'
+        );
+
+        // check that transport unit isnt blocked
+        let transport_unit = get!(world, *transport_units.at(index), Movable);
+        assert(transport_unit.blocked == false, 'should not be blocked');
+
+        index += 1;
+    };
+
+
+    // verify that the caravan has been disassembled
+    let (caravan_members, caravan_movable, caravan_capacity, caravan_position, caravan_owner, caravan_entity_owner) 
+    = get!(world, caravan_id, (CaravanMembers, Movable, Capacity, Position, Owner, EntityOwner));
+            
+    assert(caravan_entity_owner.entity_owner_id == Zeroable::zero(), 'wrong entity owner');
+    assert(caravan_members.count == 0, 'wrong count');
+    assert(caravan_members.key == 0, 'key should not be set');
+    assert(caravan_movable.sec_per_km == 0, 'average speed should be 0');
+    assert(caravan_capacity.weight_gram == 0, 'weight_gram should be 0');
+    assert(caravan_position.x == 0, 'x should be 0');
+    assert(caravan_position.y == 0, 'y should be 0');
+    assert(caravan_owner.address == Zeroable::zero(), 'owner should be 0');
+
+    // verify that the caravan foreign keys have been unset
+    let foreign_key_1: Array<felt252> = array![caravan_id.into(), original_caravan_members.key.into(), 0];
+    let foreign_key_1: felt252 = poseidon_hash_span(foreign_key_1.span());
+    let first_transport = get!(world, foreign_key_1, ForeignKey);
+    assert(first_transport.entity_id.into() == 0, 'foreign key is set');
+
+
+    let foreign_key_2: Array<felt252> = array![caravan_id.into(), original_caravan_members.key.into(), 1];
+    let foreign_key_2: felt252 = poseidon_hash_span(foreign_key_2.span());
+    let second_transport = get!(world, foreign_key_2, ForeignKey);
+    assert(second_transport.entity_id.into() == 0, 'foreign key is set');
+
+}
+
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('caller not owner','ENTRYPOINT_FAILED' ))]
+fn test_disassemble_caravan__caller_not_owner() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    // create caravan
+    let caravan_id 
+        = caravan_systems_dispatcher.create(world, transport_units.clone());
+
+
+    // disassemble caravan
+    starknet::testing::set_contract_address(contract_address_const::<0x99>());
+    let disassembled_transport_ids 
+        = caravan_systems_dispatcher.disassemble(world, caravan_id);
+}
+
+
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('not a caravan','ENTRYPOINT_FAILED' ))]
+fn test_disassemble_caravan__not_caravan() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    let caravan_id = 0x1234567890; // fictituous id
+    // disassemble caravan
+    caravan_systems_dispatcher.disassemble(world, caravan_id);
+}
+
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('inventory not empty','ENTRYPOINT_FAILED' ))]
+fn test_disassemble_caravan__non_empty_inventory() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    // create caravan
+    let caravan_id 
+        = caravan_systems_dispatcher.create(world, transport_units.clone());
+
+    // add item to inventory
+    starknet::testing::set_contract_address(world.executor());
+    let mut inventory = get!(world, caravan_id, Inventory);
+    inventory.items_count = 1;
+    set!(world, (inventory));
+
+    // disassemble caravan
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    caravan_systems_dispatcher.disassemble(world, caravan_id);
+}
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('caravan is blocked','ENTRYPOINT_FAILED' ))]
+fn test_disassemble_caravan__blocked_caravan() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    // create caravan
+    let caravan_id 
+        = caravan_systems_dispatcher.create(world, transport_units.clone());
+
+    // block caravan
+    starknet::testing::set_contract_address(world.executor());
+    let mut movable = get!(world, caravan_id, Movable);
+    movable.blocked = true;
+    set!(world, (movable));
+
+    // disassemble caravan
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    caravan_systems_dispatcher.disassemble(world, caravan_id);
+}
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('caravan in transit','ENTRYPOINT_FAILED' ))]
+fn test_disassemble_caravan__caravan_in_transit() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    // create caravan
+    let caravan_id 
+        = caravan_systems_dispatcher.create(world, transport_units.clone());
+
+    // update arrival time
+    starknet::testing::set_contract_address(world.executor());
+    let mut arrival_time = get!(world, caravan_id, ArrivalTime);
+    arrival_time.arrives_at = 1;
+    set!(world, (arrival_time));
+
+    // disassemble caravan
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    caravan_systems_dispatcher.disassemble(world, caravan_id);
+}
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('mismatched positions','ENTRYPOINT_FAILED' ))]
+fn test_disassemble_caravan__not_at_realm() {
+
+    let (world, transport_units, caravan_systems_dispatcher, realm_entity_id) 
+        = setup();
+    
+    // create caravan
+    let caravan_id 
+        = caravan_systems_dispatcher.create(world, transport_units.clone());
+
+    // update position
+    starknet::testing::set_contract_address(world.executor());
+    let mut position = get!(world, caravan_id, Position);
+    position.x = 1;
+    set!(world, (position));
+
+    // disassemble caravan
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    caravan_systems_dispatcher.disassemble(world, caravan_id);
+}

--- a/contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
@@ -38,6 +38,7 @@ use core::poseidon::poseidon_hash_span;
 use core::traits::Into;
 use core::array::ArrayTrait;
 use core::clone::Clone;
+use core::zeroable::Zeroable;
 
 
 fn setup() -> (IWorldDispatcher, u128, ITransportUnitSystemsDispatcher) {
@@ -158,7 +159,7 @@ fn test_create_free_transport_unit() {
 #[test]
 #[available_gas(300000000000)]
 #[should_panic(expected: ('entity is not owned by caller', 'ENTRYPOINT_FAILED' ))]
-fn test_not_owner() {
+fn test_create_unit__not_owner() {
 
     let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
 
@@ -175,7 +176,7 @@ fn test_not_owner() {
 #[test]
 #[available_gas(300000000000)]
 #[should_panic(expected: ('not enough free transport unit', 'ENTRYPOINT_FAILED' ))]
-fn test_not_enough_free_transport_unit() {
+fn test_create_unit__not_enough_free_transport_unit() {
 
     let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
 
@@ -188,3 +189,163 @@ fn test_not_enough_free_transport_unit() {
 
 
 
+#[test]
+#[available_gas(300000000000)]
+fn test_return_free_transport_unit() {
+
+    let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
+
+    // create 2 free transport unit of 10 quantity each
+    let free_transport_unit_id_1 
+        = transport_unit_systems_dispatcher.create_free_unit(
+            world, realm_entity_id, 10
+        );
+    let free_transport_unit_id_2
+        = transport_unit_systems_dispatcher.create_free_unit(
+            world, realm_entity_id, 10
+        );
+
+    // check that the number of transport units in the realm == 20 before deletion
+    let quantity_tracker_arr = array![realm_entity_id.into(), FREE_TRANSPORT_ENTITY_TYPE.into()];
+    let quantity_tracker_key = poseidon_hash_span(quantity_tracker_arr.span());
+    let quantity_tracker = get!(world, quantity_tracker_key, QuantityTracker);
+    assert(quantity_tracker.count == 20, 'quantity tracker not updated 1');
+
+
+    // return free transport unit 1
+    transport_unit_systems_dispatcher.return_free_units(
+        world, array![free_transport_unit_id_1].span()
+    );
+    
+
+    // check that the free transport unit 1 has been returned
+    let (quantity, position, metadata, owner, capacity, movable, arrival_time) 
+    = get!(world, free_transport_unit_id_1, (Quantity, Position, EntityMetadata, Owner, Capacity, Movable, ArrivalTime));
+
+    assert(quantity.value == 0, 'unit not returnd');
+
+    assert(position.x == 0, 'position is set');
+    assert(position.y == 0, 'position is set');
+
+    assert(metadata.entity_type == 0, 'entity type is set');
+
+    assert(owner.address == Zeroable::zero(), 'owner is set');
+
+    assert(capacity.weight_gram == 0, 'capacity is set');
+
+    assert(movable.sec_per_km == 0, 'speed is set');
+
+    // check that the number of transport units in the realm == 10 after deletion
+    let quantity_tracker = get!(world, quantity_tracker_key, QuantityTracker);
+    assert(quantity_tracker.count == 10, 'quantity tracker not updated 2');
+}
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('not a free transport unit', 'ENTRYPOINT_FAILED' ))]
+fn test_return__wrong_unit_type() {
+
+    let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
+
+    // create a free transport unit of 10 quantity 
+    let free_transport_unit_id
+        = transport_unit_systems_dispatcher.create_free_unit(
+            world, realm_entity_id, 10
+        );
+
+    
+    // set the entity type to 0
+    starknet::testing::set_contract_address(world.executor());
+    let mut metadata = get!(world, free_transport_unit_id, EntityMetadata);
+    metadata.entity_type = 0;
+    set!(world, (metadata));
+
+
+    // return free transport unit 
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    transport_unit_systems_dispatcher.return_free_units(
+        world, array![free_transport_unit_id].span()
+    );
+}
+
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('unit not owned by caller', 'ENTRYPOINT_FAILED' ))]
+fn test_return__not_owner() {
+
+    let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
+
+    // create a free transport unit of 10 quantity 
+    let free_transport_unit_id
+        = transport_unit_systems_dispatcher.create_free_unit(
+            world, realm_entity_id, 10
+        );
+
+    // return free transport unit 
+    starknet::testing::set_contract_address(contract_address_const::<'unknown'>());
+    transport_unit_systems_dispatcher.return_free_units(
+        world, array![free_transport_unit_id].span()
+    );
+}
+
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('unit is blocked', 'ENTRYPOINT_FAILED' ))]
+fn test_return__movable_blocked() {
+
+    let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
+
+    // create a free transport unit of 10 quantity 
+    let free_transport_unit_id
+        = transport_unit_systems_dispatcher.create_free_unit(
+            world, realm_entity_id, 10
+        );
+
+    // set the unit as blocked
+    starknet::testing::set_contract_address(world.executor());
+    let mut unit_movable = get!(world, free_transport_unit_id, Movable);
+    unit_movable.blocked = true;
+    set!(world, (unit_movable));
+
+    
+
+    // return free transport unit 
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    transport_unit_systems_dispatcher.return_free_units(
+        world, array![free_transport_unit_id].span()
+    );
+}
+
+
+
+#[test]
+#[available_gas(300000000000)]
+#[should_panic(expected: ('unit has no quantity', 'ENTRYPOINT_FAILED' ))]
+fn test_return__no_quantity() {
+
+    let (world, realm_entity_id, transport_unit_systems_dispatcher) = setup();
+
+    // create a free transport unit of 10 quantity 
+    let free_transport_unit_id
+        = transport_unit_systems_dispatcher.create_free_unit(
+            world, realm_entity_id, 10
+        );
+
+    // set the quantity to 0
+    starknet::testing::set_contract_address(world.executor());
+    let mut unit_quantity = get!(world, free_transport_unit_id, Quantity);
+    unit_quantity.value = 0;
+    set!(world, (unit_quantity));
+
+
+    // return free transport unit again
+    starknet::testing::set_contract_address(contract_address_const::<0>());
+    transport_unit_systems_dispatcher.return_free_units(
+        world, array![free_transport_unit_id].span()
+    );
+}

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -3539,7 +3539,7 @@
     {
       "name": "eternum::systems::transport::contracts::caravan_systems::caravan_systems",
       "address": "0x3f8d39786c3f984482b25a770fc85fd2a4f45725e74fdd385c5c38e9f5681c6",
-      "class_hash": "0x26d8441fd2b13fe067a85fcb932c8ec28331b980dd6b4e22080590deaac377f",
+      "class_hash": "0x57b7448d548e03e1f80782f8bb5abca16e39609b816bff402c25c7b90a50edb",
       "abi": [
         {
           "type": "impl",
@@ -3579,6 +3579,16 @@
           "interface_name": "eternum::systems::transport::interface::caravan_systems_interface::ICaravanSystems"
         },
         {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u128>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u128>"
+            }
+          ]
+        },
+        {
           "type": "interface",
           "name": "eternum::systems::transport::interface::caravan_systems_interface::ICaravanSystems",
           "items": [
@@ -3598,6 +3608,26 @@
               "outputs": [
                 {
                   "type": "core::integer::u128"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "disassemble",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "caravan_id",
+                  "type": "core::integer::u128"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u128>"
                 }
               ],
               "state_mutability": "view"
@@ -3847,7 +3877,7 @@
     {
       "name": "eternum::systems::transport::contracts::transport_unit_systems::transport_unit_systems",
       "address": "0x4146e12ea99aeb071b29776bd591bbc74174817dad41521650e9164e226b5eb",
-      "class_hash": "0x462ed4c61027d073e863fcf2a4f4e59653528e0598169300460b2b7f36730da",
+      "class_hash": "0x6835068964d120bd756ffc81c646eaf354ba998bde535eef92398cf74fe030",
       "abi": [
         {
           "type": "impl",
@@ -3887,6 +3917,16 @@
           "interface_name": "eternum::systems::transport::interface::transport_unit_systems_interface::ITransportUnitSystems"
         },
         {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u128>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u128>"
+            }
+          ]
+        },
+        {
           "type": "interface",
           "name": "eternum::systems::transport::interface::transport_unit_systems_interface::ITransportUnitSystems",
           "items": [
@@ -3912,6 +3952,22 @@
                   "type": "core::integer::u128"
                 }
               ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "delete_free_units",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "unit_ids",
+                  "type": "core::array::Span::<core::integer::u128>"
+                }
+              ],
+              "outputs": [],
               "state_mutability": "view"
             }
           ]

--- a/contracts/target/release/manifest.json
+++ b/contracts/target/release/manifest.json
@@ -3539,7 +3539,7 @@
     {
       "name": "eternum::systems::transport::contracts::caravan_systems::caravan_systems",
       "address": "0x3f8d39786c3f984482b25a770fc85fd2a4f45725e74fdd385c5c38e9f5681c6",
-      "class_hash": "0x26d8441fd2b13fe067a85fcb932c8ec28331b980dd6b4e22080590deaac377f",
+      "class_hash": "0x36b1420dee488031d45b4d66d581dd9a5af0baab1c91a5f505c370b82c827dc",
       "abi": [
         {
           "type": "impl",
@@ -3579,6 +3579,16 @@
           "interface_name": "eternum::systems::transport::interface::caravan_systems_interface::ICaravanSystems"
         },
         {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u128>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u128>"
+            }
+          ]
+        },
+        {
           "type": "interface",
           "name": "eternum::systems::transport::interface::caravan_systems_interface::ICaravanSystems",
           "items": [
@@ -3598,6 +3608,26 @@
               "outputs": [
                 {
                   "type": "core::integer::u128"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "disassemble",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "caravan_id",
+                  "type": "core::integer::u128"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u128>"
                 }
               ],
               "state_mutability": "view"
@@ -3847,7 +3877,7 @@
     {
       "name": "eternum::systems::transport::contracts::transport_unit_systems::transport_unit_systems",
       "address": "0x4146e12ea99aeb071b29776bd591bbc74174817dad41521650e9164e226b5eb",
-      "class_hash": "0x462ed4c61027d073e863fcf2a4f4e59653528e0598169300460b2b7f36730da",
+      "class_hash": "0x7f2ec7c0adb68ebe1f7d83db81c9dc19b47cca50076713befa53353f1a5a5ec",
       "abi": [
         {
           "type": "impl",
@@ -3887,6 +3917,16 @@
           "interface_name": "eternum::systems::transport::interface::transport_unit_systems_interface::ITransportUnitSystems"
         },
         {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u128>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u128>"
+            }
+          ]
+        },
+        {
           "type": "interface",
           "name": "eternum::systems::transport::interface::transport_unit_systems_interface::ITransportUnitSystems",
           "items": [
@@ -3912,6 +3952,22 @@
                   "type": "core::integer::u128"
                 }
               ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "return_free_units",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "unit_ids",
+                  "type": "core::array::Span::<core::integer::u128>"
+                }
+              ],
+              "outputs": [],
               "state_mutability": "view"
             }
           ]


### PR DESCRIPTION
- added a way to disassemble caravan into its transport units in `caravan_systems.disassemble`
- added a way to return unused free transport units in `transport_unit_systems.return_free_units`