### PR TITLE
Combat pillage fixes

### DIFF
--- a/client/src/ui/components/military/Battle.tsx
+++ b/client/src/ui/components/military/Battle.tsx
@@ -351,7 +351,7 @@ export const PillageHistory = ({
               <div className="text-center">
                 <Headline>Outcome</Headline>
                 <div className={`text-xl font-bold ${history.winner === 0 ? "text-blue-500" : "text-red-500"}`}>
-                  {history.winner === 0 ? "No Winner" : history.winner === 1 ? "Attacker Wins" : "Defender Wins"}
+                  {history.winner === 0 ? "No Winner" : history.winner === 1 ? "Attacker Won" : "Defender Won"}
                 </div>
               </div>
             </div>

--- a/client/src/ui/components/military/Battle.tsx
+++ b/client/src/ui/components/military/Battle.tsx
@@ -351,7 +351,7 @@ export const PillageHistory = ({
               <div className="text-center">
                 <Headline>Outcome</Headline>
                 <div className={`text-xl font-bold ${history.winner === 0 ? "text-blue-500" : "text-red-500"}`}>
-                  {history.winner === 0 ? "Defender Wins" : "Attacker Wins"}
+                  {history.winner === 0 ? "No Winner" : history.winner === 1 ? "Attacker Wins" : "Defender Wins"}
                 </div>
               </div>
             </div>

--- a/client/src/ui/components/military/Battle.tsx
+++ b/client/src/ui/components/military/Battle.tsx
@@ -375,7 +375,9 @@ export const PillageHistory = ({
                   <Headline>Destroyed Building</Headline>
                   {history.destroyedBuildingType !== "None" && (
                     <img
-                      src={`${BUILDING_IMAGES_PATH[history.destroyedBuildingType as BuildingType]})`}
+                      src={`${
+                        BUILDING_IMAGES_PATH[BuildingType[history.destroyedBuildingType as keyof typeof BuildingType]]
+                      }`}
                       alt="Destroyed Building"
                       className="w-24 h-24 mx-auto"
                     />

--- a/contracts/src/models/loyalty.cairo
+++ b/contracts/src/models/loyalty.cairo
@@ -20,10 +20,6 @@ struct Loyalty {
 #[generate_trait]
 impl LoyaltyImpl of LoyaltyTrait {
     fn value(self: Loyalty, tick: TickConfig) -> u64 {
-        if self.last_updated_tick == 0 {
-            return 0;
-        }
-
         let ticks_passed: u64 = tick.current() - self.last_updated_tick;
         let value: u64 = (ticks_passed / LOYALTY_TICK_INTERVAL) * LOYALTY_PER_TICK_INTERVAL;
         return min(value, LOYALTY_MAX_VALUE);

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -602,7 +602,7 @@ mod combat_systems {
             if *attack_successful {
                 let attack_success_probability = attacking_army_strength
                     * PercentageValueImpl::_100().into()
-                    / (structure_army_strength + 1);
+                    / (attacking_army_strength + structure_army_strength + 1);
 
                 // choose x random resource to be stolen
                 let mut chosen_resource_types: Span<u8> = random::choices(

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -564,6 +564,8 @@ mod combat_systems {
             // get structure army and health
 
             let structure_army_id: u128 = get!(world, structure_id, Protector).army_id;
+            assert!(structure_army_id != army_id, "self attack");
+
             let mut structure_army: Army = Default::default();
             let mut structure_army_health: Health = Default::default();
             if structure_army_id.is_non_zero() {

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -591,6 +591,11 @@ mod combat_systems {
                 * attacking_army_health.percentage_left()
                 / PercentageValueImpl::_100().into();
 
+            // prevent `weights sum is zero` error 
+            if attacking_army_strength == 0 {
+                panic!("attacking army strength too low");
+            }
+
             let attack_successful: @bool = random::choices(
                 array![true, false].span(),
                 array![attacking_army_strength, structure_army_strength].span(),
@@ -600,7 +605,6 @@ mod combat_systems {
             )[0];
 
             let mut pillaged_resources: Array<(u8, u128)> = array![];
-
             if *attack_successful {
                 let attack_success_probability = attacking_army_strength
                     * PercentageValueImpl::_100().into()

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -573,13 +573,13 @@ mod combat_systems {
             }
 
             // a percentage of it's full strength depending on structure army's health
-            let structure_army_strength = structure_army.troops.full_strength(troop_config)
+            let mut structure_army_strength = structure_army.troops.full_strength(troop_config)
                 * structure_army_health.percentage_left()
                 / PercentageValueImpl::_100().into();
 
             // a percentage of its relative strength depending on loyalty
             let structure_loyalty: Loyalty = get!(world, structure_id, Loyalty);
-            let structure_army_strength = structure_army_strength
+            structure_army_strength += structure_army_strength
                 * structure_loyalty.value(tick).into()
                 / LOYALTY_MAX_VALUE.into();
 


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a new state "No Winner" to the battle outcome display in the UI to handle cases without a clear winner.
- Simplified the loyalty calculation in the Cairo contract by removing unnecessary initial checks.
- Enhanced the combat system by preventing self-attacks and adjusting the strength and attack probability calculations to factor in loyalty.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Battle.tsx</strong><dd><code>Update Winner Display Logic in Pillage History</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/military/Battle.tsx
<li>Updated the display logic for the winner in the <code>PillageHistory</code> <br>component to include a "No Winner" state.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/759/files#diff-9f3726f9bbcb484108a0b6184660bcd0f0c5ffcdbffaf734ceb72ee17f95ed75">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>loyalty.cairo</strong><dd><code>Simplify Loyalty Calculation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/loyalty.cairo
<li>Removed the initial loyalty check that set loyalty to zero if <br><code>last_updated_tick</code> was zero.<br> <li> Simplified the loyalty value calculation.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/759/files#diff-2e1f03f39b962a9edbbbb897a95795a6a4012fb49180b31fa1327eacdb4ac43f">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts.cairo</strong><dd><code>Enhance Combat System Logic and Prevent Self-Attacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/contracts.cairo
<li>Added a check to prevent self-attacks in the combat system.<br> <li> Modified the strength calculation to include loyalty and adjusted the <br>attack success probability formula.


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/759/files#diff-4bdcda25a764215afd907449c2bb112a726bf3281fc1a7e6b9f7f0d4351ddb52">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

