### PR TITLE
cost cycle fix

### DIFF
--- a/client/src/ui/components/construction/SelectPreviewBuilding.tsx
+++ b/client/src/ui/components/construction/SelectPreviewBuilding.tsx
@@ -306,6 +306,10 @@ export const BuildingInfo = ({ buildingId }: { buildingId: number }) => {
 
   const resourceProduced = BUILDING_RESOURCE_PRODUCED[buildingId];
 
+  const ongoingCost = RESOURCE_INPUTS[resourceProduced];
+
+  console.log(ongoingCost);
+
   return (
     <div className="p-2 text-sm text-gold">
       {/* <div className="w-32 my-2">{information}</div> */}
@@ -326,6 +330,26 @@ export const BuildingInfo = ({ buildingId }: { buildingId: number }) => {
           {findResourceById(resourceProduced)?.trait || ""} every cycle
         </div>
       )}
+
+      {resourceProduced && (
+        <>
+          <Headline className="py-3">COST PER CYCLE</Headline>
+          <div className="grid grid-cols-2 gap-2">
+            {resourceProduced !== 0 &&
+              ongoingCost &&
+              Object.keys(ongoingCost).map((resourceId, index) => {
+                return (
+                  <ResourceCost
+                    key={index}
+                    resourceId={ongoingCost[Number(resourceId)].resource}
+                    amount={ongoingCost[Number(resourceId)].amount / 1000}
+                  />
+                );
+              })}
+          </div>
+        </>
+      )}
+
       <Headline className="py-3"> One time cost</Headline>
       <div className="grid grid-cols-2 gap-2 text-sm">
         {Object.keys(cost).map((resourceId, index) => {


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new UI section in `SelectPreviewBuilding.tsx` to display ongoing costs per cycle for each building.
- Implemented a check to display the costs only if `resourceProduced` is not zero and `ongoingCost` is defined.
- Costs are now displayed in a grid format, showing the resource and its amount required per cycle.
- Added a debug log statement to help trace the values of ongoing costs during development.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectPreviewBuilding.tsx</strong><dd><code>Enhance Building Info Component with Ongoing Cost Display</code></dd></summary>
<hr>

client/src/ui/components/construction/SelectPreviewBuilding.tsx
<li>Added display of ongoing costs per cycle for buildings.<br> <li> Introduced a new section in the UI to show resource costs per cycle if <br>applicable.<br> <li> Enhanced logging for debugging with <code>console.log</code> to output ongoing <br>costs.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/710/files#diff-c6a222463602fe87932fbbc060d2d99cdd1b151dcb9fcd9be42b602a77f18d97">+24/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

