### PR TITLE
Restrict quests on non-realm entities: client + contract + tests

### DIFF
--- a/client/src/ui/modules/navigation/BottomNavigation.tsx
+++ b/client/src/ui/modules/navigation/BottomNavigation.tsx
@@ -74,11 +74,11 @@ export const BottomNavigation = () => {
   const { claimableQuests } = useQuests({ entityId: realmEntityId || BigInt("0") });
 
   const { playerStructures } = useEntities();
+  const structures = useMemo(() => playerStructures(), [playerStructures]);
 
   const isRealmSelected = () => {
-    const structures = playerStructures();
-    const index = structures?.findIndex((structure) => structure?.entity_id === realmEntityId);
-    return structures[index]?.category === "Realm";
+    const selectedStructure = structures?.find((structure) => structure?.entity_id === realmEntityId);
+    return selectedStructure?.category === "Realm";
   };
 
   const secondaryNavigation = useMemo(() => {

--- a/client/src/ui/modules/navigation/BottomNavigation.tsx
+++ b/client/src/ui/modules/navigation/BottomNavigation.tsx
@@ -33,6 +33,7 @@ import { useArmyByEntityId } from "@/hooks/helpers/useArmies";
 import { EternumGlobalConfig, TROOPS_STAMINAS } from "@bibliothecadao/eternum";
 import { ResourceIcon } from "@/ui/elements/ResourceIcon";
 import { TroopMenuRow } from "@/ui/components/military/TroopChip";
+import { useEntities } from "@/hooks/helpers/useEntities";
 
 export enum MenuEnum {
   realm = "realm",
@@ -72,6 +73,14 @@ export const BottomNavigation = () => {
 
   const { claimableQuests } = useQuests({ entityId: realmEntityId || BigInt("0") });
 
+  const { playerStructures } = useEntities();
+
+  const isRealmSelected = () => {
+    const structures = playerStructures();
+    const index = structures?.findIndex((structure) => structure?.entity_id === realmEntityId);
+    return structures[index]?.category === "Realm";
+  };
+
   const secondaryNavigation = useMemo(() => {
     return [
       {
@@ -97,7 +106,8 @@ export const BottomNavigation = () => {
               size="lg"
               onClick={() => togglePopup(quests)}
               className="forth-step"
-              notification={claimableQuests.length}
+              notification={isRealmSelected() ? claimableQuests.length : undefined}
+              disabled={!isRealmSelected()}
             />
 
             {population?.population == null && location !== "/map" && (

--- a/contracts/manifests/dev/manifest.json
+++ b/contracts/manifests/dev/manifest.json
@@ -3187,8 +3187,8 @@
     {
       "kind": "DojoContract",
       "address": "0x2d4304c3ac359b8852a70c4f029f94cd145da88ed2e4fcfb769708a1dd80ef",
-      "class_hash": "0x3d62508438fa3249e2d190b7359f146bce1fd365c1c681edab35c693314dc90",
-      "original_class_hash": "0x3d62508438fa3249e2d190b7359f146bce1fd365c1c681edab35c693314dc90",
+      "class_hash": "0x74f2d632afdec1a4d5227b2c09a294fa53b516fd35ede842d7047a64d7161d",
+      "original_class_hash": "0x74f2d632afdec1a4d5227b2c09a294fa53b516fd35ede842d7047a64d7161d",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -4279,8 +4279,8 @@
     {
       "kind": "DojoContract",
       "address": "0x78954c3172d81b184a548c25b9ac6831881f2a1bf0eda25a7576529fe70811e",
-      "class_hash": "0x224dceac90c1d064eca8346eca73d1cb832d1aca3045e7536e7da7de8ad12d8",
-      "original_class_hash": "0x224dceac90c1d064eca8346eca73d1cb832d1aca3045e7536e7da7de8ad12d8",
+      "class_hash": "0x3ed3b4775073599fe2d95a6716dadb894e1ebea83e8cd2a6ed1ab423f61f6f",
+      "original_class_hash": "0x3ed3b4775073599fe2d95a6716dadb894e1ebea83e8cd2a6ed1ab423f61f6f",
       "base_class_hash": "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76",
       "abi": [
         {
@@ -14802,6 +14802,559 @@
       "kind": "DojoModel",
       "members": [
         {
+          "name": "entity_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "hyperstructure_type",
+          "type": "u8",
+          "key": false
+        },
+        {
+          "name": "controlling_order",
+          "type": "u8",
+          "key": false
+        },
+        {
+          "name": "completed",
+          "type": "bool",
+          "key": false
+        },
+        {
+          "name": "completion_cost_id",
+          "type": "u128",
+          "key": false
+        },
+        {
+          "name": "completion_resource_count",
+          "type": "u32",
+          "key": false
+        }
+      ],
+      "class_hash": "0x5c155bf1246b96b20a902f34eadefa15f2f8a6e701786ecd7828c11b465576c",
+      "original_class_hash": "0x5c155bf1246b96b20a902f34eadefa15f2f8a6e701786ecd7828c11b465576c",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "DojoModelImpl",
+          "interface_name": "dojo::model::IDojoModel"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            },
+            {
+              "name": "Array",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::model::IDojoModel",
+          "items": [
+            {
+              "type": "function",
+              "name": "name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "unpacked_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "packed_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "layout",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u8>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "schema",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Ty"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "hyper_structureImpl",
+          "interface_name": "eternum::models::hyperstructure::Ihyper_structure"
+        },
+        {
+          "type": "enum",
+          "name": "core::bool",
+          "variants": [
+            {
+              "name": "False",
+              "type": "()"
+            },
+            {
+              "name": "True",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "eternum::models::hyperstructure::HyperStructure",
+          "members": [
+            {
+              "name": "entity_id",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "hyperstructure_type",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "controlling_order",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "completed",
+              "type": "core::bool"
+            },
+            {
+              "name": "completion_cost_id",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "completion_resource_count",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "eternum::models::hyperstructure::Ihyper_structure",
+          "items": [
+            {
+              "type": "function",
+              "name": "ensure_abi",
+              "inputs": [
+                {
+                  "name": "model",
+                  "type": "eternum::models::hyperstructure::HyperStructure"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::hyperstructure::hyper_structure::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ],
+      "name": "eternum::models::hyperstructure::hyper_structure"
+    },
+    {
+      "kind": "DojoModel",
+      "members": [
+        {
+          "name": "entity_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "owner",
+          "type": "u128",
+          "key": false
+        },
+        {
+          "name": "completed",
+          "type": "bool",
+          "key": false
+        },
+        {
+          "name": "settlement_cost",
+          "type": "u32",
+          "key": false
+        },
+        {
+          "name": "settlment_tax",
+          "type": "u32",
+          "key": false
+        }
+      ],
+      "class_hash": "0x6a27eefe89fbb233f297ab2e5437bea2a98f4992ead34ecfdecb76d8bb98d9b",
+      "original_class_hash": "0x6a27eefe89fbb233f297ab2e5437bea2a98f4992ead34ecfdecb76d8bb98d9b",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "DojoModelImpl",
+          "interface_name": "dojo::model::IDojoModel"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            },
+            {
+              "name": "Array",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::model::IDojoModel",
+          "items": [
+            {
+              "type": "function",
+              "name": "name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "unpacked_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "packed_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "layout",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u8>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "schema",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Ty"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "hyper_structure_v_2Impl",
+          "interface_name": "eternum::models::hyperstructure::Ihyper_structure_v_2"
+        },
+        {
+          "type": "enum",
+          "name": "core::bool",
+          "variants": [
+            {
+              "name": "False",
+              "type": "()"
+            },
+            {
+              "name": "True",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "eternum::models::hyperstructure::HyperStructureV2",
+          "members": [
+            {
+              "name": "entity_id",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "owner",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "completed",
+              "type": "core::bool"
+            },
+            {
+              "name": "settlement_cost",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "settlment_tax",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "eternum::models::hyperstructure::Ihyper_structure_v_2",
+          "items": [
+            {
+              "type": "function",
+              "name": "ensure_abi",
+              "inputs": [
+                {
+                  "name": "model",
+                  "type": "eternum::models::hyperstructure::HyperStructureV2"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::hyperstructure::hyper_structure_v_2::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ],
+      "name": "eternum::models::hyperstructure::hyper_structure_v_2"
+    },
+    {
+      "kind": "DojoModel",
+      "members": [
+        {
           "name": "hyperstructure_entity_id",
           "type": "u128",
           "key": true
@@ -22474,6 +23027,246 @@
         }
       ],
       "name": "eternum::models::structure::structure_count"
+    },
+    {
+      "kind": "DojoModel",
+      "members": [
+        {
+          "name": "entity_id",
+          "type": "u128",
+          "key": true
+        },
+        {
+          "name": "tick",
+          "type": "u64",
+          "key": false
+        },
+        {
+          "name": "count",
+          "type": "u8",
+          "key": false
+        }
+      ],
+      "class_hash": "0x70b0d7a75f4f826e2d8556abe0c1c0891539611d98658421f9eb2754f263be8",
+      "original_class_hash": "0x70b0d7a75f4f826e2d8556abe0c1c0891539611d98658421f9eb2754f263be8",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "DojoModelImpl",
+          "interface_name": "dojo::model::IDojoModel"
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+            },
+            {
+              "name": "Array",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::model::IDojoModel",
+          "items": [
+            {
+              "type": "function",
+              "name": "name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "unpacked_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "packed_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u32"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "layout",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::array::Span::<core::integer::u8>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "schema",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Ty"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "tick_moveImpl",
+          "interface_name": "eternum::models::tick::Itick_move"
+        },
+        {
+          "type": "struct",
+          "name": "eternum::models::tick::TickMove",
+          "members": [
+            {
+              "name": "entity_id",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "tick",
+              "type": "core::integer::u64"
+            },
+            {
+              "name": "count",
+              "type": "core::integer::u8"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "eternum::models::tick::Itick_move",
+          "items": [
+            {
+              "type": "function",
+              "name": "ensure_abi",
+              "inputs": [
+                {
+                  "name": "model",
+                  "type": "eternum::models::tick::TickMove"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "eternum::models::tick::tick_move::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ],
+      "name": "eternum::models::tick::tick_move"
     },
     {
       "kind": "DojoModel",

--- a/contracts/manifests/dev/manifest.toml
+++ b/contracts/manifests/dev/manifest.toml
@@ -118,8 +118,8 @@ name = "eternum::systems::dev::contracts::resource::dev_resource_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x2d4304c3ac359b8852a70c4f029f94cd145da88ed2e4fcfb769708a1dd80ef"
-class_hash = "0x3d62508438fa3249e2d190b7359f146bce1fd365c1c681edab35c693314dc90"
-original_class_hash = "0x3d62508438fa3249e2d190b7359f146bce1fd365c1c681edab35c693314dc90"
+class_hash = "0x74f2d632afdec1a4d5227b2c09a294fa53b516fd35ede842d7047a64d7161d"
+original_class_hash = "0x74f2d632afdec1a4d5227b2c09a294fa53b516fd35ede842d7047a64d7161d"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_guild_contracts_guild_systems.json"
 reads = []
@@ -178,8 +178,8 @@ name = "eternum::systems::name::contracts::name_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x78954c3172d81b184a548c25b9ac6831881f2a1bf0eda25a7576529fe70811e"
-class_hash = "0x224dceac90c1d064eca8346eca73d1cb832d1aca3045e7536e7da7de8ad12d8"
-original_class_hash = "0x224dceac90c1d064eca8346eca73d1cb832d1aca3045e7536e7da7de8ad12d8"
+class_hash = "0x3ed3b4775073599fe2d95a6716dadb894e1ebea83e8cd2a6ed1ab423f61f6f"
+original_class_hash = "0x3ed3b4775073599fe2d95a6716dadb894e1ebea83e8cd2a6ed1ab423f61f6f"
 base_class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 abi = "abis/deployments/contracts/eternum_systems_realm_contracts_realm_systems.json"
 reads = []
@@ -1209,6 +1209,75 @@ key = false
 
 [[models]]
 kind = "DojoModel"
+class_hash = "0x5c155bf1246b96b20a902f34eadefa15f2f8a6e701786ecd7828c11b465576c"
+original_class_hash = "0x5c155bf1246b96b20a902f34eadefa15f2f8a6e701786ecd7828c11b465576c"
+abi = "abis/deployments/models/eternum_models_hyperstructure_hyper_structure.json"
+name = "eternum::models::hyperstructure::hyper_structure"
+
+[[models.members]]
+name = "entity_id"
+type = "u128"
+key = true
+
+[[models.members]]
+name = "hyperstructure_type"
+type = "u8"
+key = false
+
+[[models.members]]
+name = "controlling_order"
+type = "u8"
+key = false
+
+[[models.members]]
+name = "completed"
+type = "bool"
+key = false
+
+[[models.members]]
+name = "completion_cost_id"
+type = "u128"
+key = false
+
+[[models.members]]
+name = "completion_resource_count"
+type = "u32"
+key = false
+
+[[models]]
+kind = "DojoModel"
+class_hash = "0x6a27eefe89fbb233f297ab2e5437bea2a98f4992ead34ecfdecb76d8bb98d9b"
+original_class_hash = "0x6a27eefe89fbb233f297ab2e5437bea2a98f4992ead34ecfdecb76d8bb98d9b"
+abi = "abis/deployments/models/eternum_models_hyperstructure_hyper_structure_v_2.json"
+name = "eternum::models::hyperstructure::hyper_structure_v_2"
+
+[[models.members]]
+name = "entity_id"
+type = "u128"
+key = true
+
+[[models.members]]
+name = "owner"
+type = "u128"
+key = false
+
+[[models.members]]
+name = "completed"
+type = "bool"
+key = false
+
+[[models.members]]
+name = "settlement_cost"
+type = "u32"
+key = false
+
+[[models.members]]
+name = "settlment_tax"
+type = "u32"
+key = false
+
+[[models]]
+kind = "DojoModel"
 class_hash = "0x2b591d11dc31ff00cde5fcb598b8872782985c3533f36ee0626bc5818ef34bb"
 original_class_hash = "0x2b591d11dc31ff00cde5fcb598b8872782985c3533f36ee0626bc5818ef34bb"
 abi = "abis/deployments/models/eternum_models_hyperstructure_progress.json"
@@ -1938,6 +2007,28 @@ name = "eternum::models::structure::structure_count"
 name = "coord"
 type = "Coord"
 key = true
+
+[[models.members]]
+name = "count"
+type = "u8"
+key = false
+
+[[models]]
+kind = "DojoModel"
+class_hash = "0x70b0d7a75f4f826e2d8556abe0c1c0891539611d98658421f9eb2754f263be8"
+original_class_hash = "0x70b0d7a75f4f826e2d8556abe0c1c0891539611d98658421f9eb2754f263be8"
+abi = "abis/deployments/models/eternum_models_tick_tick_move.json"
+name = "eternum::models::tick::tick_move"
+
+[[models.members]]
+name = "entity_id"
+type = "u128"
+key = true
+
+[[models.members]]
+name = "tick"
+type = "u64"
+key = false
 
 [[models.members]]
 name = "count"

--- a/contracts/src/models/combat.cairo
+++ b/contracts/src/models/combat.cairo
@@ -476,8 +476,6 @@ impl BattleImpl of BattleTrait {
         return BattleSide::None;
     }
 }
-
-
 // #[cfg(test)]
 // mod battle_tests {
 //     use eternum::models::combat::BattleTrait;
@@ -563,4 +561,5 @@ impl BattleImpl of BattleTrait {
 //         print!("\n\n Duration in Hours: {} \n\n", battle.duration_left / (60 * 60));
 //     }
 // }
+
 

--- a/contracts/src/models/realm.cairo
+++ b/contracts/src/models/realm.cairo
@@ -25,6 +25,7 @@ struct Realm {
 
 trait RealmTrait {
     fn has_resource(self: Realm, resource_type: u8) -> bool;
+    fn assert_is_set(self: Realm);
 }
 
 impl RealmImpl of RealmTrait {
@@ -43,5 +44,9 @@ impl RealmImpl of RealmTrait {
             };
         };
         has_resource
+    }
+
+    fn assert_is_set(self: Realm) {
+        assert(self.realm_id != 0, 'Entity is not a realm');
     }
 }

--- a/contracts/src/systems/realm/contracts.cairo
+++ b/contracts/src/systems/realm/contracts.cairo
@@ -33,7 +33,7 @@ mod realm_systems {
     use eternum::models::owner::{Owner, EntityOwner};
     use eternum::models::position::{Position, Coord};
     use eternum::models::quantity::QuantityTracker;
-    use eternum::models::realm::Realm;
+    use eternum::models::realm::{Realm, RealmTrait};
     use eternum::models::resources::{DetachedResource, Resource, ResourceImpl, ResourceTrait};
     use eternum::models::structure::{
         Structure, StructureCategory, StructureCount, StructureCountTrait
@@ -46,9 +46,9 @@ mod realm_systems {
 
     #[abi(embed_v0)]
     impl RealmSystemsImpl of super::IRealmSystems<ContractState> {
-        // TODO: mint_starting_resources
-        // exploit as any entity can do this, not just Realms
         fn mint_starting_resources(world: IWorldDispatcher, config_id: u32, entity_id: u128) -> ID {
+            get!(world, (entity_id), Realm).assert_is_set();
+
             let mut claimed_resources = get!(
                 world, (entity_id, config_id), HasClaimedStartingResources
             );

--- a/contracts/src/systems/realm/tests.cairo
+++ b/contracts/src/systems/realm/tests.cairo
@@ -7,16 +7,23 @@ use eternum::constants::ResourceTypes;
 use eternum::models::map::Tile;
 use eternum::models::owner::Owner;
 use eternum::models::position::Position;
+
+use eternum::models::position::{Coord};
 use eternum::models::realm::Realm;
 use eternum::models::resources::Resource;
 
 use eternum::systems::config::contracts::{
     config_systems, IRealmFreeMintConfigDispatcher, IRealmFreeMintConfigDispatcherTrait
 };
+use eternum::systems::hyperstructure::contracts::{
+    hyperstructure_systems, IHyperstructureSystems, IHyperstructureSystemsDispatcher,
+    IHyperstructureSystemsDispatcherTrait
+};
 
 use eternum::systems::realm::contracts::{
     realm_systems, IRealmSystemsDispatcher, IRealmSystemsDispatcherTrait
 };
+use eternum::utils::map::biomes::Biome;
 
 
 use eternum::utils::testing::{spawn_eternum, deploy_system};
@@ -30,6 +37,8 @@ const INITIAL_RESOURCE_1_AMOUNT: u128 = 800;
 
 const INITIAL_RESOURCE_2_TYPE: u8 = 2;
 const INITIAL_RESOURCE_2_AMOUNT: u128 = 700;
+
+const REALM_FREE_MINT_CONFIG_ID: u32 = 0;
 
 fn setup() -> IWorldDispatcher {
     let world = spawn_eternum();
@@ -46,12 +55,28 @@ fn setup() -> IWorldDispatcher {
         contract_address: config_systems_address
     };
 
-    let config_index = 0;
+    let REALM_FREE_MINT_CONFIG_ID = 0;
 
     realm_free_mint_config_dispatcher
-        .set_mint_config(config_id: config_index, resources: initial_resources.span());
+        .set_mint_config(config_id: REALM_FREE_MINT_CONFIG_ID, resources: initial_resources.span());
 
     world
+}
+
+fn generate_positions() -> Array<Position> {
+    let mut positions = ArrayTrait::<Position>::new();
+
+    let mut i = 0;
+    let mut entity_id = 1_u128;
+    let mut x = 10;
+    let mut y = 10;
+    while (i < MAX_REALMS_PER_ADDRESS + 1) {
+        positions
+            .append(Position { x: x + i.into(), y: y + i.into(), entity_id: entity_id + i.into() });
+        i += 1;
+    };
+
+    positions
 }
 
 #[test]
@@ -95,15 +120,16 @@ fn test_realm_create() {
             position.clone(),
         );
 
-    let realm_initial_resource_1 = get!(
-        world, (realm_entity_id, INITIAL_RESOURCE_1_TYPE), Resource
-    );
-    assert(realm_initial_resource_1.balance == INITIAL_RESOURCE_1_AMOUNT, 'wrong mint 1 amount');
+    // let realm_initial_resource_1 = get!(
+    //     world, (realm_entity_id, INITIAL_RESOURCE_1_TYPE), Resource
+    // );
 
-    let realm_initial_resource_2 = get!(
-        world, (realm_entity_id, INITIAL_RESOURCE_2_TYPE), Resource
-    );
-    assert(realm_initial_resource_2.balance == INITIAL_RESOURCE_2_AMOUNT, 'wrong mint 2 amount');
+    // assert(realm_initial_resource_1.balance == INITIAL_RESOURCE_1_AMOUNT, 'wrong mint 1 amount');
+
+    // let realm_initial_resource_2 = get!(
+    //     world, (realm_entity_id, INITIAL_RESOURCE_2_TYPE), Resource
+    // );
+    // assert(realm_initial_resource_2.balance == INITIAL_RESOURCE_2_AMOUNT, 'wrong mint 2 amount');
 
     let realm_owner = get!(world, realm_entity_id, Owner);
     assert(realm_owner.address == contract_address_const::<'caller'>(), 'wrong realm owner');
@@ -131,7 +157,7 @@ fn test_realm_create_equal_max_realms_per_address() {
         contract_address: realm_systems_address
     };
 
-    let position = Position { x: 20, y: 30, entity_id: 1_u128 };
+    let positions = generate_positions();
 
     let realm_id = 1;
     let resource_types_packed = 1;
@@ -143,7 +169,7 @@ fn test_realm_create_equal_max_realms_per_address() {
     let wonder = 1;
     let order = 1;
 
-    let mut index = 0;
+    let mut index = 0_u8;
     loop {
         if index == MAX_REALMS_PER_ADDRESS {
             break;
@@ -159,7 +185,7 @@ fn test_realm_create_equal_max_realms_per_address() {
                 regions,
                 wonder,
                 order,
-                position.clone(),
+                (*positions.at(index.into())).clone(),
             );
 
         index += 1;
@@ -179,7 +205,8 @@ fn test_realm_create_greater_than_max_realms_per_address() {
         contract_address: realm_systems_address
     };
 
-    let position = Position { x: 20, y: 30, entity_id: 1_u128 };
+    // let position = Position { x: 20, y: 30, entity_id: 1_u128 };
+    let positions = generate_positions();
 
     let realm_id = 1;
     let resource_types_packed = 1;
@@ -209,9 +236,130 @@ fn test_realm_create_greater_than_max_realms_per_address() {
                 regions,
                 wonder,
                 order,
-                position.clone(),
+                (*positions.at(index.into())).clone(),
             );
 
         index += 1;
     };
+}
+
+#[test]
+#[available_gas(3000000000000)]
+fn test_mint_starting_resources() {
+    let world = setup();
+
+    starknet::testing::set_block_timestamp(TIMESTAMP);
+
+    // create realm
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
+    let realm_systems_dispatcher = IRealmSystemsDispatcher {
+        contract_address: realm_systems_address
+    };
+
+    let position = Position { x: 20, y: 30, entity_id: 1_u128 };
+
+    let realm_id = 1;
+    let resource_types_packed = 1;
+    let resource_types_count = 1;
+    let cities = 6;
+    let harbors = 5;
+    let rivers = 5;
+    let regions = 5;
+    let wonder = 1;
+    let order = 1;
+
+    starknet::testing::set_contract_address(contract_address_const::<'caller'>());
+
+    let realm_entity_id = realm_systems_dispatcher
+        .create(
+            realm_id,
+            resource_types_packed,
+            resource_types_count,
+            cities,
+            harbors,
+            rivers,
+            regions,
+            wonder,
+            order,
+            position.clone(),
+        );
+
+    realm_systems_dispatcher.mint_starting_resources(REALM_FREE_MINT_CONFIG_ID, realm_entity_id);
+
+    let realm_initial_resource_1 = get!(
+        world, (realm_entity_id, INITIAL_RESOURCE_1_TYPE), Resource
+    );
+
+    assert(realm_initial_resource_1.balance == INITIAL_RESOURCE_1_AMOUNT, 'wrong mint 1 amount');
+
+    let realm_initial_resource_2 = get!(
+        world, (realm_entity_id, INITIAL_RESOURCE_2_TYPE), Resource
+    );
+    assert(realm_initial_resource_2.balance == INITIAL_RESOURCE_2_AMOUNT, 'wrong mint 2 amount');
+}
+
+#[test]
+#[available_gas(3000000000000)]
+#[should_panic(expected: ('Entity is not a realm', 'ENTRYPOINT_FAILED'))]
+fn test_mint_starting_resources_as_not_realm() {
+    let world = setup();
+
+    let realm_systems_address = deploy_system(world, realm_systems::TEST_CLASS_HASH);
+    let realm_systems_dispatcher = IRealmSystemsDispatcher {
+        contract_address: realm_systems_address
+    };
+
+    let hyperstructure_systems_address = deploy_system(
+        world, hyperstructure_systems::TEST_CLASS_HASH
+    );
+    let hyperstructure_systems_dispatcher = IHyperstructureSystemsDispatcher {
+        contract_address: hyperstructure_systems_address
+    };
+
+    let position = Position { x: 20, y: 30, entity_id: 1_u128 };
+
+    let realm_id = 1;
+    let resource_types_packed = 1;
+    let resource_types_count = 1;
+    let cities = 6;
+    let harbors = 5;
+    let rivers = 5;
+    let regions = 5;
+    let wonder = 1;
+    let order = 1;
+
+    starknet::testing::set_contract_address(contract_address_const::<'caller'>());
+
+    let realm_entity_id = realm_systems_dispatcher
+        .create(
+            realm_id,
+            resource_types_packed,
+            resource_types_count,
+            cities,
+            harbors,
+            rivers,
+            regions,
+            wonder,
+            order,
+            position.clone(),
+        );
+
+    set!(
+        world,
+        Tile {
+            _col: 0,
+            _row: 0,
+            col: 0,
+            row: 0,
+            explored_by_id: realm_entity_id,
+            explored_at: 0,
+            biome: Biome::Beach
+        }
+    );
+
+    let hyperstructure_entity_id = hyperstructure_systems_dispatcher
+        .create(realm_entity_id, Coord { x: 0, y: 0 });
+
+    realm_systems_dispatcher
+        .mint_starting_resources(REALM_FREE_MINT_CONFIG_ID, hyperstructure_entity_id);
 }


### PR DESCRIPTION
### **User description**
Closes #855


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added realm selection validation in the BottomNavigation component to ensure quests are only available for realm entities.
- Updated contract class hashes and added new DojoModel definitions for `hyperstructure`, `hyperstructure_v_2`, and `tick_move`.
- Added `assert_is_set` function to the `Realm` model to validate if an entity is a realm.
- Enhanced `mint_starting_resources` function to ensure the entity is a realm before minting resources.
- Added new tests for the `mint_starting_resources` function and updated existing realm tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BottomNavigation.tsx</strong><dd><code>Add realm selection validation in BottomNavigation component.</code></dd></summary>
<hr>

client/src/ui/modules/navigation/BottomNavigation.tsx
<li>Added <code>useEntities</code> hook import.<br> <li> Introduced <code>isRealmSelected</code> function to check if the selected entity is <br>a realm.<br> <li> Updated button notification and disabled state based on <br><code>isRealmSelected</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-e88ab2bf26cead1655ae59538674a03ae7a573c4c6ea347a8ad382f197b3cc4d">+11/-1</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>realm.cairo</strong><dd><code>Add realm validation function in Realm model.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/realm.cairo
<li>Added <code>assert_is_set</code> function to <code>RealmTrait</code> to ensure entity is a <br>realm.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-20949ace6d9313e145b2084f64240b9bae95734136c55af357193fae8055c6c1">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>contracts.cairo</strong><dd><code>Ensure entity is a realm before minting resources.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/realm/contracts.cairo
<li>Added call to <code>assert_is_set</code> in <code>mint_starting_resources</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-a17b26cc5c7a317ab4c355aff513b7e733e8d90840434283dd8d465d86fd8728">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update contract class hashes and add new DojoModels.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.json
<li>Updated class hashes for existing contracts.<br> <li> Added new DojoModel definitions for <code>hyperstructure</code>, <br><code>hyperstructure_v_2</code>, and <code>tick_move</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-bc6816b30ea64e261f152a070b6e767d29d900fcbacb95c684f1c14a82dff5a8">+798/-5</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.toml</strong><dd><code>Update contract class hashes and add new model definitions.</code></dd></summary>
<hr>

contracts/manifests/dev/manifest.toml
<li>Updated class hashes for existing contracts.<br> <li> Added new model definitions for <code>hyperstructure</code>, <code>hyperstructure_v_2</code>, <br>and <code>tick_move</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-43499a9633d551acabe80100dc29d8995890cd62b12169122658233caea498b3">+95/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Formatting
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>combat.cairo</strong><dd><code>Remove extra blank lines in combat model.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/models/combat.cairo
- Removed extra blank lines.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-1f6712b9739bf0216d00ffb382094be053bf5bd8a763697a7c3de7603716056a">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tests.cairo</strong><dd><code>Add tests for minting starting resources and update realm tests.</code></dd></summary>
<hr>

contracts/src/systems/realm/tests.cairo
<li>Added tests for <code>mint_starting_resources</code> function.<br> <li> Added helper function <code>generate_positions</code>.<br> <li> Updated existing tests to use <code>generate_positions</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/879/files#diff-77e476a21ba4108aa2af167bd8e1a60bd2cee55429aaea5511cf420a05262ab8">+163/-15</a></td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

