### PR TITLE
fix: fixed camera angle for worldmap

### DIFF
--- a/client/src/ui/utils/Camera.tsx
+++ b/client/src/ui/utils/Camera.tsx
@@ -136,6 +136,8 @@ const CameraControls = ({ position, target }: Props) => {
       minDistance={minDistance}
       maxPolarAngle={maxPolarAngle}
       minPolarAngle={minPolarAngle}
+      minAzimuthAngle={isMapView ? Math.PI * 2 : undefined}
+      maxAzimuthAngle={isMapView ? Math.PI * 2 : undefined}
       zoomToCursor={isMapView}
       makeDefault
       onChange={handleChange}


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed camera angle constraints for the world map view by adding `minAzimuthAngle` and `maxAzimuthAngle` properties to the `CameraControls` component.
- Set the azimuth angle limits conditionally based on whether the view is a map view.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Camera.tsx</strong><dd><code>Fix camera angle constraints for world map view.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/utils/Camera.tsx
<li>Added <code>minAzimuthAngle</code> and <code>maxAzimuthAngle</code> properties to <code>CameraControls</code> <br>component.<br> <li> Set azimuth angle limits based on <code>isMapView</code> condition.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/801/files#diff-4dfb619ce95fdd0f7db51d19e40b93e26c80636b93e0d277a21c7353c083aa6d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

