### PR TITLE
conquest update

### DIFF
--- a/contracts/src/models.cairo
+++ b/contracts/src/models.cairo
@@ -20,3 +20,4 @@ mod combat;
 mod level;
 mod name;
 mod bank;
+mod order;

--- a/contracts/src/models/order.cairo
+++ b/contracts/src/models/order.cairo
@@ -1,0 +1,18 @@
+#[derive(Model, Copy, Drop, Serde)]
+struct Order {
+    #[key]
+    order_id: u128,
+    hyperstructure_count: u128
+}
+
+#[generate_trait]
+impl OrderImpl of OrderTrait {
+    fn get_bonus_multiplier(self: Order) -> u128 {
+        self.hyperstructure_count * 25
+    }
+
+    fn get_bonus_denominator(self: Order) -> u128 {
+        100
+    }
+}
+

--- a/contracts/src/systems.cairo
+++ b/contracts/src/systems.cairo
@@ -8,5 +8,6 @@ mod combat;
 mod leveling;
 mod name;
 mod bank;
+mod hyperstructure;
 
 mod test;

--- a/contracts/src/systems/combat/interface.cairo
+++ b/contracts/src/systems/combat/interface.cairo
@@ -30,11 +30,11 @@ trait ISoldierSystems<TContractState> {
 trait ICombatSystems<TContractState> {
     fn attack( 
         self: @TContractState, world: IWorldDispatcher, 
-        attacker_ids: Span<u128>, target_realm_entity_id: u128
+        attacker_ids: Span<u128>, target_entity_id: u128
     );
     
     fn steal(
         self: @TContractState, world: IWorldDispatcher,
-        attacker_id: u128, target_realm_entity_id: u128
+        attacker_id: u128, target_entity_id: u128
     );
 }

--- a/contracts/src/systems/hyperstructure.cairo
+++ b/contracts/src/systems/hyperstructure.cairo
@@ -1,0 +1,4 @@
+mod contracts;
+mod interface;
+#[cfg(test)]
+mod tests;

--- a/contracts/src/systems/hyperstructure/contracts.cairo
+++ b/contracts/src/systems/hyperstructure/contracts.cairo
@@ -1,0 +1,96 @@
+#[dojo::contract]
+mod hyperstructure_systems {
+    use eternum::alias::ID;
+    use eternum::models::resources::{Resource, ResourceCost};
+    use eternum::models::owner::Owner;
+    use eternum::models::hyperstructure::{HyperStructure};
+    use eternum::models::realm::{Realm};
+    use eternum::models::order::{Order};
+    use eternum::models::position::{Coord, Position, PositionTrait};
+
+    use eternum::systems::hyperstructure::interface::IHyperstructureSystems;
+    use eternum::constants::WORLD_CONFIG_ID;
+
+
+
+    #[external(v0)]
+    impl HyperstructureSystemsImpl of IHyperstructureSystems<ContractState> {
+
+        fn build(
+            self: @ContractState, world: IWorldDispatcher, hyperstructure_id: ID, order_id: u8
+        ) {
+
+            let mut hyperstructure = get!(world, hyperstructure_id, HyperStructure);
+            assert(hyperstructure.completion_resource_count > 0, 'hyperstructure does not exist');
+
+            if hyperstructure.controlling_order != 0 {
+                // ensure that the hyperstructure has been completely
+                // conquered by checking that it has no resources
+
+                let completion_cost_id = hyperstructure.completion_cost_id;
+                let mut index = 0;
+                loop {
+                    if index == hyperstructure.completion_resource_count {
+                        break;
+                    }
+
+                    let resource_cost = get!(world, (completion_cost_id, index), ResourceCost);
+                    let resource = get!(world, (hyperstructure_id, resource_cost.resource_type), Resource);
+                    assert(resource.balance == 0, 'not conquered');
+
+                    index += 1;
+                };
+
+                // update controlling order's hyperstructure count 
+                // if it completed the hyperstructure
+                if hyperstructure.completed {
+                    let mut order = get!(world, hyperstructure.controlling_order, Order);
+                    order.hyperstructure_count -= 1;
+                    set!(world, (order));
+                }
+            }
+
+            // set the controlling order to the new order
+            hyperstructure.controlling_order = order_id;
+            hyperstructure.completed = false;
+            set!(world, (hyperstructure));
+        }
+
+
+        fn complete(
+            self: @ContractState, world: IWorldDispatcher, hyperstructure_id: ID
+        ) {
+
+            let mut hyperstructure = get!(world, hyperstructure_id, HyperStructure);
+            assert(hyperstructure.completion_resource_count > 0, 'hyperstructure does not exist');
+            assert(hyperstructure.controlling_order != 0, 'not controlled by any order');
+
+
+            let completion_cost_id = hyperstructure.completion_cost_id;
+            let mut index = 0;
+            loop {
+                if index == hyperstructure.completion_resource_count {
+                    break;
+                }
+
+                let resource_cost = get!(world, (completion_cost_id, index), ResourceCost);
+                let resource = get!(world, (hyperstructure_id, resource_cost.resource_type), Resource);
+                assert(resource.balance >= resource_cost.amount, 'not enough resources');
+
+                index += 1;
+            }; 
+
+
+            // set hyperstructure to completed
+            hyperstructure.completed = true;
+            set!(world, (hyperstructure));
+
+            // update order hyperstructure count
+            let mut order = get!(world, hyperstructure.controlling_order, Order);
+            order.hyperstructure_count += 1;
+            set!(world, (order));
+        }
+
+       
+    }
+}

--- a/contracts/src/systems/hyperstructure/contracts.cairo
+++ b/contracts/src/systems/hyperstructure/contracts.cairo
@@ -16,7 +16,7 @@ mod hyperstructure_systems {
     #[external(v0)]
     impl HyperstructureSystemsImpl of IHyperstructureSystems<ContractState> {
 
-        fn build(
+        fn control(
             self: @ContractState, world: IWorldDispatcher, hyperstructure_id: ID, order_id: u8
         ) {
 

--- a/contracts/src/systems/hyperstructure/interface.cairo
+++ b/contracts/src/systems/hyperstructure/interface.cairo
@@ -1,0 +1,12 @@
+use eternum::alias::ID;
+use dojo::world::IWorldDispatcher;
+
+#[starknet::interface]
+trait IHyperstructureSystems<TContractState> {
+    fn build(
+        self: @TContractState, world: IWorldDispatcher, hyperstructure_id: ID, order_id: u8
+    );
+    fn complete( 
+        self: @TContractState, world: IWorldDispatcher, hyperstructure_id: ID
+    );
+}

--- a/contracts/src/systems/hyperstructure/interface.cairo
+++ b/contracts/src/systems/hyperstructure/interface.cairo
@@ -3,7 +3,7 @@ use dojo::world::IWorldDispatcher;
 
 #[starknet::interface]
 trait IHyperstructureSystems<TContractState> {
-    fn build(
+    fn control(
         self: @TContractState, world: IWorldDispatcher, hyperstructure_id: ID, order_id: u8
     );
     fn complete( 

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -2207,7 +2207,7 @@
     {
       "name": "eternum::systems::hyperstructure::contracts::hyperstructure_systems",
       "address": null,
-      "class_hash": "0x2f4b59c3e88b84ca3a2b488acfac8a8444a2d03755d6eec24c7ae2e07ef073e",
+      "class_hash": "0x45512bfada679482cd6fb00045df968a08d5781bad84f42f398ebbd5d5559c9",
       "abi": [
         {
           "type": "impl",
@@ -2252,7 +2252,7 @@
           "items": [
             {
               "type": "function",
-              "name": "build",
+              "name": "control",
               "inputs": [
                 {
                   "name": "world",

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -1104,7 +1104,7 @@
     {
       "name": "eternum::systems::combat::contracts::combat_systems",
       "address": "0x1b0a83a27a357e0574393ab06c0c774db7312a0993538cc0186d054f75ee84e",
-      "class_hash": "0x5df10dcf9a128b79fca4a2fb47de02ed69fc3bc5ee81f6b6c4ec9f76f1f8cdd",
+      "class_hash": "0xa6277be559ef80a45c9468ab6e790865913f0378adcefbed9f94dc989e750c",
       "abi": [
         {
           "type": "impl",
@@ -1279,7 +1279,7 @@
                   "type": "core::array::Span::<core::integer::u128>"
                 },
                 {
-                  "name": "target_realm_entity_id",
+                  "name": "target_entity_id",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1299,7 +1299,7 @@
                   "type": "core::integer::u128"
                 },
                 {
-                  "name": "target_realm_entity_id",
+                  "name": "target_entity_id",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1401,7 +1401,7 @@
               "kind": "key"
             },
             {
-              "name": "target_realm_entity_id",
+              "name": "target_entity_id",
               "type": "core::integer::u128",
               "kind": "key"
             },
@@ -2190,6 +2190,165 @@
         {
           "type": "event",
           "name": "eternum::systems::config::contracts::config_systems::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "UpgradeableEvent",
+              "type": "dojo::components::upgradeable::upgradeable::Event",
+              "kind": "nested"
+            }
+          ]
+        }
+      ],
+      "reads": [],
+      "writes": [],
+      "computed": []
+    },
+    {
+      "name": "eternum::systems::hyperstructure::contracts::hyperstructure_systems",
+      "address": null,
+      "class_hash": "0x2f4b59c3e88b84ca3a2b488acfac8a8444a2d03755d6eec24c7ae2e07ef073e",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "WorldProviderImpl",
+          "interface_name": "dojo::world::IWorldProvider"
+        },
+        {
+          "type": "struct",
+          "name": "dojo::world::IWorldDispatcher",
+          "members": [
+            {
+              "name": "contract_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::world::IWorldProvider",
+          "items": [
+            {
+              "type": "function",
+              "name": "world",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::world::IWorldDispatcher"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "HyperstructureSystemsImpl",
+          "interface_name": "eternum::systems::hyperstructure::interface::IHyperstructureSystems"
+        },
+        {
+          "type": "interface",
+          "name": "eternum::systems::hyperstructure::interface::IHyperstructureSystems",
+          "items": [
+            {
+              "type": "function",
+              "name": "build",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "hyperstructure_id",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "order_id",
+                  "type": "core::integer::u8"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "complete",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "hyperstructure_id",
+                  "type": "core::integer::u128"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "UpgradableImpl",
+          "interface_name": "dojo::components::upgradeable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::components::upgradeable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "dojo_resource",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::felt252"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "event",
+          "name": "dojo::components::upgradeable::upgradeable::Upgraded",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "class_hash",
+              "type": "core::starknet::class_hash::ClassHash",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::components::upgradeable::upgradeable::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "Upgraded",
+              "type": "dojo::components::upgradeable::upgradeable::Upgraded",
+              "kind": "nested"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::systems::hyperstructure::contracts::hyperstructure_systems::Event",
           "kind": "enum",
           "variants": [
             {
@@ -11513,6 +11672,183 @@
         {
           "type": "event",
           "name": "eternum::models::name::address_name::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ]
+    },
+    {
+      "name": "eternum::models::order::order",
+      "members": [
+        {
+          "name": "order_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "hyperstructure_count",
+          "type": "u128",
+          "key": false
+        }
+      ],
+      "class_hash": "0x7acab29295141687754bcda1d5e465ab7d9e0ae3fe175b75eb9380c4c03097b",
+      "abi": [
+        {
+          "type": "function",
+          "name": "name",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::felt252"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "unpacked_size",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::integer::u32"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "packed_size",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::integer::u32"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "layout",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::array::Span::<core::integer::u8>"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "schema",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "dojo::database::introspect::Ty"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::order::order::Event",
           "kind": "enum",
           "variants": []
         }

--- a/contracts/target/release/manifest.json
+++ b/contracts/target/release/manifest.json
@@ -2207,7 +2207,7 @@
     {
       "name": "eternum::systems::hyperstructure::contracts::hyperstructure_systems",
       "address": null,
-      "class_hash": "0x2f4b59c3e88b84ca3a2b488acfac8a8444a2d03755d6eec24c7ae2e07ef073e",
+      "class_hash": "0x45512bfada679482cd6fb00045df968a08d5781bad84f42f398ebbd5d5559c9",
       "abi": [
         {
           "type": "impl",
@@ -2252,7 +2252,7 @@
           "items": [
             {
               "type": "function",
-              "name": "build",
+              "name": "control",
               "inputs": [
                 {
                   "name": "world",

--- a/contracts/target/release/manifest.json
+++ b/contracts/target/release/manifest.json
@@ -1104,7 +1104,7 @@
     {
       "name": "eternum::systems::combat::contracts::combat_systems",
       "address": "0x1b0a83a27a357e0574393ab06c0c774db7312a0993538cc0186d054f75ee84e",
-      "class_hash": "0x3d8f65769dc5ec2dd36370f17edbd6633f1e27ab0e6372e01400716ad406039",
+      "class_hash": "0xa6277be559ef80a45c9468ab6e790865913f0378adcefbed9f94dc989e750c",
       "abi": [
         {
           "type": "impl",
@@ -1279,7 +1279,7 @@
                   "type": "core::array::Span::<core::integer::u128>"
                 },
                 {
-                  "name": "target_realm_entity_id",
+                  "name": "target_entity_id",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1299,7 +1299,7 @@
                   "type": "core::integer::u128"
                 },
                 {
-                  "name": "target_realm_entity_id",
+                  "name": "target_entity_id",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1401,7 +1401,7 @@
               "kind": "key"
             },
             {
-              "name": "target_realm_entity_id",
+              "name": "target_entity_id",
               "type": "core::integer::u128",
               "kind": "key"
             },
@@ -1457,7 +1457,7 @@
     {
       "name": "eternum::systems::config::contracts::config_systems",
       "address": "0x7fff06bbcbe4f42f22c86b14e7a80604495c8b2034d14cbb10d32402c933ca8",
-      "class_hash": "0x4498d0c8199de153830ba0721b39c426f8a4631d550a67d14266a4e4de49864",
+      "class_hash": "0x537c1f5a3261eb0dadb3038469f5774a8d4b9ede5e2ba3cf241cc5744d6c719",
       "abi": [
         {
           "type": "impl",
@@ -2029,8 +2029,8 @@
                   "type": "eternum::models::position::Coord"
                 },
                 {
-                  "name": "order",
-                  "type": "core::integer::u8"
+                  "name": "completion_cost",
+                  "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>"
                 }
               ],
               "outputs": [
@@ -2205,9 +2205,168 @@
       "computed": []
     },
     {
+      "name": "eternum::systems::hyperstructure::contracts::hyperstructure_systems",
+      "address": null,
+      "class_hash": "0x2f4b59c3e88b84ca3a2b488acfac8a8444a2d03755d6eec24c7ae2e07ef073e",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "WorldProviderImpl",
+          "interface_name": "dojo::world::IWorldProvider"
+        },
+        {
+          "type": "struct",
+          "name": "dojo::world::IWorldDispatcher",
+          "members": [
+            {
+              "name": "contract_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::world::IWorldProvider",
+          "items": [
+            {
+              "type": "function",
+              "name": "world",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::world::IWorldDispatcher"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "HyperstructureSystemsImpl",
+          "interface_name": "eternum::systems::hyperstructure::interface::IHyperstructureSystems"
+        },
+        {
+          "type": "interface",
+          "name": "eternum::systems::hyperstructure::interface::IHyperstructureSystems",
+          "items": [
+            {
+              "type": "function",
+              "name": "build",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "hyperstructure_id",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "order_id",
+                  "type": "core::integer::u8"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "complete",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "hyperstructure_id",
+                  "type": "core::integer::u128"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "UpgradableImpl",
+          "interface_name": "dojo::components::upgradeable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::components::upgradeable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "dojo_resource",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::felt252"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "event",
+          "name": "dojo::components::upgradeable::upgradeable::Upgraded",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "class_hash",
+              "type": "core::starknet::class_hash::ClassHash",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::components::upgradeable::upgradeable::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "Upgraded",
+              "type": "dojo::components::upgradeable::upgradeable::Upgraded",
+              "kind": "nested"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::systems::hyperstructure::contracts::hyperstructure_systems::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "UpgradeableEvent",
+              "type": "dojo::components::upgradeable::upgradeable::Event",
+              "kind": "nested"
+            }
+          ]
+        }
+      ],
+      "reads": [],
+      "writes": [],
+      "computed": []
+    },
+    {
       "name": "eternum::systems::labor::contracts::labor_systems",
       "address": "0x38258ae4007920aacda4f00c6960837ff9b235e8af95f648347f36550e6d1ee",
-      "class_hash": "0x332f5ce561ff4b6b9ec3947a5e9ce5a53637b0131f87f029532090e87cc0fe6",
+      "class_hash": "0x14dc03dedf9a88111f08a9ef077bfe8300cd380732f8ad6e853a425794169b7",
       "abi": [
         {
           "type": "impl",
@@ -2402,7 +2561,7 @@
     {
       "name": "eternum::systems::leveling::contracts::leveling_systems",
       "address": "0x29ae99df03a05e0be62f21c42ed50e18c3c5eff9372030791e6f6ed8377b5b3",
-      "class_hash": "0x3bebafb096c5ff90466ccca710f83de2e87e1b35894133b7c37efc1533f2234",
+      "class_hash": "0x1285508c7650c1b619f184e08d892cd4803c54993fe98eb73ee15fcdd5c52db",
       "abi": [
         {
           "type": "impl",
@@ -3326,7 +3485,7 @@
     {
       "name": "eternum::systems::trade::contracts::trade_systems::trade_systems",
       "address": "0x63cbe849cf6325e727a8d6f82f25fad7dc7eb9433767f5c1b8c59189e36c9b6",
-      "class_hash": "0x809d89839a6c8f424e1f9dd9dd7701e288b38dee6671a605bd94f8053d6af8",
+      "class_hash": "0x51a4c83693b6e3a74b1f44ac4650071b2bd2e787c04b8a199ef99f5e222a67",
       "abi": [
         {
           "type": "impl",
@@ -4087,7 +4246,7 @@
     {
       "name": "eternum::systems::transport::contracts::travel_systems::travel_systems",
       "address": "0x740ea95e67b0b7533ee4891524c5c7edfd7fefc09297c0304b21515cc1223ec",
-      "class_hash": "0x2ef12492dd583bcf7ecbdf26a229e1d4a0500f6460afafe3f739b4fe3eac311",
+      "class_hash": "0x1c50063c68bd895328daaeaf169a24a5c1e857a4587bf13398ac8bd59bebfe5",
       "abi": [
         {
           "type": "impl",
@@ -9672,12 +9831,27 @@
           "key": false
         },
         {
-          "name": "order",
+          "name": "controlling_order",
           "type": "u8",
+          "key": false
+        },
+        {
+          "name": "completed",
+          "type": "bool",
+          "key": false
+        },
+        {
+          "name": "completion_cost_id",
+          "type": "u128",
+          "key": false
+        },
+        {
+          "name": "completion_resource_count",
+          "type": "u32",
           "key": false
         }
       ],
-      "class_hash": "0x61bb5546b8a5ed4ac19659818e01e5090500ce9e9d02f21b7c0b4c786d1a44d",
+      "class_hash": "0x5e2f9c8e16c89a647c588e81383c1d0404b928cc904af922f6a06760dda2c5e",
       "abi": [
         {
           "type": "function",
@@ -11498,6 +11672,183 @@
         {
           "type": "event",
           "name": "eternum::models::name::address_name::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ]
+    },
+    {
+      "name": "eternum::models::order::order",
+      "members": [
+        {
+          "name": "order_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "hyperstructure_count",
+          "type": "u128",
+          "key": false
+        }
+      ],
+      "class_hash": "0x7acab29295141687754bcda1d5e465ab7d9e0ae3fe175b75eb9380c4c03097b",
+      "abi": [
+        {
+          "type": "function",
+          "name": "name",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::felt252"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "unpacked_size",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::integer::u32"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "function",
+          "name": "packed_size",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::integer::u32"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "layout",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "core::array::Span::<core::integer::u8>"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "schema",
+          "inputs": [],
+          "outputs": [
+            {
+              "type": "dojo::database::introspect::Ty"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::order::order::Event",
           "kind": "enum",
           "variants": []
         }


### PR DESCRIPTION
- changed the field `target_realm_entity_id` in `CombatOutcome` event struct to `target_entity_id`
- added endpoints to start building hyperstructure and to complete hyperstructure
- created a way to keep tract of order bonus
- fixed an issue with attack calculation:
     if an attacker's unboosted attack value was `20` for example, and they had both the realm level bonus (25%) and hyperstructure bonus(25%), you would expect that they new total attack value would be `20 + (25/100 * 20) + (25/100 * 20)` == `20 + 5 + 5` == `30`. however, the calculation would be `20 * 125/100 * 125 / 100` which would equal `31.25`