### PR TITLE
fix: switch positions of structures and battles in Location details OSWindow

### DIFF
--- a/client/src/ui/components/worldmap/hexagon/HexagonInformationPanel.tsx
+++ b/client/src/ui/components/worldmap/hexagon/HexagonInformationPanel.tsx
@@ -16,8 +16,8 @@ export const HexagonInformationPanel = () => {
           </div>
         </div>
 
-        <ArmiesAtLocation />
         <Battle />
+        <ArmiesAtLocation />
       </div>
     </>
   );


### PR DESCRIPTION
### **PR Type**
enhancement

solves #743 
___

### **Description**
- Swapped the positions of `<ArmiesAtLocation />` and `<Battle />` components to enhance the user interface in the `HexagonInformationPanel`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HexagonInformationPanel.tsx</strong><dd><code>Swap Positions of Components in HexagonInformationPanel</code>&nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/HexagonInformationPanel.tsx
<li>Swapped the positions of <code><ArmiesAtLocation /></code> and <code><Battle /></code> <br>components within the <code>HexagonInformationPanel</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/750/files#diff-9db373339d3521390ef906ccde8d7948d4c82fe8ee55d03c8a654968272a832a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

