### PR TITLE
fix: Remove extra multipliers in config

### DIFF
--- a/sdk/packages/eternum/src/config/index.ts
+++ b/sdk/packages/eternum/src/config/index.ts
@@ -23,12 +23,12 @@ export const setProductionConfig = async (account: Account, provider: EternumPro
   for (const resourceId of Object.keys(RESOURCE_INPUTS) as unknown as ResourcesIds[]) {
     const tx = await provider.set_production_config({
       signer: account,
-      amount: RESOURCE_OUTPUTS[resourceId] * 1000,
+      amount: RESOURCE_OUTPUTS[resourceId] * EternumGlobalConfig.resources.resourcePrecision,
       resource_type: resourceId,
       cost: RESOURCE_INPUTS[resourceId].map((cost) => {
         return {
           ...cost,
-          amount: cost.amount * 1000,
+          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision,
         };
       }),
     });
@@ -59,7 +59,7 @@ export const setBuildingConfig = async (account: Account, provider: EternumProvi
       cost_of_building: BUILDING_COSTS[buildingId].map((cost) => {
         return {
           ...cost,
-          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision * 1000,
+          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision,
         };
       }),
     });
@@ -77,7 +77,7 @@ export const setResourceBuildingConfig = async (account: Account, provider: Eter
       cost_of_building: RESOURCE_BUILDING_COSTS[resourceId].map((cost) => {
         return {
           ...cost,
-          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision * 1000,
+          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision,
         };
       }),
     });
@@ -130,7 +130,7 @@ export const setupGlobals = async (account: Account, provider: EternumProvider) 
   // Set the bank config
   const txBank = await provider.set_bank_config({
     signer: account,
-    lords_cost: EternumGlobalConfig.resources.resourcePrecision * EternumGlobalConfig.banks.lordsCost * 1000,
+    lords_cost: EternumGlobalConfig.resources.resourcePrecision * EternumGlobalConfig.banks.lordsCost,
     lp_fee_scaled: EternumGlobalConfig.banks.lpFees,
   });
 
@@ -146,10 +146,9 @@ export const setupGlobals = async (account: Account, provider: EternumProvider) 
 
   const txExplore = await provider.set_explore_config({
     signer: account,
-    wheat_burn_amount:
-      EternumGlobalConfig.exploration.wheatBurn * EternumGlobalConfig.resources.resourcePrecision * 1000,
-    fish_burn_amount: EternumGlobalConfig.exploration.fishBurn * EternumGlobalConfig.resources.resourcePrecision * 1000,
-    reward_amount: EternumGlobalConfig.exploration.reward * EternumGlobalConfig.resources.resourcePrecision * 1000,
+    wheat_burn_amount: EternumGlobalConfig.exploration.wheatBurn * EternumGlobalConfig.resources.resourcePrecision,
+    fish_burn_amount: EternumGlobalConfig.exploration.fishBurn * EternumGlobalConfig.resources.resourcePrecision,
+    reward_amount: EternumGlobalConfig.exploration.reward * EternumGlobalConfig.resources.resourcePrecision,
   });
 
   console.log(`Configuring bank config ${txExplore.statusReceipt}...`);
@@ -199,7 +198,7 @@ export const setQuestConfig = async (account: Account, provider: EternumProvider
       resources: QuestResources[type].map((cost) => {
         return {
           ...cost,
-          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision * 1000,
+          amount: cost.amount * EternumGlobalConfig.resources.resourcePrecision,
         };
       }),
     });


### PR DESCRIPTION
### **User description**
Closes #753


___

### **PR Type**
enhancement


___

### **Description**
- Standardized the resource amount calculations by replacing hardcoded multipliers with a configurable precision value (`EternumGlobalConfig.resources.resourcePrecision`).
- This change affects multiple configuration settings including production, building, resource building, bank, and quest configurations, ensuring consistency and flexibility in resource amount calculations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Standardize Resource Precision in Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

sdk/packages/eternum/src/config/index.ts
<li>Updated multiplier for resource amounts to use <br><code>EternumGlobalConfig.resources.resourcePrecision</code> instead of a hardcoded <br>value of 1000.<br> <li> Applied the new precision configuration across various configuration <br>functions including production, building, resource building, bank, and <br>quest configurations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/757/files#diff-6aecc823aea65bfad1461922fd49c884b2c705a136856aecefc623f166212043">+9/-10</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

