### PR TITLE
client: allow for multiple hex exploration before return to realm

### DIFF
--- a/client/src/components/worldmap/ChooseActionPopup.tsx
+++ b/client/src/components/worldmap/ChooseActionPopup.tsx
@@ -93,7 +93,7 @@ export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
               <Button
                 variant="primary"
                 size="md"
-                disabled={hasResources || isTraveling}
+                disabled={isTraveling}
                 onClick={onExplore}
                 className=""
               >

--- a/client/src/components/worldmap/ChooseActionPopup.tsx
+++ b/client/src/components/worldmap/ChooseActionPopup.tsx
@@ -12,6 +12,8 @@ import { TIME_PER_TICK } from "../network/EpochCountdown";
 import { getTotalResourceWeight } from "../cityview/realm/trade/utils";
 import { Resource, ResourcesIds, WEIGHTS } from "@bibliothecadao/eternum";
 
+const EXPLORATION_REWARD_RESOURCE_AMOUNT: number = 20;
+
 type ChooseActionPopupProps = {};
 
 export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
@@ -70,7 +72,7 @@ export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
 
   const isTraveling = isPassiveTravel || isActiveTravel;
 
-  const sampleRewardResource: Resource = {resourceId: ResourcesIds.Ignium, amount: multiplyByPrecision(20)};
+  const sampleRewardResource: Resource = {resourceId: ResourcesIds.Ignium, amount: multiplyByPrecision(EXPLORATION_REWARD_RESOURCE_AMOUNT)};
   const sampleRewardResourceWeightKg = getTotalResourceWeight([sampleRewardResource]);
   const entityWeightInKg = divideByPrecision(Number(weight?.value || 0));
   const canCarryNewReward 

