### PR TITLE
contracts: set correct battle position

### DIFF
--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -341,7 +341,7 @@ mod combat_systems {
 
             // set battle position 
             let mut battle_position: Position = Default::default();
-            battle_position.y = attacking_army_position.x;
+            battle_position.x = attacking_army_position.x;
             battle_position.y = attacking_army_position.y;
             set!(world, (battle_position));
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Corrected the assignment of the `battle_position` coordinates in the combat system.
- Changed the x-coordinate assignment from `battle_position.y` to `battle_position.x`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts.cairo</strong><dd><code>Fix battle position assignment in combat system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/combat/contracts.cairo
<li>Corrected the assignment of the <code>battle_position</code> coordinates.<br> <li> Changed <code>battle_position.y</code> to <code>battle_position.x</code> for the x-coordinate.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/920/files#diff-4bdcda25a764215afd907449c2bb112a726bf3281fc1a7e6b9f7f0d4351ddb52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

