### PR TITLE
fix precision bug with cost

### DIFF
--- a/client/src/ui/components/construction/SelectPreviewBuilding.tsx
+++ b/client/src/ui/components/construction/SelectPreviewBuilding.tsx
@@ -91,7 +91,7 @@ export const SelectPreviewBuildingMenu = () => {
     Object.keys(cost).every((resourceId) => {
       const resourceCost = cost[Number(resourceId)];
       const balance = getBalance(realmEntityId, resourceCost.resource);
-      return balance.balance >= resourceCost.amount * EternumGlobalConfig.resources.resourcePrecision * 1000;
+      return balance.balance >= resourceCost.amount * EternumGlobalConfig.resources.resourcePrecision;
     });
 
   const [selectedTab, setSelectedTab] = useState(0);
@@ -111,7 +111,6 @@ export const SelectPreviewBuildingMenu = () => {
               const resource = findResourceById(resourceId)!;
               const cost = BUILDING_COSTS[BuildingType.Resource];
               const hasBalance = checkBalance(cost);
-
               return (
                 <BuildingCard
                   key={resourceId}


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a precision error in the `checkBalance` function within `SelectPreviewBuildingMenu`. The balance calculation was previously multiplied by an extra 1000, which has been removed to correct the resource balance check.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectPreviewBuilding.tsx</strong><dd><code>Fix precision error in balance calculation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/construction/SelectPreviewBuilding.tsx
<li>Corrected the calculation of balance check in <code>checkBalance</code> function by <br>removing an unnecessary multiplication by 1000.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/746/files#diff-c6a222463602fe87932fbbc060d2d99cdd1b151dcb9fcd9be42b602a77f18d97">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

