### PR TITLE
solves  #669 by reverting explore and travel animation if tx fail

### DIFF
--- a/client/src/hooks/helpers/useExplore.tsx
+++ b/client/src/hooks/helpers/useExplore.tsx
@@ -114,6 +114,9 @@ export function useExplore() {
       unit_id: explorerId,
       direction,
       signer: account,
+    }).catch(() => {
+      // revert animation so that it goes back to the original position
+      setAnimationPaths([...animationPaths, { id: explorerId, path: path.reverse(), enemy: false }]);
     });
   };
   return { isExplored, exploredColsRows, useFoundResources, getExplorationInput, exploreHex };

--- a/client/src/hooks/helpers/useTravel.tsx
+++ b/client/src/hooks/helpers/useTravel.tsx
@@ -24,6 +24,9 @@ export function useTravel() {
       signer: account,
       travelling_entity_id: travelingEntityId,
       directions,
+    }).catch(() => {
+      // revert animation so that it goes back to the original position
+      setAnimationPaths([...animationPaths, { id: travelingEntityId, path: path.reverse(), enemy: false }]);
     });
   };
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Added error handling in `useExplore` and `useTravel` hooks to revert animations if transactions fail.
- This update ensures that both explorers and traveling entities return to their original positions if the associated blockchain transactions do not succeed.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useExplore.tsx</strong><dd><code>Add error handling to revert explorer animations on failure</code></dd></summary>
<hr>

client/src/hooks/helpers/useExplore.tsx
<li>Added error handling to revert animations if the <code>explore</code> function <br>fails.<br> <li> This ensures that the explorer's position is reset to the original <br>state upon transaction failure.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/680/files#diff-45821874b656c15cf5d9d6a603afd6d4858df5008f6353317b5a2d75482aa9a9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useTravel.tsx</strong><dd><code>Add error handling to revert travel animations on failure</code></dd></summary>
<hr>

client/src/hooks/helpers/useTravel.tsx
<li>Added error handling to revert animations if the <code>travel_hex</code> function <br>fails.<br> <li> This ensures that the traveling entity's position is reset to the <br>original state upon transaction failure.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/680/files#diff-a3ae3bb7c20e0f95e121cc173b192dadd3a166fd8c2dc84cd37c28c8ed59126a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

