### PR TITLE
show missing balance in red

### DIFF
--- a/client/src/ui/elements/ResourceCost.tsx
+++ b/client/src/ui/elements/ResourceCost.tsx
@@ -25,6 +25,8 @@ export const ResourceCost = ({
   ...props
 }: ResourceCostProps) => {
   const trait = useMemo(() => findResourceById(props.resourceId)?.trait, [props.resourceId]);
+  const balanceColor = props.balance !== undefined && props.balance < props.amount ? "text-red/90" : "text-green/90";
+  console.log({ balance: props.balance, amount: props.amount, balanceColor });
   return (
     <div
       className={clsx(
@@ -42,8 +44,8 @@ export const ResourceCost = ({
       />
       <div
         className={clsx(
-          "relative flex flex-col shrink-0  self-center ml-2",
-          type === "horizontal" ? "ml-1  text-left" : "items-center",
+          "relative flex flex-col shrink-0 self-center ml-2",
+          type === "horizontal" ? "ml-1 text-left" : "items-center",
         )}
       >
         <div onClick={onClick} className={clsx("relative text-xs font-bold", props.color)}>
@@ -52,7 +54,9 @@ export const ResourceCost = ({
             notation: "compact",
             maximumFractionDigits: 1,
           }).format(props.amount || 0)}{" "}
-          <span className="text-green/90 font-normal">{props.balance && `(${currencyFormat(props.balance, 0)})`} </span>
+          <span className={clsx(balanceColor, "font-normal")}>
+            {props.balance !== undefined && `(${currencyFormat(props.balance, 0)})`}{" "}
+          </span>
         </div>
         {type === "horizontal" && (
           <div className="text-xs leading-[10px] self-start relative mt-1 font-normal">{trait}</div>


### PR DESCRIPTION
### **User description**
![image](https://github.com/BibliothecaDAO/eternum/assets/38816784/496172ee-0785-4de4-b2e3-335539c84cf9)


___

### **PR Type**
enhancement


___

### **Description**
- Added conditional text coloring to the `ResourceCost` component to visually indicate when the balance is less than the amount, using red color for deficits and green for normal or surplus values.
- Included a console log for debugging purposes, which logs balance, amount, and the resulting color.
- Minor adjustments to JSX formatting and spacing for better readability and consistency.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ResourceCost.tsx</strong><dd><code>Enhance Resource Cost Component with Conditional Text Coloring</code></dd></summary>
<hr>

client/src/ui/elements/ResourceCost.tsx
<li>Added logic to change text color based on balance: red if balance is <br>less than amount, green otherwise.<br> <li> Added console log to debug balance and amount values along with the <br>determined color.<br> <li> Adjusted formatting and spacing in the JSX structure for clarity.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/764/files#diff-3a39b2a659bbd9184a5ea77d33fad2271c9f4141daa23f59f0a6c6eee54256b3">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

