### PR TITLE
production bug fix: use accurate end tick

### DIFF
--- a/contracts/manifests/dev/base/contracts/eternum_systems_buildings_contracts_building_systems.toml
+++ b/contracts/manifests/dev/base/contracts/eternum_systems_buildings_contracts_building_systems.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x7177805e2c26b87335cae45c0e91603bd6a0b958b90ddc2552d1313136ddbc6"
-original_class_hash = "0x7177805e2c26b87335cae45c0e91603bd6a0b958b90ddc2552d1313136ddbc6"
+class_hash = "0x7faede95a0fdd22ae8bf404790f6e1e85950e87ad71cbeeb31a35cb9c2f8417"
+original_class_hash = "0x7faede95a0fdd22ae8bf404790f6e1e85950e87ad71cbeeb31a35cb9c2f8417"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/eternum_systems_buildings_contracts_building_systems.json"
 reads = []

--- a/contracts/manifests/dev/manifest.json
+++ b/contracts/manifests/dev/manifest.json
@@ -662,7 +662,7 @@
     ],
     "address": "0x177a3f3d912cf4b55f0f74eccf3b7def7c6144efeba033e9f21d9cdb0230c64",
     "transaction_hash": "0x52d225e62111b2912d60d547d09d4f02b6113cf424097ff6078ba1dd3231355",
-    "block_number": 3,
+    "block_number": 334,
     "seed": "eternum",
     "name": "dojo::world::world"
   },
@@ -677,8 +677,8 @@
     {
       "kind": "DojoContract",
       "address": "0x5e248d25812ebb9ffa35d7d15f37e37a84b7631d691b5c8191e359ef3071776",
-      "class_hash": "0x7177805e2c26b87335cae45c0e91603bd6a0b958b90ddc2552d1313136ddbc6",
-      "original_class_hash": "0x7177805e2c26b87335cae45c0e91603bd6a0b958b90ddc2552d1313136ddbc6",
+      "class_hash": "0x7eb00fe5c5ef9be9435d49c2ea7d91382f6527eab7e76872296300fbb21cd7",
+      "original_class_hash": "0x7eb00fe5c5ef9be9435d49c2ea7d91382f6527eab7e76872296300fbb21cd7",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {

--- a/contracts/manifests/dev/manifest.toml
+++ b/contracts/manifests/dev/manifest.toml
@@ -5,7 +5,7 @@ original_class_hash = "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea44
 abi = "abis/deployments/dojo_world_world.json"
 address = "0x177a3f3d912cf4b55f0f74eccf3b7def7c6144efeba033e9f21d9cdb0230c64"
 transaction_hash = "0x52d225e62111b2912d60d547d09d4f02b6113cf424097ff6078ba1dd3231355"
-block_number = 3
+block_number = 334
 seed = "eternum"
 name = "dojo::world::world"
 
@@ -18,8 +18,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x5e248d25812ebb9ffa35d7d15f37e37a84b7631d691b5c8191e359ef3071776"
-class_hash = "0x7177805e2c26b87335cae45c0e91603bd6a0b958b90ddc2552d1313136ddbc6"
-original_class_hash = "0x7177805e2c26b87335cae45c0e91603bd6a0b958b90ddc2552d1313136ddbc6"
+class_hash = "0x7eb00fe5c5ef9be9435d49c2ea7d91382f6527eab7e76872296300fbb21cd7"
+original_class_hash = "0x7eb00fe5c5ef9be9435d49c2ea7d91382f6527eab7e76872296300fbb21cd7"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_buildings_contracts_building_systems.json"
 reads = []

--- a/contracts/src/models/buildings.cairo
+++ b/contracts/src/models/buildings.cairo
@@ -117,6 +117,11 @@ impl BuildingProductionImpl of BuildingProductionTrait {
             );
             resource_production.set_rate(production_config.amount);
             resource_production.increase_building_count(ref produced_resource, @tick);
+            let resource_production_finish_tick
+                = ProductionInputImpl::least_resource_finish_tick(@resource_production, world);
+            resource_production
+                    .set_end_tick(
+                        ref produced_resource, @tick, resource_production_finish_tick);
 
             set!(world, (produced_resource));
             set!(world, (resource_production));
@@ -170,6 +175,11 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                 world, (self.outer_entity_id, produced_resource_type), Production
             );
             resource_production.decrease_building_count(ref produced_resource, @tick);
+            let resource_production_finish_tick
+                = ProductionInputImpl::least_resource_finish_tick(@resource_production, world);
+            resource_production
+                    .set_end_tick(
+                        ref produced_resource, @tick, resource_production_finish_tick);
 
             // stop payment for production and decrease consumption rate
 
@@ -198,13 +208,6 @@ impl BuildingProductionImpl of BuildingProductionTrait {
 
                 set!(world, (input_production, input_resource));
             };
-
-            let resource_production_finish_tick
-                = ProductionInputImpl::least_resource_finish_tick(@resource_production, world);
-            resource_production
-                    .set_end_tick(
-                        ref produced_resource, @tick, resource_production_finish_tick);
-
 
             set!(world, (produced_resource));
             set!(world, (resource_production));
@@ -387,7 +390,9 @@ impl BuildingImpl of BuildingTrait {
                 );
                 building.produced_resource_type = resource_type;
             },
-            Option::None => ()
+            Option::None => {
+                building.produced_resource_type = building.produced_resource();
+            }
         }
 
         set!(world, (building));


### PR DESCRIPTION
## **User description**
- fix production end tick bug


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Updated contract hashes in TOML and JSON configurations to reflect new contract versions.
- Modified block numbers in manifest files to the latest block (334) for accurate contract deployment tracking.
- Enhanced resource production logic in Cairo contracts to dynamically update the end tick based on the least resource finish tick, improving accuracy in resource management.
- Ensured `produced_resource_type` is set to a default value if not explicitly specified, enhancing robustness in building model handling.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>eternum_systems_buildings_contracts_building_systems.toml</strong><dd><code>Update Contract Hashes in TOML Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/manifests/dev/base/contracts/eternum_systems_buildings_contracts_building_systems.toml
- Updated `class_hash` and `original_class_hash` with new values.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/555/files#diff-5ba180b11bfa89abbcc4893a798e3227bc2d01b17446921c813fd73d295d4096">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update Contract Details and Block Number in Manifest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.json
<li>Updated <code>block_number</code> to 334 in multiple sections.<br> <li> Updated <code>class_hash</code> and <code>original_class_hash</code> in the contracts section.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/555/files#diff-bc6816b30ea64e261f152a070b6e767d29d900fcbacb95c684f1c14a82dff5a8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.toml</strong><dd><code>Update Block Number and Contract Hashes in TOML Manifest</code>&nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.toml
<li>Updated <code>block_number</code> to 334.<br> <li> Updated <code>class_hash</code> and <code>original_class_hash</code> for a contract.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/555/files#diff-43499a9633d551acabe80100dc29d8995890cd62b12169122658233caea498b3">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>buildings.cairo</strong><dd><code>Enhance Resource Production End Tick Calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/buildings.cairo
<li>Added logic to update the end tick based on the least resource finish <br>tick during production increase and decrease.<br> <li> Set <code>produced_resource_type</code> to the default produced resource if not <br>specified.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/555/files#diff-d98a082b4990bd2f45a454b6fbeef40ee7acbd1650edbdcb1657071706a34ca7">+13/-8</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

