### PR TITLE
fix: wrong usage of useMemo

### DIFF
--- a/client/src/hooks/store/_mapStore.tsx
+++ b/client/src/hooks/store/_mapStore.tsx
@@ -136,7 +136,7 @@ export const useSetExistingStructures = () => {
     subCreated.current = true;
   }, []);
 
-  useMemo(() => {
+  useEffect(() => {
     const _tmp = builtStructures
       .map((entity) => {
         const position = getComponentValue(setup.components.Position, entity);

--- a/client/src/ui/components/worldmap/hexagon/WorldHexagon.tsx
+++ b/client/src/ui/components/worldmap/hexagon/WorldHexagon.tsx
@@ -108,7 +108,7 @@ export const WorldMap = () => {
   const { useStaminaByEntityId } = useStamina();
   const stamina = useStaminaByEntityId({ travelingEntityId: selectedEntity?.id || 0n });
 
-  useMemo(() => {
+  useEffect(() => {
     if (!selectedEntity || !stamina) return;
 
     const maxTravelPossible = Math.floor((stamina.amount || 0) / EternumGlobalConfig.stamina.travelCost);


### PR DESCRIPTION
### **User description**
Fixed wrong usage of useMemo.
All setState calls should be placed inside useEffect hooks instead of useMemo.

Wrong usage causing such errors:
![image](https://github.com/BibliothecaDAO/eternum/assets/4090500/1ad06e68-3f32-4179-b584-014088823dc7)


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced incorrect usage of `useMemo` with `useEffect` in two files to ensure state updates are correctly handled.
- Updated built structures setup logic in `_mapStore.tsx`.
- Updated stamina-related calculations in `WorldHexagon.tsx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_mapStore.tsx</strong><dd><code>Replace `useMemo` with `useEffect` for built structures setup</code></dd></summary>
<hr>

client/src/hooks/store/_mapStore.tsx
<li>Replaced <code>useMemo</code> with <code>useEffect</code> for setting up built structures.<br> <li> Ensured state updates are correctly placed inside <code>useEffect</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/913/files#diff-6d3df53ed6fbfb737106e9d7b48fa7c3fa33d11521804ea10a7f5d2fad2517be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WorldHexagon.tsx</strong><dd><code>Replace `useMemo` with `useEffect` for stamina calculations</code></dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/WorldHexagon.tsx
<li>Replaced <code>useMemo</code> with <code>useEffect</code> for stamina-related calculations.<br> <li> Ensured state updates are correctly placed inside <code>useEffect</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/913/files#diff-eab0cbdc1c33d4db9d2fda4be1bb8f506aff500e566c896d59d061882758345c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

