### PR TITLE
destroy building properly

### DIFF
--- a/contracts/src/models/buildings.cairo
+++ b/contracts/src/models/buildings.cairo
@@ -616,6 +616,8 @@ impl BuildingImpl of BuildingTrait {
         building.entity_id = 0;
         building.category = BuildingCategory::None;
         building.outer_entity_id = 0;
+        building.produced_resource_type = 0;
+        building.bonus_percent = 0;
 
         set!(world, (building));
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Ensures that when a building is destroyed, all its relevant attributes are reset to default values, preventing any unintended carryover of state.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>buildings.cairo</strong><dd><code>Properly Reset Building Attributes on Destruction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/buildings.cairo
<li>Reset <code>produced_resource_type</code> and <code>bonus_percent</code> attributes of a <br>building when it is destroyed.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/779/files#diff-d98a082b4990bd2f45a454b6fbeef40ee7acbd1650edbdcb1657071706a34ca7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

