### PR TITLE
show transaction status component above all others

### DIFF
--- a/client/src/ui/modules/transactions/Transactions.tsx
+++ b/client/src/ui/modules/transactions/Transactions.tsx
@@ -44,7 +44,7 @@ export const Transactions = () => {
   }, [provider]);
 
   return (
-    <div>
+    <div style={{ zIndex: 100 }}>
       {transactions.map((transaction, index) => (
         <div className={`${transaction.execution_status == "REVERTED" ? "text-red/40" : "text-green/70"}`} key={index}>
           Status: {transaction.execution_status} {shortenHex(transaction.transaction_hash)}


### PR DESCRIPTION
### **User description**
always show transaction status component above all others so the error is always visible.

transaction status is usually hidden under pillage screen so people cant see error


___

### **PR Type**
enhancement


___

### **Description**
- The `div` element wrapping the transaction status messages in `Transactions.tsx` now has a `zIndex` of 100. This change ensures that the transaction status is always visible, addressing the issue where it could be hidden under other UI elements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Transactions.tsx</strong><dd><code>Ensure Transaction Status Component Visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/modules/transactions/Transactions.tsx
<li>Added a <code>zIndex</code> of 100 to the <code>div</code> element to ensure the transaction <br>status component is always visible above other components.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/716/files#diff-81d7fe8af73b69a975fa3986d494ffc7e95bba2c2fb98681e379b20352934194">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

