### PR TITLE
feat: got to hex on double click

### DIFF
--- a/client/src/ui/components/worldmap/hexagon/HexLayers.tsx
+++ b/client/src/ui/components/worldmap/hexagon/HexLayers.tsx
@@ -128,7 +128,7 @@ export const BiomesGrid = ({ startRow, endRow, startCol, endCol, explored }: Hex
 };
 
 export const HexagonGrid = ({ startRow, endRow, startCol, endCol, explored }: HexagonGridProps) => {
-  const hexData = useUIStore((state) => state.hexData);
+  const { hexData, moveCameraToTarget } = useUIStore((state) => state);
 
   const { hoverHandler, clickHandler } = useEventHandlers(explored);
 
@@ -202,10 +202,23 @@ export const HexagonGrid = ({ startRow, endRow, startCol, endCol, explored }: He
 
   const throttledHoverHandler = useMemo(() => throttle(hoverHandler, 50), []);
 
+  const goToHex = useCallback(
+    (e: any) => {
+      const intersect = e.intersections.find((intersect: any) => intersect.object instanceof THREE.InstancedMesh);
+      if (!intersect) return;
+      const instanceId = intersect.instanceId;
+      const mesh = intersect.object;
+      const pos = getPositionsAtIndex(mesh, instanceId);
+      if (pos) {
+        moveCameraToTarget(pos);
+      }
+    },
+    [moveCameraToTarget],
+  );
   return (
     <Bvh firstHitOnly>
       <group onPointerEnter={(e) => throttledHoverHandler(e)} onClick={clickHandler}>
-        <primitive object={mesh} />
+        <primitive object={mesh} onDoubleClick={goToHex} />
       </group>
     </Bvh>
   );


### PR DESCRIPTION
## **User description**
Double click on a hex on worldmap will move camera to that hex


___

## **Type**
enhancement


___

## **Description**
- Added functionality to move the camera to a hexagon's position upon double-clicking it in the world map.
- This enhancement improves user interaction by allowing quick navigation to specific hexagons.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HexLayers.tsx</strong><dd><code>Implement Camera Movement on Hexagon Double-Click</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/HexLayers.tsx
<li>Introduced <code>moveCameraToTarget</code> function from <code>useUIStore</code> hook.<br> <li> Added <code>goToHex</code> callback function to handle double-click events on <br>hexagons.<br> <li> Bound <code>goToHex</code> to the double-click event on hexagon mesh primitives.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/538/files#diff-32d953460a4689eeda29120db48be52828dc4e94c6e6dab11277ba52ce4db0fe">+15/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

