### PR TITLE
fix: not show attack if not on realm

### DIFF
--- a/client/src/components/cityview/realm/combat/raids/AttackRaidsPopup.tsx
+++ b/client/src/components/cityview/realm/combat/raids/AttackRaidsPopup.tsx
@@ -82,7 +82,7 @@ export const AttackRaidsPopup = ({ selectedRaider, enemyRaider, onClose }: Attac
     } else if (defendingRealmId) {
       return `Attacking ${defendingRealmName}`;
     } else {
-      return "Attacking Hyperstructure";
+      return "Attacking";
     }
   }, [defendingRealmId, enemyRaider]);
 

--- a/client/src/components/cityview/realm/combat/raids/Raid.tsx
+++ b/client/src/components/cityview/realm/combat/raids/Raid.tsx
@@ -103,6 +103,7 @@ export const Raid = ({ raider, isSelected, ...props }: RaidProps) => {
   const isYours = raider.owner === BigInt(account.address);
   const hasResources = inventoryResources && inventoryResources.resources.length > 0;
   const isTraveling = raider.arrivalTime && nextBlockTimestamp ? raider.arrivalTime > nextBlockTimestamp : false;
+  const isOnWatchTower = watchTowerId !== undefined;
   const hasMaxHealth = health === 10 * quantity;
   const destinationRealmId = raider.position ? getRealmIdByPosition(raider.position) : undefined;
   const destinationName = destinationRealmId ? getRealmNameById(destinationRealmId) : "Map";
@@ -304,7 +305,7 @@ export const Raid = ({ raider, isSelected, ...props }: RaidProps) => {
                   {`Return`}
                 </Button>
               )}
-              {!isTraveling && !isHome && !isLoading && (
+              {!isTraveling && !isHome && !isLoading && isOnWatchTower && (
                 <Button
                   size="xs"
                   className="ml-auto"
@@ -315,7 +316,7 @@ export const Raid = ({ raider, isSelected, ...props }: RaidProps) => {
                   variant="outline"
                   withoutSound
                 >
-                  {`Attack`}
+                  {`Attack Realm`}
                 </Button>
               )}
               {!isTraveling && !hasResources && (

--- a/client/src/hooks/helpers/useCombat.tsx
+++ b/client/src/hooks/helpers/useCombat.tsx
@@ -98,7 +98,7 @@ export function useCombat() {
     }
   };
 
-  const getDefenceOnPosition = (position: Position): CombatInfo | undefined => {
+  const getWatchTowerOnPosition = (position: Position): CombatInfo | undefined => {
     const { x, y } = position;
     const realmEntityIds = Array.from(runQuery([HasValue(Position, { x, y }), Has(TownWatch)]));
     const watchTower = realmEntityIds.length === 1 ? getComponentValue(TownWatch, realmEntityIds[0]) : undefined;
@@ -293,7 +293,7 @@ export function useCombat() {
   return {
     getEntityWatchTowerId,
     getDefenceOnRealm,
-    getDefenceOnPosition,
+    getDefenceOnPosition: getWatchTowerOnPosition,
     getRealmRaidersEntities,
     getRealmRaidersIds,
     useRealmRaiders,


### PR DESCRIPTION
## **User description**
resolves #441


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Simplified the fallback text in `AttackRaidsPopup.tsx` to just "Attacking" for clarity when no defending realm is specified.
- Added a condition in `Raid.tsx` to only show the "Attack Realm" button when the raider is on a watchtower, enhancing user experience by clarifying when attacks can be initiated.
- Renamed and refined a function in `useCombat.tsx` for fetching watchtower information, improving code readability and accuracy.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttackRaidsPopup.tsx</strong><dd><code>Simplify Attack Popup Text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/cityview/realm/combat/raids/AttackRaidsPopup.tsx
<li>Changed the fallback text from "Attacking Hyperstructure" to <br>"Attacking" when no defending realm is specified.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/464/files#diff-d63244f03af38c0e51a5a1c1e4985c0788e5bafb31e7e5ff258e6c41f16a7a5d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Raid.tsx</strong><dd><code>Conditionally Show "Attack Realm" Button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/cityview/realm/combat/raids/Raid.tsx
<li>Added a condition to check if the raider is on a watchtower before <br>showing the "Attack Realm" button.<br> <li> Changed the "Attack" button text to "Attack Realm" to clarify the <br>action.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/464/files#diff-9d34a8ec4aba1c4b149755b7884a8a2d64943e6e5ae170be4d33ee4c4d18e53e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useCombat.tsx</strong><dd><code>Rename and Refine WatchTower Fetch Function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useCombat.tsx
<li>Renamed <code>getDefenceOnPosition</code> to <code>getWatchTowerOnPosition</code> to better <br>reflect its functionality.<br> <li> Adjusted the function to fetch watchtower information based on <br>position.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/464/files#diff-4d4d2f573b4d45087edb071f52192f86529b78a01b4d70be07518057138a5496">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

