### PR TITLE
allow only one structure per hex

### DIFF
--- a/contracts/scripts/system_models.json
+++ b/contracts/scripts/system_models.json
@@ -15,7 +15,8 @@
     "Tile",
     "Production",
     "HasClaimedStartingResources",
-    "Structure"
+    "Structure",
+    "StructureCount"
   ],
   "DONKEY_SYSTEMS": [],
   "TRADE_SYSTEMS": [
@@ -65,7 +66,9 @@
     "Resource",
     "Production",
     "EntityOwner",
-    "OwnedResourcesTracker"
+    "OwnedResourcesTracker",
+    "Structure",
+    "StructureCount"
   ],
   "SWAP_SYSTEMS": ["Market", "OwnedResourcesTracker", "Resource", "Production"],
   "LIQUIDITY_SYSTEMS": ["Market", "OwnedResourcesTracker", "Production", "Resource", "Liquidity"],

--- a/contracts/src/models/structure.cairo
+++ b/contracts/src/models/structure.cairo
@@ -1,5 +1,6 @@
 use array::SpanTrait;
 use eternum::alias::ID;
+use eternum::models::position::Coord;
 use eternum::utils::unpack::unpack_resource_types;
 use starknet::ContractAddress;
 use traits::Into;
@@ -42,3 +43,17 @@ impl StructureCategoryIntoFelt252 of Into<StructureCategory, felt252> {
     }
 }
 
+
+#[derive(Model, Copy, Drop, Serde)]
+struct StructureCount {
+    #[key]
+    coord: Coord,
+    count: u8
+}
+
+#[generate_trait]
+impl StructureCountImpl of StructureCountTrait {
+    fn assert_none(self: StructureCount) {
+        assert!(self.count == 0, "structure exists at this location");
+    }
+}

--- a/contracts/src/systems/bank/contracts/bank_systems.cairo
+++ b/contracts/src/systems/bank/contracts/bank_systems.cairo
@@ -18,7 +18,9 @@ mod bank_systems {
     use eternum::models::owner::{Owner, EntityOwner};
     use eternum::models::position::{Position, Coord};
     use eternum::models::resources::{Resource, ResourceImpl};
-    use eternum::models::structure::{Structure, StructureCategory};
+    use eternum::models::structure::{
+        Structure, StructureCategory, StructureCount, StructureCountTrait
+    };
 
     use traits::Into;
 
@@ -34,8 +36,10 @@ mod bank_systems {
             let bank_entity_id: ID = world.uuid().into();
 
             //todo: check that tile is explored
-            //todo: check that no bank on this position
-            //todo: check that no realm on this position
+
+            // ensure that the coord is not occupied by any other structure
+            let structure_count: StructureCount = get!(world, coord, StructureCount);
+            structure_count.assert_none();
 
             // remove the resources from the realm
             let bank_config = get!(world, WORLD_CONFIG_ID, BankConfig);
@@ -51,6 +55,7 @@ mod bank_systems {
                 world,
                 (
                     Structure { entity_id: bank_entity_id, category: StructureCategory::Bank },
+                    StructureCount { coord, count: 1 },
                     Bank { entity_id: bank_entity_id, owner_fee_scaled, exists: true },
                     Position { entity_id: bank_entity_id, x: coord.x, y: coord.y },
                     Owner { entity_id: bank_entity_id, address: starknet::get_caller_address() }


### PR DESCRIPTION
### **User description**
resolves #625


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new `StructureCount` model in `structure.cairo` to track structures per coordinate and ensure only one structure exists per hex.
- Updated `bank_systems.cairo` and `realm_systems.cairo` to include checks using `StructureCount` to prevent multiple structures from being placed on the same hex.
- This change enforces a rule that only one structure can exist per hex, enhancing the game's strategic elements and preventing errors from multiple structures in a single location.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>structure.cairo</strong><dd><code>Add StructureCount Model to Enforce Single Structure Rule</code></dd></summary>
<hr>

contracts/src/models/structure.cairo
<li>Added import for <code>Coord</code> from <code>eternum::models::position</code>.<br> <li> Defined a new struct <code>StructureCount</code> to track the number of structures <br>at a specific coordinate.<br> <li> Implemented <code>StructureCountImpl</code> with a method <code>assert_none</code> to ensure no <br>pre-existing structures at a location.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/693/files#diff-01c004ae8db32dee5614f033add21e1f8af35adec24f4a403ebbc4f67ca9f3cc">+15/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>bank_systems.cairo</strong><dd><code>Enforce Single Structure Rule in Bank System</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/bank/contracts/bank_systems.cairo
<li>Imported <code>StructureCount</code> and its trait.<br> <li> Added checks using <code>StructureCount</code> to ensure no existing structure at a <br>bank's position before creation.<br> <li> Updated the bank creation logic to include a <code>StructureCount</code> entry.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/693/files#diff-24bb5fd04f5d5d04a337f23053384620a86856d5d4d3a10687717c8ef26ba7c4">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts.cairo</strong><dd><code>Enforce Single Structure Rule in Realm System</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/realm/contracts.cairo
<li>Imported <code>StructureCount</code> and its trait for realm systems.<br> <li> Added checks using <code>StructureCount</code> to ensure no existing structure at a <br>realm's position before creation.<br> <li> Updated realm creation logic to include a <code>StructureCount</code> entry.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/693/files#diff-a17b26cc5c7a317ab4c355aff513b7e733e8d90840434283dd8d465d86fd8728">+10/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