--- a/client/src/components/worldmap/ChooseActionPopup.tsx
+++ b/client/src/components/worldmap/ChooseActionPopup.tsx
@@ -1,23 +1,23 @@
-import { useMemo, useState } from "react";
 import { getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import useUIStore from "../../hooks/store/useUIStore";
 import { useDojo } from "../../DojoContext";
-import { formatTimeLeftDaysHoursMinutes, getUIPositionFromColRow } from "../../utils/utils";
+import { divideByPrecision, formatTimeLeftDaysHoursMinutes, getUIPositionFromColRow, multiplyByPrecision } from "../../utils/utils";
 import { SecondaryPopup } from "../../elements/SecondaryPopup";
 import Button from "../../elements/Button";
 import { TravelPopup } from "./traveling/TravelPopup";
 import { ExploreMapPopup } from "./explore/ExploreHexPopup";
-import { useResources } from "../../hooks/helpers/useResources";
 import useBlockchainStore from "../../hooks/store/useBlockchainStore";
 import { TIME_PER_TICK } from "../network/EpochCountdown";
+import { getTotalResourceWeight } from "../cityview/realm/trade/utils";
+import { Resource, ResourcesIds, WEIGHTS } from "@bibliothecadao/eternum";
 
 type ChooseActionPopupProps = {};
 
 export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
   const {
     setup: {
-      components: { TickMove, ArrivalTime },
+      components: { TickMove, ArrivalTime, Weight, Quantity, Capacity },
     },
   } = useDojo();
 
@@ -48,6 +48,20 @@ export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
   const arrivalTime = selectedEntity
     ? getComponentValue(ArrivalTime, getEntityIdFromKeys([selectedEntity.id]))
     : undefined;
+
+  const weight = selectedEntity
+    ? getComponentValue(Weight, getEntityIdFromKeys([selectedEntity.id]))
+    : undefined;
+
+  const quantity = selectedEntity
+    ? getComponentValue(Quantity, getEntityIdFromKeys([selectedEntity.id]))
+    : undefined;
+
+  const capacity = selectedEntity
+    ? getComponentValue(Capacity, getEntityIdFromKeys([selectedEntity.id]))
+    : undefined;
+  
+  const totalCapacityInKg = divideByPrecision(Number(capacity?.weight_gram)) * Number(quantity?.value);
   const tickMove = selectedEntity ? getComponentValue(TickMove, getEntityIdFromKeys([selectedEntity.id])) : undefined;
   const isPassiveTravel = arrivalTime && nextBlockTimestamp ? arrivalTime.arrives_at > nextBlockTimestamp : false;
 
@@ -56,9 +70,12 @@ export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
 
   const isTraveling = isPassiveTravel || isActiveTravel;
 
-  const { getResourcesFromInventory } = useResources();
-  const inventoryResources = selectedEntity ? getResourcesFromInventory(selectedEntity.id) : undefined;
-  const hasResources = inventoryResources && inventoryResources.resources.length > 0;
+  const sampleRewardResource: Resource = {resourceId: ResourcesIds.Ignium, amount: multiplyByPrecision(20)};
+  const sampleRewardResourceWeightKg = getTotalResourceWeight([sampleRewardResource]);
+  const entityWeightInKg = divideByPrecision(Number(weight?.value || 0));
+  const canCarryNewReward 
+      =  totalCapacityInKg 
+          >= entityWeightInKg + sampleRewardResourceWeightKg;
 
   const onTravel = () => setIsTravelMode(true);
   const onExplore = () => setIsExploreMode(true);
@@ -93,7 +110,7 @@ export const ChooseActionPopup = ({}: ChooseActionPopupProps) => {
               <Button
                 variant="primary"
                 size="md"
-                disabled={isTraveling}
+                disabled={isTraveling || !canCarryNewReward}
                 onClick={onExplore}
                 className=""
               >

--- a/client/src/hooks/helpers/useCombat.tsx
+++ b/client/src/hooks/helpers/useCombat.tsx
@@ -268,7 +268,7 @@ export function useCombat() {
         defence: Number(defence?.value) || 0,
         sec_per_km: movable?.sec_per_km || 0,
         blocked: movable?.blocked,
-        capacity: divideByPrecision(Number(capacity?.weight_gram) || 0),
+        capacity: divideByPrecision(Number(capacity?.weight_gram) * Number(quantity?.value)  || 0),
         arrivalTime: arrivalTime?.arrives_at,
         position: position ? { x: position.x, y: position.y } : undefined,
         entityOwnerId: entityOwner?.entity_owner_id,

--- a/contracts/manifests/deployments/KATANA.toml
+++ b/contracts/manifests/deployments/KATANA.toml
@@ -32,7 +32,7 @@ name = "eternum::systems::test::contracts::resource::test_resource_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x62ebd901967e87dde96da3e297e0c65623f5cb7c4b6cfc1b1766d660ee3cca1"
-class_hash = "0x1d33a01a175ea9d046f6e254999a81313fdbeb6885e4b7a1fbcc3eb5fcdc212"
+class_hash = "0x73cc9238488d651eb395329ef31247188c8c63ec2430d9563d83e728b94beb2"
 abi = "abis/deployments/KATANA/contracts/trade_systems.json"
 reads = []
 writes = []
@@ -52,7 +52,7 @@ name = "eternum::systems::transport::contracts::road_systems::road_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x1054af867855ba7dd1c2351c59cf0543e02faceeb554fc7b95160eeea7a355b"
-class_hash = "0x3478a2a4e81174672cda3f13730ae39b0f7154d19fe746831518e66c149eb80"
+class_hash = "0xa0fdeb0a797a85de9b72007552a89c6c2c01712959c3061b6208f94708382"
 abi = "abis/deployments/KATANA/contracts/map_systems.json"
 reads = []
 writes = []
@@ -62,7 +62,7 @@ name = "eternum::systems::map::contracts::map_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x3d166d0646d4dac27c1cdbed6289c386ba3ca616925438fc1334ba98241eb42"
-class_hash = "0x596077fc9115693131311f7fce61008907e5282ccee45f0593772c31decf49a"
+class_hash = "0x458b477b3b29e46652c9fed7d2c6d36eac2cadf155b051ba374d13e9cf92a01"
 abi = "abis/deployments/KATANA/contracts/combat_systems.json"
 reads = []
 writes = []
@@ -92,7 +92,7 @@ name = "eternum::systems::transport::contracts::transport_unit_systems::transpor
 [[contracts]]
 kind = "DojoContract"
 address = "0xbe771ffeadeaa291cc4b09a592f3d77ae837e64c1b7d71559084a8734277b5"
-class_hash = "0x19a05b262d22a4d2dda54aa78385131f4366387f6bf61d962ba87567b586909"
+class_hash = "0x5e96d58056c87d0d20abc610dfb5c2278f656516cb149e48e59b62c5bdeeeb3"
 abi = "abis/deployments/KATANA/contracts/travel_systems.json"
 reads = []
 writes = []
@@ -142,7 +142,7 @@ name = "eternum::systems::name::contracts::name_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x28af36343da64931975f7100dbd18c7632d571f207d8418c3df07d1b4c3ca18"
-class_hash = "0x5694a0d4df4c9728fdaeb79e2da34b81b8be2ebdcb8bb48f682d966f1231ad6"
+class_hash = "0x1da1d4f89a9b862a01a9ef5c15bb7eed2d2467b6cf9e82054f7b2b08810f0b7"
 abi = "abis/deployments/KATANA/contracts/resource_systems.json"
 reads = []
 writes = []
@@ -152,7 +152,7 @@ name = "eternum::systems::resources::contracts::resource_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0xbec90d167e0831347b7cdd21817342dbbb66b0f8e08676e1b02e8d29c21ee3"
-class_hash = "0x47f6df3f110faa3db948702713ce075d69328fd976a0b6c053d02bbda054406"
+class_hash = "0x75d008d8780b27a9c93ccebb4d76ccb8f99cb4dc74aaa542c8c399dd0ac93c6"
 abi = "abis/deployments/KATANA/contracts/labor_systems.json"
 reads = []
 writes = []
@@ -162,7 +162,7 @@ name = "eternum::systems::labor::contracts::labor_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x4a3e0da2cc518cc75d8a5c7fbb5e18a7e3d188401463e517c194c256ec3d593"
-class_hash = "0x389abe222e817088adf097fb6b6bae924eee2b3a9dae88b0a0f2627512a14d3"
+class_hash = "0x1ea75213d31c666460b6b84bc87135239df5da93f674bc9675cb68d409b430c"
 abi = "abis/deployments/KATANA/contracts/buildings_systems.json"
 reads = []
 writes = []
@@ -172,7 +172,7 @@ name = "eternum::systems::buildings::contracts::buildings_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x14569fcc0420bf7e7843261d4defe508a19dd4e7db5bc2aadc1487f0fe148c9"
-class_hash = "0x2924bb3ca1cf1e73103b38bca6017e00e6ef54c4a9691b4d59ab740f0056f30"
+class_hash = "0x2b00ccd8064896a8cfa6c5c9caed3ed6ed29b64e862282bf62971a674991323"
 abi = "abis/deployments/KATANA/contracts/bank_systems.json"
 reads = []
 writes = []

--- a/sdk/packages/eternum/src/provider/index.ts
+++ b/sdk/packages/eternum/src/provider/index.ts
@@ -286,11 +286,26 @@ export class EternumProvider extends DojoProvider {
         calldata: [this.getWorldAddress(), sender_id, index, receiver_id],
       };
     });
-    const tx = await this.executeMulti(signer, calldata);
 
-    return await this.provider.waitForTransaction(tx.transaction_hash, {
-      retryInterval: 500,
-    });
+    // send request to transfer items in batches of `BATCH_SIZE`
+
+    const BATCH_SIZE = 3;
+    let batchCalldata = [];
+
+    for(let i = 1; i <= calldata.length; i++) {
+      
+      batchCalldata.push(calldata[i - 1]);
+      if (i % BATCH_SIZE == 0 || i == calldata.length ) {
+
+          const tx = await this.executeMulti(signer, batchCalldata);
+          await this.provider.waitForTransaction(tx.transaction_hash, {
+            retryInterval: 500,
+          });
+          
+          // reset batchCalldata
+          batchCalldata = [];
+      }
+    }
   }
 
   public async create_free_transport_unit(props: CreateFreeTransportUnitProps) {


### PR DESCRIPTION
- Allow for multiple hex exploration before return to realm
- batch calls to transfer inventory items to realm to avoid hitting cairo step limit
- only enable explore button when army has enough capacity to carry reward