### PR TITLE
fix pillage history not showing + improve layout

### DIFF
--- a/client/src/ui/components/construction/SelectPreviewBuilding.tsx
+++ b/client/src/ui/components/construction/SelectPreviewBuilding.tsx
@@ -34,7 +34,7 @@ import Button from "@/ui/elements/Button";
 // TODO: THIS IS TERRIBLE CODE, PLEASE REFACTOR
 
 const BUILD_IMAGES_PREFIX = "/images/buildings/construction/";
-const BUILDING_IMAGES_PATH = {
+export const BUILDING_IMAGES_PATH = {
   [BuildingType.None]: "",
   [BuildingType.Castle]: "",
   [BuildingType.Resource]: BUILD_IMAGES_PREFIX + "mine.png",

--- a/client/src/ui/components/military/Battle.tsx
+++ b/client/src/ui/components/military/Battle.tsx
@@ -18,6 +18,7 @@ import { Event } from "@/dojo/events/graphqlClient";
 import { BuildingType, Resource } from "@bibliothecadao/eternum";
 import { ResourceCost } from "@/ui/elements/ResourceCost";
 import { Subscription } from "rxjs";
+import { BUILDING_IMAGES_PATH } from "../construction/SelectPreviewBuilding";
 
 export const ArmiesAtLocation = () => {
   const clickedHex = useUIStore((state) => state.clickedHex);
@@ -318,9 +319,9 @@ export const PillageHistory = ({
 
   useEffect(() => {
     const subscribeToFoundResources = async () => {
+      if (!isComponentMounted.current) return;
       const observable = await eventUpdates.createPillageHistoryEvents(structureId, attackerRealmEntityId);
       const subscription = observable.subscribe((event) => {
-        if (!isComponentMounted.current) return;
         if (event) {
           // Check if component is still mounted
           setPillageHistory((prev) => [formatPillageEvent(event), ...prev]);
@@ -338,38 +339,50 @@ export const PillageHistory = ({
   }, [structureId, attackerRealmEntityId, eventUpdates]);
 
   return (
-    <div className="border p-2 ">
-      <div className="m-3">
-        <Headline> Pillage History </Headline>
+    <div className="border p-2">
+      <div className="m-3 text-center">
+        <Headline>Pillage History</Headline>
       </div>
       <div className="overflow-auto max-h-[300px]">
         {pillageHistory.map((history, index) => (
-          <div key={index} className={`group hover:bg-gold/10 border relative bg-gold/5 text-gold`}>
-            <div className="flex">
-              <div className="flex items-center p-1 border-t-0 border-l-0 border pr-3 h5">
-                <div>Army ID: {history.armyId.toString()}</div>
+          <div key={index} className="group hover:bg-gold/10 border relative bg-gold/5 text-gold my-3">
+            <div className="absolute top-0 left-0 p-2 text-sm">Army ID: {history.armyId.toString()}</div>
+            <div className="flex justify-center items-center p-3">
+              <div className="text-center">
+                <Headline>Outcome</Headline>
+                <div className={`text-xl font-bold ${history.winner === 0 ? "text-blue-500" : "text-red-500"}`}>
+                  {history.winner === 0 ? "Defender Wins" : "Attacker Wins"}
+                </div>
               </div>
             </div>
             <div className="p-2">
-              <div className="my-2">
-                <Headline>Winner </Headline>
-                {history.winner === 0 ? "Defender" : "Attacker"}
-              </div>
-              <div className="flex flex-col space-y-2 items-center">
-                <Headline> Pillaged Resources</Headline>
-                <div className="flex flex-wrap justify-center gap-4">
-                  {history.pillagedResources.map((resource: Resource) => (
-                    <ResourceCost
-                      key={resource.resourceId}
-                      resourceId={resource.resourceId}
-                      amount={divideByPrecision(resource.amount)}
-                    />
-                  ))}
+              <div className="flex justify-around items-start my-2">
+                <div className="text-center">
+                  <Headline>Pillaged Resources</Headline>
+                  <div className="flex flex-wrap justify-center gap-4">
+                    {history.pillagedResources.length > 0
+                      ? history.pillagedResources.map((resource: Resource) => (
+                          <ResourceCost
+                            key={resource.resourceId}
+                            resourceId={resource.resourceId}
+                            amount={divideByPrecision(resource.amount)}
+                          />
+                        ))
+                      : "None"}
+                  </div>
                 </div>
-              </div>
-              <div>
-                <Headline> Destroyed Building</Headline>
-                <div>{history.destroyedBuildingType}</div>
+                <div className="text-center">
+                  <Headline>Destroyed Building</Headline>
+                  {history.destroyedBuildingType !== "None" && (
+                    <img
+                      src={`${BUILDING_IMAGES_PATH[history.destroyedBuildingType as BuildingType]})`}
+                      alt="Destroyed Building"
+                      className="w-24 h-24 mx-auto"
+                    />
+                  )}
+                  {/* Placeholder for Building Image */}
+                  <div>{history.destroyedBuildingType}</div>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### **User description**
solves #744


___

### **PR Type**
bug_fix, enhancement


___

### **Description**
- Exported `BUILDING_IMAGES_PATH` from `SelectPreviewBuilding.tsx` for use in other components.
- Improved the Pillage History component in `Battle.tsx` by:
  - Adding early return if component is unmounted during event subscription.
  - Enhancing the UI layout to be more centered and adding visual cues for army ID and outcomes.
  - Displaying images for destroyed buildings based on their type.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectPreviewBuilding.tsx</strong><dd><code>Export BUILDING_IMAGES_PATH for Reuse</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/construction/SelectPreviewBuilding.tsx
<li>Exported <code>BUILDING_IMAGES_PATH</code> as a constant for use in other <br>components.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/752/files#diff-c6a222463602fe87932fbbc060d2d99cdd1b151dcb9fcd9be42b602a77f18d97">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Battle.tsx</strong><dd><code>Enhance Pillage History Display and Code Robustness</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/military/Battle.tsx
<li>Added import for <code>BUILDING_IMAGES_PATH</code> from <code>SelectPreviewBuilding</code>.<br> <li> Added early return in <code>subscribeToFoundResources</code> if component is <br>unmounted to prevent updates on unmounted components.<br> <li> Improved layout and styling of the Pillage History component.<br> <li> Added display logic for destroyed buildings with an image based on the <br>building type.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/752/files#diff-9f3726f9bbcb484108a0b6184660bcd0f0c5ffcdbffaf734ceb72ee17f95ed75">+38/-25</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

