### PR TITLE
contract: nearby tile exploration

### DIFF
--- a/contracts/src/models/map.cairo
+++ b/contracts/src/models/map.cairo
@@ -1,7 +1,8 @@
 use eternum::utils::map::biomes::Biome;
+use eternum::models::position::Coord;
 
 #[derive(Model, Copy, Drop, Serde)]
-struct ExploredMap {
+struct Tile {
     #[key]
     _col: u128,
     #[key]
@@ -11,4 +12,10 @@ struct ExploredMap {
     explored_by_id: u128,
     explored_at: u64,
     biome: Biome,
+}
+
+impl TileIntoCoord of Into<Tile, Coord>{
+    fn into(self: Tile) -> Coord {
+        Coord {x: self.col, y: self.row}
+    }
 }

--- a/contracts/src/models/position.cairo
+++ b/contracts/src/models/position.cairo
@@ -93,13 +93,54 @@ impl CubeImpl of CubeTrait {
     }
 }
 
+#[derive(Drop, Copy, Serde)]
+enum Direction {
+    East: (),
+    NorthEast: (),
+    NorthWest: (),
+    West: (),
+    SouthWest: (),
+    SouthEast: (),
+}
 
-
-#[derive(Copy, Drop, PartialEq, Serde, Print, Introspect)]
+#[derive(Copy, Drop, PartialEq, Serde, Print, Introspect, Debug)]
 struct Coord {
     x: u128,
     y: u128
 }
+
+#[generate_trait]
+impl CoordImpl of CoordTrait {
+    fn neighbor(self: Coord, direction: Direction) -> Coord{
+
+        // https://www.redblobgames.com/grids/hexagons/#neighbors-offset
+
+        if self.y & 1 == 0 {
+            // where self.y (row) is even 
+            match direction {
+                Direction::East(()) => Coord{ x: self.x + 1, y: self.y },
+                Direction::NorthEast(()) => Coord{ x: self.x, y: self.y - 1 },
+                Direction::NorthWest(()) => Coord{ x: self.x - 1, y: self.y - 1 },
+                Direction::West(()) => Coord{ x: self.x - 1, y: self.y },
+                Direction::SouthWest(()) => Coord{ x: self.x -1 , y: self.y + 1 },
+                Direction::SouthEast(()) => Coord{ x: self.x, y: self.y + 1 },
+            }
+        } else {
+            // where self.y (row) is odd
+            match direction {
+                Direction::East(()) => Coord{ x: self.x + 1, y: self.y },
+                Direction::NorthEast(()) => Coord{ x: self.x + 1, y: self.y - 1 },
+                Direction::NorthWest(()) => Coord{ x: self.x, y: self.y - 1 },
+                Direction::West(()) => Coord{ x: self.x - 1, y: self.y },
+                Direction::SouthWest(()) => Coord{ x: self.x, y: self.y + 1 },
+                Direction::SouthEast(()) => Coord{ x: self.x + 1, y: self.y + 1 },
+            }
+
+        }
+        
+    }
+}
+    
 
 impl CoordZeroable of Zeroable<Coord> {
     fn zero() -> Coord {
@@ -296,6 +337,151 @@ mod tests {
         let a = Position { entity_id: 0, x: 1333333, y: 200000 };
         let zone = a.get_zone();
         assert(zone == 4, 'zone should be 4');
+    }
+
+    mod coord {
+        use super::super::{Coord, CoordTrait, Direction};
+
+
+            fn odd_row_coord() -> Coord {
+                Coord {x: 7, y: 7}
+            }
+
+            fn even_row_coord() -> Coord {
+                Coord {x: 7, y: 6}
+            }
+
+
+            //- Even row 
+
+            #[test]
+            fn test_neighbor_even_row_east() { 
+                let start = even_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::East), 
+                    Coord{x: start.x + 1, y: start.y}
+                );
+            }
+
+            #[test]
+            fn test_neighbor_even_row_north_east() { 
+                let start = even_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::NorthEast), 
+                    Coord{x: start.x , y: start.y - 1}
+                );
+            }
+
+            #[test]
+            fn test_neighbor_even_row_north_west() { 
+                let start = even_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::NorthWest), 
+                    Coord{x: start.x - 1, y: start.y - 1}
+                );
+            }
+
+            #[test]
+            fn test_neighbor_even_row_west() { 
+                let start = even_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::West), 
+                    Coord{x: start.x - 1, y: start.y}
+                );
+            }
+
+
+            #[test]
+            fn test_neighbor_even_row_south_west() { 
+                let start = even_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::SouthWest), 
+                    Coord{x: start.x - 1, y: start.y + 1}
+                );
+            }
+
+
+            #[test]
+            fn test_neighbor_even_row_south_east() { 
+                let start = even_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::SouthEast), 
+                    Coord{x: start.x, y: start.y + 1 }
+                );
+            }
+
+
+            //- Odd row 
+
+            #[test]
+            fn test_neighbor_odd_row_east() { 
+                let start = odd_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::East), 
+                    Coord{x: start.x + 1, y: start.y}
+                );
+            }
+
+            #[test]
+            fn test_neighbor_odd_row_north_east() { 
+                let start = odd_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::NorthEast), 
+                    Coord{x: start.x + 1 , y: start.y - 1}
+                );
+            }
+
+            #[test]
+            fn test_neighbor_odd_row_north_west() { 
+                let start = odd_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::NorthWest), 
+                    Coord{x: start.x, y: start.y - 1}
+                );
+            }
+
+            #[test]
+            fn test_neighbor_odd_row_west() { 
+                let start = odd_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::West), 
+                    Coord{x: start.x - 1, y: start.y}
+                );
+            }
+
+
+            #[test]
+            fn test_neighbor_odd_row_south_west() { 
+                let start = odd_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::SouthWest), 
+                    Coord{x: start.x, y: start.y + 1}
+                );
+            }
+
+
+            #[test]
+            fn test_neighbor_odd_row_south_east() { 
+                let start = odd_row_coord();
+                
+                assert_eq!(
+                    start.neighbor(Direction::SouthEast), 
+                    Coord{x: start.x + 1, y: start.y + 1 }
+                );
+            }
+
+
     }
 }
 

