### PR TITLE
contracts: add hex tick, travel, army exploration

### DIFF
--- a/contracts/scripts/set_config.sh
+++ b/contracts/scripts/set_config.sh
@@ -59,7 +59,7 @@ commands=(
 commands+=(
     # wheat_burn_amount = 300000
     # fish_burn_amount = 150000
-    # random_mint_amount = 20000
+    # reward_resource_amount = 20000
     "sozo execute $CONFIG_SYSTEMS set_exploration_config --account-address $DOJO_ACCOUNT_ADDRESS --calldata $SOZO_WORLD,100000,50000,20000"
 )
 

--- a/contracts/src/models.cairo
+++ b/contracts/src/models.cairo
@@ -23,3 +23,4 @@ mod bank;
 mod order;
 mod buildings;
 mod map;
+mod tick;

--- a/contracts/src/models/capacity.cairo
+++ b/contracts/src/models/capacity.cairo
@@ -8,7 +8,7 @@ struct Capacity {
 
 #[generate_trait]
 impl CapacityImpl of CapacityTrait {
-    fn can_carry_weight(self: Capacity, entity_id: u128, quantity: u128, weight: u128) -> bool {
+    fn can_carry_weight(self: Capacity, quantity: u128, weight: u128) -> bool {
         if self.is_capped() {
             let entity_total_weight_capacity = self.weight_gram * quantity;
             if entity_total_weight_capacity < weight {

--- a/contracts/src/models/combat.cairo
+++ b/contracts/src/models/combat.cairo
@@ -33,3 +33,11 @@ enum Duty {
     Attack,
     Defence
 }
+
+
+#[derive(Copy, Drop, Serde)]
+enum TargetType {
+    RealmTownWatch,
+    Army
+}
+

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -155,7 +155,27 @@ struct MapExploreConfig {
     config_id: u128,
     wheat_burn_amount: u128,
     fish_burn_amount: u128,
-    random_mint_amount: u128
+    reward_resource_amount: u128
+}
+
+
+#[derive(Model, Copy, Drop, Serde)]
+struct TickConfig {
+    #[key]
+    config_id: u128, 
+    max_moves_per_tick: u8,
+    tick_interval_in_seconds: u64
+}
+
+
+
+#[generate_trait]
+impl TickConfigImpl of TickConfigTrait {
+
+    fn current(self: TickConfig) -> u64 {
+        let now = starknet::get_block_timestamp();
+        now / self.tick_interval_in_seconds
+    }
 }
 
 

--- a/contracts/src/models/inventory.cairo
+++ b/contracts/src/models/inventory.cairo
@@ -1,7 +1,63 @@
+use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+use eternum::models::metadata::ForeignKey;
+
 #[derive(Model, Copy, Drop, Serde)]
 struct Inventory {
     #[key]
     entity_id: u128,
     items_key: felt252,
     items_count: u128,
+}
+
+#[generate_trait]
+impl InventoryImpl of InventoryTrait {
+
+    fn item_fk(self: Inventory, world: IWorldDispatcher, item_index: u128) -> ForeignKey {
+        assert(item_index < self.items_count, 'wrong inventory item index');
+        let foreign_key_arr : Array<felt252>
+            = array![
+                self.entity_id.into(), 
+                self.items_key.into(), 
+                item_index.into()
+            ];
+        let foreign_key_id: felt252 = 
+            core::poseidon::poseidon_hash_span(foreign_key_arr.span());
+        let foreign_key: ForeignKey = 
+                get!(world, foreign_key_id, ForeignKey);
+
+        return foreign_key;
+    }
+
+    fn item_id(self: Inventory, world: IWorldDispatcher, item_index: u128) -> u128 {
+        self.item_fk(world, item_index).entity_id
+    }
+
+
+    fn last_item_fk(self: Inventory, world: IWorldDispatcher) -> ForeignKey {
+        self.item_fk(world, self.items_count - 1)
+    }
+
+    fn last_item_id(self: Inventory, world: IWorldDispatcher) -> u128 {
+        self.last_item_fk(world).entity_id
+    }
+
+    fn next_item_fk(self: Inventory, world: IWorldDispatcher) -> ForeignKey {
+        // next_item_fk.entity_id should always be 0
+        self.item_fk(world, self.items_count)
+    }    
+
+    fn set_next_item(ref self: Inventory, world: IWorldDispatcher, item_id: u128) {
+        // next_item_fk.entity_id should always be 0
+        let mut next_item_fk = self.next_item_fk(world);
+        assert(next_item_fk.entity_id == 0, 'wrong next item fk');
+        next_item_fk.entity_id = item_id;
+
+        set!(world, (next_item_fk));
+
+        // update inventory item count
+        self.items_count += 1;
+        set!(world, (self));
+
+    }    
+    
 }

--- a/contracts/src/models/inventory.cairo
+++ b/contracts/src/models/inventory.cairo
@@ -13,7 +13,6 @@ struct Inventory {
 impl InventoryImpl of InventoryTrait {
 
     fn item_fk(self: Inventory, world: IWorldDispatcher, item_index: u128) -> ForeignKey {
-        assert(item_index < self.items_count, 'wrong inventory item index');
         let foreign_key_arr : Array<felt252>
             = array![
                 self.entity_id.into(), 

--- a/contracts/src/models/tick.cairo
+++ b/contracts/src/models/tick.cairo
@@ -1,19 +1,49 @@
 // TODO next milestone
-// use eternum::models::config::WorldConfig;
-// use eternum::utils::math::get_past_time;
+use eternum::models::config::{WorldConfig, TickConfig, TickConfigTrait};
+use eternum::constants::WORLD_CONFIG_ID;
+use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 
-// #[derive(Model, Copy, Drop, Serde)]
-// struct Tick {
-//     last_update: u128
-// }
-// trait TickTrait {
-//     fn needs_update(self: Tick, world_config: WorldConfig, block_timestamp: u128) -> bool;
-// }
 
-// impl TickImpl of TickTrait {
-//     fn needs_update(self: Tick, world_config: WorldConfig, block_timestamp: u128) -> bool {
-//         get_past_time(self.last_update + world_config.tick_time, block_timestamp)
-//     }
-// }
 
+#[derive(Model, Copy, Drop, Serde)]
+struct TickMove {
+    #[key]
+    entity_id: u128, 
+    tick: u64,
+    count: u8
+}
+
+
+#[generate_trait]
+impl TickMoveImpl of TickMoveTrait {
+    fn add(ref self: TickMove, world: IWorldDispatcher, num: u8) {
+        let tick_config: TickConfig = get!(world, WORLD_CONFIG_ID, TickConfig);
+        
+        // reset tick count if a future tick has occured
+        
+        if self.tick != tick_config.current() {
+            self.count = 0;
+        }
+
+        // ensure entity moves within tick moves limit
+        assert!(
+            self.count + num <= tick_config.max_moves_per_tick ,
+                "max moves per tick exceeded"
+        );
+
+        self.count += num;
+        self.tick = tick_config.current();
+        set!(world, (self));
+    }
+
+    /// Max out an entity's tick move
+    fn max_out(ref self: TickMove, world: IWorldDispatcher) {
+        let tick_config: TickConfig = get!(world, WORLD_CONFIG_ID, TickConfig);
+
+        self.tick = tick_config.current();
+        self.count = tick_config.max_moves_per_tick;
+
+        set!(world, (self));
+    }
+}
 

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -13,7 +13,7 @@ mod combat_systems {
         LevelingConfig
     };
     use eternum::models::movable::{Movable, ArrivalTime};
-    use eternum::models::inventory::Inventory;
+    use eternum::models::inventory::{Inventory, InventoryTrait};
     use eternum::models::level::{Level, LevelTrait};
     use eternum::models::capacity::Capacity;
     use eternum::models::weight::Weight;
@@ -22,7 +22,7 @@ mod combat_systems {
     use eternum::models::hyperstructure::HyperStructure;
     use eternum::models::quantity::{Quantity, QuantityTrait};    
     use eternum::models::combat::{
-        Attack, Health, Defence, Duty, TownWatch
+        Attack, Health, Defence, Duty, TownWatch, TargetType
     };
     
 
@@ -30,7 +30,7 @@ mod combat_systems {
         ISoldierSystems, ICombatSystems
     };
     use eternum::systems::resources::contracts::resource_systems::{
-        InternalResourceSystemsImpl
+        InternalResourceSystemsImpl, InternalInventorySystemsImpl
     };
 
     use eternum::systems::transport::contracts::travel_systems::travel_systems::{
@@ -63,6 +63,7 @@ mod combat_systems {
         target_entity_id: u128,
         attacking_entity_ids: Span<u128>,
         stolen_resources: Span<(u8, u128)>,
+        stolen_chests: Span<u128>,
         winner: Winner,
         damage: u128,
         ts: u64
@@ -571,17 +572,20 @@ mod combat_systems {
     #[external(v0)]
     impl CombatSystemsImpl of ICombatSystems<ContractState> {
 
+        /// Attack an entity
+        ///
+        /// # Arguments
+        /// - attacker_ids: entity ids of armies 
+        /// - target_entity_id: realm's town watch id or another entity army
+
         fn attack(
             self: @ContractState, world: IWorldDispatcher,
             attacker_ids: Span<u128>, target_entity_id: u128
         ) {
             let caller = starknet::get_caller_address();
 
-            let target_town_watch_id 
-                = get!(world, target_entity_id, TownWatch).town_watch_id;
-            
-            let mut target_town_watch_health = get!(world, target_town_watch_id, Health);
-            assert(target_town_watch_health.value > 0, 'target is dead');
+            let mut target_health = get!(world, target_entity_id, Health);
+            assert(target_health.value > 0, 'target is dead');
 
             let ts = starknet::get_block_timestamp();
 
@@ -595,6 +599,7 @@ mod combat_systems {
                     break;
                 }
                 let attacker_id = *attacker_ids.at(index);
+                assert(target_entity_id != attacker_id, 'self attack');
 
                 let attacker_owner = get!(world, attacker_id, Owner);
                 assert(attacker_owner.address == caller, 'not attacker owner');
@@ -629,25 +634,27 @@ mod combat_systems {
                 = get!(world, *attacker_ids.at(0), EntityOwner).entity_owner_id;
             let attacker_realm = get!(world, attacker_realm_entity_id, Realm );
 
-
-            let mut target_town_watch_attack = get!(world, target_town_watch_id, Attack);
-            let mut target_town_watch_defense = get!(world, target_town_watch_id, Defence);
-            let mut target_town_watch_health = get!(world, target_town_watch_id, Health);
+            let target_realm_entity_id 
+                = get!(world, target_entity_id, EntityOwner).entity_owner_id;
+            let target_realm = get!(world, target_realm_entity_id, Realm );
+            let mut target_attack = get!(world, target_entity_id, Attack);
+            let mut target_defense = get!(world, target_entity_id, Defence);
+            let mut target_health = get!(world, target_entity_id, Health);
 
             // TODO: use the leveling helper function to get bonus
 
 
             /////// REALM LEVEL BONUS ///////
             let leveling_config: LevelingConfig = get!(world, REALM_LEVELING_CONFIG_ID, LevelingConfig);
-            let attacker_level = get!(world, (attacker_realm_entity_id), Level);
-            let attacker_level_bonus 
-                = attacker_level.get_index_multiplier(
+            let attacker_realm_level = get!(world, (attacker_realm_entity_id), Level);
+            let attacker_realm_level_bonus 
+                = attacker_realm_level.get_index_multiplier(
                     leveling_config, LevelIndex::COMBAT, REALM_LEVELING_START_TIER
                     ) - 100;
 
-            let target_level = get!(world, (target_entity_id), Level);
-            let target_level_bonus 
-                = target_level.get_index_multiplier(
+            let target_realm_level = get!(world, (target_realm_entity_id), Level);
+            let target_realm_level_bonus 
+                = target_realm_level.get_index_multiplier(
                     leveling_config, LevelIndex::COMBAT, REALM_LEVELING_START_TIER
                     ) - 100;
 
@@ -659,7 +666,6 @@ mod combat_systems {
             
 
             // defender order bonus (if it is a realm)      
-            let target_realm = get!(world, target_entity_id, Realm);
             let target_order = get!(world, target_realm.order, Orders);
             let target_order_bonus = target_order.get_bonus_multiplier();
 
@@ -667,17 +673,18 @@ mod combat_systems {
 
             let attackers_total_attack 
                     = attackers_total_attack 
-                        + ((attackers_total_attack * attacker_level_bonus) / 100) 
+                        + ((attackers_total_attack * attacker_realm_level_bonus) / 100) 
                         + ((attackers_total_attack * attacker_order_bonus) / attacker_order.get_bonus_denominator());
 
             let target_total_attack = 
-                    target_town_watch_attack.value 
-                        + ((target_town_watch_attack.value * target_level_bonus) / 100) 
-                        + ((target_town_watch_attack.value * target_order_bonus) / target_order.get_bonus_denominator());
+                    target_attack.value 
+                        + ((target_attack.value * target_realm_level_bonus) / 100) 
+                        + ((target_attack.value * target_order_bonus) / target_order.get_bonus_denominator());
+
             let target_total_defence = 
-                    target_town_watch_defense.value 
-                        + ((target_town_watch_defense.value * target_level_bonus) / 100) 
-                        + ((target_town_watch_defense.value * target_order_bonus) / target_order.get_bonus_denominator());
+                    target_defense.value 
+                        + ((target_defense.value * target_realm_level_bonus) / 100) 
+                        + ((target_defense.value * target_order_bonus) / target_order.get_bonus_denominator());
 
 
             let mut damage: u128 = 0; 
@@ -686,7 +693,7 @@ mod combat_systems {
                 array![true, false].span(), 
                 array![
                     attackers_total_attack * attackers_total_health, 
-                    target_total_defence * target_town_watch_health.value
+                    target_total_defence * target_health.value
                 ].span(), 
                 array![].span(), 1, true
             )[0];
@@ -699,9 +706,9 @@ mod combat_systems {
                 let damage_percent = random::random(salt, 100 + 1 );
                 damage = (attackers_total_attack * damage_percent) / 100;
 
-                target_town_watch_health.value -= min(damage, target_town_watch_health.value);
+                target_health.value -= min(damage, target_health.value);
 
-                set!(world, (target_town_watch_attack, target_town_watch_defense, target_town_watch_health));
+                set!(world, (target_attack, target_defense, target_health));
 
             } else {
 
@@ -745,6 +752,7 @@ mod combat_systems {
                     attacking_entity_ids: attacker_ids,
                     target_entity_id,
                     stolen_resources: array![].span(),
+                    stolen_chests: array![].span(),
                     winner,
                     damage,
                     ts,
@@ -753,16 +761,16 @@ mod combat_systems {
         }
 
 
-
+        /// Try to steal from an entity
+        ///
+        /// # Arguments
+        /// - attacker_id: entity id of attacking army
+        /// - target_entity_id: realm's town watch id or another entity army
         fn steal(
             self: @ContractState, world: IWorldDispatcher,
             attacker_id: u128, target_entity_id: u128
         ) {
-            // check that target is a realm
-            // let target_realm = get!(world, target_entity_id, Realm);
-            
-            // assert(target_realm.realm_id != 0, 'target not realm');
-
+  
             let caller = starknet::get_caller_address();
             let ts = starknet::get_block_timestamp();
 
@@ -791,32 +799,29 @@ mod combat_systems {
             let mut attacker_attack = get!(world, attacker_id, Attack);
             let mut attacker_defence = get!(world, attacker_id, Defence);
             
-            let target_town_watch_id 
-                = get!(world, target_entity_id, TownWatch).town_watch_id;
 
-            let target_town_watch_health = get!(world, target_town_watch_id, Health);
-            let target_town_watch_attack = get!(world, target_town_watch_id, Attack);
-            let target_town_watch_defense = get!(world, target_town_watch_id, Defence);
+            let target_realm_entity_id = get!(world, target_entity_id, EntityOwner).entity_owner_id;
+            let target_realm = get!(world, target_realm_entity_id, Realm );
 
             let attacker_realm_entity_id = get!(world, attacker_id, EntityOwner).entity_owner_id;
             let attacker_realm = get!(world, attacker_realm_entity_id, Realm );
             let combat_config = get!(world, COMBAT_CONFIG_ID, CombatConfig);
 
-            let mut target_town_watch_attack = get!(world, target_town_watch_id, Attack);
-            let mut target_town_watch_defense = get!(world, target_town_watch_id, Defence);
-            let mut target_town_watch_health = get!(world, target_town_watch_id, Health);
+            let target_health = get!(world, target_entity_id, Health);
+            let target_attack = get!(world, target_entity_id, Attack);
+            let target_defense = get!(world, target_entity_id, Defence);
 
             /////// REALM LEVEL BONUS ///////
             let leveling_config: LevelingConfig = get!(world, REALM_LEVELING_CONFIG_ID, LevelingConfig);
-            let attacker_level = get!(world, (attacker_realm_entity_id), Level);
-            let attacker_level_bonus 
-                = attacker_level.get_index_multiplier(
+            let attacker_realm_level = get!(world, (attacker_realm_entity_id), Level);
+            let attacker_realm_level_bonus 
+                = attacker_realm_level.get_index_multiplier(
                     leveling_config, LevelIndex::COMBAT, REALM_LEVELING_START_TIER
                     ) - 100;
 
-            let target_level = get!(world, (target_entity_id), Level);
-            let target_level_bonus 
-                = target_level.get_index_multiplier(
+            let target_realm_level = get!(world, (target_realm_entity_id), Level);
+            let target_realm_level_bonus 
+                = target_realm_level.get_index_multiplier(
                     leveling_config, LevelIndex::COMBAT, REALM_LEVELING_START_TIER
                     ) - 100;
 
@@ -827,34 +832,32 @@ mod combat_systems {
             let attacker_order = get!(world, attacker_realm.order, Orders);
             let attacker_order_bonus = attacker_order.get_bonus_multiplier();
             
-
             // defender order bonus (if it is a realm)      
-            let target_realm = get!(world, target_entity_id, Realm);
             let target_order = get!(world, target_realm.order, Orders);
             let target_order_bonus = target_order.get_bonus_multiplier();
 
             // need to divide by 100**2 because level_bonus in precision 100
             let attackers_total_attack 
                     = attacker_attack.value 
-                        + ((attacker_attack.value * attacker_level_bonus) / 100) 
+                        + ((attacker_attack.value * attacker_realm_level_bonus) / 100) 
                         + ((attacker_attack.value * attacker_order_bonus) / attacker_order.get_bonus_denominator());
 
             // need to divide by 100**2 because level_bonus in precision 100
             let target_total_attack = 
-                    target_town_watch_attack.value 
-                        + ((target_town_watch_attack.value * target_level_bonus) / 100) 
-                        + ((target_town_watch_attack.value * target_order_bonus) / target_order.get_bonus_denominator());
+                    target_attack.value 
+                        + ((target_attack.value * target_realm_level_bonus) / 100) 
+                        + ((target_attack.value * target_order_bonus) / target_order.get_bonus_denominator());
             let target_total_defence = 
-                    target_town_watch_defense.value 
-                        + ((target_town_watch_defense.value * target_level_bonus) / 100) 
-                        + ((target_town_watch_defense.value * target_order_bonus) / target_order.get_bonus_denominator());
+                    target_defense.value 
+                        + ((target_defense.value * target_realm_level_bonus) / 100) 
+                        + ((target_defense.value * target_order_bonus) / target_order.get_bonus_denominator());
 
 
             let attack_successful: bool = *random::choices(
                 array![true, false].span(), 
                 array![
                     attackers_total_attack * attacker_health.value, 
-                    target_total_defence * target_town_watch_health.value
+                    target_total_defence * target_health.value
                 ].span(), 
                 array![].span(), 1, true
             )[0];
@@ -862,9 +865,114 @@ mod combat_systems {
 
             if attack_successful {
 
+                let target_type 
+                    = InternalCombatSystemsImpl::target_type(world, target_entity_id);
+                let (stolen_resources, stolen_chests) = match target_type {
+                    TargetType::RealmTownWatch => {
+                        let stolen_resources 
+                            = InternalCombatSystemsImpl::steal_from_realm(
+                                world, attacker_id, target_entity_id, target_realm_entity_id, combat_config
+                            );
+                        (stolen_resources, array![].span())
+                    },
+                    TargetType::Army => {
+                        let stolen_chests 
+                            = InternalCombatSystemsImpl::steal_from_army(
+                                world, attacker_id, target_entity_id
+                            );
+                        (array![].span(), stolen_chests)
+                    }
+                };
 
-                // burn target's food (fish and wheat)
-                let attacker_quantity = get!(world, attacker_id, Quantity);
+                // emit combat event
+                let attacker_realm_entity_id 
+                    = get!(world, attacker_id, EntityOwner).entity_owner_id;
+                emit!(world, CombatOutcome { 
+                        attacker_realm_entity_id,
+                        attacking_entity_ids: array![attacker_id].span(),
+                        target_entity_id,
+                        stolen_resources: stolen_resources,
+                        stolen_chests: stolen_chests,
+                        winner: Winner::Attacker,
+                        damage: 0,
+                        ts
+                });
+
+            
+            } else {
+                
+                // attack failed && target deals damage to attacker
+                 
+                
+                // get damage to attacker based on the target's attack value 
+                let salt: u128 = ts.into();
+                let damage_percent = random::random(salt, 100 + 1 );
+                let damage = (target_total_attack * damage_percent) / 100;
+
+                attacker_health.value -= min(damage, attacker_health.value);
+
+                set!(world, (attacker_health));
+
+
+                let attacker_realm_entity_id 
+                    = get!(world, attacker_id, EntityOwner).entity_owner_id;
+                emit!(world, CombatOutcome { 
+                        attacker_realm_entity_id,
+                        attacking_entity_ids: array![attacker_id].span(),
+                        target_entity_id,
+                        stolen_resources: array![].span(),
+                        stolen_chests: array![].span(),
+                        winner: Winner::Target,
+                        damage,
+                        ts
+                });
+            }    
+
+
+            // send attacker back to home realm
+            let attacker_movable = get!(world, attacker_id, Movable);
+            let attacker_home_position 
+                = get!(world, attacker_realm_entity_id, Position);
+            InternalTravelSystemsImpl::travel(
+                world, attacker_id, attacker_movable, 
+                attacker_position.into(), attacker_home_position.into()
+            );
+        }
+    }
+
+    #[generate_trait]
+    impl InternalCombatSystemsImpl of InternalCombatSystemsTrait {
+
+        fn target_type(world: IWorldDispatcher, target_entity_id: u128 ) -> TargetType {
+            if get!(world, target_entity_id, TownWatch).town_watch_id == 0 {
+                return TargetType::Army;
+            } else {
+                return TargetType::RealmTownWatch;
+            }
+        }
+
+        fn steal_from_army(
+            world: IWorldDispatcher, attacker_entity_id: u128, target_entity_id: u128
+        ) -> Span<u128> {
+
+            // steal resources from army 
+
+            // @security-note: target can make stealing impossible by having too many
+            //          items causing call to exceed katana step limit
+            let attacker_inventory: Inventory = get!(world, attacker_entity_id, Inventory);
+            let target_inventory: Inventory = get!(world, target_entity_id, Inventory);
+
+            let stolen_chests = InternalInventorySystemsImpl::transfer_max_between_inventories(
+                world, target_inventory, attacker_inventory
+            );
+            return stolen_chests;
+        }
+
+        fn steal_from_realm(
+            world: IWorldDispatcher, attacker_entity_id: u128, target_entity_id: u128, target_realm_entity_id: u128, combat_config: CombatConfig 
+            ) -> Span<(u8, u128)> {
+                // burn target realm's  food (fish and wheat)
+                let attacker_quantity: Quantity = get!(world, attacker_entity_id, Quantity);
                 let mut wheat_burn_amount = combat_config.wheat_burn_per_soldier * attacker_quantity.value;
                 let mut fish_burn_amount = combat_config.fish_burn_per_soldier * attacker_quantity.value;
                 ResourceFoodImpl::burn_food(
@@ -874,13 +982,12 @@ mod combat_systems {
 
                 // steal resources
                 let mut stolen_resources: Array<(u8, u128)> = array![];
-
-                let attacker_capacity = get!(world, attacker_id, Capacity);
+                let attacker_capacity = get!(world, attacker_entity_id, Capacity);
                 let attacker_total_weight_capacity 
-                            = attacker_capacity.weight_gram * attacker_quantity.get_value();
+                            = attacker_capacity.weight_gram * attacker_quantity.value;
 
-                let mut attacker_current_weight = get!(world, attacker_id, Weight).value;
-                let mut attacker_remaining_weight 
+                let mut attacker_current_weight = get!(world, attacker_entity_id, Weight).value;
+                let mut attacker_remaining_capacity 
                     = attacker_total_weight_capacity - attacker_current_weight; 
 
                 // get all the (stealable) resources that the target owns
@@ -888,7 +995,6 @@ mod combat_systems {
                 let entitys_resources = get!(world, target_entity_id, OwnedResourcesTracker);
                 let (stealable_resource_types, stealable_resources_probs) 
                     =  entitys_resources.get_owned_resources_and_probs();
-
 
 
                 let mut chosen_resource_types: Span<u8> = stealable_resource_types;
@@ -929,13 +1035,13 @@ mod combat_systems {
                                 target_resource.balance
                             } else {
 
-                                attacker_remaining_weight / resource_weight
+                                attacker_remaining_capacity / resource_weight
                             };
 
                         if stolen_resource_amount > 0 {
                             attacker_current_weight 
                                 += stolen_resource_amount * resource_weight;
-                            attacker_remaining_weight
+                            attacker_remaining_capacity
                                  -= stolen_resource_amount * resource_weight;
 
                             stolen_resources.append(
@@ -952,64 +1058,14 @@ mod combat_systems {
                     InternalResourceSystemsImpl::transfer(
                         world,
                         target_entity_id,
-                        attacker_id,
+                        attacker_entity_id,
                         stolen_resources.span()
                     );
                     
                 }
 
+                return stolen_resources.span();
+            }
         
-       
-                let attacker_realm_entity_id 
-                    = get!(world, attacker_id, EntityOwner).entity_owner_id;
-                emit!(world, CombatOutcome { 
-                        attacker_realm_entity_id,
-                        attacking_entity_ids: array![attacker_id].span(),
-                        target_entity_id,
-                        stolen_resources: stolen_resources.span(),
-                        winner: Winner::Attacker,
-                        damage: 0,
-                        ts
-                });
-
-            
-            } else {
-                
-                // attack failed && target deals damage to attacker
-                 
-                
-                // get damage to attacker based on the target's attack value 
-                let salt: u128 = ts.into();
-                let damage_percent = random::random(salt, 100 + 1 );
-                let damage = (target_total_attack * damage_percent) / 100;
-
-                attacker_health.value -= min(damage, attacker_health.value);
-
-                set!(world, (attacker_health));
-
-
-                let attacker_realm_entity_id 
-                    = get!(world, attacker_id, EntityOwner).entity_owner_id;
-                emit!(world, CombatOutcome { 
-                        attacker_realm_entity_id,
-                        attacking_entity_ids: array![attacker_id].span(),
-                        target_entity_id,
-                        stolen_resources: array![].span(),
-                        winner: Winner::Target,
-                        damage,
-                        ts
-                });
-            }    
-
-
-            // send attacker back to home realm
-            let attacker_movable = get!(world, attacker_id, Movable);
-            let attacker_home_position 
-                = get!(world, attacker_realm_entity_id, Position);
-            InternalTravelSystemsImpl::travel(
-                world, attacker_id, attacker_movable, 
-                attacker_position.into(), attacker_home_position.into()
-            );
-        }
     }
 }

--- a/contracts/src/systems/config/contracts.cairo
+++ b/contracts/src/systems/config/contracts.cairo
@@ -9,13 +9,13 @@ mod config_systems {
         LaborCostResources, LaborCostAmount, LaborConfig, CapacityConfig, RoadConfig, SpeedConfig,
         TravelConfig, WeightConfig, WorldConfig, SoldierConfig, HealthConfig, AttackConfig,
         DefenceConfig, CombatConfig, LevelingConfig, RealmFreeMintConfig, LaborBuildingsConfig,
-        LaborBuildingCost, MapExploreConfig
+        LaborBuildingCost, MapExploreConfig, TickConfig
     };
 
     use eternum::systems::config::interface::{
         IWorldConfig, IWeightConfig, ICapacityConfig, ILaborConfig, ITransportConfig,
         IHyperstructureConfig, ICombatConfig, ILevelingConfig, IBankConfig, IRealmFreeMintConfig,
-        IBuildingsConfig, IMapConfig
+        IBuildingsConfig, IMapConfig, ITickConfig
     };
 
     use eternum::constants::{
@@ -108,7 +108,7 @@ mod config_systems {
     impl MapConfigImpl of IMapConfig<ContractState> {
         fn set_exploration_config(
             self: @ContractState, world: IWorldDispatcher, 
-            wheat_burn_amount: u128, fish_burn_amount: u128, random_mint_amount: u128
+            wheat_burn_amount: u128, fish_burn_amount: u128, reward_resource_amount: u128
         ) {
             assert_caller_is_admin(world);
 
@@ -118,7 +118,7 @@ mod config_systems {
                     config_id: WORLD_CONFIG_ID,
                     wheat_burn_amount,
                     fish_burn_amount, 
-                    random_mint_amount
+                    reward_resource_amount
                 })
             );
         }
@@ -159,6 +159,27 @@ mod config_systems {
                     entity_type,
                     weight_gram,
                 })
+            );
+        }
+    }
+
+    #[external(v0)]
+    impl TickConfigImpl of ITickConfig<ContractState> {
+        fn set_tick_config(
+            self: @ContractState,
+            world: IWorldDispatcher,
+            max_moves_per_tick: u8,
+            tick_interval_in_seconds: u64
+        ) {
+            assert_caller_is_admin(world);
+
+            set!( world,(
+                TickConfig { 
+                    config_id: WORLD_CONFIG_ID, 
+                    max_moves_per_tick, 
+                    tick_interval_in_seconds
+                }
+            )
             );
         }
     }

--- a/contracts/src/systems/config/interface.cairo
+++ b/contracts/src/systems/config/interface.cairo
@@ -36,6 +36,12 @@ trait ICapacityConfig<TContractState> {
 
 
 #[starknet::interface]
+trait ITickConfig<TContractState> {
+    fn set_tick_config(self: @TContractState, world: IWorldDispatcher, max_moves_per_tick: u8, tick_interval_in_seconds: u64 );
+}
+
+
+#[starknet::interface]
 trait ICombatConfig<TContractState> {
     fn set_combat_config(
         self: @TContractState,
@@ -204,7 +210,7 @@ trait IBuildingsConfig<TContractState> {
 #[starknet::interface]
 trait IMapConfig<TContractState> {
     fn set_exploration_config(
-        self: @TContractState, world: IWorldDispatcher, wheat_burn_amount: u128, fish_burn_amount: u128, random_mint_amount: u128
+        self: @TContractState, world: IWorldDispatcher, wheat_burn_amount: u128, fish_burn_amount: u128, reward_resource_amount: u128
     );
 }
 

--- a/contracts/src/systems/map/contracts.cairo
+++ b/contracts/src/systems/map/contracts.cairo
@@ -1,11 +1,16 @@
 #[dojo::contract]
 mod map_systems {
+    use core::traits::Into;
     use eternum::alias::ID;
     use eternum::models::resources::{Resource, ResourceCost, ResourceTrait, ResourceFoodImpl};
     use eternum::constants::ResourceTypes;
-    use eternum::models::owner::{Owner};
+    use eternum::models::owner::{Owner, EntityOwner};
     use eternum::models::hyperstructure::HyperStructure;
+    use eternum::models::quantity::Quantity;
+    use eternum::models::movable::{Movable,ArrivalTime};
+    use eternum::models::inventory::Inventory;
     use eternum::models::map::Tile;
+    use eternum::models::position::{Position};
     use eternum::models::config::{LevelingConfig};
     use eternum::models::realm::{Realm};
     use eternum::models::level::{Level, LevelTrait};
@@ -15,7 +20,14 @@ mod map_systems {
     use eternum::utils::random;
     use eternum::models::position::{Coord, CoordTrait, Direction};
     use eternum::constants::{WORLD_CONFIG_ID, split_resources_and_probs};
-
+    use eternum::systems::resources::contracts::resource_systems::{
+        InternalResourceSystemsImpl
+    };
+    use eternum::systems::transport::contracts::travel_systems::travel_systems::{
+        InternalTravelSystemsImpl
+    };
+    use eternum::models::tick::{TickMove, TickMoveTrait};
+    
     use starknet::ContractAddress;
 
 
@@ -23,13 +35,13 @@ mod map_systems {
     struct MapExplored {
         #[key]
         entity_id: u128,
+        entity_owner_id: u128,
         #[key]
         col: u128,
         #[key]
         row: u128,
         biome: Biome,
-        minted_resource_id: u8,
-        minted_resource_amount: u128
+        reward: Span<(u8, u128)>
     }
 
     #[event]
@@ -41,59 +53,59 @@ mod map_systems {
 
     #[external(v0)]
     impl MapSystemsImpl of IMapSystems<ContractState> {
-        /// Allows a player explore a tile in any direction 
-        /// from a tile they have previously explored
-        ///
-        /// The first tile that would be explored would be the one 
-        /// their realm sits on and it would be explored once the realm is 
-        /// created
-        ///
+
+
         fn explore(
             self: @ContractState, world: IWorldDispatcher, 
-            realm_entity_id: u128, from_coord: Coord, direction: Direction
+            unit_id: u128, direction: Direction
         ) {
 
-            // check that entity is a realm
-            let realm: Realm = get!(world, realm_entity_id, Realm);
-            assert(realm.realm_id != 0, 'not a realm');
+            // check that caller owns unit
+            let caller = starknet::get_caller_address();
+            let unit_owner = get!(world, unit_id, Owner);
+            assert(unit_owner.address == caller, 'not unit owner');
 
-            // check realm ownership
-            let caller: ContractAddress = starknet::get_caller_address();
-            let realm_owner = get!(world, realm_entity_id, Owner);
-            assert(
-                realm_owner.address == caller,
-                    'not realm owner'
+            // check that entity owner is a realm
+            let unit_entity_owner = get!(world, unit_id, EntityOwner);
+            let unit_realm = get!(world, unit_entity_owner.entity_owner_id, Realm);
+            assert(unit_realm.realm_id != 0, 'not owned by realm');
+
+            // check that there is more than one entity in unit
+            let mut unit_quantity = get!(world, unit_id, Quantity);
+            assert(unit_quantity.value > 1, 'not enough quantity');
+
+            // ensure unit can move
+            let unit_movable = get!(world, unit_id, Movable);      
+            assert(unit_movable.sec_per_km != 0, 'entity has no speed');  
+            assert(unit_movable.blocked == false, 'entity is blocked');  
+
+            // ensure unit is not in transit
+            let unit_arrival_time = get!(world, unit_id, ArrivalTime);
+            let ts = starknet::get_block_timestamp();
+            assert(unit_arrival_time.arrives_at <= ts.into(), 'entity is in transit');
+
+
+            // check that unit isn't carrying anything
+            let unit_inventory = get!(world, unit_id, Inventory);
+            assert(unit_inventory.items_count == 0, 'unit inventory not empty');
+
+            // explore coordinate and mint reward
+            let exploration_reward = InternalMapSystemsImpl::get_explore_reward(world);
+            InternalResourceSystemsImpl::transfer(world, 0, unit_id, exploration_reward);
+
+            let current_coord: Coord = get!(world, unit_id, Position).into();
+            let next_coord = current_coord.neighbor(direction);
+            InternalMapSystemsImpl::explore(world, unit_id, next_coord, exploration_reward);
+
+            // travel to explored tile location 
+            InternalTravelSystemsImpl::travel_instant(
+                world, unit_id, current_coord, array![direction].span()
             );
-
-            // ensure that the from_tile is owned by caller
-
-            let from_tile: Tile 
-                = get!(world, (from_coord.x, from_coord.y), Tile);
-            assert(from_tile.explored_at != 0, 'not explored');
-            assert(from_tile.explored_by_id == realm_entity_id, 'not explored by caller');
-
-            // get reward resource id and amount
-
-            let explore_config: MapExploreConfig = get!(world, WORLD_CONFIG_ID, MapExploreConfig);
-            let (resource_types, resources_probs) = split_resources_and_probs();
-            let reward_resource_id: u8 
-                = *random::choices(resource_types, resources_probs, array![].span(), 1, true).at(0);
-            let reward_resource_amount: u128 = explore_config.random_mint_amount;
-
-            // explore tile
-
-            InternalMapSystemsImpl::explore(
-                world, realm_entity_id, from_coord.neighbor(direction),
-                reward_resource_id, reward_resource_amount
-            );
-
-
-            // pay for exploration by burning food
-
-            ResourceFoodImpl::burn_food(
-                world, realm_entity_id, 
-                explore_config.wheat_burn_amount, explore_config.fish_burn_amount, check_balance: true
-            );
+            
+            // max out the army's movement for that tick so 
+            // they can no longer travel during tick
+            let mut tick_move : TickMove = get!(world, unit_id, TickMove);
+            tick_move.max_out(world);
         }
 
     }
@@ -102,17 +114,14 @@ mod map_systems {
     #[generate_trait]
     impl InternalMapSystemsImpl of InternalMapSystemsTrait {
         
-        fn explore(
-            world: IWorldDispatcher, explorer_id: u128, coord: Coord,
-            reward_resource_id: u8, reward_resource_amount: u128
-        ) -> Tile {
+        fn explore(world: IWorldDispatcher, entity_id: u128, coord: Coord, reward: Span<(u8, u128)>) -> Tile {
 
             let mut tile: Tile
                  = get!(world, (coord.x, coord.y), Tile);
             assert(tile.explored_at == 0, 'already explored');
 
             // set tile as explored
-            tile.explored_by_id = explorer_id;
+            tile.explored_by_id = entity_id;
             tile.explored_at = starknet::get_block_timestamp();
             tile.biome = get_biome(coord.x, coord.y);
             tile.col = coord.x;
@@ -121,27 +130,32 @@ mod map_systems {
             set!(world, (tile));
 
 
-            // mint reward for exploration
-            if reward_resource_amount > 0 {
-                let mut explorer_reward_resource = get!(world, (explorer_id, reward_resource_id), Resource);
-                explorer_reward_resource.add(world, reward_resource_amount);
-            }
-
             // emit explored event
+            let entity_owned_by = get!(world, entity_id, EntityOwner);
+
             emit!(world,  MapExplored {
-                entity_id: explorer_id,
+                entity_id: entity_id,
+                entity_owner_id: entity_owned_by.entity_owner_id,
                 col: tile.col,
                 row: tile.row,
                 biome: tile.biome,
-                minted_resource_id: reward_resource_id,
-                minted_resource_amount: reward_resource_amount
+                reward
             });
-
-
-
 
             tile
         }
+
+        fn get_explore_reward(world: IWorldDispatcher) -> Span<(u8, u128)> {
+            
+            let explore_config: MapExploreConfig = get!(world, WORLD_CONFIG_ID, MapExploreConfig);
+            let (resource_types, resources_probs) = split_resources_and_probs();
+            let reward_resource_id: u8 
+                = *random::choices(resource_types, resources_probs, array![].span(), 1, true).at(0);
+            let reward_resource_amount: u128 = explore_config.reward_resource_amount;
+            array![(reward_resource_id, reward_resource_amount)].span()
+        }
+        
+
     }
 
 

--- a/contracts/src/systems/map/contracts.cairo
+++ b/contracts/src/systems/map/contracts.cairo
@@ -98,7 +98,7 @@ mod map_systems {
             InternalMapSystemsImpl::explore(world, unit_id, next_coord, exploration_reward);
 
             // travel to explored tile location 
-            InternalTravelSystemsImpl::travel_instant(
+            InternalTravelSystemsImpl::travel_hex(
                 world, unit_id, current_coord, array![direction].span()
             );
             

--- a/contracts/src/systems/map/interface.cairo
+++ b/contracts/src/systems/map/interface.cairo
@@ -6,6 +6,6 @@ use eternum::models::position::{Coord, Direction};
 trait IMapSystems<TContractState> {
     fn explore(
         self: @TContractState, world: IWorldDispatcher, 
-        realm_entity_id: u128,  from_coord: Coord, direction: Direction
+        unit_id: u128, direction: Direction
     );
 }

--- a/contracts/src/systems/realm/contracts.cairo
+++ b/contracts/src/systems/realm/contracts.cairo
@@ -136,7 +136,7 @@ mod realm_systems {
 
             // set realm's position tile to explored
             InternalMapSystemsImpl::explore(
-                world, entity_id.into(), position.into(), 0 , 0 
+                world, entity_id.into(), position.into(), array![].span()
             );
             
 

--- a/contracts/src/systems/resources/contracts.cairo
+++ b/contracts/src/systems/resources/contracts.cairo
@@ -377,14 +377,15 @@ mod resource_systems {
                 }
                 
                 let (resource_type, resource_amount) = *resources.at(index);
-
-                let mut donor_resource = get!(world, (donor_id, resource_type), Resource);
-                assert(donor_resource.balance >= resource_amount, 'insufficient balance');
+                if donor_id != 0 {
+                    let mut donor_resource = get!(world, (donor_id, resource_type), Resource);
+                    assert(donor_resource.balance >= resource_amount, 'insufficient balance');
+                    
+                    // remove resources from donor's balance
+                    donor_resource.balance -= resource_amount;
+                    donor_resource.save(world);
+                }
                 
-                // remove resources from donor's balance
-                donor_resource.balance -= resource_amount;
-                donor_resource.save(world);
-
                 // create detached resource
                 set!(world,(
                     DetachedResource {

--- a/contracts/src/systems/transport/contracts/caravan_systems.cairo
+++ b/contracts/src/systems/transport/contracts/caravan_systems.cairo
@@ -325,7 +325,6 @@ mod caravan_systems {
             assert(
                 transport_capacity
                     .can_carry_weight(
-                            transport_id, 
                             transport_quantity.get_value(), 
                             transport_weight.value + weight
                         ),

--- a/contracts/src/systems/transport/contracts/travel_systems.cairo
+++ b/contracts/src/systems/transport/contracts/travel_systems.cairo
@@ -6,11 +6,13 @@ mod travel_systems {
     use eternum::models::realm::Realm;
     use eternum::models::order::{Orders, OrdersTrait};
     use eternum::models::hyperstructure::HyperStructure;
-    use eternum::models::position::{Coord, Position, TravelTrait};
+    use eternum::models::position::{Coord, Position, TravelTrait, CoordTrait, Direction};
     use eternum::models::owner::{Owner, EntityOwner};
     use eternum::models::level::{Level, LevelTrait};
     use eternum::models::road::RoadImpl;
+    use eternum::models::tick::{TickMove, TickMoveTrait};
     use eternum::models::config::{RoadConfig, LevelingConfig};
+    use eternum::models::map::Tile;
 
     use eternum::constants::{ROAD_CONFIG_ID, REALM_LEVELING_CONFIG_ID, LevelIndex};
     
@@ -78,24 +80,52 @@ mod travel_systems {
             let travelling_entity_coord: Coord = travelling_entity_position.into();
             assert(travelling_entity_coord != destination_coord, 'entity is at destination');
 
-            let entity_owner = get!(world, travelling_entity_id, EntityOwner);
-
-            emit!(world, Travel { 
-                    destination_coord_x: destination_coord.x,
-                    destination_coord_y: destination_coord.y,
-                    realm_entity_id: entity_owner.entity_owner_id,
-                    entity_id: travelling_entity_id
-             });
             
             InternalTravelSystemsImpl::travel(world,
                 travelling_entity_id, travelling_entity_movable, 
                 travelling_entity_coord, destination_coord
             );
-        }        
+        }
+
+
+        fn travel_instant(
+            self: @ContractState, world: IWorldDispatcher, 
+            travelling_entity_id: ID, directions: Span<Direction>
+        ) {
+
+            let travelling_entity_owner = get!(world, travelling_entity_id, Owner);
+            assert(
+                travelling_entity_owner.address == starknet::get_caller_address(), 
+                    'not owner of entity'
+            );
+
+            let travelling_entity_movable = get!(world, travelling_entity_id, Movable);      
+            assert(travelling_entity_movable.sec_per_km != 0, 'entity has no speed');  
+            assert(travelling_entity_movable.blocked == false, 'entity is blocked');  
+            
+            let travelling_entity_arrival_time = get!(world, travelling_entity_id, ArrivalTime);
+            let ts = starknet::get_block_timestamp();
+            assert(travelling_entity_arrival_time.arrives_at <= ts.into(), 'entity is in transit');
+
+
+            let travelling_entity_position = get!(world, travelling_entity_id, Position);
+            let travelling_entity_coord: Coord = travelling_entity_position.into();
+
+            
+            InternalTravelSystemsImpl::travel_instant(world,
+                travelling_entity_id, travelling_entity_coord, directions
+            );
+        }
     }
 
     #[generate_trait]
     impl InternalTravelSystemsImpl of InternalTravelSystemsTrait {
+
+        fn assert_tile_explored(world: IWorldDispatcher, coord: Coord) {
+            let mut tile: Tile
+                 = get!(world, (coord.x, coord.y), Tile);
+            assert(tile.explored_at != 0, 'tile not explored');
+        }
 
 
         fn use_travel_bonus(world: IWorldDispatcher, realm: @Realm, entity_owner: @EntityOwner, travel_time: u64) -> u64 {
@@ -121,11 +151,73 @@ mod travel_systems {
 
         }
 
+        fn travel_instant(
+            world: IWorldDispatcher, transport_id: ID,
+            from_coord: Coord, mut directions: Span<Direction>
+        ){
+
+
+          
+            // check if entity owner is a realm and apply bonuses if it is
+            let entity_owner = get!(world, (transport_id), EntityOwner);
+            let realm = get!(world, entity_owner.entity_owner_id, Realm);
+
+            // check and update tick move steps
+            let mut tick_move = get!(world, transport_id, TickMove);
+            tick_move.add(world, directions.len().try_into().unwrap());
+
+
+            // get destination coordinate
+            let mut to_coord = from_coord;
+            loop {
+                match directions.pop_front() {
+                    Option::Some(direction) => {
+                        // update destination to  next tile
+                        to_coord = to_coord.neighbor(*direction);
+
+                        // ensure tile is explored
+                        InternalTravelSystemsImpl::assert_tile_explored(world, to_coord);
+                    },
+                    Option::None => {break;}
+                }
+            };
+
+            let mut transport_movable : Movable = get!(world, transport_id, Movable);
+            transport_movable.blocked = false;
+            transport_movable.round_trip = false;
+            transport_movable.intermediate_coord_x = 0;
+            transport_movable.intermediate_coord_y = 0;
+
+            set!(world,(transport_movable));
+            set!(world,(
+                ArrivalTime {
+                    entity_id: transport_id,
+                    arrives_at: starknet::get_block_timestamp().into() 
+                },
+                Position {
+                    entity_id: transport_id,
+                    x: to_coord.x,
+                    y: to_coord.y
+                }
+            ));
+
+            // emit travel event 
+            let entity_owner = get!(world, transport_id, EntityOwner);
+            emit!(world, Travel { 
+                    destination_coord_x: to_coord.x,
+                    destination_coord_y: to_coord.y,
+                    realm_entity_id: entity_owner.entity_owner_id,
+                    entity_id: transport_id
+             });
+        }
+
 
         fn travel(
             world: IWorldDispatcher, transport_id: ID, transport_movable: Movable, 
             from_coord: Coord, to_coord: Coord
         ){
+            // ensure destination tile is explored
+            InternalTravelSystemsImpl::assert_tile_explored(world, to_coord);
 
             let mut travel_time = from_coord.calculate_travel_time(
                 to_coord, transport_movable.sec_per_km
@@ -166,6 +258,15 @@ mod travel_systems {
                     intermediate_coord_y: 0,
                 }
             ));
+
+            // emit travel event 
+            let entity_owner = get!(world, transport_id, EntityOwner);
+            emit!(world, Travel { 
+                    destination_coord_x: to_coord.x,
+                    destination_coord_y: to_coord.y,
+                    realm_entity_id: entity_owner.entity_owner_id,
+                    entity_id: transport_id
+             });
         }
 
     }

--- a/contracts/src/systems/transport/contracts/travel_systems.cairo
+++ b/contracts/src/systems/transport/contracts/travel_systems.cairo
@@ -90,7 +90,7 @@ mod travel_systems {
         }
 
 
-        fn travel_instant(
+        fn travel_hex(
             self: @ContractState, world: IWorldDispatcher, 
             travelling_entity_id: ID, directions: Span<Direction>
         ) {
@@ -114,7 +114,7 @@ mod travel_systems {
             let travelling_entity_coord: Coord = travelling_entity_position.into();
 
             
-            InternalTravelSystemsImpl::travel_instant(world,
+            InternalTravelSystemsImpl::travel_hex(world,
                 travelling_entity_id, travelling_entity_coord, directions
             );
         }
@@ -153,7 +153,7 @@ mod travel_systems {
 
         }
 
-        fn travel_instant(
+        fn travel_hex(
             world: IWorldDispatcher, transport_id: ID,
             from_coord: Coord, mut directions: Span<Direction>
         ){

--- a/contracts/src/systems/transport/interface/travel_systems_interface.cairo
+++ b/contracts/src/systems/transport/interface/travel_systems_interface.cairo
@@ -1,5 +1,6 @@
 use eternum::alias::ID;
 use eternum::models::position::Coord;
+use eternum::models::position::Direction;
 
 use dojo::world::IWorldDispatcher;
 
@@ -8,5 +9,10 @@ trait ITravelSystems<TContractState> {
     fn travel(
         self: @TContractState, world: IWorldDispatcher, 
         travelling_entity_id: ID, destination_coord: Coord
+    );
+
+    fn travel_instant(
+        self: @TContractState, world: IWorldDispatcher, 
+        travelling_entity_id: ID, directions: Span<Direction>
     );
 }

--- a/contracts/src/systems/transport/interface/travel_systems_interface.cairo
+++ b/contracts/src/systems/transport/interface/travel_systems_interface.cairo
@@ -11,7 +11,7 @@ trait ITravelSystems<TContractState> {
         travelling_entity_id: ID, destination_coord: Coord
     );
 
-    fn travel_instant(
+    fn travel_hex(
         self: @TContractState, world: IWorldDispatcher, 
         travelling_entity_id: ID, directions: Span<Direction>
     );

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -5001,7 +5001,7 @@
     {
       "name": "eternum::systems::transport::contracts::travel_systems::travel_systems",
       "address": "0x740ea95e67b0b7533ee4891524c5c7edfd7fefc09297c0304b21515cc1223ec",
-      "class_hash": "0x314b1faf5f03eb651c7ea10c153fbc732347f72968ca65196a78f533b8e084a",
+      "class_hash": "0x3a48d0189820e4fdec91806de4bb4b723a8a7792271da176136db7715b615aa",
       "abi": [
         {
           "type": "impl",
@@ -5142,7 +5142,7 @@
             },
             {
               "type": "function",
-              "name": "travel_instant",
+              "name": "travel_hex",
               "inputs": [
                 {
                   "name": "world",

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -1285,7 +1285,7 @@
     {
       "name": "eternum::systems::combat::contracts::combat_systems",
       "address": "0x1b0a83a27a357e0574393ab06c0c774db7312a0993538cc0186d054f75ee84e",
-      "class_hash": "0x36e489c60dfc5b8f037da7747ecb7b0c7ec8bc8e211066dfb4c42026f8635a4",
+      "class_hash": "0x703ce86d1aab6f96ffee61e98134201792282cb095ea171fde3a2f310828cb7",
       "abi": [
         {
           "type": "impl",
@@ -3081,7 +3081,7 @@
     {
       "name": "eternum::systems::map::contracts::map_systems",
       "address": "0x3fda5d1f7500f799eb30aa1293b2b6c354d350ed359593eb75390893cc7ec3d",
-      "class_hash": "0x62945c372c7fe9248da6a758cf3b0ef34dc6c1fcb91f07ff55ea0eb4ccfb2cc",
+      "class_hash": "0x25ff4d44f11ccb3c92ed67a512e8d6093a63b2f24c4aabbfe94f77bbdd35a1b",
       "abi": [
         {
           "type": "impl",
@@ -5001,7 +5001,7 @@
     {
       "name": "eternum::systems::transport::contracts::travel_systems::travel_systems",
       "address": "0x740ea95e67b0b7533ee4891524c5c7edfd7fefc09297c0304b21515cc1223ec",
-      "class_hash": "0x48738c98e940cb716ffd21db54222f7fdec351133eef6f6e81b795eef79c590",
+      "class_hash": "0x314b1faf5f03eb651c7ea10c153fbc732347f72968ca65196a78f533b8e084a",
       "abi": [
         {
           "type": "impl",
@@ -5210,6 +5210,16 @@
           ]
         },
         {
+          "type": "struct",
+          "name": "core::array::Span::<eternum::models::position::Coord>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<eternum::models::position::Coord>"
+            }
+          ]
+        },
+        {
           "type": "event",
           "name": "eternum::systems::transport::contracts::travel_systems::travel_systems::Travel",
           "kind": "struct",
@@ -5232,6 +5242,16 @@
             {
               "name": "entity_id",
               "type": "core::integer::u128",
+              "kind": "data"
+            },
+            {
+              "name": "travel_time",
+              "type": "core::integer::u64",
+              "kind": "data"
+            },
+            {
+              "name": "travel_path",
+              "type": "core::array::Span::<eternum::models::position::Coord>",
               "kind": "data"
             }
           ]

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -949,7 +949,7 @@
     {
       "name": "eternum::systems::bank::contracts::bank_systems",
       "address": "0x193936374e972c355f2246c66c62860c986dea275ce8fbd03d7d7a1d853a572",
-      "class_hash": "0x7222e8a23319bc0e233f0b075663f521a213ce22cf68aeff72421c0757d3808",
+      "class_hash": "0x61d2c4df0d1cef8b4c44638590841ad1c8f608e7d1740ebec5a52fd14cd85dc",
       "abi": [
         {
           "type": "impl",
@@ -1285,7 +1285,7 @@
     {
       "name": "eternum::systems::combat::contracts::combat_systems",
       "address": "0x1b0a83a27a357e0574393ab06c0c774db7312a0993538cc0186d054f75ee84e",
-      "class_hash": "0x2edadb5248ce87b8d18c499ddfaac19cb7875f0dc2928cfba2f7675e5fa643a",
+      "class_hash": "0x36e489c60dfc5b8f037da7747ecb7b0c7ec8bc8e211066dfb4c42026f8635a4",
       "abi": [
         {
           "type": "impl",
@@ -1649,7 +1649,7 @@
     {
       "name": "eternum::systems::config::contracts::config_systems",
       "address": "0x7fff06bbcbe4f42f22c86b14e7a80604495c8b2034d14cbb10d32402c933ca8",
-      "class_hash": "0x1683df19ef6f3c93e221b7194773328ee7bfa14397487a347079fa2bc799a0e",
+      "class_hash": "0x61196b011c25f71150df09eee22c1479442a4f6d95e4bca8b37bd9300cfad3c",
       "abi": [
         {
           "type": "impl",
@@ -1799,7 +1799,7 @@
                   "type": "core::integer::u128"
                 },
                 {
-                  "name": "random_mint_amount",
+                  "name": "reward_resource_amount",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1863,6 +1863,37 @@
                 {
                   "name": "weight_gram",
                   "type": "core::integer::u128"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "TickConfigImpl",
+          "interface_name": "eternum::systems::config::interface::ITickConfig"
+        },
+        {
+          "type": "interface",
+          "name": "eternum::systems::config::interface::ITickConfig",
+          "items": [
+            {
+              "type": "function",
+              "name": "set_tick_config",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "max_moves_per_tick",
+                  "type": "core::integer::u8"
+                },
+                {
+                  "name": "tick_interval_in_seconds",
+                  "type": "core::integer::u64"
                 }
               ],
               "outputs": [],
@@ -3050,7 +3081,7 @@
     {
       "name": "eternum::systems::map::contracts::map_systems",
       "address": "0x3fda5d1f7500f799eb30aa1293b2b6c354d350ed359593eb75390893cc7ec3d",
-      "class_hash": "0x7f62cf3ed595714625b5ef9e6c8bd025aa2f0f51228279e380ec3cb39b56c14",
+      "class_hash": "0x62945c372c7fe9248da6a758cf3b0ef34dc6c1fcb91f07ff55ea0eb4ccfb2cc",
       "abi": [
         {
           "type": "impl",
@@ -3112,20 +3143,6 @@
           "interface_name": "eternum::systems::map::interface::IMapSystems"
         },
         {
-          "type": "struct",
-          "name": "eternum::models::position::Coord",
-          "members": [
-            {
-              "name": "x",
-              "type": "core::integer::u128"
-            },
-            {
-              "name": "y",
-              "type": "core::integer::u128"
-            }
-          ]
-        },
-        {
           "type": "enum",
           "name": "eternum::models::position::Direction",
           "variants": [
@@ -3168,12 +3185,8 @@
                   "type": "dojo::world::IWorldDispatcher"
                 },
                 {
-                  "name": "realm_entity_id",
+                  "name": "unit_id",
                   "type": "core::integer::u128"
-                },
-                {
-                  "name": "from_coord",
-                  "type": "eternum::models::position::Coord"
                 },
                 {
                   "name": "direction",
@@ -3303,6 +3316,16 @@
           ]
         },
         {
+          "type": "struct",
+          "name": "core::array::Span::<(core::integer::u8, core::integer::u128)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::integer::u8, core::integer::u128)>"
+            }
+          ]
+        },
+        {
           "type": "event",
           "name": "eternum::systems::map::contracts::map_systems::MapExplored",
           "kind": "struct",
@@ -3311,6 +3334,11 @@
               "name": "entity_id",
               "type": "core::integer::u128",
               "kind": "key"
+            },
+            {
+              "name": "entity_owner_id",
+              "type": "core::integer::u128",
+              "kind": "data"
             },
             {
               "name": "col",
@@ -3328,13 +3356,8 @@
               "kind": "data"
             },
             {
-              "name": "minted_resource_id",
-              "type": "core::integer::u8",
-              "kind": "data"
-            },
-            {
-              "name": "minted_resource_amount",
-              "type": "core::integer::u128",
+              "name": "reward",
+              "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>",
               "kind": "data"
             }
           ]
@@ -3514,7 +3537,7 @@
     {
       "name": "eternum::systems::realm::contracts::realm_systems",
       "address": "0x25df90992b8eebca69f08035ceda822dee73028e828ceb8421895814eacd3d",
-      "class_hash": "0x7b9990b9c820c9292c6393cc9d758654eb4dcfe19a26b94d7e456a23ace3fb1",
+      "class_hash": "0x401fcd33234c05249d84cc5182b71ddc9d21bd22e14072fccb65df550a3ab3c",
       "abi": [
         {
           "type": "impl",
@@ -3722,7 +3745,7 @@
     {
       "name": "eternum::systems::resources::contracts::resource_systems",
       "address": "0x406b259886beb36b2474c7a85ad8298b948eeca68b3a185ee7ba870dbc025c8",
-      "class_hash": "0x5fc8be6ae8da77e7964ebb5256961989debfa0f5dbff754045b2bb7e6d3e038",
+      "class_hash": "0x6b5b1c987c0bd34728a998e250621852e3c67b95a2ab2589581d51ea60f8bb1",
       "abi": [
         {
           "type": "impl",
@@ -4978,7 +5001,7 @@
     {
       "name": "eternum::systems::transport::contracts::travel_systems::travel_systems",
       "address": "0x740ea95e67b0b7533ee4891524c5c7edfd7fefc09297c0304b21515cc1223ec",
-      "class_hash": "0xf4f908ed6af7695709d3c2ddb6d8b0f2aec46e0e394c7c002c34416ca1723",
+      "class_hash": "0x48738c98e940cb716ffd21db54222f7fdec351133eef6f6e81b795eef79c590",
       "abi": [
         {
           "type": "impl",
@@ -5054,6 +5077,46 @@
           ]
         },
         {
+          "type": "enum",
+          "name": "eternum::models::position::Direction",
+          "variants": [
+            {
+              "name": "East",
+              "type": "()"
+            },
+            {
+              "name": "NorthEast",
+              "type": "()"
+            },
+            {
+              "name": "NorthWest",
+              "type": "()"
+            },
+            {
+              "name": "West",
+              "type": "()"
+            },
+            {
+              "name": "SouthWest",
+              "type": "()"
+            },
+            {
+              "name": "SouthEast",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<eternum::models::position::Direction>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<eternum::models::position::Direction>"
+            }
+          ]
+        },
+        {
           "type": "interface",
           "name": "eternum::systems::transport::interface::travel_systems_interface::ITravelSystems",
           "items": [
@@ -5072,6 +5135,26 @@
                 {
                   "name": "destination_coord",
                   "type": "eternum::models::position::Coord"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "travel_instant",
+              "inputs": [
+                {
+                  "name": "world",
+                  "type": "dojo::world::IWorldDispatcher"
+                },
+                {
+                  "name": "travelling_entity_id",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "directions",
+                  "type": "core::array::Span::<eternum::models::position::Direction>"
                 }
               ],
               "outputs": [],
@@ -10579,12 +10662,12 @@
           "key": false
         },
         {
-          "name": "random_mint_amount",
+          "name": "reward_resource_amount",
           "type": "u128",
           "key": false
         }
       ],
-      "class_hash": "0x3774324bf826a5240e094e61d2fe8c5b2bea39541cb664a7f87086b2acceb82",
+      "class_hash": "0x469a5d35ed69798e93a0cca2a2ad833f8770de7b4d843f597d0bf255a563ca4",
       "abi": [
         {
           "type": "impl",
@@ -10772,7 +10855,7 @@
               "type": "core::integer::u128"
             },
             {
-              "name": "random_mint_amount",
+              "name": "reward_resource_amount",
               "type": "core::integer::u128"
             }
           ]
@@ -11770,6 +11853,240 @@
         {
           "type": "event",
           "name": "eternum::models::config::speed_config::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ]
+    },
+    {
+      "name": "eternum::models::config::tick_config",
+      "members": [
+        {
+          "name": "config_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "max_moves_per_tick",
+          "type": "u8",
+          "key": false
+        },
+        {
+          "name": "tick_interval_in_seconds",
+          "type": "u64",
+          "key": false
+        }
+      ],
+      "class_hash": "0x58a0049bfded77d8f63339cc57b891d248f3d4372c800fdde58579f1bfcc871",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "DojoModelImpl",
+          "interface_name": "dojo::model::IDojoModel"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::model::IDojoModel",
+          "items": [
+            {
+              "type": "function",
+              "name": "name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "unpacked_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "packed_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "layout",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u8>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "schema",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Ty"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "tick_configImpl",
+          "interface_name": "eternum::models::config::Itick_config"
+        },
+        {
+          "type": "struct",
+          "name": "eternum::models::config::TickConfig",
+          "members": [
+            {
+              "name": "config_id",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "max_moves_per_tick",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "tick_interval_in_seconds",
+              "type": "core::integer::u64"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "eternum::models::config::Itick_config",
+          "items": [
+            {
+              "type": "function",
+              "name": "ensure_abi",
+              "inputs": [
+                {
+                  "name": "model",
+                  "type": "eternum::models::config::TickConfig"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::config::tick_config::Event",
           "kind": "enum",
           "variants": []
         }
@@ -18596,6 +18913,240 @@
         {
           "type": "event",
           "name": "eternum::models::road::road::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ]
+    },
+    {
+      "name": "eternum::models::tick::tick_move",
+      "members": [
+        {
+          "name": "entity_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "tick",
+          "type": "u64",
+          "key": false
+        },
+        {
+          "name": "count",
+          "type": "u8",
+          "key": false
+        }
+      ],
+      "class_hash": "0x6d70cf4b0efe9a00f1d4f2dcc034a12ac78586a89151360acef6bb62ddf7046",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "DojoModelImpl",
+          "interface_name": "dojo::model::IDojoModel"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::model::IDojoModel",
+          "items": [
+            {
+              "type": "function",
+              "name": "name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "unpacked_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "packed_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "layout",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u8>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "schema",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Ty"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "tick_moveImpl",
+          "interface_name": "eternum::models::tick::Itick_move"
+        },
+        {
+          "type": "struct",
+          "name": "eternum::models::tick::TickMove",
+          "members": [
+            {
+              "name": "entity_id",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "tick",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "count",
+              "type": "core::integer::u8"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "eternum::models::tick::Itick_move",
+          "items": [
+            {
+              "type": "function",
+              "name": "ensure_abi",
+              "inputs": [
+                {
+                  "name": "model",
+                  "type": "eternum::models::tick::TickMove"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::tick::tick_move::Event",
           "kind": "enum",
           "variants": []
         }

--- a/contracts/target/dev/manifest.json
+++ b/contracts/target/dev/manifest.json
@@ -949,7 +949,7 @@
     {
       "name": "eternum::systems::bank::contracts::bank_systems",
       "address": "0x193936374e972c355f2246c66c62860c986dea275ce8fbd03d7d7a1d853a572",
-      "class_hash": "0x61d2c4df0d1cef8b4c44638590841ad1c8f608e7d1740ebec5a52fd14cd85dc",
+      "class_hash": "0x59830dc8272c77116f255dbf5aef76243fc5201df8ddcf230ad2e95cac63817",
       "abi": [
         {
           "type": "impl",
@@ -1285,7 +1285,7 @@
     {
       "name": "eternum::systems::combat::contracts::combat_systems",
       "address": "0x1b0a83a27a357e0574393ab06c0c774db7312a0993538cc0186d054f75ee84e",
-      "class_hash": "0x703ce86d1aab6f96ffee61e98134201792282cb095ea171fde3a2f310828cb7",
+      "class_hash": "0x232597c9c9280e73a4544245fe658953c14939a26dd56396cc4a94a7820ca2",
       "abi": [
         {
           "type": "impl",
@@ -1605,6 +1605,11 @@
             {
               "name": "stolen_resources",
               "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>",
+              "kind": "data"
+            },
+            {
+              "name": "stolen_chests",
+              "type": "core::array::Span::<core::integer::u128>",
               "kind": "data"
             },
             {
@@ -3081,7 +3086,7 @@
     {
       "name": "eternum::systems::map::contracts::map_systems",
       "address": "0x3fda5d1f7500f799eb30aa1293b2b6c354d350ed359593eb75390893cc7ec3d",
-      "class_hash": "0x25ff4d44f11ccb3c92ed67a512e8d6093a63b2f24c4aabbfe94f77bbdd35a1b",
+      "class_hash": "0x31698d54138398ee153f95a8df762ff5932c7a13c67dec14b8644de48a95cec",
       "abi": [
         {
           "type": "impl",
@@ -3745,7 +3750,7 @@
     {
       "name": "eternum::systems::resources::contracts::resource_systems",
       "address": "0x406b259886beb36b2474c7a85ad8298b948eeca68b3a185ee7ba870dbc025c8",
-      "class_hash": "0x6b5b1c987c0bd34728a998e250621852e3c67b95a2ab2589581d51ea60f8bb1",
+      "class_hash": "0x1b3d6c112240eaeb749320df26452c96d56c468786874108c9b5e60c51b0704",
       "abi": [
         {
           "type": "impl",
@@ -4196,7 +4201,7 @@
     {
       "name": "eternum::systems::trade::contracts::trade_systems::trade_systems",
       "address": "0x63cbe849cf6325e727a8d6f82f25fad7dc7eb9433767f5c1b8c59189e36c9b6",
-      "class_hash": "0x2dbd00712a4782077f7a25d4119109f83ac069bd885d2b0510bc0434ec98911",
+      "class_hash": "0x27ae1e424104954e898f7a80a43c96cfa701fcb60f6b65c01f235bdbf906718",
       "abi": [
         {
           "type": "impl",


### PR DESCRIPTION
- created tick so that actions such as travel may be limited by tick
- created a travel_hex function for hex travel. Travel is instantanious but is limited by amount of hex moves per tick
- allow exploration to be done by armies and use up all tick moves during exploration
- updated MapExplored Event
- Add travel time and travel path to `Travel` event