### PR TITLE
Fix guild names UI

### DIFF
--- a/client/src/hooks/helpers/useEntities.tsx
+++ b/client/src/hooks/helpers/useEntities.tsx
@@ -1,11 +1,11 @@
 import { getRealmNameById } from "@/ui/utils/realms";
-import { divideByPrecision, getEntityIdFromKeys, getPosition, numberToHex } from "@/ui/utils/utils";
+import { divideByPrecision, getEntityIdFromKeys, getPosition } from "@/ui/utils/utils";
 import { EntityType } from "@bibliothecadao/eternum";
 import { useEntityQuery } from "@dojoengine/react";
 import { Has, HasValue, NotValue, getComponentValue, getEntitiesWithValue } from "@dojoengine/recs";
-import { hexToAscii } from "@dojoengine/utils";
 import { useDojo } from "../context/DojoContext";
 import { useResources } from "./useResources";
+import { shortString } from "starknet";
 
 export const useEntities = () => {
   const {
@@ -37,7 +37,7 @@ export const useEntities = () => {
 
   const getEntityName = (entityId: bigint) => {
     const entityName = getComponentValue(EntityName, getEntityIdFromKeys([entityId]));
-    return entityName ? hexToAscii(numberToHex(Number(entityName.name))) : entityId.toString();
+    return entityName ? shortString.decodeShortString(entityName.name.toString()) : entityId.toString();
   };
 
   const getEntityInfo = (entityId: bigint) => {

--- a/client/src/hooks/helpers/useGuilds.tsx
+++ b/client/src/hooks/helpers/useGuilds.tsx
@@ -80,7 +80,7 @@ export const useGuilds = () => {
         (id) => getComponentValue(GuildMember, id),
       )[0]?.guild_entity_id;
 
-      const guildName = userGuildEntityId ? getEntityName(BigInt(userGuildEntityId!)) : undefined;
+      const guildName = userGuildEntityId ? getEntityName(BigInt(userGuildEntityId)) : undefined;
 
       const owner = Array.from(
         runQuery([HasValue(Owner, { address: BigInt(accountAddress), entity_id: userGuildEntityId })]),
@@ -91,6 +91,7 @@ export const useGuilds = () => {
       const memberCount = Array.from(runQuery([HasValue(Guild, { entity_id: userGuildEntityId })])).map((id) =>
         getComponentValue(Guild, id),
       )[0]?.member_count;
+
       return {
         userGuildEntityId,
         guildName,
@@ -113,9 +114,9 @@ const formatGuilds = (
   return guilds.map((guild_entity_id) => {
     const guild = getComponentValue(Guild, guild_entity_id) as ClientComponents["Guild"]["schema"];
     const name = getEntityName(BigInt(guild?.entity_id));
-
     const index = guildPointsLeaderboard.findIndex((item) => item.guildEntityId === BigInt(guild.entity_id));
     const rank = index != -1 ? guildPointsLeaderboard[index].rank : "";
+
     return {
       ...guild,
       rank,


### PR DESCRIPTION
### **User description**
Closes #947


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated the method for decoding entity names in `useEntities.tsx` to use `shortString.decodeShortString` instead of `hexToAscii`.
- Simplified the `getEntityName` function call in `useGuilds.tsx` by removing unnecessary non-null assertion.
- Improved code readability in the `formatGuilds` function in `useGuilds.tsx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useEntities.tsx</strong><dd><code>Update entity name decoding method to use `shortString`.</code>&nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useEntities.tsx
<li>Removed <code>hexToAscii</code> import.<br> <li> Added <code>shortString</code> import from <code>starknet</code>.<br> <li> Replaced <code>hexToAscii</code> with <code>shortString.decodeShortString</code> for decoding <br>entity names.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/950/files#diff-655bd94eaba19bfcec06d7b736d2e64944c31d55f2b38819201a2b0b612787e4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useGuilds.tsx</strong><dd><code>Simplify guild name retrieval and improve readability.</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useGuilds.tsx
<li>Simplified <code>getEntityName</code> function call by removing unnecessary <br>non-null assertion.<br> <li> Added spacing for better readability in <code>formatGuilds</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/950/files#diff-4a6ae30a3969851b248ce9c56e472b99b3f3ae1a4598fd3610e91aadc0899fa0">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

