### PR TITLE
fix tests

### DIFF
--- a/contracts/src/systems/bank/tests/bank.cairo
+++ b/contracts/src/systems/bank/tests/bank.cairo
@@ -20,7 +20,7 @@ const _0_1: u128 = 1844674407370955161; // 0.1
 fn setup() -> (IWorldDispatcher, IBankConfigDispatcher, IBankSystemsDispatcher, u128) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let bank_config_dispatcher = IBankConfigDispatcher { contract_address: config_systems_address };
 
     let owner_fee_scaled: u128 = _0_1;
@@ -28,7 +28,7 @@ fn setup() -> (IWorldDispatcher, IBankConfigDispatcher, IBankSystemsDispatcher, 
     let bank_entity_id = bank_config_dispatcher
         .create_bank(Coord { x: 30, y: 800 }, owner_fee_scaled);
 
-    let bank_systems_address = deploy_system(bank_systems::TEST_CLASS_HASH);
+    let bank_systems_address = deploy_system(world, bank_systems::TEST_CLASS_HASH);
     let bank_systems_dispatcher = IBankSystemsDispatcher { contract_address: bank_systems_address };
     // add some resources in the bank account
     (world, bank_config_dispatcher, bank_systems_dispatcher, bank_entity_id)

--- a/contracts/src/systems/bank/tests/liquidity.cairo
+++ b/contracts/src/systems/bank/tests/liquidity.cairo
@@ -37,7 +37,7 @@ fn setup() -> (
 ) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let bank_config_dispatcher = IBankConfigDispatcher { contract_address: config_systems_address };
 
     let owner_fee_scaled: u128 = _0_1;
@@ -45,12 +45,12 @@ fn setup() -> (
     let bank_entity_id = bank_config_dispatcher
         .create_bank(Coord { x: 30, y: 800 }, owner_fee_scaled);
 
-    let bank_systems_address = deploy_system(bank_systems::TEST_CLASS_HASH);
+    let bank_systems_address = deploy_system(world, bank_systems::TEST_CLASS_HASH);
     let bank_systems_dispatcher = IBankSystemsDispatcher { contract_address: bank_systems_address };
 
     let bank_account_entity_id = bank_systems_dispatcher.open_account(bank_entity_id);
 
-    let liquidity_systems_address = deploy_system(liquidity_systems::TEST_CLASS_HASH);
+    let liquidity_systems_address = deploy_system(world, liquidity_systems::TEST_CLASS_HASH);
     let liquidity_systems_dispatcher = ILiquiditySystemsDispatcher {
         contract_address: liquidity_systems_address
     };
@@ -125,8 +125,7 @@ fn test_liquidity_remove() {
 
     liquidity_systems_dispatcher.add(bank_entity_id, ResourceTypes::WOOD, 1000, 1000);
     let liquidity = get!(world, (bank_entity_id, player, ResourceTypes::WOOD), Liquidity);
-    liquidity_systems_dispatcher
-        .remove(bank_entity_id, ResourceTypes::WOOD, liquidity.shares);
+    liquidity_systems_dispatcher.remove(bank_entity_id, ResourceTypes::WOOD, liquidity.shares);
 
     // player resources
     let bank_account = get!(world, (bank_entity_id, player), BankAccounts);

--- a/contracts/src/systems/bank/tests/swap.cairo
+++ b/contracts/src/systems/bank/tests/swap.cairo
@@ -42,24 +42,24 @@ fn setup(
 ) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let bank_config_dispatcher = IBankConfigDispatcher { contract_address: config_systems_address };
 
     let bank_entity_id = bank_config_dispatcher
         .create_bank(Coord { x: 30, y: 800 }, owner_fee_scaled);
     bank_config_dispatcher.set_bank_config(0, lp_fee_scaled);
 
-    let bank_systems_address = deploy_system(bank_systems::TEST_CLASS_HASH);
+    let bank_systems_address = deploy_system(world, bank_systems::TEST_CLASS_HASH);
     let bank_systems_dispatcher = IBankSystemsDispatcher { contract_address: bank_systems_address };
 
     let bank_account_entity_id = bank_systems_dispatcher.open_account(bank_entity_id);
 
-    let liquidity_systems_address = deploy_system(liquidity_systems::TEST_CLASS_HASH);
+    let liquidity_systems_address = deploy_system(world, liquidity_systems::TEST_CLASS_HASH);
     let liquidity_systems_dispatcher = ILiquiditySystemsDispatcher {
         contract_address: liquidity_systems_address
     };
 
-    let swap_systems_address = deploy_system(swap_systems::TEST_CLASS_HASH);
+    let swap_systems_address = deploy_system(world, swap_systems::TEST_CLASS_HASH);
     let swap_systems_dispatcher = ISwapSystemsDispatcher { contract_address: swap_systems_address };
 
     // add some resources in the bank account

--- a/contracts/src/systems/combat/tests/combat_attack_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/combat_attack_system_tests.cairo
@@ -47,7 +47,7 @@ const TARGET_SOLDIER_COUNT: u128 = 5;
 fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set soldier cost configuration 
     let combat_config_dispatcher = ICombatConfigDispatcher {
@@ -76,7 +76,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(SOLDIER_ENTITY_TYPE, 44);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -166,7 +166,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
         })
     );
 
-    let combat_systems_address = deploy_system(combat_systems::TEST_CLASS_HASH);
+    let combat_systems_address = deploy_system(world, combat_systems::TEST_CLASS_HASH);
     let soldier_systems_dispatcher = ISoldierSystemsDispatcher {
         contract_address: combat_systems_address
     };

--- a/contracts/src/systems/combat/tests/combat_steal_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/combat_steal_system_tests.cairo
@@ -66,7 +66,7 @@ const TYPE_TWO_RESOURCE_TO_BE_STOLEN_FROM_TARGET: u8 = 14;
 fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set soldier cost configuration 
     let combat_config_dispatcher = ICombatConfigDispatcher {
@@ -83,8 +83,10 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
 
     combat_config_dispatcher
         .set_soldier_config(
-            array![// pay for each soldier with the following
-            (ResourceTypes::DRAGONHIDE, 40), (ResourceTypes::DEMONHIDE, 40),].span(),
+            array![ // pay for each soldier with the following
+                (ResourceTypes::DRAGONHIDE, 40), (ResourceTypes::DEMONHIDE, 40),
+            ]
+                .span(),
             WHEAT_BURN_PER_SOLDIER_DURING_ATTACK,
             FISH_BURN_PER_SOLDIER_DURING_ATTACK
         );
@@ -109,7 +111,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
     IWeightConfigDispatcher { contract_address: config_systems_address }
         .set_weight_config(TYPE_TWO_RESOURCE_TO_BE_STOLEN_FROM_TARGET.into(), 200);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -252,7 +254,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, u128, ICombatSystemsDispatche
     };
     target_resource_precalc_2.save(world);
 
-    let combat_systems_address = deploy_system(combat_systems::TEST_CLASS_HASH);
+    let combat_systems_address = deploy_system(world, combat_systems::TEST_CLASS_HASH);
     let soldier_systems_dispatcher = ISoldierSystemsDispatcher {
         contract_address: combat_systems_address
     };

--- a/contracts/src/systems/combat/tests/soldier_create_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_create_system_tests.cairo
@@ -43,7 +43,7 @@ use core::traits::Into;
 fn setup() -> (IWorldDispatcher, u128, ISoldierSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set soldier cost configuration 
     let combat_config_dispatcher = ICombatConfigDispatcher {
@@ -72,7 +72,7 @@ fn setup() -> (IWorldDispatcher, u128, ISoldierSystemsDispatcher) {
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(SOLDIER_ENTITY_TYPE, 44);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -121,7 +121,7 @@ fn setup() -> (IWorldDispatcher, u128, ISoldierSystemsDispatcher) {
 
     starknet::testing::set_contract_address(contract_address_const::<'caller'>());
 
-    let combat_systems_address = deploy_system(combat_systems::TEST_CLASS_HASH);
+    let combat_systems_address = deploy_system(world, combat_systems::TEST_CLASS_HASH);
     let soldier_systems_dispatcher = ISoldierSystemsDispatcher {
         contract_address: combat_systems_address
     };

--- a/contracts/src/systems/combat/tests/soldier_detach_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_detach_system_tests.cairo
@@ -38,7 +38,7 @@ use core::traits::Into;
 fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set soldier cost configuration 
     let combat_config_dispatcher = ICombatConfigDispatcher {
@@ -67,7 +67,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(SOLDIER_ENTITY_TYPE, 44);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -115,7 +115,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
 
     starknet::testing::set_contract_address(contract_address_const::<'caller'>());
 
-    let combat_systems_address = deploy_system(combat_systems::TEST_CLASS_HASH);
+    let combat_systems_address = deploy_system(world, combat_systems::TEST_CLASS_HASH);
     let soldier_systems_dispatcher = ISoldierSystemsDispatcher {
         contract_address: combat_systems_address
     };

--- a/contracts/src/systems/combat/tests/soldier_heal_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_heal_system_tests.cairo
@@ -36,7 +36,7 @@ use core::traits::Into;
 fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set soldier cost configuration 
     let combat_config_dispatcher = ICombatConfigDispatcher {
@@ -72,7 +72,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(SOLDIER_ENTITY_TYPE, 44);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -125,7 +125,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, ISoldierSystemsDispatcher) {
 
     starknet::testing::set_contract_address(contract_address_const::<'caller'>());
 
-    let combat_systems_address = deploy_system(combat_systems::TEST_CLASS_HASH);
+    let combat_systems_address = deploy_system(world, combat_systems::TEST_CLASS_HASH);
     let soldier_systems_dispatcher = ISoldierSystemsDispatcher {
         contract_address: combat_systems_address
     };

--- a/contracts/src/systems/combat/tests/soldier_merge_system_tests.cairo
+++ b/contracts/src/systems/combat/tests/soldier_merge_system_tests.cairo
@@ -43,7 +43,7 @@ use core::traits::Into;
 fn setup() -> (IWorldDispatcher, u128, Span<u128>, ISoldierSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set soldier cost configuration 
     let combat_config_dispatcher = ICombatConfigDispatcher {
@@ -72,7 +72,7 @@ fn setup() -> (IWorldDispatcher, u128, Span<u128>, ISoldierSystemsDispatcher) {
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(SOLDIER_ENTITY_TYPE, 44);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -120,7 +120,7 @@ fn setup() -> (IWorldDispatcher, u128, Span<u128>, ISoldierSystemsDispatcher) {
 
     starknet::testing::set_contract_address(contract_address_const::<'caller'>());
 
-    let combat_systems_address = deploy_system(combat_systems::TEST_CLASS_HASH);
+    let combat_systems_address = deploy_system(world, combat_systems::TEST_CLASS_HASH);
     let soldier_systems_dispatcher = ISoldierSystemsDispatcher {
         contract_address: combat_systems_address
     };

--- a/contracts/src/systems/config/tests/bank_config_tests.cairo
+++ b/contracts/src/systems/config/tests/bank_config_tests.cairo
@@ -17,7 +17,7 @@ const _0_1: u128 = 1844674407370955161; // 0.1
 fn test_create_bank() {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     let bank_config_dispatcher = IBankConfigDispatcher { contract_address: config_systems_address };
 
@@ -38,7 +38,7 @@ fn test_create_bank() {
 fn test_set_bank_config() {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     let bank_config_dispatcher = IBankConfigDispatcher { contract_address: config_systems_address };
 

--- a/contracts/src/systems/config/tests/hyperstructure_config_tests.cairo
+++ b/contracts/src/systems/config/tests/hyperstructure_config_tests.cairo
@@ -25,7 +25,7 @@ use core::array::{ArrayTrait, SpanTrait};
 fn setup() -> (IWorldDispatcher, IHyperstructureConfigDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     let hyperstructure_config_dispatcher = IHyperstructureConfigDispatcher {
         contract_address: config_systems_address

--- a/contracts/src/systems/config/tests/labor_config_tests/labor_auction_config_tests.cairo
+++ b/contracts/src/systems/config/tests/labor_config_tests/labor_auction_config_tests.cairo
@@ -14,7 +14,7 @@ const _0_1: u128 = 1844674407370955161; // 0.1
 fn test_set_labor_auction() {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address

--- a/contracts/src/systems/labor/tests/labor_build_tests.cairo
+++ b/contracts/src/systems/labor/tests/labor_build_tests.cairo
@@ -26,7 +26,7 @@ fn setup() -> (IWorldDispatcher, ID, ILaborSystemsDispatcher) {
     let world = spawn_eternum();
 
     // set labor configuration entity
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -39,7 +39,7 @@ fn setup() -> (IWorldDispatcher, ID, ILaborSystemsDispatcher) {
         );
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -60,7 +60,7 @@ fn setup() -> (IWorldDispatcher, ID, ILaborSystemsDispatcher) {
         // x needs to be > 470200 to get zone
         );
 
-    let labor_systems_address = deploy_system(labor_systems::TEST_CLASS_HASH);
+    let labor_systems_address = deploy_system(world, labor_systems::TEST_CLASS_HASH);
     let labor_systems_dispatcher = ILaborSystemsDispatcher {
         contract_address: labor_systems_address
     };

--- a/contracts/src/systems/labor/tests/labor_harvest_tests.cairo
+++ b/contracts/src/systems/labor/tests/labor_harvest_tests.cairo
@@ -39,7 +39,7 @@ fn test_harvest_labor_non_food() {
     let world = spawn_eternum();
 
     // set labor configuration entity
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -51,7 +51,7 @@ fn test_harvest_labor_non_food() {
         .set_labor_config(base_labor_units, base_resources_per_cycle, base_food_per_cycle);
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -73,7 +73,7 @@ fn test_harvest_labor_non_food() {
 
         );
 
-    let labor_systems_address = deploy_system(labor_systems::TEST_CLASS_HASH);
+    let labor_systems_address = deploy_system(world, labor_systems::TEST_CLASS_HASH);
     let labor_systems_dispatcher = ILaborSystemsDispatcher {
         contract_address: labor_systems_address
     };
@@ -135,7 +135,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_non_food() {
     let world = spawn_eternum();
 
     // set labor configuration entity
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -147,7 +147,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_non_food() {
         .set_labor_config(base_labor_units, base_resources_per_cycle, base_food_per_cycle);
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -170,7 +170,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_non_food() {
 
         );
 
-    let labor_systems_address = deploy_system(labor_systems::TEST_CLASS_HASH);
+    let labor_systems_address = deploy_system(world, labor_systems::TEST_CLASS_HASH);
     let labor_systems_dispatcher = ILaborSystemsDispatcher {
         contract_address: labor_systems_address
     };
@@ -267,7 +267,7 @@ fn test_harvest_labor_food() {
     let world = spawn_eternum();
 
     // set labor configuration entity
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -279,7 +279,7 @@ fn test_harvest_labor_food() {
         .set_labor_config(base_labor_units, base_resources_per_cycle, base_food_per_cycle);
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -301,7 +301,7 @@ fn test_harvest_labor_food() {
 
         );
 
-    let labor_systems_address = deploy_system(labor_systems::TEST_CLASS_HASH);
+    let labor_systems_address = deploy_system(world, labor_systems::TEST_CLASS_HASH);
     let labor_systems_dispatcher = ILaborSystemsDispatcher {
         contract_address: labor_systems_address
     };
@@ -364,7 +364,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_food() {
     let world = spawn_eternum();
 
     // set labor configuration entity
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -376,7 +376,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_food() {
         .set_labor_config(base_labor_units, base_resources_per_cycle, base_food_per_cycle);
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -399,7 +399,7 @@ fn test_harvest_labor_plus_realm_and_hyperstructure_bonus_for_food() {
 
         );
 
-    let labor_systems_address = deploy_system(labor_systems::TEST_CLASS_HASH);
+    let labor_systems_address = deploy_system(world, labor_systems::TEST_CLASS_HASH);
     let labor_systems_dispatcher = ILaborSystemsDispatcher {
         contract_address: labor_systems_address
     };

--- a/contracts/src/systems/labor/tests/labor_purchase_tests.cairo
+++ b/contracts/src/systems/labor/tests/labor_purchase_tests.cairo
@@ -31,7 +31,7 @@ const _0_1: u128 = 1844674407370955161; // 0.1
 fn setup(labor_cost_resource_type: u8) -> (IWorldDispatcher, u128, ILaborSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let labor_config_dispatcher = ILaborConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -59,7 +59,7 @@ fn setup(labor_cost_resource_type: u8) -> (IWorldDispatcher, u128, ILaborSystems
     labor_config_dispatcher.set_labor_auction(decay_constant, per_time_unit, price_update_interval);
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -123,7 +123,7 @@ fn setup(labor_cost_resource_type: u8) -> (IWorldDispatcher, u128, ILaborSystems
         })
     );
 
-    let labor_systems_address = deploy_system(labor_systems::TEST_CLASS_HASH);
+    let labor_systems_address = deploy_system(world, labor_systems::TEST_CLASS_HASH);
     let labor_systems_dispatcher = ILaborSystemsDispatcher {
         contract_address: labor_systems_address
     };

--- a/contracts/src/systems/leveling/tests/internal_leveling_tests.cairo
+++ b/contracts/src/systems/leveling/tests/internal_leveling_tests.cairo
@@ -51,7 +51,7 @@ mod internal_leveling_systems {
         ]
             .span();
 
-        let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+        let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
         let level_config_dispatcher = ILevelingConfigDispatcher {
             contract_address: config_systems_address
         };

--- a/contracts/src/systems/leveling/tests/realm_leveling_tests.cairo
+++ b/contracts/src/systems/leveling/tests/realm_leveling_tests.cairo
@@ -28,7 +28,7 @@ use starknet::contract_address_const;
 fn setup() -> (IWorldDispatcher, u128, ILevelingSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     let level_config_dispatcher = ILevelingConfigDispatcher {
         contract_address: config_systems_address
     };
@@ -67,7 +67,7 @@ fn setup() -> (IWorldDispatcher, u128, ILevelingSystemsDispatcher) {
         );
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -103,7 +103,7 @@ fn setup() -> (IWorldDispatcher, u128, ILevelingSystemsDispatcher) {
         )
     );
 
-    let leveling_systems_address = deploy_system(leveling_systems::TEST_CLASS_HASH);
+    let leveling_systems_address = deploy_system(world, leveling_systems::TEST_CLASS_HASH);
     let leveling_systems_dispatcher = ILevelingSystemsDispatcher {
         contract_address: leveling_systems_address
     };

--- a/contracts/src/systems/map/tests.cairo
+++ b/contracts/src/systems/map/tests.cairo
@@ -54,7 +54,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, IMapSystemsDispatcher) {
 
     starknet::testing::set_block_timestamp(TIMESTAMP);
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set initial food resources
     let initial_resources = array![
@@ -85,7 +85,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, IMapSystemsDispatcher) {
     set!(world, (tick_config));
 
     // create realm
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -152,7 +152,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, IMapSystemsDispatcher) {
     );
 
     // deploy map systems
-    let map_systems_address = deploy_system(map_systems::TEST_CLASS_HASH);
+    let map_systems_address = deploy_system(world, map_systems::TEST_CLASS_HASH);
     let map_systems_dispatcher = IMapSystemsDispatcher { contract_address: map_systems_address };
 
     (world, realm_entity_id, realm_army_unit_id, map_systems_dispatcher)
@@ -203,7 +203,7 @@ fn test_map_explore() {
 #[test]
 #[should_panic(expected: ("max moves per tick exceeded", 'ENTRYPOINT_FAILED'))]
 fn test_map_explore__ensure_explorer_cant_hex_travel_till_next_tick() {
-    let (_, _, realm_army_unit_id, map_systems_dispatcher) = setup();
+    let (world, _, realm_army_unit_id, map_systems_dispatcher) = setup();
 
     starknet::testing::set_contract_address(contract_address_const::<'realm_owner'>());
 
@@ -214,7 +214,7 @@ fn test_map_explore__ensure_explorer_cant_hex_travel_till_next_tick() {
     map_systems_dispatcher.explore(realm_army_unit_id, explore_tile_direction);
 
     // deploy travel systems
-    let travel_systems_address = deploy_system(travel_systems::TEST_CLASS_HASH);
+    let travel_systems_address = deploy_system(world, travel_systems::TEST_CLASS_HASH);
     let travel_systems_dispatcher = ITravelSystemsDispatcher {
         contract_address: travel_systems_address
     };

--- a/contracts/src/systems/realm/tests.cairo
+++ b/contracts/src/systems/realm/tests.cairo
@@ -34,7 +34,7 @@ const INITIAL_RESOURCE_2_AMOUNT: u128 = 700;
 fn setup() -> IWorldDispatcher {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set initially minted resources
     let initial_resources = array![
@@ -56,7 +56,7 @@ fn test_realm_create() {
     starknet::testing::set_block_timestamp(TIMESTAMP);
 
     // create realm
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -117,10 +117,10 @@ fn test_realm_create() {
 #[test]
 #[available_gas(3000000000000)]
 fn test_realm_create_equal_max_realms_per_address() {
-    setup();
+    let world = setup();
 
     // create realm
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -165,10 +165,10 @@ fn test_realm_create_equal_max_realms_per_address() {
 #[available_gas(3000000000000)]
 #[should_panic(expected: ('max num of realms settled', 'ENTRYPOINT_FAILED'))]
 fn test_realm_create_greater_than_max_realms_per_address() {
-    setup();
+    let world = setup();
 
     // create realm
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };

--- a/contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
@@ -36,7 +36,7 @@ mod inventory_transfer_system_tests {
     fn setup() -> (IWorldDispatcher, u128, u128, u128, IInventorySystemsDispatcher) {
         let world = spawn_eternum();
 
-        let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+        let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
         // set weight configuration for stone
         IWeightConfigDispatcher { contract_address: config_systems_address }
@@ -46,7 +46,7 @@ mod inventory_transfer_system_tests {
         IWeightConfigDispatcher { contract_address: config_systems_address }
             .set_weight_config(ResourceTypes::GOLD.into(), 200);
 
-        let resource_systems_address = deploy_system(resource_systems::TEST_CLASS_HASH);
+        let resource_systems_address = deploy_system(world, resource_systems::TEST_CLASS_HASH);
 
         let inventory_systems_dispatcher = IInventorySystemsDispatcher {
             contract_address: resource_systems_address

--- a/contracts/src/systems/resources/tests/resource_approval_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/resource_approval_system_tests.cairo
@@ -27,7 +27,7 @@ mod resource_approval_system_tests {
     fn setup() -> (IWorldDispatcher, IResourceSystemsDispatcher) {
         let world = spawn_eternum();
 
-        let resource_systems_address = deploy_system(resource_systems::TEST_CLASS_HASH);
+        let resource_systems_address = deploy_system(world, resource_systems::TEST_CLASS_HASH);
 
         let resource_systems_dispatcher = IResourceSystemsDispatcher {
             contract_address: resource_systems_address

--- a/contracts/src/systems/resources/tests/resource_transfer_system_tests.cairo
+++ b/contracts/src/systems/resources/tests/resource_transfer_system_tests.cairo
@@ -34,7 +34,7 @@ mod resource_transfer_system_tests {
     fn setup() -> (IWorldDispatcher, IResourceSystemsDispatcher) {
         let world = spawn_eternum();
 
-        let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+        let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
         // set weight configuration for stone
         IWeightConfigDispatcher { contract_address: config_systems_address }
@@ -44,7 +44,7 @@ mod resource_transfer_system_tests {
         IWeightConfigDispatcher { contract_address: config_systems_address }
             .set_weight_config(ResourceTypes::WOOD.into(), 200);
 
-        let resource_systems_address = deploy_system(resource_systems::TEST_CLASS_HASH);
+        let resource_systems_address = deploy_system(world, resource_systems::TEST_CLASS_HASH);
 
         let resource_systems_dispatcher = IResourceSystemsDispatcher {
             contract_address: resource_systems_address

--- a/contracts/src/systems/trade/tests/trade_systems_tests/accept_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/accept_order.cairo
@@ -63,7 +63,7 @@ fn setup(
 ) -> (IWorldDispatcher, u128, u128, u128, u128, ITradeSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set travel configuration
     ITransportConfigDispatcher { contract_address: config_systems_address }
@@ -94,7 +94,7 @@ fn setup(
     IWeightConfigDispatcher { contract_address: config_systems_address }
         .set_weight_config(ResourceTypes::SILVER.into(), 200);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -165,7 +165,7 @@ fn setup(
     starknet::testing::set_contract_address(contract_address_const::<'maker'>());
 
     // create two free transport unit for maker realm
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };
@@ -178,13 +178,13 @@ fn setup(
     ];
 
     // create maker caravan
-    let caravan_systems_address = deploy_system(caravan_systems::TEST_CLASS_HASH);
+    let caravan_systems_address = deploy_system(world, caravan_systems::TEST_CLASS_HASH);
     let caravan_systems_dispatcher = ICaravanSystemsDispatcher {
         contract_address: caravan_systems_address
     };
     let maker_transport_id = caravan_systems_dispatcher.create(maker_transport_units);
 
-    let trade_systems_address = deploy_system(trade_systems::TEST_CLASS_HASH);
+    let trade_systems_address = deploy_system(world, trade_systems::TEST_CLASS_HASH);
     let trade_systems_dispatcher = ITradeSystemsDispatcher {
         contract_address: trade_systems_address
     };
@@ -937,7 +937,7 @@ fn test_transport_in_transit() {
 #[available_gas(3000000000000)]
 #[should_panic(expected: ('not enough capacity', 'ENTRYPOINT_FAILED'))]
 fn test_transport_not_enough_capacity() {
-    let (_, trade_id, _, taker_id, _, trade_systems_dispatcher) = setup(true);
+    let (world, trade_id, _, taker_id, _, trade_systems_dispatcher) = setup(true);
 
     //          note
     // all previous tests passed because they didn't have 
@@ -945,12 +945,12 @@ fn test_transport_not_enough_capacity() {
     // capacity is unlimited
 
     // set capacity for transport to a very low amount
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(FREE_TRANSPORT_ENTITY_TYPE, 1);
 
     // create two free transport unit for taker realm
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };
@@ -966,7 +966,7 @@ fn test_transport_not_enough_capacity() {
     // create taker caravan
 
     starknet::testing::set_contract_address(contract_address_const::<'taker'>());
-    let caravan_systems_address = deploy_system(caravan_systems::TEST_CLASS_HASH);
+    let caravan_systems_address = deploy_system(world, caravan_systems::TEST_CLASS_HASH);
     let caravan_systems_dispatcher = ICaravanSystemsDispatcher {
         contract_address: caravan_systems_address
     };

--- a/contracts/src/systems/trade/tests/trade_systems_tests/cancel_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/cancel_order.cairo
@@ -51,7 +51,7 @@ use core::traits::Into;
 fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set travel configuration
     ITransportConfigDispatcher { contract_address: config_systems_address }
@@ -77,7 +77,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     IWeightConfigDispatcher { contract_address: config_systems_address }
         .set_weight_config(ResourceTypes::SILVER.into(), 200);
 
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -150,7 +150,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     starknet::testing::set_contract_address(contract_address_const::<'maker'>());
 
     // create two free transport unit for maker realm
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };
@@ -163,13 +163,13 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     ];
 
     // create maker caravan
-    let caravan_systems_address = deploy_system(caravan_systems::TEST_CLASS_HASH);
+    let caravan_systems_address = deploy_system(world, caravan_systems::TEST_CLASS_HASH);
     let caravan_systems_dispatcher = ICaravanSystemsDispatcher {
         contract_address: caravan_systems_address
     };
     let maker_transport_id = caravan_systems_dispatcher.create(maker_transport_units);
 
-    let trade_systems_address = deploy_system(trade_systems::TEST_CLASS_HASH);
+    let trade_systems_address = deploy_system(world, trade_systems::TEST_CLASS_HASH);
     let trade_systems_dispatcher = ITradeSystemsDispatcher {
         contract_address: trade_systems_address
     };

--- a/contracts/src/systems/trade/tests/trade_systems_tests/create_order.cairo
+++ b/contracts/src/systems/trade/tests/trade_systems_tests/create_order.cairo
@@ -47,7 +47,7 @@ use core::array::{ArrayTrait, SpanTrait};
 fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set travel configuration
     ITransportConfigDispatcher { contract_address: config_systems_address }
@@ -62,7 +62,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
         .set_weight_config(ResourceTypes::GOLD.into(), 200);
 
     // create maker's realm
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -115,7 +115,7 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     starknet::testing::set_contract_address(contract_address_const::<'maker'>());
 
     // create two free transport unit for the realm
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };
@@ -128,13 +128,13 @@ fn setup() -> (IWorldDispatcher, u128, u128, u128, ITradeSystemsDispatcher) {
     ];
 
     // create maker caravan
-    let caravan_systems_address = deploy_system(caravan_systems::TEST_CLASS_HASH);
+    let caravan_systems_address = deploy_system(world, caravan_systems::TEST_CLASS_HASH);
     let caravan_systems_dispatcher = ICaravanSystemsDispatcher {
         contract_address: caravan_systems_address
     };
     let maker_transport_id = caravan_systems_dispatcher.create(transport_units);
 
-    let trade_systems_address = deploy_system(trade_systems::TEST_CLASS_HASH);
+    let trade_systems_address = deploy_system(world, trade_systems::TEST_CLASS_HASH);
     let trade_systems_dispatcher = ITradeSystemsDispatcher {
         contract_address: trade_systems_address
     };
@@ -304,7 +304,7 @@ fn test_transport_in_transit() {
 #[available_gas(3000000000000)]
 #[should_panic(expected: ('not enough capacity', 'ENTRYPOINT_FAILED'))]
 fn test_transport_not_enough_capacity() {
-    let (_, maker_id, _, taker_id, trade_systems_dispatcher) = setup();
+    let (world, maker_id, _, taker_id, trade_systems_dispatcher) = setup();
 
     //          note
     // all previous tests passed because they didn't have 
@@ -312,12 +312,12 @@ fn test_transport_not_enough_capacity() {
     // capacity is unlimited
 
     // set capacity for transport to a very low amount
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
     ICapacityConfigDispatcher { contract_address: config_systems_address }
         .set_capacity_config(FREE_TRANSPORT_ENTITY_TYPE, 1);
 
     // create two free transport unit for maker realm
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };
@@ -333,7 +333,7 @@ fn test_transport_not_enough_capacity() {
     // create maker caravan
 
     starknet::testing::set_contract_address(contract_address_const::<'maker'>());
-    let caravan_systems_address = deploy_system(caravan_systems::TEST_CLASS_HASH);
+    let caravan_systems_address = deploy_system(world, caravan_systems::TEST_CLASS_HASH);
     let caravan_systems_dispatcher = ICaravanSystemsDispatcher {
         contract_address: caravan_systems_address
     };

--- a/contracts/src/systems/transport/tests/caravan_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/caravan_systems_tests.cairo
@@ -44,7 +44,7 @@ fn setup() -> (IWorldDispatcher, Array<u128>, ICaravanSystemsDispatcher, u128) {
     let world = spawn_eternum();
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -75,7 +75,7 @@ fn setup() -> (IWorldDispatcher, Array<u128>, ICaravanSystemsDispatcher, u128) {
             position.clone(),
         );
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set speed configuration 
     ITransportConfigDispatcher { contract_address: config_systems_address }
@@ -96,7 +96,7 @@ fn setup() -> (IWorldDispatcher, Array<u128>, ICaravanSystemsDispatcher, u128) {
         .set_travel_config(5); // 5 free transport per city
 
     // create two free transport unit for the realm
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };
@@ -109,7 +109,7 @@ fn setup() -> (IWorldDispatcher, Array<u128>, ICaravanSystemsDispatcher, u128) {
     ];
 
     // deploy caravan systems
-    let caravan_systems_address = deploy_system(caravan_systems::TEST_CLASS_HASH);
+    let caravan_systems_address = deploy_system(world, caravan_systems::TEST_CLASS_HASH);
     let caravan_systems_dispatcher = ICaravanSystemsDispatcher {
         contract_address: caravan_systems_address
     };

--- a/contracts/src/systems/transport/tests/road_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/road_systems_tests.cairo
@@ -24,7 +24,7 @@ use core::clone::Clone;
 fn setup() -> (IWorldDispatcher, IRoadSystemsDispatcher) {
     let world = spawn_eternum();
 
-    let road_systems_address = deploy_system(road_systems::TEST_CLASS_HASH);
+    let road_systems_address = deploy_system(world, road_systems::TEST_CLASS_HASH);
     let road_systems_dispatcher = IRoadSystemsDispatcher { contract_address: road_systems_address };
 
     (world, road_systems_dispatcher)

--- a/contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
@@ -40,7 +40,7 @@ fn setup() -> (IWorldDispatcher, u128, ITransportUnitSystemsDispatcher) {
     let world = spawn_eternum();
 
     // set realm entity
-    let realm_systems_address = deploy_system(realm_systems::TEST_CLASS_HASH);
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
     let realm_systems_dispatcher = IRealmSystemsDispatcher {
         contract_address: realm_systems_address
     };
@@ -71,7 +71,7 @@ fn setup() -> (IWorldDispatcher, u128, ITransportUnitSystemsDispatcher) {
             position.clone(),
         );
 
-    let config_systems_address = deploy_system(config_systems::TEST_CLASS_HASH);
+    let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
 
     // set speed configuration 
     ITransportConfigDispatcher { contract_address: config_systems_address }
@@ -85,7 +85,7 @@ fn setup() -> (IWorldDispatcher, u128, ITransportUnitSystemsDispatcher) {
     ITransportConfigDispatcher { contract_address: config_systems_address }
         .set_travel_config(5); // 5 free transport per city
 
-    let transport_unit_systems_address = deploy_system(transport_unit_systems::TEST_CLASS_HASH);
+    let transport_unit_systems_address = deploy_system(world, transport_unit_systems::TEST_CLASS_HASH);
     let transport_unit_systems_dispatcher = ITransportUnitSystemsDispatcher {
         contract_address: transport_unit_systems_address
     };

--- a/contracts/src/systems/transport/tests/travel_systems_tests.cairo
+++ b/contracts/src/systems/transport/tests/travel_systems_tests.cairo
@@ -63,7 +63,7 @@ fn setup() -> (IWorldDispatcher, u64, Position, Coord, ITravelSystemsDispatcher)
     destination_tile.explored_at = 78671;
     set!(world, (destination_tile));
 
-    let travel_systems_address = deploy_system(travel_systems::TEST_CLASS_HASH);
+    let travel_systems_address = deploy_system(world, travel_systems::TEST_CLASS_HASH);
     let travel_systems_dispatcher = ITravelSystemsDispatcher {
         contract_address: travel_systems_address
     };
@@ -486,7 +486,7 @@ fn setup_hex_travel() -> (IWorldDispatcher, u64, Position, ITravelSystemsDispatc
         })
     );
 
-    let travel_systems_address = deploy_system(travel_systems::TEST_CLASS_HASH);
+    let travel_systems_address = deploy_system(world, travel_systems::TEST_CLASS_HASH);
     let travel_systems_dispatcher = ITravelSystemsDispatcher {
         contract_address: travel_systems_address
     };

--- a/contracts/src/utils/testing.cairo
+++ b/contracts/src/utils/testing.cairo
@@ -69,11 +69,9 @@ fn spawn_eternum() -> IWorldDispatcher {
 }
 
 
-fn deploy_system(class_hash_felt: felt252) -> ContractAddress {
-    let (system_contract_address, _) = deploy_syscall(
-        class_hash_felt.try_into().unwrap(), 0, array![].span(), false
-    )
-        .unwrap();
+fn deploy_system(world: IWorldDispatcher, class_hash_felt: felt252) -> ContractAddress {
+    let contract_address = world
+            .deploy_contract(class_hash_felt, class_hash_felt.try_into().unwrap());
 
-    system_contract_address
+    contract_address
 }


### PR DESCRIPTION
## **Type**
enhancement, tests


___

## **Description**
- Refactored `deploy_system` function in `testing.cairo` to use `world.deploy_contract`, enhancing the deployment process for tests.
- Updated all test files to pass `world` as a parameter to `deploy_system`, aligning with the new function signature.
- Simplified code in `liquidity.cairo` tests by removing unnecessary line breaks.
- Improved array initialization formatting in `combat_steal_system_tests.cairo` for clarity.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>testing.cairo</strong><dd><code>Refactor deploy_system Function to Use World Dispatcher</code>&nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/utils/testing.cairo
<li>Modified <code>deploy_system</code> function to accept <code>world</code> as a parameter and use <br><code>world.deploy_contract</code> for deploying contracts.<br> <li> Removed the direct use of <code>deploy_syscall</code> for deploying contracts.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-720d3d460287774c08c51e42e42c68660044f6c6914506e1f91dbfd619bed760">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>26 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>bank.cairo</strong><dd><code>Update Bank Tests to Use Modified deploy_system Function</code>&nbsp; </dd></summary>
<hr>

contracts/src/systems/bank/tests/bank.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-8336606fdaabdcea9f292be67a796dd5df4b94f7b3987322b1306aef9232c4b4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>liquidity.cairo</strong><dd><code>Update Liquidity Tests and Simplify Code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/bank/tests/liquidity.cairo
<li>Updated calls to <code>deploy_system</code> to include <code>world</code> parameter.<br> <li> Simplified call to <code>liquidity_systems_dispatcher.remove</code> by removing <br>unnecessary line break.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-01e1cddec6d61592277a2401a1073dcd1b35d310be9e37cd827f182b0abff132">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>swap.cairo</strong><dd><code>Update Swap Tests to Use Modified deploy_system Function</code>&nbsp; </dd></summary>
<hr>

contracts/src/systems/bank/tests/swap.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-252f85297fd5e71623be7168c3dc1c631517ab923a2929a1b55eed6309c91f4d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>combat_attack_system_tests.cairo</strong><dd><code>Update Combat Attack System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/tests/combat_attack_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-9158758c6d1f6b4ad43a73090d3729ced29de0fb9b9e2898ed55b4a60a8882b2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>combat_steal_system_tests.cairo</strong><dd><code>Update Combat Steal System Tests and Improve Formatting</code>&nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/tests/combat_steal_system_tests.cairo
<li>Updated calls to <code>deploy_system</code> to include <code>world</code> parameter.<br> <li> Reformatted array initialization for clarity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-ceecb38a7be38cb426c5cace1b468208a3c1bc7d08b62bf2c1aab313820d424b">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>soldier_create_system_tests.cairo</strong><dd><code>Update Soldier Create System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/tests/soldier_create_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-484d553365a25f32d0d9be8f3e14aef2ed03c3579620c763e259c3b581bcae11">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>soldier_detach_system_tests.cairo</strong><dd><code>Update Soldier Detach System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/tests/soldier_detach_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-0f0754597b3313d63cba3d9119dfe498488a83ba1691475f787117cfbaf961c4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>soldier_heal_system_tests.cairo</strong><dd><code>Update Soldier Heal System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/tests/soldier_heal_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-b04de863584439f6b9b241269bd54c0b7aec856d70baa7070ff0e9c6968d0caf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>soldier_merge_system_tests.cairo</strong><dd><code>Update Soldier Merge System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/tests/soldier_merge_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-df17374585f9e443dcfd16be376597784fe0b401dd770d93231345be62b2b3fa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bank_config_tests.cairo</strong><dd><code>Update Bank Config Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/config/tests/bank_config_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-ea5e17bd5fcca39d5352c47d91732744e9a2b8a86401425898677c1c06b2f410">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hyperstructure_config_tests.cairo</strong><dd><code>Update Hyperstructure Config Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/config/tests/hyperstructure_config_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-9f2f06aae5a03d62cd08ca9a707507615e4fe674114898c8d33a5338cf333bac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>labor_auction_config_tests.cairo</strong><dd><code>Update Labor Auction Config Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/config/tests/labor_config_tests/labor_auction_config_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-6a692dff276a2dc235777b24bb391813832d9c4cc88feaa8a9480c5365aee037">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>labor_build_tests.cairo</strong><dd><code>Update Labor Build Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/labor/tests/labor_build_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-5bda1c36edde93448ed8eef3965e13e8e8b739729ee3abd574b373f74cbb2a1d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>labor_harvest_tests.cairo</strong><dd><code>Update Labor Harvest Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/labor/tests/labor_harvest_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-f4286e14e07aa8c42c133b542575a4413e438866679a382dadadb14e93bdddc6">+12/-12</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>labor_purchase_tests.cairo</strong><dd><code>Update Labor Purchase Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/labor/tests/labor_purchase_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-46c88b459fcab31758d43363e7347a68ca6c3db72b777cb835c36831a19e5319">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>internal_leveling_tests.cairo</strong><dd><code>Update Internal Leveling Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/leveling/tests/internal_leveling_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-cdd087d91745e0ccf0f4b38ce6bad30587fb7a5c79aad607b6c374c40f6df595">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realm_leveling_tests.cairo</strong><dd><code>Update Realm Leveling Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/leveling/tests/realm_leveling_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-184b1e0fcd1306bee8b16791a19264e79b46dd2a9898bbe878472f4913500150">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tests.cairo</strong><dd><code>Update Map System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/map/tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-8a9625b3bf39e74d605afc405a8aa2c05b42eb38228f441a647150bdbc8ae0fe">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tests.cairo</strong><dd><code>Update Realm System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/realm/tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-77e476a21ba4108aa2af167bd8e1a60bd2cee55429aaea5511cf420a05262ab8">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>inventory_transfer_item_system_tests.cairo</strong><dd><code>Update Inventory Transfer Item System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/resources/tests/inventory_transfer_item_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-7fe5aeeae9f1a6c210e03d4d526bf68c11b3f46a87186bb807e273c720f4cda9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_approval_system_tests.cairo</strong><dd><code>Update Resource Approval System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/resources/tests/resource_approval_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-200c6761fea62cb32e0b4136a46b2b8cb1228ca0eedecddcca4a4a5733bdda56">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_transfer_system_tests.cairo</strong><dd><code>Update Resource Transfer System Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/resources/tests/resource_transfer_system_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-bf605ca54ecc8b1c2a39684ee03ebe77b9d544c20b95fcf8155d267ca7e1beb1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>caravan_systems_tests.cairo</strong><dd><code>Update Caravan Systems Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/transport/tests/caravan_systems_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-fbe1e25f84866d54970a684b579f404643860193732b5dce0c488056cddc0b93">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>road_systems_tests.cairo</strong><dd><code>Update Road Systems Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/transport/tests/road_systems_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-86c3681007e80daee1f1d3f79a347e0a0024cf9038e133e6902ef783590e2864">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transport_unit_systems_tests.cairo</strong><dd><code>Update Transport Unit Systems Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/transport/tests/transport_unit_systems_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-379310475eccbbe502c00c15ac1e3c7ab1712f5bbc28bc8600839b215c5bfa25">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>travel_systems_tests.cairo</strong><dd><code>Update Travel Systems Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/transport/tests/travel_systems_tests.cairo
- Updated calls to `deploy_system` to include `world` parameter.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/533/files#diff-20651580fd7f9fbd52c03941a9ea43cb5ce5289f4c9b9a428479669d849ca336">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

