### PR TITLE
fix store capacity bug

### DIFF
--- a/client/src/dojo/modelManager/ProductionManager.ts
+++ b/client/src/dojo/modelManager/ProductionManager.ts
@@ -66,9 +66,8 @@ export class ProductionManager {
       getComponentValue(
         this.buildingQuantity,
         getEntityIdFromKeys([BigInt(this.entityId || "0"), BigInt(BuildingType.Storehouse)]),
-      )?.value || "0n";
-
-    return (Number(quantity) * STOREHOUSE_CAPACITY + STOREHOUSE_CAPACITY) * 100;
+      )?.value || "0";
+    return (Number(quantity) * STOREHOUSE_CAPACITY + STOREHOUSE_CAPACITY) * 1000;
   }
 
   private _balance(currentTick: number, resourceId: bigint): number {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the default value for `quantity` was incorrectly set as a BigInt ("0n") instead of a string ("0").
- Enhanced the store capacity calculation by changing the multiplier from 100 to 1000, increasing the capacity calculation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProductionManager.ts</strong><dd><code>Fix and Enhance Store Capacity Calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/dojo/modelManager/ProductionManager.ts
<li>Changed default value of <code>quantity</code> from "0n" to "0".<br> <li> Modified the formula for calculating store capacity to multiply by <br>1000 instead of 100.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/718/files#diff-fa5e42d9091f46f2d707b1cd4e0ac5aed421e83f7b1509abe66c9be9eaf85f7b">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

