### PR TITLE
CI: update dojo version in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Download Dojo release artifact
         run: |
-          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v0.4.0/dojo_v0.4.0_linux_amd64.tar.gz
+          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v0.6.0-alpha.4/dojo_v0.6.0-alpha.4_linux_amd64.tar.gz
           tar -xzf dojo-linux-x86_64.tar.gz
           sudo mv sozo /usr/local/bin/
 


### PR DESCRIPTION
- update CI dojo version
- test won't run in CI though because of this issue https://github.com/dojoengine/dojo/issues/1646 but to confirm that it works, `sozo build` should work in CI and `sozo test` should be attempted in CI