### PR TITLE
katana: mine block every 3 seconds

### DIFF
--- a/scripts/contracts.sh
+++ b/scripts/contracts.sh
@@ -8,4 +8,4 @@ echo "Building Contracts"
 cd contracts
 
 # Run katana with the disable-fee option
-katana --invoke-max-steps 25000000 --disable-fee --allowed-origins "*"
+katana --invoke-max-steps 25000000 --disable-fee --allowed-origins "*" --block-time 3000


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added the `--block-time 3000` option to the `katana` command in the `scripts/contracts.sh` file to enable automatic block mining every 3 seconds.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts.sh</strong><dd><code>Add block time option to katana command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/contracts.sh
- Added `--block-time 3000` option to the `katana` command.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/919/files#diff-424056d6eb01604418b6059c712b6d3390722a5762ff76ff44def87bab506f53">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

