### PR TITLE
Add v to tag of dojo version in scarb.toml

### DIFF
--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -7,7 +7,7 @@ version = "0.5.0"
 sierra-replace-ids = true
 
 [dependencies]
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "0.6.1-alpha.4" }
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v0.6.1-alpha.4" }
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "cairo-v2.5.4" }
 cubit = { git = "https://github.com/ponderingdemocritus/cubit" }
 


### PR DESCRIPTION
Had an issue with `sozo build`, turns out you have to add the `v` in front of the tag in the `Scarb.toml` for the dojo version