### PR TITLE
fix: Fix resource already claimed bug in onboarding

### DIFF
--- a/client/src/ui/modules/onboarding/Steps.tsx
+++ b/client/src/ui/modules/onboarding/Steps.tsx
@@ -397,12 +397,13 @@ export const NavigateToRealm = ({ text, showWalkthrough = false }: { text: strin
       size="md"
       variant="primary"
       onClick={async () => {
-        await mint_starting_resources({
-          signer: account,
-          config_id: QuestType.Food,
-          realm_entity_id: playerRealms()[0].entity_id || "0",
-        });
-
+        if (!quests.some((quest: any) => quest.name === "Claim Food" && quest.completed === true)) {
+          await mint_starting_resources({
+            signer: account,
+            config_id: QuestType.Food,
+            realm_entity_id: playerRealms()[0].entity_id || "0",
+          });
+        }
         setIsLoadingScreenEnabled(true);
         setTimeout(() => {
           showBlankOverlay(false);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a condition to check if the "Claim Food" quest is already completed before calling `mint_starting_resources` in the onboarding steps.
- Prevented the resource claiming process from being triggered if the quest is already completed, resolving the "resource already claimed" bug.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Steps.tsx</strong><dd><code>Fix resource already claimed bug in onboarding steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/modules/onboarding/Steps.tsx
<li>Added a condition to check if the "Claim Food" quest is already <br>completed before calling <code>mint_starting_resources</code>.<br> <li> Prevented the resource claiming process from being triggered if the <br>quest is already completed.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/851/files#diff-0bb7e9e5135bf95ef8376c6e361487312fa9a0226f14fb2e82c63cb57cf5d301">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

