### PR TITLE
Bug fixes and tests

### DIFF
--- a/contracts/src/models/buildings.cairo
+++ b/contracts/src/models/buildings.cairo
@@ -194,7 +194,7 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                     .decrease_consumption_rate(ref input_resource, @tick, input_resource_amount);
 
                 // reset production stop time
-                resource_production.set_end_tick(@input_production, @input_resource, @tick);
+                resource_production.set_input_exhaustion_tick(@input_production, @input_resource, @tick);
 
                 count += 1;
 

--- a/contracts/src/models/buildings.cairo
+++ b/contracts/src/models/buildings.cairo
@@ -1,6 +1,7 @@
 use eternum::models::position::CoordTrait;
 use core::zeroable::Zeroable;
 use eternum::models::production::{Production,ProductionInput, ProductionRateTrait, ProductionBonusPercentageImpl};
+use eternum::models::production::{ProductionInputImpl};
 use eternum::models::resources::{Resource, ResourceImpl, ResourceCost};
 use eternum::models::owner::Owner;
 use eternum::models::owner::EntityOwner;
@@ -42,7 +43,7 @@ enum BuildingCategory {
     Stable,
 }
 
-impl DirectionIntoFelt252 of Into<BuildingCategory, felt252> {
+impl BuildingCategoryIntoFelt252 of Into<BuildingCategory, felt252> {
     fn into(self: BuildingCategory) -> felt252 {
         match self {
             BuildingCategory::None => 0,
@@ -193,13 +194,17 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                 input_production
                     .decrease_consumption_rate(ref input_resource, @tick, input_resource_amount);
 
-                // reset production stop time
-                resource_production.set_input_exhaustion_tick(@input_production, @input_resource, @tick);
-
                 count += 1;
 
                 set!(world, (input_production, input_resource));
             };
+
+            let resource_production_finish_tick
+                = ProductionInputImpl::least_resource_finish_tick(@resource_production, world);
+            resource_production
+                    .set_end_tick(
+                        ref produced_resource, @tick, resource_production_finish_tick);
+
 
             set!(world, (produced_resource));
             set!(world, (resource_production));

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -1,3 +1,4 @@
+use core::debug::PrintTrait;
 use eternum::constants::{WORLD_CONFIG_ID};
 use eternum::utils::unpack::unpack_resource_types;
 

--- a/contracts/src/models/production.cairo
+++ b/contracts/src/models/production.cairo
@@ -197,8 +197,9 @@ struct ProductionInput {
 
 #[generate_trait]
 impl ProductionInputImpl of ProductionInputTrait {
-    /// Get the tick that the production inputs will finish at and return the
-    /// first one to end
+    /// Production ends when any input material runs out of balance so what this 
+    /// function does is that it finds the first input resource to run out of balance that 
+    /// returns the tick it runs out 
     fn least_resource_finish_tick(production: @Production, world: IWorldDispatcher) -> u64 {
         let production_config = get!(world, *production.resource_type, ProductionConfig);
         let tick_config = TickImpl::get(world);

--- a/contracts/src/models/resources.cairo
+++ b/contracts/src/models/resources.cairo
@@ -7,6 +7,7 @@ use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 
 use eternum::models::production::{Production, ProductionOutputImpl, ProductionRateTrait};
 use core::integer::BoundedInt;
+use debug::PrintTrait;
 
 
 #[derive(Model, Copy, Drop, Serde)]
@@ -89,7 +90,7 @@ impl ResourceImpl of ResourceTrait {
         set!(world, (self));
 
         // sync end ticks of resources that depend on this one
-        ProductionOutputImpl::sync_input_exhaustion_ticks(@self,world);
+        ProductionOutputImpl::sync_all_inputs_exhaustion_ticks_for(@self,world);
 
         // Update the entity's owned resources
 
@@ -113,7 +114,6 @@ impl ResourceImpl of ResourceTrait {
     fn harvest(ref self: Resource, world: IWorldDispatcher) {
         let mut production: Production = get!(world, (self.entity_id, self.resource_type), Production);
         let tick = TickImpl::get(world);
-
         if production.last_updated_tick != tick.current() {
             production.harvest(ref self, @tick);
             set!(world, (self));
@@ -279,6 +279,166 @@ impl OwnedResourcesTrackerImpl of OwnedResourcesTrackerTrait {
         return position; // since resource types start from 1
     }
 }
+
+#[cfg(test)]
+mod tests_resource_traits {
+    use eternum::models::resources::ResourceTrait;
+use eternum::models::production::ProductionRateTrait;
+    use core::option::OptionTrait;
+    use super::{Production, ProductionOutputImpl, Resource, ResourceImpl};
+    use debug::PrintTrait;
+    use traits::Into;
+    use traits::TryInto;
+    use eternum::constants::{ResourceTypes, WORLD_CONFIG_ID};
+    use eternum::models::config::{TickConfig, TickImpl, TickTrait};
+    use core::integer::BoundedInt;
+    use eternum::utils::testing::{spawn_eternum, deploy_system};
+    use eternum::systems::config::contracts::config_systems;
+    use eternum::systems::config::interface::{
+        IProductionConfigDispatcher, IProductionConfigDispatcherTrait
+    };
+    use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+
+    fn setup() -> (IWorldDispatcher, u128, u128, Span<(u8, u128)>) {
+        let world = spawn_eternum();
+        let config_systems_address = deploy_system(world, config_systems::TEST_CLASS_HASH);
+
+        // set tick config 
+        let tick_config = TickConfig {
+            config_id: WORLD_CONFIG_ID,
+            max_moves_per_tick: 5,
+            tick_interval_in_seconds: 5
+        };
+        set!(world, (tick_config));
+
+        // wood production cost 3 gold per tick
+        let wood_cost_gold_rate : u128 = 3;
+        let wood_cost = array![(ResourceTypes::GOLD, wood_cost_gold_rate)];
+        let entity_id: u128 = 1;
+
+
+
+        // set wood production
+
+        let wood_production_rate: u128 = 50;
+        let mut wood_production: Production = Production {
+            entity_id,
+            resource_type: ResourceTypes::WOOD,
+            building_count: 1,
+            production_rate: wood_production_rate,
+            bonus_percent: 0,
+            consumption_rate: 2,
+            last_updated_tick: 0,
+            end_tick: 0
+        };
+        set!(world, (wood_production));
+
+
+
+        // set gold consumption rate to be wood cost
+
+
+        let mut gold_production: Production = Production {
+            entity_id,
+            resource_type: ResourceTypes::GOLD,
+            building_count: 0,
+            production_rate: 0,
+            bonus_percent: 0,
+            consumption_rate: wood_cost_gold_rate,
+            last_updated_tick: 0,
+            end_tick: 0
+        };
+
+        // set gold resource balance 
+        let mut gold_resource: Resource = Resource {
+            entity_id,
+            resource_type: ResourceTypes::GOLD,
+            balance: 100
+        };
+        set!(world, (gold_production, gold_resource));
+
+   
+
+        IProductionConfigDispatcher { contract_address: config_systems_address }
+            .set_production_config(ResourceTypes::WOOD, wood_production_rate, wood_cost.span());
+
+        // update wood end tick
+        ProductionOutputImpl::sync_all_inputs_exhaustion_ticks_for(@gold_resource, world);
+        
+        return (world, entity_id, wood_production_rate, wood_cost.span());
+    }
+
+    #[test]
+    fn test_resource_get_while_gold_is_available() {
+        // Ensure production is harvested and added to the
+        // resource's balance when ResourceImpl::get is called
+        //
+        let (world, entity_id, _, _) = setup();
+
+        let tick_config = TickImpl::get(world);
+
+        // advance time by 3 ticks
+        starknet::testing::set_block_timestamp(
+            3 * tick_config.tick_interval_in_seconds);
+
+
+        // check wood balance after 3 ticks
+        let wood_resource = ResourceImpl::get(world, (entity_id, ResourceTypes::WOOD));
+        assert_eq!(wood_resource.balance, (50 - 2) * 3);
+
+
+        // check that wood production end tick was computed correctly
+        let gold_resource: Resource
+            = get!(world, (entity_id, ResourceTypes::GOLD), Resource);
+        let gold_production_end 
+            = gold_resource.balance / 3; // wood_cost_gold_rate
+        let wood_production: Production 
+            = get!(world, (entity_id, ResourceTypes::WOOD), Production);
+        assert_eq!(gold_production_end, wood_production.end_tick.into());
+
+    }
+
+
+
+    #[test]
+    fn test_resource_get_after_gold_has_finished() {
+        // Ensure production is harvested and added to the
+        // resource's balance when ResourceImpl::get is called
+        //
+        let (world, entity_id, _, _) = setup();
+
+        let tick_config = TickImpl::get(world);
+
+        // advance time by 900 ticks (way after 33 ticks when gold finishes)
+        starknet::testing::set_block_timestamp(
+            900 * tick_config.tick_interval_in_seconds);
+
+        let wood_resource = ResourceImpl::get(world, (entity_id, ResourceTypes::WOOD));
+        assert_eq!(wood_resource.balance, (50 - 2) * 33);
+
+    }
+
+
+    #[test]
+    fn test_resource_save() {
+        // Ensure wood production end tick is reset after
+        // gold's balance gets updated
+        //
+        let (world, entity_id, _, _) = setup();
+
+       
+        let mut gold_resource = ResourceImpl::get(world, (entity_id, ResourceTypes::GOLD));
+        gold_resource.balance += 4; // makes balance 104
+        gold_resource.save(world);
+        assert_eq!(gold_resource.balance, 104);
+
+        let wood_production: Production 
+            = get!(world, (entity_id, ResourceTypes::WOOD), Production);
+        assert_eq!(wood_production.end_tick, (104 - 2) / 3); // 3 =  wood_cost_gold_rate
+
+    }
+}
+
 
 
 #[cfg(test)]

--- a/contracts/src/models/resources.cairo
+++ b/contracts/src/models/resources.cairo
@@ -89,7 +89,7 @@ impl ResourceImpl of ResourceTrait {
         set!(world, (self));
 
         // sync end ticks of resources that depend on this one
-        ProductionOutputImpl::sync_end_ticks(@self,world);
+        ProductionOutputImpl::sync_input_exhaustion_ticks(@self,world);
 
         // Update the entity's owned resources
 


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced `ProductionInputImpl` for better management of production inputs and their exhaustion ticks.
- Enhanced production and resource models to accurately calculate and update end ticks based on resource consumption and production rates.
- Added debugging support in configuration model and improved clarity in building models by renaming traits.
- Expanded testing to cover new functionalities and ensure the accuracy of resource and production calculations.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>buildings.cairo</strong><dd><code>Enhancements and Bug Fixes in Building Models</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/buildings.cairo
<li>Added import for <code>ProductionInputImpl</code>.<br> <li> Renamed <code>DirectionIntoFelt252</code> to <code>BuildingCategoryIntoFelt252</code> for <br>clarity.<br> <li> Enhanced <code>BuildingProductionImpl</code> to calculate and set the end tick <br>based on the least resource finish tick.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/551/files#diff-d98a082b4990bd2f45a454b6fbeef40ee7acbd1650edbdcb1657071706a34ca7">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.cairo</strong><dd><code>Debugging Support Enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/config.cairo
- Introduced `PrintTrait` for debugging purposes.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/551/files#diff-e91086e1cdfc697fffe91cd62d9f8ae6882c51f6b3296b60d91a92c47c13b61e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>production.cairo</strong><dd><code>Production Model Enhancements and Refactoring</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/production.cairo
<li>Added <code>ResourceImpl</code> import and enhanced <code>ProductionRateImpl</code> to consider <br>consumption rate for activity status.<br> <li> Removed outdated <code>set_end_tick</code> method and replaced it with an updated <br>version that sets the end tick based on resource and tick.<br> <li> Introduced <code>ProductionInputImpl</code> with a method to find the least <br>resource finish tick, enhancing the production end tick calculation.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/551/files#diff-e8638c9f67cccf2422416ca5df1b4d5f4f97423708aa506741b026b967772624">+115/-82</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resources.cairo</strong><dd><code>Resource Model Enhancements and Testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/resources.cairo
<li>Added <code>PrintTrait</code> for debugging.<br> <li> Updated <code>ResourceImpl</code> to use the new <br><code>sync_all_inputs_exhaustion_ticks_for</code> method, improving how end ticks <br>are synchronized across resources.<br> <li> Added comprehensive tests to validate resource trait behaviors, <br>especially focusing on production and resource balance management.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/551/files#diff-558661ac54dd2eb4fec8c924666cc4e2ff3d946c69e170bc3c194b1a24e2df31">+162/-2</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

