### PR TITLE
Fixes quest claim rewards loading state

### DIFF
--- a/client/src/ui/components/hints/HintBox.tsx
+++ b/client/src/ui/components/hints/HintBox.tsx
@@ -2,9 +2,10 @@ import { useDojo } from "@/hooks/context/DojoContext";
 import { useQuests } from "@/hooks/helpers/useQuests";
 import Button from "@/ui/elements/Button";
 import { Check, ShieldQuestion } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useEffect } from "react";
 import useUIStore from "@/hooks/store/useUIStore";
-import { quests } from "../../components/navigation/Config";
+import { quests as QuestOSWindow } from "../../components/navigation/Config";
+
 interface Quest {
   name: string;
   description: string;
@@ -31,9 +32,13 @@ export const HintBox = ({ quest, entityId }: { quest: Quest; entityId: bigint })
     account: { account },
   } = useDojo();
 
-  const togglePopup = useUIStore((state) => state.togglePopup);
-
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (quest.completed === false) {
+      setIsLoading(false);
+    }
+  }, [quest]);
 
   const handleClaimResources = async (config_id: string) => {
     setIsLoading(true);
@@ -66,9 +71,7 @@ export const HintBox = ({ quest, entityId }: { quest: Quest; entityId: bigint })
       }
     } catch (error) {
       console.error("Failed to claim resources:", error);
-    } finally {
       setIsLoading(false);
-      togglePopup(quests);
     }
   };
 
@@ -100,6 +103,15 @@ export const QuestList = ({ entityId }: { entityId: bigint | undefined }) => {
   const firstUnclaimedQuest = useMemo(() => {
     return quests.find((quest: Quest) => !quest.claimed);
   }, [quests]);
+
+  const togglePopup = useUIStore((state) => state.togglePopup);
+  const isPopupOpen = useUIStore((state) => state.isPopupOpen);
+
+  useEffect(() => {
+    if (firstUnclaimedQuest === undefined && isPopupOpen(QuestOSWindow)) {
+      togglePopup(QuestOSWindow);
+    }
+  }, [firstUnclaimedQuest]);
 
   return (
     <div className="p-3 flex flex-col gap-2">


### PR DESCRIPTION
### **User description**
- Fixes quest claim rewards loading state
- Reverted close quest popup on claim, now the popup only closes when the last quest is claimed
Closes #899


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed the quest claim rewards loading state by adding a `useEffect` to reset the loading state when the quest is not completed.
- Removed the `togglePopup` call from the `finally` block in `handleClaimResources` to prevent premature popup closure.
- Added logic to close the quest popup only when the last quest is claimed.
- Updated the import alias for `quests` to `QuestOSWindow` for better clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HintBox.tsx</strong><dd><code>Fix quest claim loading state and popup behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/hints/HintBox.tsx
<li>Added <code>useEffect</code> to reset loading state when quest is not completed.<br> <li> Removed <code>togglePopup</code> call from <code>finally</code> block in <code>handleClaimResources</code>.<br> <li> Introduced logic to close popup only when the last quest is claimed.<br> <li> Updated import alias for <code>quests</code> to <code>QuestOSWindow</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/922/files#diff-5cf22aac8f0607d764110992d7cb5eac12ced82af11478c86e79fd3659cefc6a">+18/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

