### PR TITLE
fix: scrollable build menu, camera transition

### DIFF
--- a/client/src/hooks/store/useUIStore.tsx
+++ b/client/src/hooks/store/useUIStore.tsx
@@ -48,7 +48,7 @@ interface UIStore {
   setShowRealmsFlags: (show: boolean) => void;
   moveCameraToWorldMapView: () => void;
   moveCameraToRealmView: () => void;
-  moveCameraToColRow: (col: number, row: number, speed?: number | undefined) => void;
+  moveCameraToColRow: (col: number, row: number, speed?: number | undefined, transitionMode?: boolean) => void;
   isLoadingScreenEnabled: boolean;
   setIsLoadingScreenEnabled: (enabled: boolean) => void;
 }
@@ -156,16 +156,17 @@ const useUIStore = create<UIStore & PopupsStore & DataStore & MapStore & BuildMo
     };
     set({ cameraPosition: pos, cameraTarget: target });
   },
-  moveCameraToColRow: (col: number, row: number, speed = undefined) => {
+  moveCameraToColRow: (col: number, row: number, speed = undefined, transitionMode = false) => {
     const pos = getUIPositionFromColRow(col, row);
     const x = pos.x;
     const y = pos.y * -1;
     const targetPos = new Vector3(x, 0, y);
-    const cameraPos = new Vector3(
-      x + 125 * (Math.random() < 0.5 ? 1 : -1),
-      100,
-      y + 75 * (Math.random() < 0.5 ? 1 : -1),
-    );
+    let cameraPos;
+    if (transitionMode) {
+      cameraPos = new Vector3(x + 25, 25, y + 25); // Camera dives into exactly target position
+    } else {
+      cameraPos = new Vector3(x + 125 * (Math.random() < 0.5 ? 1 : -1), 100, y + 75 * (Math.random() < 0.5 ? 1 : -1));
+    }
     set({ cameraPosition: speed ? { ...cameraPos, transitionDuration: speed } : cameraPos });
     set({ cameraTarget: speed ? { ...targetPos, transitionDuration: speed } : targetPos });
   },

--- a/client/src/ui/components/construction/SelectPreviewBuilding.tsx
+++ b/client/src/ui/components/construction/SelectPreviewBuilding.tsx
@@ -14,7 +14,7 @@ import {
   ResourcesIds,
   findResourceById,
 } from "@bibliothecadao/eternum";
-import { useAutoAnimate } from "@formkit/auto-animate/react";
+
 import useRealmStore from "@/hooks/store/useRealmStore";
 import { useGetRealm } from "@/hooks/helpers/useRealm";
 import { useMemo } from "react";
@@ -58,7 +58,7 @@ export const SelectPreviewBuilding = () => {
     isDestroyMode,
     setIsDestroyMode,
   } = useUIStore();
-  const [parent] = useAutoAnimate();
+
   const { playResourceSound } = usePlayResourceSound();
 
   const buildingTypes = Object.keys(BuildingType).filter(
@@ -98,7 +98,7 @@ export const SelectPreviewBuilding = () => {
     });
 
   return (
-    <div className="flex flex-col overflow-hidden" ref={parent}>
+    <div className="flex flex-col">
       <div className="grid grid-cols-2 gap-2 p-2">
         {realmResourceIds.map((resourceId) => {
           const resource = findResourceById(resourceId)!;

--- a/client/src/ui/components/worldmap/hexagon/HexLayers.tsx
+++ b/client/src/ui/components/worldmap/hexagon/HexLayers.tsx
@@ -134,7 +134,7 @@ export const BiomesGrid = ({ startRow, endRow, startCol, endCol, explored }: Hex
 };
 
 export const HexagonGrid = ({ startRow, endRow, startCol, endCol, explored }: HexagonGridProps) => {
-  const { hexData, moveCameraToTarget, setIsLoadingScreenEnabled } = useUIStore((state) => state);
+  const { hexData, moveCameraToTarget, moveCameraToColRow, setIsLoadingScreenEnabled } = useUIStore((state) => state);
 
   const { hoverHandler, clickHandler } = useEventHandlers(explored);
 
@@ -219,10 +219,13 @@ export const HexagonGrid = ({ startRow, endRow, startCol, endCol, explored }: He
       const pos = getPositionsAtIndex(mesh, instanceId);
       if (!pos) return;
       const colRow = getColRowFromUIPosition(pos.x, pos.y);
-      setIsLoadingScreenEnabled(true);
+      moveCameraToColRow(colRow.col, colRow.row, 1.5, true);
+      setTimeout(() => {
+        setIsLoadingScreenEnabled(true);
+      }, 1000);
       setTimeout(() => {
         setLocation(`/hex?col=${colRow.col}&row=${colRow.row}`);
-      }, 300);
+      }, 1300);
     },
     [moveCameraToTarget],
   );

--- a/client/src/ui/modules/navigation/TopMiddleNavigation.tsx
+++ b/client/src/ui/modules/navigation/TopMiddleNavigation.tsx
@@ -68,7 +68,10 @@ export const TopMiddleNavigation = () => {
               setTimeout(() => {
                 setLocation("/map");
                 if (hexPosition.col !== 0 && hexPosition.row !== 0) {
-                  moveCameraToColRow(hexPosition.col, hexPosition.row, 0.01);
+                  moveCameraToColRow(hexPosition.col, hexPosition.row, 0.01, true);
+                  setTimeout(() => {
+                    moveCameraToColRow(hexPosition.col, hexPosition.row, 1.5);
+                  }, 10);
                 }
               }, 100);
             } else {


### PR DESCRIPTION
1. Fixed scroll in construction menu #652 
2. Improved camera transition between worldmap view and hexception view #600 

## **Type**
enhancement


___

## **Description**
- Removed dependency on `useAutoAnimate` from `@formkit/auto-animate/react`, which simplifies the component by removing unnecessary animations.
- Updated the main container div by removing the `overflow-hidden` class and the `ref` attribute, making the component structure cleaner and potentially improving performance.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectPreviewBuilding.tsx</strong><dd><code>Remove Auto Animation and Simplify Container in Building Selection</code></dd></summary>
<hr>

client/src/ui/components/construction/SelectPreviewBuilding.tsx
<li>Removed the use of <code>useAutoAnimate</code> hook and its associated parent <br>reference in the component.<br> <li> Simplified the main container by removing the <code>overflow-hidden</code> class <br>and the <code>ref</code> attribute.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/655/files#diff-c6a222463602fe87932fbbc060d2d99cdd1b151dcb9fcd9be42b602a77f18d97">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

