### PR TITLE
enh: Change weight deduct assert message to be more explicit

### DIFF
--- a/contracts/manifests/dev/manifest.json
+++ b/contracts/manifests/dev/manifest.json
@@ -1672,8 +1672,8 @@
     {
       "kind": "DojoContract",
       "address": "0x490d8572029a070064c52d09d2fdb4d5a538bd26f723abfcdeeaff38e47dfeb",
-      "class_hash": "0x6979203c57264b838e29f4dc0e1985d62b8601d50edc33acf1e718980055025",
-      "original_class_hash": "0x6979203c57264b838e29f4dc0e1985d62b8601d50edc33acf1e718980055025",
+      "class_hash": "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7",
+      "original_class_hash": "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -3473,8 +3473,8 @@
     {
       "kind": "DojoContract",
       "address": "0xe41bb92d0734340f4d6ad423426f5bf2f611fa13b3c94d325c5f3b64c7ddea",
-      "class_hash": "0x79cf8d43e496bf53ba505be9b86a08284a3b32261cb4c3cd22f810e63d9890",
-      "original_class_hash": "0x79cf8d43e496bf53ba505be9b86a08284a3b32261cb4c3cd22f810e63d9890",
+      "class_hash": "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc",
+      "original_class_hash": "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4170,8 +4170,8 @@
     {
       "kind": "DojoContract",
       "address": "0x3d2e8efbfb6b507fcdbdfac3d74a1f2b0852f6193b57aa01573aa95e8472c59",
-      "class_hash": "0x3c43add7f8b50f3253d53d5354f7b1655f906a438cc3d7541b7e80ec727427a",
-      "original_class_hash": "0x3c43add7f8b50f3253d53d5354f7b1655f906a438cc3d7541b7e80ec727427a",
+      "class_hash": "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315",
+      "original_class_hash": "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4409,8 +4409,8 @@
     {
       "kind": "DojoContract",
       "address": "0x33be47a5861a422cb123bbdc81851e526db54b56bfde6e2b8069c7b93a7503",
-      "class_hash": "0x4f109eca7ca818aac8ae904445640f656220efb46591694d84bb25ab283fb93",
-      "original_class_hash": "0x4f109eca7ca818aac8ae904445640f656220efb46591694d84bb25ab283fb93",
+      "class_hash": "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b",
+      "original_class_hash": "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -6656,312 +6656,6 @@
         }
       ],
       "name": "eternum::models::buildings::building"
-    },
-    {
-      "kind": "DojoModel",
-      "members": [
-        {
-          "name": "entity_id",
-          "type": "u128",
-          "key": true
-        },
-        {
-          "name": "category",
-          "type": "BuildingCategory",
-          "key": true
-        },
-        {
-          "name": "value",
-          "type": "u8",
-          "key": false
-        }
-      ],
-      "class_hash": "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2",
-      "original_class_hash": "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2",
-      "abi": [
-        {
-          "type": "impl",
-          "name": "DojoModelImpl",
-          "interface_name": "dojo::model::IDojoModel"
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::integer::u8>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::integer::u8>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::felt252>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::felt252>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "dojo::database::introspect::Struct",
-          "members": [
-            {
-              "name": "name",
-              "type": "core::felt252"
-            },
-            {
-              "name": "attrs",
-              "type": "core::array::Span::<core::felt252>"
-            },
-            {
-              "name": "children",
-              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "dojo::database::introspect::Enum",
-          "members": [
-            {
-              "name": "name",
-              "type": "core::felt252"
-            },
-            {
-              "name": "attrs",
-              "type": "core::array::Span::<core::felt252>"
-            },
-            {
-              "name": "children",
-              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
-            }
-          ]
-        },
-        {
-          "type": "enum",
-          "name": "dojo::database::introspect::Ty",
-          "variants": [
-            {
-              "name": "Primitive",
-              "type": "core::felt252"
-            },
-            {
-              "name": "Struct",
-              "type": "dojo::database::introspect::Struct"
-            },
-            {
-              "name": "Enum",
-              "type": "dojo::database::introspect::Enum"
-            },
-            {
-              "name": "Tuple",
-              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
-            },
-            {
-              "name": "Array",
-              "type": "core::integer::u32"
-            }
-          ]
-        },
-        {
-          "type": "interface",
-          "name": "dojo::model::IDojoModel",
-          "items": [
-            {
-              "type": "function",
-              "name": "name",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::felt252"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "unpacked_size",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::integer::u32"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "packed_size",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::integer::u32"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "layout",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::array::Span::<core::integer::u8>"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "schema",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "dojo::database::introspect::Ty"
-                }
-              ],
-              "state_mutability": "view"
-            }
-          ]
-        },
-        {
-          "type": "impl",
-          "name": "building_quantityImpl",
-          "interface_name": "eternum::models::buildings::Ibuilding_quantity"
-        },
-        {
-          "type": "enum",
-          "name": "eternum::models::buildings::BuildingCategory",
-          "variants": [
-            {
-              "name": "None",
-              "type": "()"
-            },
-            {
-              "name": "Castle",
-              "type": "()"
-            },
-            {
-              "name": "Resource",
-              "type": "()"
-            },
-            {
-              "name": "Farm",
-              "type": "()"
-            },
-            {
-              "name": "FishingVillage",
-              "type": "()"
-            },
-            {
-              "name": "Barracks",
-              "type": "()"
-            },
-            {
-              "name": "Market",
-              "type": "()"
-            },
-            {
-              "name": "ArcheryRange",
-              "type": "()"
-            },
-            {
-              "name": "Stable",
-              "type": "()"
-            },
-            {
-              "name": "DonkeyFarm",
-              "type": "()"
-            },
-            {
-              "name": "TradingPost",
-              "type": "()"
-            },
-            {
-              "name": "WorkersHut",
-              "type": "()"
-            },
-            {
-              "name": "WatchTower",
-              "type": "()"
-            },
-            {
-              "name": "Walls",
-              "type": "()"
-            },
-            {
-              "name": "Storehouse",
-              "type": "()"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "eternum::models::buildings::BuildingQuantity",
-          "members": [
-            {
-              "name": "entity_id",
-              "type": "core::integer::u128"
-            },
-            {
-              "name": "category",
-              "type": "eternum::models::buildings::BuildingCategory"
-            },
-            {
-              "name": "value",
-              "type": "core::integer::u8"
-            }
-          ]
-        },
-        {
-          "type": "interface",
-          "name": "eternum::models::buildings::Ibuilding_quantity",
-          "items": [
-            {
-              "type": "function",
-              "name": "ensure_abi",
-              "inputs": [
-                {
-                  "name": "model",
-                  "type": "eternum::models::buildings::BuildingQuantity"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "view"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "eternum::models::buildings::building_quantity::Event",
-          "kind": "enum",
-          "variants": []
-        }
-      ],
-      "name": "eternum::models::buildings::building_quantity"
     },
     {
       "kind": "DojoModel",

--- a/contracts/manifests/dev/manifest.toml
+++ b/contracts/manifests/dev/manifest.toml
@@ -70,8 +70,8 @@ name = "eternum::systems::buildings::contracts::building_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x490d8572029a070064c52d09d2fdb4d5a538bd26f723abfcdeeaff38e47dfeb"
-class_hash = "0x6979203c57264b838e29f4dc0e1985d62b8601d50edc33acf1e718980055025"
-original_class_hash = "0x6979203c57264b838e29f4dc0e1985d62b8601d50edc33acf1e718980055025"
+class_hash = "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7"
+original_class_hash = "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_combat_contracts_combat_systems.json"
 reads = []
@@ -142,8 +142,8 @@ name = "eternum::systems::leveling::contracts::leveling_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0xe41bb92d0734340f4d6ad423426f5bf2f611fa13b3c94d325c5f3b64c7ddea"
-class_hash = "0x79cf8d43e496bf53ba505be9b86a08284a3b32261cb4c3cd22f810e63d9890"
-original_class_hash = "0x79cf8d43e496bf53ba505be9b86a08284a3b32261cb4c3cd22f810e63d9890"
+class_hash = "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc"
+original_class_hash = "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_map_contracts_map_systems.json"
 reads = []
@@ -178,8 +178,8 @@ name = "eternum::systems::realm::contracts::realm_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x3d2e8efbfb6b507fcdbdfac3d74a1f2b0852f6193b57aa01573aa95e8472c59"
-class_hash = "0x3c43add7f8b50f3253d53d5354f7b1655f906a438cc3d7541b7e80ec727427a"
-original_class_hash = "0x3c43add7f8b50f3253d53d5354f7b1655f906a438cc3d7541b7e80ec727427a"
+class_hash = "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315"
+original_class_hash = "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_resources_contracts_resource_systems.json"
 reads = []
@@ -190,8 +190,8 @@ name = "eternum::systems::resources::contracts::resource_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x33be47a5861a422cb123bbdc81851e526db54b56bfde6e2b8069c7b93a7503"
-class_hash = "0x4f109eca7ca818aac8ae904445640f656220efb46591694d84bb25ab283fb93"
-original_class_hash = "0x4f109eca7ca818aac8ae904445640f656220efb46591694d84bb25ab283fb93"
+class_hash = "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b"
+original_class_hash = "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_trade_contracts_trade_systems_trade_systems.json"
 reads = []
@@ -388,28 +388,6 @@ key = false
 [[models.members]]
 name = "outer_entity_id"
 type = "u128"
-key = false
-
-[[models]]
-kind = "DojoModel"
-class_hash = "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2"
-original_class_hash = "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2"
-abi = "abis/deployments/models/eternum_models_buildings_building_quantity.json"
-name = "eternum::models::buildings::building_quantity"
-
-[[models.members]]
-name = "entity_id"
-type = "u128"
-key = true
-
-[[models.members]]
-name = "category"
-type = "BuildingCategory"
-key = true
-
-[[models.members]]
-name = "value"
-type = "u8"
 key = false
 
 [[models]]

--- a/contracts/manifests/prod/manifest.json
+++ b/contracts/manifests/prod/manifest.json
@@ -681,8 +681,8 @@
     {
       "kind": "DojoContract",
       "address": "0x2f6de5a11f7eb5dc8cd616751800f034e387f6dd3e9f85d58a5fd79802c46fc",
-      "class_hash": "0x69c3fb95340f8853417881e5f72414a37bf48636851c01a36d6d59e5812d56c",
-      "original_class_hash": "0x69c3fb95340f8853417881e5f72414a37bf48636851c01a36d6d59e5812d56c",
+      "class_hash": "0x28d09ac6faf0e3a828d1cde813db5f5eb1f0a1b71dd76d9c4b37dfa2d07a762",
+      "original_class_hash": "0x28d09ac6faf0e3a828d1cde813db5f5eb1f0a1b71dd76d9c4b37dfa2d07a762",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -892,8 +892,8 @@
     {
       "kind": "DojoContract",
       "address": "0x5777787d1a6f43c333dcdeb0c02e3afbdd9eeb3cc74d111c38a26a0104652b6",
-      "class_hash": "0x28b9c2588f46391f3ca35855fc55b988baa601d9fa9771cbb6a3cb8b40131bc",
-      "original_class_hash": "0x28b9c2588f46391f3ca35855fc55b988baa601d9fa9771cbb6a3cb8b40131bc",
+      "class_hash": "0x5097b3bae0c00223a8d4375d8e5350239941c58eab6aec2021b4647f64de988",
+      "original_class_hash": "0x5097b3bae0c00223a8d4375d8e5350239941c58eab6aec2021b4647f64de988",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -1148,8 +1148,8 @@
     {
       "kind": "DojoContract",
       "address": "0x24cedd3154abc642500ab1a805ee8f1124009441d79d9bd25ef4cbd88dfcffe",
-      "class_hash": "0x57e41cb5cad35b56ff358c451f595e3c3d72fd21e098ebc447ce8871f02e0a",
-      "original_class_hash": "0x57e41cb5cad35b56ff358c451f595e3c3d72fd21e098ebc447ce8871f02e0a",
+      "class_hash": "0x3bd5f21ba7f0a8dfea0e9d7b731ab97e15e06733322e1434784d3065a154b79",
+      "original_class_hash": "0x3bd5f21ba7f0a8dfea0e9d7b731ab97e15e06733322e1434784d3065a154b79",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -1367,6 +1367,11 @@
               "name": "buy",
               "type": "core::bool",
               "kind": "data"
+            },
+            {
+              "name": "timestamp",
+              "type": "core::integer::u64",
+              "kind": "data"
             }
           ]
         },
@@ -1396,8 +1401,8 @@
     {
       "kind": "DojoContract",
       "address": "0x2426211b8b5b87ceb2dd06fc6ba7f69c71e6d108cc50783ace03edba4b7526d",
-      "class_hash": "0x57dcdf7362a851e33c249b404189bc72d941ec7430dd2e00248e418a8bd40f7",
-      "original_class_hash": "0x57dcdf7362a851e33c249b404189bc72d941ec7430dd2e00248e418a8bd40f7",
+      "class_hash": "0x77b7c96118602865d822c227ca0b5c2467e36c2be09966eb2c44d47900dc195",
+      "original_class_hash": "0x77b7c96118602865d822c227ca0b5c2467e36c2be09966eb2c44d47900dc195",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -1667,8 +1672,8 @@
     {
       "kind": "DojoContract",
       "address": "0x260a4420c0760fae4b2cf193d0dd7c6c64b8bba86e291437d68c64a8f87d656",
-      "class_hash": "0x865b8fc01640da4a2dcba9f28b9ab77fec84d535c0f0a37e8978b1e435fce8",
-      "original_class_hash": "0x865b8fc01640da4a2dcba9f28b9ab77fec84d535c0f0a37e8978b1e435fce8",
+      "class_hash": "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7",
+      "original_class_hash": "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -2112,8 +2117,8 @@
     {
       "kind": "DojoContract",
       "address": "0x276795bda4181bce6167d104869a9938df0059721ae1715f165b51f26c36b8b",
-      "class_hash": "0x7427e0e333dc1b5d616ed3314be7f1d38b53cc64cc04331de9788059d7bc0ec",
-      "original_class_hash": "0x7427e0e333dc1b5d616ed3314be7f1d38b53cc64cc04331de9788059d7bc0ec",
+      "class_hash": "0x523e9561a0dacf3781522ce6c8d1f7cb8d811a599bcc79bb5c7b9a6d31c9b57",
+      "original_class_hash": "0x523e9561a0dacf3781522ce6c8d1f7cb8d811a599bcc79bb5c7b9a6d31c9b57",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -2991,8 +2996,8 @@
     {
       "kind": "DojoContract",
       "address": "0x19c8b4bb46fbec3b7713fe09c5deac1aee700b133dbe7eea64b3c8eb5eec67",
-      "class_hash": "0x9ecee0ecc885ce273342c115407275f1dcaa25d369c82bb0938d22efc0b80a",
-      "original_class_hash": "0x9ecee0ecc885ce273342c115407275f1dcaa25d369c82bb0938d22efc0b80a",
+      "class_hash": "0x1f0a3b0b159ab9696665cac39539c148dc5a3e49d6ac3b967992fe1649b58c3",
+      "original_class_hash": "0x1f0a3b0b159ab9696665cac39539c148dc5a3e49d6ac3b967992fe1649b58c3",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -3319,8 +3324,8 @@
     {
       "kind": "DojoContract",
       "address": "0x290fd4149ad08e11e690b0fca287c2e0212eded6a16a52049d008d352274c08",
-      "class_hash": "0x6cbbda979ca804b11bfb3ea709929c5b5462e7141651e1ae6bcb7b44b5c005f",
-      "original_class_hash": "0x6cbbda979ca804b11bfb3ea709929c5b5462e7141651e1ae6bcb7b44b5c005f",
+      "class_hash": "0x7b649dfd0cee75a26a1ab1f91a96f6fcd11b288e857631747f59df4685637b6",
+      "original_class_hash": "0x7b649dfd0cee75a26a1ab1f91a96f6fcd11b288e857631747f59df4685637b6",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -3468,8 +3473,8 @@
     {
       "kind": "DojoContract",
       "address": "0x5f4262e1e14138cbfb1a72e7b3ae2e55a03f3d9ccd394ea60b03c41bf6cc7f0",
-      "class_hash": "0x20eab92d8aef364b08eda15391ba4d28ed45235153c6238af84567ae9e194ef",
-      "original_class_hash": "0x20eab92d8aef364b08eda15391ba4d28ed45235153c6238af84567ae9e194ef",
+      "class_hash": "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc",
+      "original_class_hash": "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -3938,8 +3943,8 @@
     {
       "kind": "DojoContract",
       "address": "0x11f234957598ff641475ef1daf64df11b92aba4538a4783164ebaf039d5ddbd",
-      "class_hash": "0xa9e1eb88905b3374c4eb2219fc5a1dae4918636b744a4cde5b4d3d7e4099a1",
-      "original_class_hash": "0xa9e1eb88905b3374c4eb2219fc5a1dae4918636b744a4cde5b4d3d7e4099a1",
+      "class_hash": "0x28c10f586b1d97f05653ba9a7eb9e91fca432e62f698257e164ea2a7485fe5f",
+      "original_class_hash": "0x28c10f586b1d97f05653ba9a7eb9e91fca432e62f698257e164ea2a7485fe5f",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4165,8 +4170,8 @@
     {
       "kind": "DojoContract",
       "address": "0x4c8bd338768e89cd060c8246e069fd62759286f2a1af4024109585556050fd0",
-      "class_hash": "0x349cbd39ae13daf012f0928089f78035437931adbe5e6b628d2a790921c86c",
-      "original_class_hash": "0x349cbd39ae13daf012f0928089f78035437931adbe5e6b628d2a790921c86c",
+      "class_hash": "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315",
+      "original_class_hash": "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4404,8 +4409,8 @@
     {
       "kind": "DojoContract",
       "address": "0x5872704c87338286c2a2122f05f1399cb3be7d9c6382a2d1db2978fd6c13913",
-      "class_hash": "0x3cc58a567d0648ef409bfac73a1c0dd07fd4fc722abb50b12026cc6ad9306fe",
-      "original_class_hash": "0x3cc58a567d0648ef409bfac73a1c0dd07fd4fc722abb50b12026cc6ad9306fe",
+      "class_hash": "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b",
+      "original_class_hash": "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4786,8 +4791,8 @@
     {
       "kind": "DojoContract",
       "address": "0x44c0322e9ebb9da19d4232b96cb67370884c5c1b3331149ff2ac5252cbff4fe",
-      "class_hash": "0xa7123196c6b6e9b946b80211400c7d6c796aa8cb962346b8609ee62e9d5845",
-      "original_class_hash": "0xa7123196c6b6e9b946b80211400c7d6c796aa8cb962346b8609ee62e9d5845",
+      "class_hash": "0x45bad9aeaec1a3c2d7e72a7cb3981da4bc09adfb7cd227940e434183db9520b",
+      "original_class_hash": "0x45bad9aeaec1a3c2d7e72a7cb3981da4bc09adfb7cd227940e434183db9520b",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4961,8 +4966,8 @@
     {
       "kind": "DojoContract",
       "address": "0x31512171dc106ccd4186f0f24ccaccf85df2666cf78b06e025050f2f51b092c",
-      "class_hash": "0x1b3718857777933cbf59566727cee9c53109ddfadcb5251b616d153163407ce",
-      "original_class_hash": "0x1b3718857777933cbf59566727cee9c53109ddfadcb5251b616d153163407ce",
+      "class_hash": "0x291dfcc91936893a62825c5fa21b7104c5c14861e675151ef154cb3a1a19a0f",
+      "original_class_hash": "0x291dfcc91936893a62825c5fa21b7104c5c14861e675151ef154cb3a1a19a0f",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -6651,312 +6656,6 @@
         }
       ],
       "name": "eternum::models::buildings::building"
-    },
-    {
-      "kind": "DojoModel",
-      "members": [
-        {
-          "name": "entity_id",
-          "type": "u128",
-          "key": true
-        },
-        {
-          "name": "category",
-          "type": "BuildingCategory",
-          "key": true
-        },
-        {
-          "name": "value",
-          "type": "u8",
-          "key": false
-        }
-      ],
-      "class_hash": "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2",
-      "original_class_hash": "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2",
-      "abi": [
-        {
-          "type": "impl",
-          "name": "DojoModelImpl",
-          "interface_name": "dojo::model::IDojoModel"
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::integer::u8>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::integer::u8>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::felt252>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::felt252>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "dojo::database::introspect::Struct",
-          "members": [
-            {
-              "name": "name",
-              "type": "core::felt252"
-            },
-            {
-              "name": "attrs",
-              "type": "core::array::Span::<core::felt252>"
-            },
-            {
-              "name": "children",
-              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
-          "members": [
-            {
-              "name": "snapshot",
-              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "dojo::database::introspect::Enum",
-          "members": [
-            {
-              "name": "name",
-              "type": "core::felt252"
-            },
-            {
-              "name": "attrs",
-              "type": "core::array::Span::<core::felt252>"
-            },
-            {
-              "name": "children",
-              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
-            }
-          ]
-        },
-        {
-          "type": "enum",
-          "name": "dojo::database::introspect::Ty",
-          "variants": [
-            {
-              "name": "Primitive",
-              "type": "core::felt252"
-            },
-            {
-              "name": "Struct",
-              "type": "dojo::database::introspect::Struct"
-            },
-            {
-              "name": "Enum",
-              "type": "dojo::database::introspect::Enum"
-            },
-            {
-              "name": "Tuple",
-              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
-            },
-            {
-              "name": "Array",
-              "type": "core::integer::u32"
-            }
-          ]
-        },
-        {
-          "type": "interface",
-          "name": "dojo::model::IDojoModel",
-          "items": [
-            {
-              "type": "function",
-              "name": "name",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::felt252"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "unpacked_size",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::integer::u32"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "packed_size",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::integer::u32"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "layout",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "core::array::Span::<core::integer::u8>"
-                }
-              ],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "schema",
-              "inputs": [],
-              "outputs": [
-                {
-                  "type": "dojo::database::introspect::Ty"
-                }
-              ],
-              "state_mutability": "view"
-            }
-          ]
-        },
-        {
-          "type": "impl",
-          "name": "building_quantityImpl",
-          "interface_name": "eternum::models::buildings::Ibuilding_quantity"
-        },
-        {
-          "type": "enum",
-          "name": "eternum::models::buildings::BuildingCategory",
-          "variants": [
-            {
-              "name": "None",
-              "type": "()"
-            },
-            {
-              "name": "Castle",
-              "type": "()"
-            },
-            {
-              "name": "Resource",
-              "type": "()"
-            },
-            {
-              "name": "Farm",
-              "type": "()"
-            },
-            {
-              "name": "FishingVillage",
-              "type": "()"
-            },
-            {
-              "name": "Barracks",
-              "type": "()"
-            },
-            {
-              "name": "Market",
-              "type": "()"
-            },
-            {
-              "name": "ArcheryRange",
-              "type": "()"
-            },
-            {
-              "name": "Stable",
-              "type": "()"
-            },
-            {
-              "name": "DonkeyFarm",
-              "type": "()"
-            },
-            {
-              "name": "TradingPost",
-              "type": "()"
-            },
-            {
-              "name": "WorkersHut",
-              "type": "()"
-            },
-            {
-              "name": "WatchTower",
-              "type": "()"
-            },
-            {
-              "name": "Walls",
-              "type": "()"
-            },
-            {
-              "name": "Storehouse",
-              "type": "()"
-            }
-          ]
-        },
-        {
-          "type": "struct",
-          "name": "eternum::models::buildings::BuildingQuantity",
-          "members": [
-            {
-              "name": "entity_id",
-              "type": "core::integer::u128"
-            },
-            {
-              "name": "category",
-              "type": "eternum::models::buildings::BuildingCategory"
-            },
-            {
-              "name": "value",
-              "type": "core::integer::u8"
-            }
-          ]
-        },
-        {
-          "type": "interface",
-          "name": "eternum::models::buildings::Ibuilding_quantity",
-          "items": [
-            {
-              "type": "function",
-              "name": "ensure_abi",
-              "inputs": [
-                {
-                  "name": "model",
-                  "type": "eternum::models::buildings::BuildingQuantity"
-                }
-              ],
-              "outputs": [],
-              "state_mutability": "view"
-            }
-          ]
-        },
-        {
-          "type": "event",
-          "name": "eternum::models::buildings::building_quantity::Event",
-          "kind": "enum",
-          "variants": []
-        }
-      ],
-      "name": "eternum::models::buildings::building_quantity"
     },
     {
       "kind": "DojoModel",

--- a/contracts/manifests/prod/manifest.toml
+++ b/contracts/manifests/prod/manifest.toml
@@ -22,8 +22,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x2f6de5a11f7eb5dc8cd616751800f034e387f6dd3e9f85d58a5fd79802c46fc"
-class_hash = "0x69c3fb95340f8853417881e5f72414a37bf48636851c01a36d6d59e5812d56c"
-original_class_hash = "0x69c3fb95340f8853417881e5f72414a37bf48636851c01a36d6d59e5812d56c"
+class_hash = "0x28d09ac6faf0e3a828d1cde813db5f5eb1f0a1b71dd76d9c4b37dfa2d07a762"
+original_class_hash = "0x28d09ac6faf0e3a828d1cde813db5f5eb1f0a1b71dd76d9c4b37dfa2d07a762"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_bank_contracts_bank_systems_bank_systems.json"
 reads = []
@@ -34,8 +34,8 @@ name = "eternum::systems::bank::contracts::bank_systems::bank_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x5777787d1a6f43c333dcdeb0c02e3afbdd9eeb3cc74d111c38a26a0104652b6"
-class_hash = "0x28b9c2588f46391f3ca35855fc55b988baa601d9fa9771cbb6a3cb8b40131bc"
-original_class_hash = "0x28b9c2588f46391f3ca35855fc55b988baa601d9fa9771cbb6a3cb8b40131bc"
+class_hash = "0x5097b3bae0c00223a8d4375d8e5350239941c58eab6aec2021b4647f64de988"
+original_class_hash = "0x5097b3bae0c00223a8d4375d8e5350239941c58eab6aec2021b4647f64de988"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_bank_contracts_liquidity_systems_liquidity_systems.json"
 reads = []
@@ -46,8 +46,8 @@ name = "eternum::systems::bank::contracts::liquidity_systems::liquidity_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x24cedd3154abc642500ab1a805ee8f1124009441d79d9bd25ef4cbd88dfcffe"
-class_hash = "0x57e41cb5cad35b56ff358c451f595e3c3d72fd21e098ebc447ce8871f02e0a"
-original_class_hash = "0x57e41cb5cad35b56ff358c451f595e3c3d72fd21e098ebc447ce8871f02e0a"
+class_hash = "0x3bd5f21ba7f0a8dfea0e9d7b731ab97e15e06733322e1434784d3065a154b79"
+original_class_hash = "0x3bd5f21ba7f0a8dfea0e9d7b731ab97e15e06733322e1434784d3065a154b79"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_bank_contracts_swap_systems_swap_systems.json"
 reads = []
@@ -58,8 +58,8 @@ name = "eternum::systems::bank::contracts::swap_systems::swap_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x2426211b8b5b87ceb2dd06fc6ba7f69c71e6d108cc50783ace03edba4b7526d"
-class_hash = "0x57dcdf7362a851e33c249b404189bc72d941ec7430dd2e00248e418a8bd40f7"
-original_class_hash = "0x57dcdf7362a851e33c249b404189bc72d941ec7430dd2e00248e418a8bd40f7"
+class_hash = "0x77b7c96118602865d822c227ca0b5c2467e36c2be09966eb2c44d47900dc195"
+original_class_hash = "0x77b7c96118602865d822c227ca0b5c2467e36c2be09966eb2c44d47900dc195"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_buildings_contracts_building_systems.json"
 reads = []
@@ -70,8 +70,8 @@ name = "eternum::systems::buildings::contracts::building_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x260a4420c0760fae4b2cf193d0dd7c6c64b8bba86e291437d68c64a8f87d656"
-class_hash = "0x865b8fc01640da4a2dcba9f28b9ab77fec84d535c0f0a37e8978b1e435fce8"
-original_class_hash = "0x865b8fc01640da4a2dcba9f28b9ab77fec84d535c0f0a37e8978b1e435fce8"
+class_hash = "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7"
+original_class_hash = "0x59bc29b2c90d80b0c8da71a585354ca487cbd5fd348fdd144b225cacf07dbe7"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_combat_contracts_combat_systems.json"
 reads = []
@@ -82,8 +82,8 @@ name = "eternum::systems::combat::contracts::combat_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x276795bda4181bce6167d104869a9938df0059721ae1715f165b51f26c36b8b"
-class_hash = "0x7427e0e333dc1b5d616ed3314be7f1d38b53cc64cc04331de9788059d7bc0ec"
-original_class_hash = "0x7427e0e333dc1b5d616ed3314be7f1d38b53cc64cc04331de9788059d7bc0ec"
+class_hash = "0x523e9561a0dacf3781522ce6c8d1f7cb8d811a599bcc79bb5c7b9a6d31c9b57"
+original_class_hash = "0x523e9561a0dacf3781522ce6c8d1f7cb8d811a599bcc79bb5c7b9a6d31c9b57"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_config_contracts_config_systems.json"
 reads = []
@@ -106,8 +106,8 @@ name = "eternum::systems::dev::contracts::bank::dev_bank_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x19c8b4bb46fbec3b7713fe09c5deac1aee700b133dbe7eea64b3c8eb5eec67"
-class_hash = "0x9ecee0ecc885ce273342c115407275f1dcaa25d369c82bb0938d22efc0b80a"
-original_class_hash = "0x9ecee0ecc885ce273342c115407275f1dcaa25d369c82bb0938d22efc0b80a"
+class_hash = "0x1f0a3b0b159ab9696665cac39539c148dc5a3e49d6ac3b967992fe1649b58c3"
+original_class_hash = "0x1f0a3b0b159ab9696665cac39539c148dc5a3e49d6ac3b967992fe1649b58c3"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_dev_contracts_resource_dev_resource_systems.json"
 reads = []
@@ -130,8 +130,8 @@ name = "eternum::systems::hyperstructure::contracts::hyperstructure_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x290fd4149ad08e11e690b0fca287c2e0212eded6a16a52049d008d352274c08"
-class_hash = "0x6cbbda979ca804b11bfb3ea709929c5b5462e7141651e1ae6bcb7b44b5c005f"
-original_class_hash = "0x6cbbda979ca804b11bfb3ea709929c5b5462e7141651e1ae6bcb7b44b5c005f"
+class_hash = "0x7b649dfd0cee75a26a1ab1f91a96f6fcd11b288e857631747f59df4685637b6"
+original_class_hash = "0x7b649dfd0cee75a26a1ab1f91a96f6fcd11b288e857631747f59df4685637b6"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_leveling_contracts_leveling_systems.json"
 reads = []
@@ -142,8 +142,8 @@ name = "eternum::systems::leveling::contracts::leveling_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x5f4262e1e14138cbfb1a72e7b3ae2e55a03f3d9ccd394ea60b03c41bf6cc7f0"
-class_hash = "0x20eab92d8aef364b08eda15391ba4d28ed45235153c6238af84567ae9e194ef"
-original_class_hash = "0x20eab92d8aef364b08eda15391ba4d28ed45235153c6238af84567ae9e194ef"
+class_hash = "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc"
+original_class_hash = "0xb8fb578a95dd719e39e4855d355c92434e07d7b81fd442b03e3880c9752adc"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_map_contracts_map_systems.json"
 reads = []
@@ -166,8 +166,8 @@ name = "eternum::systems::name::contracts::name_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x11f234957598ff641475ef1daf64df11b92aba4538a4783164ebaf039d5ddbd"
-class_hash = "0xa9e1eb88905b3374c4eb2219fc5a1dae4918636b744a4cde5b4d3d7e4099a1"
-original_class_hash = "0xa9e1eb88905b3374c4eb2219fc5a1dae4918636b744a4cde5b4d3d7e4099a1"
+class_hash = "0x28c10f586b1d97f05653ba9a7eb9e91fca432e62f698257e164ea2a7485fe5f"
+original_class_hash = "0x28c10f586b1d97f05653ba9a7eb9e91fca432e62f698257e164ea2a7485fe5f"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_realm_contracts_realm_systems.json"
 reads = []
@@ -178,8 +178,8 @@ name = "eternum::systems::realm::contracts::realm_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x4c8bd338768e89cd060c8246e069fd62759286f2a1af4024109585556050fd0"
-class_hash = "0x349cbd39ae13daf012f0928089f78035437931adbe5e6b628d2a790921c86c"
-original_class_hash = "0x349cbd39ae13daf012f0928089f78035437931adbe5e6b628d2a790921c86c"
+class_hash = "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315"
+original_class_hash = "0x5388a42329141070f59cf13dddd553877b16381d8ea77cff61500308fad1315"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_resources_contracts_resource_systems.json"
 reads = []
@@ -190,8 +190,8 @@ name = "eternum::systems::resources::contracts::resource_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x5872704c87338286c2a2122f05f1399cb3be7d9c6382a2d1db2978fd6c13913"
-class_hash = "0x3cc58a567d0648ef409bfac73a1c0dd07fd4fc722abb50b12026cc6ad9306fe"
-original_class_hash = "0x3cc58a567d0648ef409bfac73a1c0dd07fd4fc722abb50b12026cc6ad9306fe"
+class_hash = "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b"
+original_class_hash = "0x31a0006f1d9551e562bd827542eb09193a88b5ade2f9954cf777d51e235452b"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_trade_contracts_trade_systems_trade_systems.json"
 reads = []
@@ -214,8 +214,8 @@ name = "eternum::systems::transport::contracts::donkey_systems::donkey_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x44c0322e9ebb9da19d4232b96cb67370884c5c1b3331149ff2ac5252cbff4fe"
-class_hash = "0xa7123196c6b6e9b946b80211400c7d6c796aa8cb962346b8609ee62e9d5845"
-original_class_hash = "0xa7123196c6b6e9b946b80211400c7d6c796aa8cb962346b8609ee62e9d5845"
+class_hash = "0x45bad9aeaec1a3c2d7e72a7cb3981da4bc09adfb7cd227940e434183db9520b"
+original_class_hash = "0x45bad9aeaec1a3c2d7e72a7cb3981da4bc09adfb7cd227940e434183db9520b"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_transport_contracts_road_systems_road_systems.json"
 reads = []
@@ -226,8 +226,8 @@ name = "eternum::systems::transport::contracts::road_systems::road_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x31512171dc106ccd4186f0f24ccaccf85df2666cf78b06e025050f2f51b092c"
-class_hash = "0x1b3718857777933cbf59566727cee9c53109ddfadcb5251b616d153163407ce"
-original_class_hash = "0x1b3718857777933cbf59566727cee9c53109ddfadcb5251b616d153163407ce"
+class_hash = "0x291dfcc91936893a62825c5fa21b7104c5c14861e675151ef154cb3a1a19a0f"
+original_class_hash = "0x291dfcc91936893a62825c5fa21b7104c5c14861e675151ef154cb3a1a19a0f"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_transport_contracts_travel_systems_travel_systems.json"
 reads = []
@@ -388,28 +388,6 @@ key = false
 [[models.members]]
 name = "outer_entity_id"
 type = "u128"
-key = false
-
-[[models]]
-kind = "DojoModel"
-class_hash = "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2"
-original_class_hash = "0x6ae1405a3f117ae2579b9f5ac9273d3a6c43043c48accc9e69523d4525683d2"
-abi = "abis/deployments/models/eternum_models_buildings_building_quantity.json"
-name = "eternum::models::buildings::building_quantity"
-
-[[models.members]]
-name = "entity_id"
-type = "u128"
-key = true
-
-[[models.members]]
-name = "category"
-type = "BuildingCategory"
-key = true
-
-[[models.members]]
-name = "value"
-type = "u8"
 key = false
 
 [[models]]

--- a/contracts/src/models/weight.cairo
+++ b/contracts/src/models/weight.cairo
@@ -14,7 +14,7 @@ impl WeightImpl of WeightTrait {
             return;
         };
         if capacity.is_capped() {
-            assert(self.value >= amount, 'not enough weight');
+            assert(self.value >= amount, 'weight deducted>entity s weight');
             if amount > self.value {
                 self.value = 0;
             } else {


### PR DESCRIPTION
### **User description**
Closes #755


___

### **PR Type**
enhancement


___

### **Description**
- Updated `class_hash` and `original_class_hash` for multiple `DojoContract` entries in both development and production manifests.
- Removed a `DojoModel` entry related to `eternum::models::buildings::building_quantity` from both development and production manifests.
- Added a new data field `timestamp` to an event in the production manifest.
- Improved the assert message for weight deduction in the `weight.cairo` model to be more explicit.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update class hashes and remove specific DojoModel entry.</code>&nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.json
<li>Updated <code>class_hash</code> and <code>original_class_hash</code> for multiple <code>DojoContract</code> <br>entries.<br> <li> Removed a <code>DojoModel</code> entry related to <br><code>eternum::models::buildings::building_quantity</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/784/files#diff-bc6816b30ea64e261f152a070b6e767d29d900fcbacb95c684f1c14a82dff5a8">+8/-314</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.toml</strong><dd><code>Update class hashes and remove specific DojoModel entry.</code>&nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.toml
<li>Updated <code>class_hash</code> and <code>original_class_hash</code> for multiple <code>DojoContract</code> <br>entries.<br> <li> Removed a <code>DojoModel</code> entry related to <br><code>eternum::models::buildings::building_quantity</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/784/files#diff-43499a9633d551acabe80100dc29d8995890cd62b12169122658233caea498b3">+8/-30</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update class hashes, add timestamp field, and remove DojoModel entry.</code></dd></summary>
<hr>

contracts/manifests/prod/manifest.json
<li>Updated <code>class_hash</code> and <code>original_class_hash</code> for multiple <code>DojoContract</code> <br>entries.<br> <li> Added a new data field <code>timestamp</code> to an event.<br> <li> Removed a <code>DojoModel</code> entry related to <br><code>eternum::models::buildings::building_quantity</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/784/files#diff-782ac57560d5a0f4ea219cca69f0b77a29beba630ee384bf5bf2e5623febda9a">+33/-334</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.toml</strong><dd><code>Update class hashes and remove specific DojoModel entry.</code>&nbsp; </dd></summary>
<hr>

contracts/manifests/prod/manifest.toml
<li>Updated <code>class_hash</code> and <code>original_class_hash</code> for multiple <code>DojoContract</code> <br>entries.<br> <li> Removed a <code>DojoModel</code> entry related to <br><code>eternum::models::buildings::building_quantity</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/784/files#diff-8d6f404ac65b0970c314cc962b1967222e55e7a2a18e9a39ec227a319e46d8df">+28/-50</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>weight.cairo</strong><dd><code>Improve assert message for weight deduction.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/weight.cairo
<li>Updated the assert message for weight deduction to be more explicit.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/784/files#diff-0455564c052daba1613db3bc3623d0e804c22c8ffc263bbbaa9228108fc3305f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

