### PR TITLE
Fix continue button disabled on acc creation

### DIFF
--- a/client/src/ui/modules/onboarding/Steps.tsx
+++ b/client/src/ui/modules/onboarding/Steps.tsx
@@ -14,7 +14,7 @@ import ListSelect from "@/ui/elements/ListSelect";
 import { ResourceIcon } from "@/ui/elements/ResourceIcon";
 import TextInput from "@/ui/elements/TextInput";
 import { displayAddress } from "@/ui/utils/utils";
-import { QuestType } from "@bibliothecadao/eternum";
+import { QuestType, MAX_NAME_LENGTH } from "@bibliothecadao/eternum";
 import { useTour } from "@reactour/tour";
 import { motion } from "framer-motion";
 import { LucideArrowRight } from "lucide-react";
@@ -96,6 +96,7 @@ export const Naming = ({ onNext }: { onNext: () => void }) => {
       setLoading(false);
     }
   };
+
   const onCopy = () => {
     const burners = localStorage.getItem("burners");
     if (burners) {
@@ -179,7 +180,7 @@ export const Naming = ({ onNext }: { onNext: () => void }) => {
                 <div className="flex w-full h-full z-1000">
                   <TextInput
                     placeholder="Your Name... (Max 31 characters)"
-                    maxLength={31}
+                    maxLength={MAX_NAME_LENGTH}
                     value={inputName}
                     onChange={setInputName}
                   />
@@ -266,7 +267,13 @@ export const Naming = ({ onNext }: { onNext: () => void }) => {
         {playerRealms().length > 0 ? (
           <NavigateToRealm text={"begin"} />
         ) : (
-          <Button disabled={!name || addressIsMaster} size="md" className="mx-auto" variant="primary" onClick={onNext}>
+          <Button
+            disabled={!addressName || addressIsMaster}
+            size="md"
+            className="mx-auto"
+            variant="primary"
+            onClick={onNext}
+          >
             Continue <ArrowRight className="w-2 fill-current ml-3" />
           </Button>
         )}


### PR DESCRIPTION
### **User description**
Closes #924


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed the "Continue" button being disabled during account creation by correcting the condition that checks if the button should be enabled.
- Replaced hardcoded maximum name length with a constant (`MAX_NAME_LENGTH`) for better maintainability.
- Minor formatting adjustments for better code readability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Steps.tsx</strong><dd><code>Fix and enhance naming step in onboarding process</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/modules/onboarding/Steps.tsx
<li>Imported <code>MAX_NAME_LENGTH</code> constant.<br> <li> Replaced hardcoded max length value with <code>MAX_NAME_LENGTH</code>.<br> <li> Fixed the condition for enabling the "Continue" button.<br> <li> Minor formatting adjustments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/951/files#diff-0bb7e9e5135bf95ef8376c6e361487312fa9a0226f14fb2e82c63cb57cf5d301">+10/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