--- a/contracts/src/systems/map/contracts.cairo
+++ b/contracts/src/systems/map/contracts.cairo
@@ -5,7 +5,7 @@ mod map_systems {
     use eternum::constants::ResourceTypes;
     use eternum::models::owner::{Owner};
     use eternum::models::hyperstructure::HyperStructure;
-    use eternum::models::map::ExploredMap;
+    use eternum::models::map::Tile;
     use eternum::models::config::{LevelingConfig};
     use eternum::models::realm::{Realm};
     use eternum::models::level::{Level, LevelTrait};
@@ -13,8 +13,8 @@ mod map_systems {
     use eternum::systems::map::interface::IMapSystems;
     use eternum::utils::map::biomes::{Biome, get_biome};
     use eternum::utils::random;
+    use eternum::models::position::{Coord, CoordTrait, Direction};
     use eternum::constants::{WORLD_CONFIG_ID, split_resources_and_probs};
-
 
     use starknet::ContractAddress;
 
@@ -41,10 +41,16 @@ mod map_systems {
 
     #[external(v0)]
     impl MapSystemsImpl of IMapSystems<ContractState> {
-
+        /// Allows a player explore a tile in any direction 
+        /// from a tile they have previously explored
+        ///
+        /// The first tile that would be explored would be the one 
+        /// their realm sits on and it would be explored once the realm is 
+        /// created
+        ///
         fn explore(
             self: @ContractState, world: IWorldDispatcher, 
-            realm_entity_id: u128, col: u128, row: u128
+            realm_entity_id: u128, from_coord: Coord, direction: Direction
         ) {
 
             // check that entity is a realm
@@ -59,57 +65,85 @@ mod map_systems {
                     'not realm owner'
             );
 
+            // ensure that the from_tile is owned by caller
 
-            let mut explored_map: ExploredMap = get!(world, (col, row), ExploredMap);
-            assert(explored_map.explored_at == 0, 'already explored');
+            let from_tile: Tile 
+                = get!(world, (from_coord.x, from_coord.y), Tile);
+            assert(from_tile.explored_at != 0, 'not explored');
+            assert(from_tile.explored_by_id == realm_entity_id, 'not explored by caller');
 
-            // set map position to explored
+            // get reward resource id and amount
 
-            explored_map.explored_by_id = realm_entity_id;
-            explored_map.explored_at = starknet::get_block_timestamp();
-            explored_map.biome = get_biome(col, row);
-            explored_map.col = col;
-            explored_map.row = row;
-
-            set!(world, (explored_map));
-
-
-            // burn food
             let explore_config: MapExploreConfig = get!(world, WORLD_CONFIG_ID, MapExploreConfig);
+            let (resource_types, resources_probs) = split_resources_and_probs();
+            let reward_resource_id: u8 
+                = *random::choices(resource_types, resources_probs, array![].span(), 1, true).at(0);
+            let reward_resource_amount: u128 = explore_config.random_mint_amount;
+
+            // explore tile
+
+            InternalMapSystemsImpl::explore(
+                world, realm_entity_id, from_coord.neighbor(direction),
+                reward_resource_id, reward_resource_amount
+            );
+
+
+            // pay for exploration by burning food
+
             ResourceFoodImpl::burn_food(
                 world, realm_entity_id, 
                 explore_config.wheat_burn_amount, explore_config.fish_burn_amount, check_balance: true
             );
-
-
-            // mint one random resource
-            let (resource_types, resources_probs) = split_resources_and_probs();
-            let mint_resource_id: u8 = *random::choices(
-                resource_types, resources_probs, 
-                array![].span(), 1, true
-            ).at(0);
-            let mint_resource_amount: u128 = explore_config.random_mint_amount;
-
-            let mut mint_resource 
-                = get!(world, (realm_entity_id, mint_resource_id), Resource);
-            mint_resource.add(world, mint_resource_amount);
-
-
-
-            // emit explored event
-            emit!(world,  MapExplored {
-                    entity_id: realm_entity_id,
-                    col,
-                    row,
-                    biome: explored_map.biome,
-                    minted_resource_id: mint_resource_id,
-                    minted_resource_amount: mint_resource_amount
-                });
-            
-
         }
 
     }
+
+
+    #[generate_trait]
+    impl InternalMapSystemsImpl of InternalMapSystemsTrait {
+        
+        fn explore(
+            world: IWorldDispatcher, explorer_id: u128, coord: Coord,
+            reward_resource_id: u8, reward_resource_amount: u128
+        ) -> Tile {
+
+            let mut tile: Tile
+                 = get!(world, (coord.x, coord.y), Tile);
+            assert(tile.explored_at == 0, 'already explored');
+
+            // set tile as explored
+            tile.explored_by_id = explorer_id;
+            tile.explored_at = starknet::get_block_timestamp();
+            tile.biome = get_biome(coord.x, coord.y);
+            tile.col = coord.x;
+            tile.row = coord.y;
+
+            set!(world, (tile));
+
+
+            // mint reward for exploration
+            if reward_resource_amount > 0 {
+                let mut explorer_reward_resource = get!(world, (explorer_id, reward_resource_id), Resource);
+                explorer_reward_resource.add(world, reward_resource_amount);
+            }
+
+            // emit explored event
+            emit!(world,  MapExplored {
+                entity_id: explorer_id,
+                col: tile.col,
+                row: tile.row,
+                biome: tile.biome,
+                minted_resource_id: reward_resource_id,
+                minted_resource_amount: reward_resource_amount
+            });
+
+
+
+
+            tile
+        }
+    }
+
 
 
 }

--- a/contracts/src/systems/map/interface.cairo
+++ b/contracts/src/systems/map/interface.cairo
@@ -1,9 +1,11 @@
 use dojo::world::IWorldDispatcher;
+use eternum::models::position::{Coord, Direction};
+
 
 #[starknet::interface]
 trait IMapSystems<TContractState> {
     fn explore(
         self: @TContractState, world: IWorldDispatcher, 
-        realm_entity_id: u128, col: u128, row: u128
+        realm_entity_id: u128,  from_coord: Coord, direction: Direction
     );
 }

--- a/contracts/src/systems/realm/contracts.cairo
+++ b/contracts/src/systems/realm/contracts.cairo
@@ -1,7 +1,8 @@
 #[dojo::contract]
 mod realm_systems {
 
-    use eternum::models::realm::Realm;
+    use core::traits::Into;
+use eternum::models::realm::Realm;
     use eternum::models::movable::Movable;
     use eternum::models::quantity::QuantityTracker;
     use eternum::models::capacity::Capacity;
@@ -17,6 +18,7 @@ mod realm_systems {
      };
 
     use eternum::systems::realm::interface::IRealmSystems;
+    use eternum::systems::map::contracts::map_systems::InternalMapSystemsImpl;
 
     use eternum::constants::REALM_ENTITY_TYPE;
 
@@ -147,6 +149,13 @@ mod realm_systems {
 
                 index += 1;                  
             };
+
+
+            // set realm's position tile to explored
+            InternalMapSystemsImpl::explore(
+                world, entity_id.into(), position.into(), 0 , 0 
+            );
+            
 
             entity_id.into()
 

--- a/contracts/src/systems/realm/tests.cairo
+++ b/contracts/src/systems/realm/tests.cairo
@@ -2,6 +2,7 @@ use eternum::models::resources::{Resource, ResourceChest};
 use eternum::models::owner::Owner;
 use eternum::models::position::Position;
 use eternum::models::realm::Realm;
+use eternum::models::map::Tile;
 
 use eternum::systems::config::contracts::config_systems;
 use eternum::systems::config::interface::{
@@ -25,6 +26,8 @@ use dojo::world::{ IWorldDispatcher, IWorldDispatcherTrait};
 
 use starknet::contract_address_const;
 use core::array::{ArrayTrait, SpanTrait};
+
+const TIMESTAMP: u64 = 1000;
 
 const INITIAL_RESOURCE_1_TYPE: u8 = 1;
 const INITIAL_RESOURCE_1_AMOUNT: u128 = 800;
@@ -56,6 +59,8 @@ fn setup() -> IWorldDispatcher {
 fn test_realm_create() {
 
     let world = setup();
+
+    starknet::testing::set_block_timestamp(TIMESTAMP);
 
 
      // create realm
@@ -106,6 +111,16 @@ fn test_realm_create() {
 
     let realm = get!(world, realm_entity_id, Realm);
     assert(realm.realm_id == realm_id, 'wrong realm id');
+
+
+    // ensure realm Tile is explored
+    let tile: Tile 
+        = get!(world, (position.x, position.y), Tile);
+    assert_eq!(tile.col, tile._col, "wrong col");
+    assert_eq!(tile.row, tile._row, "wrong row");
+    assert_eq!(tile.explored_by_id, realm_entity_id, "wrong realm owner");
+    assert_eq!(tile.explored_at, TIMESTAMP, "wrong exploration time");
+
 
 }
 

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -2973,7 +2973,7 @@
     {
       "name": "eternum::systems::map::contracts::map_systems",
       "address": "0x3fda5d1f7500f799eb30aa1293b2b6c354d350ed359593eb75390893cc7ec3d",
-      "class_hash": "0x771acda4db5e67cc03e3a16b2452b9932873d680f9a89851a1a54a9244f84ae",
+      "class_hash": "0x63d76511b2a26cd9b87db08f2fda6106892ecbb3b14b7ce5bb529d1dada18b1",
       "abi": [
         {
           "type": "impl",
@@ -3013,6 +3013,50 @@
           "interface_name": "eternum::systems::map::interface::IMapSystems"
         },
         {
+          "type": "struct",
+          "name": "eternum::models::position::Coord",
+          "members": [
+            {
+              "name": "x",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "y",
+              "type": "core::integer::u128"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "eternum::models::position::Direction",
+          "variants": [
+            {
+              "name": "East",
+              "type": "()"
+            },
+            {
+              "name": "NorthEast",
+              "type": "()"
+            },
+            {
+              "name": "NorthWest",
+              "type": "()"
+            },
+            {
+              "name": "West",
+              "type": "()"
+            },
+            {
+              "name": "SouthWest",
+              "type": "()"
+            },
+            {
+              "name": "SouthEast",
+              "type": "()"
+            }
+          ]
+        },
+        {
           "type": "interface",
           "name": "eternum::systems::map::interface::IMapSystems",
           "items": [
@@ -3029,12 +3073,12 @@
                   "type": "core::integer::u128"
                 },
                 {
-                  "name": "col",
-                  "type": "core::integer::u128"
+                  "name": "from_coord",
+                  "type": "eternum::models::position::Coord"
                 },
                 {
-                  "name": "row",
-                  "type": "core::integer::u128"
+                  "name": "direction",
+                  "type": "eternum::models::position::Direction"
                 }
               ],
               "outputs": [],
@@ -3371,7 +3415,7 @@
     {
       "name": "eternum::systems::realm::contracts::realm_systems",
       "address": "0x25df90992b8eebca69f08035ceda822dee73028e828ceb8421895814eacd3d",
-      "class_hash": "0x1022e72f15b1553cc30f815cb5416aaaed381d42ff83005b7562479d83f79cc",
+      "class_hash": "0x5d73c3b16ace8c43a72021ee2fd8ae3d999ff3f4aaae20aaad1fa0be19c318",
       "abi": [
         {
           "type": "impl",
@@ -11502,7 +11546,7 @@
       ]
     },
     {
-      "name": "eternum::models::map::explored_map",
+      "name": "eternum::models::map::tile",
       "members": [
         {
           "name": "_col",
@@ -11540,7 +11584,7 @@
           "key": false
         }
       ],
-      "class_hash": "0x4ce4cffb53a207a2196f6de690c148ebc03c644fc0de18dc18dfe38cb3a2078",
+      "class_hash": "0x48b40550f319249bdfb6ee2a63d1adbaca96baaf91598818da62c4289cb3403",
       "abi": [
         {
           "type": "function",
@@ -11697,7 +11741,7 @@
         },
         {
           "type": "event",
-          "name": "eternum::models::map::explored_map::Event",
+          "name": "eternum::models::map::tile::Event",
           "kind": "enum",
           "variants": []
         }


### PR DESCRIPTION
- renamed `ExploredMap` to `Tile`
- mark realm tile as explored immediately it is created
- only allow exploration of tiles near already explored tiles