### PR TITLE
feat: worldmap clouds

### DIFF
--- a/client/src/ui/modules/scenes/MainScene.tsx
+++ b/client/src/ui/modules/scenes/MainScene.tsx
@@ -67,10 +67,10 @@ export const MainScene = () => {
     hexceptionCloudsBounds,
     hexceptionCloudsVolume,
   } = useControls("Clouds", {
-    mapCloudsPosition: { value: [1250, 400, -650], label: "Map Clouds Position" },
-    mapCloudsOpacity: { value: 0.05, min: 0, max: 1, step: 0.01, label: "Map Clouds Opacity" },
-    mapCloudsBounds: { value: [1500, 1, 700], label: "Map Clouds Bounds" },
-    mapCloudsVolume: { value: 700, min: 0, max: 1000, step: 1, label: "Map Clouds Volume" },
+    mapCloudsPosition: { value: [1250, 135, -650], label: "Map Clouds Position" },
+    mapCloudsOpacity: { value: 0.02, min: 0, max: 1, step: 0.01, label: "Map Clouds Opacity" },
+    mapCloudsBounds: { value: [1500, 50, 700], label: "Map Clouds Bounds" },
+    mapCloudsVolume: { value: 325, min: 0, max: 1000, step: 1, label: "Map Clouds Volume" },
     hexceptionCloudsPosition: { value: [45, 32, -39], label: "Hexception Clouds Position" },
     hexceptionCloudsOpacity: { value: 0.05, min: 0, max: 1, step: 0.01, label: "Hexception Clouds Opacity" },
     hexceptionCloudsBounds: { value: [30, 6, 45], label: "Hexception Clouds Bounds" },
@@ -155,6 +155,30 @@ export const MainScene = () => {
             <Switch location={locationType}>
               <Route path="map">
                 <WorldMapScene />
+                <Clouds position={mapCloudsPosition as any} material={THREE.MeshBasicMaterial}>
+                  <Cloud
+                    concentrate="random"
+                    seed={7331}
+                    speed={0.06}
+                    segments={100}
+                    castShadow={true}
+                    opacity={mapCloudsOpacity}
+                    bounds={mapCloudsBounds}
+                    volume={mapCloudsVolume}
+                    color="white"
+                  />
+                  <Cloud
+                    concentrate="random"
+                    seed={1337}
+                    castShadow={true}
+                    speed={0.03}
+                    segments={100}
+                    opacity={mapCloudsOpacity}
+                    bounds={mapCloudsBounds}
+                    volume={mapCloudsVolume}
+                    color="white"
+                  />
+                </Clouds>
               </Route>
               <Route path="hexception">
                 <CameraShake {...shakeConfig} />


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Adjusted the properties for `mapCloudsPosition`, `mapCloudsOpacity`, `mapCloudsBounds`, and `mapCloudsVolume` to new values.
- Introduced a `Clouds` component containing two `Cloud` instances to the "map" route in `MainScene.tsx`.
- Each `Cloud` instance has properties such as `concentrate`, `seed`, `speed`, `segments`, `castShadow`, `opacity`, `bounds`, `volume`, and `color`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainScene.tsx</strong><dd><code>Add clouds to WorldMapScene and adjust cloud properties</code>&nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/modules/scenes/MainScene.tsx
<li>Adjusted <code>mapCloudsPosition</code>, <code>mapCloudsOpacity</code>, <code>mapCloudsBounds</code>, and <br><code>mapCloudsVolume</code> values.<br> <li> Added <code>Clouds</code> component with two <code>Cloud</code> instances to the "map" route.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/841/files#diff-fc21828fcac93c01c5fc8d97c5f4206af9199daaf1230bc6a1b1a24d20bd50c8">+28/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

