### PR TITLE
feat: construction ux 

### DIFF
--- a/client/src/hooks/store/_buildModeStore.tsx
+++ b/client/src/hooks/store/_buildModeStore.tsx
@@ -3,8 +3,8 @@ import { BuildingType, ResourcesIds } from "@bibliothecadao/eternum";
 export interface BuildModeStore {
   previewBuilding: BuildingType | null;
   setPreviewBuilding: (previewBuilding: BuildingType | null) => void;
-  hoveredBuildHex: { col: number; row: number };
-  setHoveredBuildHex: (hoveredBuildHex: { col: number; row: number }) => void;
+  hoveredBuildHex: { col: number; row: number } | null;
+  setHoveredBuildHex: (hoveredBuildHex: { col: number; row: number } | null) => void;
   existingBuildings: { col: number; row: number; type: BuildingType }[];
   setExistingBuildings: (existingBuildings: { col: number; row: number; type: BuildingType }[]) => void;
   setResourceId: (resourceId: ResourcesIds | null) => void;
@@ -15,8 +15,8 @@ export const createBuildModeStoreSlice = (set: any) => ({
   setPreviewBuilding: (previewBuilding: BuildingType | null) => {
     set({ previewBuilding });
   },
-  hoveredBuildHex: { col: -50, row: -50 },
-  setHoveredBuildHex: (hoveredBuildHex: { col: number; row: number }) => set({ hoveredBuildHex }),
+  hoveredBuildHex: null,
+  setHoveredBuildHex: (hoveredBuildHex: { col: number; row: number } | null) => set({ hoveredBuildHex }),
   existingBuildings: [{ col: 4, row: 4, type: BuildingType.Castle }],
   setExistingBuildings: (existingBuildings: { col: number; row: number; type: BuildingType }[]) =>
     set({ existingBuildings }),

--- a/client/src/shaders/placeholderMaterial.tsx
+++ b/client/src/shaders/placeholderMaterial.tsx
@@ -1,0 +1,43 @@
+import { Color, ShaderMaterial } from "three";
+
+const vertexShader = `
+varying vec3 vPosition;
+
+#include <common>
+#include <logdepthbuf_pars_vertex>
+
+void main() {
+  vPosition = position;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  #include <logdepthbuf_vertex>
+}
+`;
+
+const fragmentShader = `
+
+uniform vec3 color;
+uniform float opacity;
+varying vec3 vPosition;
+
+#include <common>
+#include <logdepthbuf_pars_fragment>
+
+void main() {
+  #include <logdepthbuf_fragment>
+  float edgeDistance = length(vPosition.xy) * 0.15;
+  float gradient = smoothstep(1.0, 0.0, edgeDistance); 
+  float finalOpacity = mix(1.0, opacity, gradient);
+  
+  gl_FragColor = vec4(color, finalOpacity);
+}
+`;
+
+export const placeholderMaterial = new ShaderMaterial({
+  vertexShader,
+  fragmentShader,
+  uniforms: {
+    color: { value: new Color("green") },
+    opacity: { value: 0.15 },
+  },
+  transparent: true,
+});

--- a/client/src/shaders/placeholderMaterial.tsx
+++ b/client/src/shaders/placeholderMaterial.tsx
@@ -24,9 +24,9 @@ varying vec3 vPosition;
 
 void main() {
   #include <logdepthbuf_fragment>
-  float edgeDistance = length(vPosition.xy) * 0.15;
-  float gradient = smoothstep(1.0, 0.0, edgeDistance); 
-  float finalOpacity = mix(1.0, opacity, gradient);
+  float edgeDistance = length(vPosition.xy) * 0.35;
+  float gradient = smoothstep(1.5, 0.0, edgeDistance); 
+  float finalOpacity = mix(0.35, opacity, gradient);
   
   gl_FragColor = vec4(color, finalOpacity);
 }
@@ -37,7 +37,7 @@ export const placeholderMaterial = new ShaderMaterial({
   fragmentShader,
   uniforms: {
     color: { value: new Color("green") },
-    opacity: { value: 0.15 },
+    opacity: { value: 0 },
   },
   transparent: true,
 });

--- a/client/src/ui/components/construction/BuildArea.tsx
+++ b/client/src/ui/components/construction/BuildArea.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createHexagonShape } from "../worldmap/hexagon/HexagonGeometry";
 import { HEX_RADIUS } from "../worldmap/hexagon/WorldHexagon";
 import { ExistingBuildings } from "./ExistingBuildings";
+import { ShaderMaterial, Vector3 } from "three";
 
 const BuildArea = () => {
   return (
@@ -26,6 +27,7 @@ const BuildingPreview = () => {
   const existingBuildings = useUIStore((state) => state.existingBuildings);
 
   const previewCoords = useMemo(() => {
+    if (!hoveredBuildHex) return null;
     return getUIPositionFromColRow(hoveredBuildHex.col, hoveredBuildHex.row, true);
   }, [hoveredBuildHex]);
 
@@ -43,12 +45,9 @@ const BuildingPreview = () => {
   // Clone all models for manipulation
   const models = useMemo(() => originalModels.map((model) => model.scene.clone()), [originalModels]);
 
-  const [color, setColor] = useState(new THREE.Color("red"));
-
   useEffect(() => {
-    if (!previewBuilding) return;
+    if (!previewBuilding || !hoveredBuildHex) return;
     const newColor = isHexOccupied(hoveredBuildHex.col, hoveredBuildHex.row, existingBuildings) ? "red" : "green";
-    setColor(new THREE.Color(newColor));
     models[previewBuilding - 1].traverse((node) => {
       if (node instanceof THREE.Mesh) {
         node.material = node.material.clone();
@@ -64,14 +63,11 @@ const BuildingPreview = () => {
     return models[previewBuilding - 1];
   }, [previewBuilding, models]);
 
-  const hexagonGeometry = useMemo(() => new THREE.ShapeGeometry(createHexagonShape(HEX_RADIUS)), []);
-
-  return previewModel ? (
-    <group position={[previewCoords.x, 2.33, -previewCoords.y]}>
-      <primitive scale={3} object={previewModel} />
-      <mesh rotation={[-0.5 * Math.PI, 0, 0]} geometry={hexagonGeometry}>
-        <meshMatcapMaterial attach="material" color={color} transparent opacity={0.5} />
-      </mesh>
-    </group>
+  return previewModel && previewCoords ? (
+    <>
+      <group position={[previewCoords.x, 2.33, -previewCoords.y]}>
+        <primitive position={[0, 0, 0]} scale={3} object={previewModel} />
+      </group>
+    </>
   ) : null;
 };


### PR DESCRIPTION
## **User description**
1. Free hexagons are now highlighted if player is in build mode
2. Added placeholder shader

![image](https://github.com/BibliothecaDAO/eternum/assets/4090500/9a4f51a9-0909-4c6e-99a2-ae1a3de95824)


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced a new shader material for visually indicating potential building placements in build mode.
- Enhanced build mode state management to better handle hovered and selected states.
- Refactored BuildingPreview component for improved performance and readability.
- Improved user experience in build mode by highlighting free hexagons with a new placeholder shader.
- Fixed a bug where the hovered hex state was not cleared after placing a building.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_buildModeStore.tsx</strong><dd><code>Enhance Build Mode State Management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/store/_buildModeStore.tsx
<li>Changed <code>hoveredBuildHex</code> type to allow <code>null</code> for indicating no hex is <br>hovered.<br> <li> Updated <code>setHoveredBuildHex</code> to accept the new nullable type.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/559/files#diff-076f5ab3774489b71f4aeb5608ee28d8cdec5d91aef3d67517080925068785bf">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>placeholderMaterial.tsx</strong><dd><code>New Placeholder Shader for Build Mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/shaders/placeholderMaterial.tsx
<li>Introduced a new shader material for build mode placeholders.<br> <li> Defined vertex and fragment shaders with gradient and opacity <br>adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/559/files#diff-f51187d2d75595a2129b2a4cb7912c70538f723c14936148561f1ef3d02f72f4">+43/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BuildArea.tsx</strong><dd><code>Refactor Building Preview Component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/construction/BuildArea.tsx
<li>Removed unused color state and hexagon geometry in BuildingPreview.<br> <li> Adjusted preview logic to handle null <code>hoveredBuildHex</code> state.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/559/files#diff-465e8c0af68c85617612608cfd879ba62fb2e2d3aeaaab74a5190e8bfbc40967">+9/-13</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GroundGrid.tsx</strong><dd><code>Improve Build Mode UX and Fix Placement Bug</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/construction/GroundGrid.tsx
<li>Added placeholder material to unoccupied hexes in build mode.<br> <li> Fixed entity_id type mismatch in building placement function.<br> <li> Cleared hovered hex state after building placement.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/559/files#diff-6de4a7770cb2545368c176a4b647161af413fca8f38c0a9f1d456af31add0e65">+26/-13</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

