### PR TITLE
fix: only 3 hex distance travel

### DIFF
--- a/client/src/components/worldmap/hexagon/utils.tsx
+++ b/client/src/components/worldmap/hexagon/utils.tsx
@@ -121,7 +121,12 @@ export const findShortestPathBFS = (
       for (const neighbor of neighbors) {
         const neighborKey = posKey(neighbor);
         const isExplored = exploredHexes.get(neighbor.x - 2147483647)?.has(neighbor.y - 2147483647);
-        if (!visited.has(neighborKey) && !queue.some((e) => posKey(e.position) === neighborKey) && isExplored) {
+        if (
+          !visited.has(neighborKey) &&
+          !queue.some((e) => posKey(e.position) === neighborKey) &&
+          isExplored &&
+          distance + 1 <= maxHex
+        ) {
           path.set(neighborKey, current); // Map each neighbor back to the current position
           queue.push({ position: neighbor, distance: distance + 1 });
         }

--- a/contracts/scripts/set_config.sh
+++ b/contracts/scripts/set_config.sh
@@ -58,9 +58,9 @@ commands=(
 
 ## set tick config
 commands+=(
-    # max_moves_per_tick = 4
+    # max_moves_per_tick = 3
     # tick_interval_in_seconds = 60
-    "sozo execute $CONFIG_SYSTEMS set_tick_config --account-address $DOJO_ACCOUNT_ADDRESS --calldata $SOZO_WORLD,4,60"
+    "sozo execute $CONFIG_SYSTEMS set_tick_config --account-address $DOJO_ACCOUNT_ADDRESS --calldata $SOZO_WORLD,3,60"
 )
 
 ## set exploration config


### PR DESCRIPTION
## **User description**
solves #468


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Limited pathfinding to a maximum hex distance to prevent excessive travel.
- Adjusted the maximum moves per tick from 4 to 3 in the game's configuration script, aligning game mechanics with intended limits.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.tsx</strong><dd><code>Limit Pathfinding to Maximum Hex Distance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/components/worldmap/hexagon/utils.tsx
<li>Added a condition to check if the distance is within the maximum <br>allowed hex distance (<code>maxHex</code>) before adding a neighbor to the queue.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/470/files#diff-e1e5fc539ebfda38eeb6241abcafd987c297bd3df1d18537817bd83cc5c12008">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>set_config.sh</strong><dd><code>Adjust Maximum Moves Per Tick in Configuration Script</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/scripts/set_config.sh
<li>Changed the <code>max_moves_per_tick</code> parameter from 4 to 3 in the tick <br>configuration command.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/470/files#diff-58f7b419406011c0a7de50d406ecdd330c13d3eacaa25345c03757aca3f45707">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

