### PR TITLE
Fix tick

### DIFF
--- a/client/src/hooks/helpers/useExplore.tsx
+++ b/client/src/hooks/helpers/useExplore.tsx
@@ -21,6 +21,7 @@ interface ExploreHexProps {
   explorerId: bigint | undefined;
   direction: number | undefined;
   path: Position[];
+  currentArmiesTick: number;
 }
 
 export function useExplore() {
@@ -118,12 +119,12 @@ export function useExplore() {
     }
   };
 
-  const optimisticExplore = (entityId: bigint, col: number, row: number) => {
+  const optimisticExplore = (entityId: bigint, col: number, row: number, currentArmiesTick: number) => {
     let overrideId = uuid();
 
     const entity = getEntityIdFromKeys([entityId]);
 
-    optimisticStaminaUpdate(overrideId, entityId, EternumGlobalConfig.stamina.exploreCost);
+    optimisticStaminaUpdate(overrideId, entityId, EternumGlobalConfig.stamina.exploreCost, currentArmiesTick);
 
     Position.addOverride(overrideId, {
       entity,
@@ -136,11 +137,11 @@ export function useExplore() {
     return overrideId;
   };
 
-  const exploreHex = async ({ explorerId, direction, path }: ExploreHexProps) => {
+  const exploreHex = async ({ explorerId, direction, path, currentArmiesTick }: ExploreHexProps) => {
     if (!explorerId || direction === undefined) return;
     setExploredHexes(path[1].x - FELT_CENTER, path[1].y - FELT_CENTER);
 
-    const overrideId = optimisticExplore(explorerId, path[1].x, path[1].y);
+    const overrideId = optimisticExplore(explorerId, path[1].x, path[1].y, currentArmiesTick);
 
     explore({
       unit_id: explorerId,

--- a/client/src/hooks/helpers/useStamina.tsx
+++ b/client/src/hooks/helpers/useStamina.tsx
@@ -67,7 +67,6 @@ export const useStamina = () => {
   const optimisticStaminaUpdate = (overrideId: string, entityId: bigint, cost: number, currentArmiesTick: number) => {
     const entity = getEntityIdFromKeys([entityId]);
 
-    // todo: add stamina
     const stamina = getStamina({ travelingEntityId: entityId, currentArmiesTick });
 
     // substract the costs

--- a/client/src/hooks/helpers/useStamina.tsx
+++ b/client/src/hooks/helpers/useStamina.tsx
@@ -32,7 +32,13 @@ export const useStamina = () => {
     return staminaEntity as unknown as ClientComponents["Stamina"]["schema"];
   };
 
-  const getStamina = ({ travelingEntityId }: { travelingEntityId: bigint; armiesTick?: number }) => {
+  const getStamina = ({
+    travelingEntityId,
+    currentArmiesTick,
+  }: {
+    travelingEntityId: bigint;
+    currentArmiesTick: number;
+  }) => {
     const staminasEntityIds = runQuery([HasValue(Stamina, { entity_id: travelingEntityId })]);
     let staminaEntity = getComponentValue(Stamina, staminasEntityIds.values().next().value);
 
@@ -58,11 +64,11 @@ export const useStamina = () => {
     return maxStamina;
   };
 
-  const optimisticStaminaUpdate = (overrideId: string, entityId: bigint, cost: number) => {
+  const optimisticStaminaUpdate = (overrideId: string, entityId: bigint, cost: number, currentArmiesTick: number) => {
     const entity = getEntityIdFromKeys([entityId]);
 
     // todo: add stamina
-    const stamina = getStamina({ travelingEntityId: entityId });
+    const stamina = getStamina({ travelingEntityId: entityId, currentArmiesTick });
 
     // substract the costs
     Stamina.addOverride(overrideId, {

--- a/client/src/hooks/helpers/useTravel.tsx
+++ b/client/src/hooks/helpers/useTravel.tsx
@@ -30,12 +30,23 @@ export function useTravel() {
     return Math.floor(((distanceFromPosition / speed) * 3600) / 60 / 60);
   };
 
-  const optimisticTravelHex = (entityId: bigint, col: number, row: number, currentArmiesTick: number) => {
+  const optimisticTravelHex = (
+    entityId: bigint,
+    col: number,
+    row: number,
+    pathLength: number,
+    currentArmiesTick: number,
+  ) => {
     let overrideId = uuid();
 
     const entity = getEntityIdFromKeys([entityId]);
 
-    optimisticStaminaUpdate(overrideId, entityId, EternumGlobalConfig.stamina.travelCost, currentArmiesTick);
+    optimisticStaminaUpdate(
+      overrideId,
+      entityId,
+      EternumGlobalConfig.stamina.travelCost * pathLength,
+      currentArmiesTick,
+    );
 
     components.Position.addOverride(overrideId, {
       entity,
@@ -55,6 +66,7 @@ export function useTravel() {
       travelingEntityId,
       path[path.length - 1].x,
       path[path.length - 1].y,
+      path.length - 1,
       currentArmiesTick,
     );
 

--- a/client/src/hooks/helpers/useTravel.tsx
+++ b/client/src/hooks/helpers/useTravel.tsx
@@ -9,6 +9,7 @@ interface TravelToHexProps {
   travelingEntityId: bigint | undefined;
   directions: number[];
   path: Position[];
+  currentArmiesTick: number;
 }
 
 export function useTravel() {
@@ -29,12 +30,12 @@ export function useTravel() {
     return Math.floor(((distanceFromPosition / speed) * 3600) / 60 / 60);
   };
 
-  const optimisticTravelHex = (entityId: bigint, col: number, row: number) => {
+  const optimisticTravelHex = (entityId: bigint, col: number, row: number, currentArmiesTick: number) => {
     let overrideId = uuid();
 
     const entity = getEntityIdFromKeys([entityId]);
 
-    optimisticStaminaUpdate(overrideId, entityId, EternumGlobalConfig.stamina.travelCost);
+    optimisticStaminaUpdate(overrideId, entityId, EternumGlobalConfig.stamina.travelCost, currentArmiesTick);
 
     components.Position.addOverride(overrideId, {
       entity,
@@ -47,10 +48,15 @@ export function useTravel() {
     return overrideId;
   };
 
-  const travelToHex = async ({ travelingEntityId, directions, path }: TravelToHexProps) => {
+  const travelToHex = async ({ travelingEntityId, directions, path, currentArmiesTick }: TravelToHexProps) => {
     if (!travelingEntityId) return;
 
-    const overrideId = optimisticTravelHex(travelingEntityId, path[path.length - 1].x, path[path.length - 1].y);
+    const overrideId = optimisticTravelHex(
+      travelingEntityId,
+      path[path.length - 1].x,
+      path[path.length - 1].y,
+      currentArmiesTick,
+    );
 
     travel_hex({
       signer: account,

--- a/client/src/ui/components/worldmap/hexagon/useEventHandlers.tsx
+++ b/client/src/ui/components/worldmap/hexagon/useEventHandlers.tsx
@@ -6,8 +6,10 @@ import { useNotificationsStore } from "../../../../hooks/store/useNotificationsS
 import useUIStore from "../../../../hooks/store/useUIStore";
 import { findDirection, getColRowFromUIPosition } from "../../../utils/utils";
 import { getPositionsAtIndex } from "./utils";
+import useBlockchainStore from "@/hooks/store/useBlockchainStore";
 
 export const useEventHandlers = (explored: Map<number, Set<number>>) => {
+  const currentArmiesTick = useBlockchainStore((state) => state.currentArmiesTick);
   const { exploreHex } = useExplore();
   const { travelToHex } = useTravel();
 
@@ -95,9 +97,9 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
         if (!travelPath) return;
         const { path, isExplored } = travelPath;
         if (isExplored) {
-          handleTravelClick({ id, path });
+          handleTravelClick({ id, path, currentArmiesTick });
         } else {
-          handleExploreClick({ id, path });
+          handleExploreClick({ id, path, currentArmiesTick });
         }
       };
 
@@ -107,10 +109,18 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
         handleArmyActionClick(selectedEntityRef.current.id);
       }
     },
-    [hexData],
+    [hexData, currentArmiesTick],
   );
 
-  async function handleTravelClick({ id, path }: { id: bigint; path: any[] }) {
+  async function handleTravelClick({
+    id,
+    path,
+    currentArmiesTick,
+  }: {
+    id: bigint;
+    path: any[];
+    currentArmiesTick: number;
+  }) {
     const directions = path
       .map((_, i) => {
         if (path[i + 1] === undefined) return undefined;
@@ -118,10 +128,18 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
       })
       .filter((d) => d !== undefined) as number[];
     clearSelection();
-    await travelToHex({ travelingEntityId: id, directions, path });
+    await travelToHex({ travelingEntityId: id, directions, path, currentArmiesTick });
   }
 
-  async function handleExploreClick({ id, path }: { id: bigint; path: any[] }) {
+  async function handleExploreClick({
+    id,
+    path,
+    currentArmiesTick,
+  }: {
+    id: bigint;
+    path: any[];
+    currentArmiesTick: number;
+  }) {
     if (!hexData) return;
     const direction =
       path.length === 2
@@ -140,6 +158,7 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
       explorerId: id,
       direction,
       path,
+      currentArmiesTick,
     });
   }
 

--- a/client/src/ui/components/worldmap/hexagon/useEventHandlers.tsx
+++ b/client/src/ui/components/worldmap/hexagon/useEventHandlers.tsx
@@ -30,13 +30,15 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
   const hoveredHexRef = useRef<any>(hoveredHex);
   const clickedHexRef = useRef(clickedHex);
   const travelPathsRef = useRef(travelPaths);
+  const currentArmiesTickRef = useRef(currentArmiesTick);
 
   useEffect(() => {
     selectedEntityRef.current = selectedEntity;
     clickedHexRef.current = clickedHex;
     travelPathsRef.current = travelPaths;
     hoveredHexRef.current = hoveredHex;
-  }, [hoveredHex, travelPaths, selectedEntity, hexData, explored, clickedHex]);
+    currentArmiesTickRef.current = currentArmiesTick;
+  }, [hoveredHex, travelPaths, selectedEntity, explored, clickedHex, currentArmiesTick]);
 
   const hoverHandler = useCallback((e: any) => {
     const intersect = e.intersections.find((intersect: any) => intersect.object instanceof THREE.InstancedMesh);
@@ -97,9 +99,9 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
         if (!travelPath) return;
         const { path, isExplored } = travelPath;
         if (isExplored) {
-          handleTravelClick({ id, path, currentArmiesTick });
+          handleTravelClick({ id, path, currentArmiesTick: currentArmiesTickRef.current });
         } else {
-          handleExploreClick({ id, path, currentArmiesTick });
+          handleExploreClick({ id, path, currentArmiesTick: currentArmiesTickRef.current });
         }
       };
 
@@ -109,7 +111,7 @@ export const useEventHandlers = (explored: Map<number, Set<number>>) => {
         handleArmyActionClick(selectedEntityRef.current.id);
       }
     },
-    [hexData, currentArmiesTick],
+    [hexData],
   );
 
   async function handleTravelClick({

--- a/client/src/ui/modules/navigation/LeftNavigationModule.tsx
+++ b/client/src/ui/modules/navigation/LeftNavigationModule.tsx
@@ -24,6 +24,7 @@ import { Questing } from "../questing/Questing";
 import { SettingsWindow } from "../settings/Settings";
 import { WorldStructuresMenu } from "../world-structures/WorldStructuresMenu";
 import { MenuEnum } from "./BottomNavigation";
+import useBlockchainStore from "@/hooks/store/useBlockchainStore";
 
 export const BuildingThumbs = {
   hex: "/images/buildings/thumb/question.png",
@@ -54,6 +55,7 @@ export enum View {
 export const LeftNavigationModule = () => {
   const [lastView, setLastView] = useState<View>(View.None);
 
+  const currentArmiesTick = useBlockchainStore((state) => state.currentArmiesTick);
   const view = useUIStore((state) => state.leftNavigationView);
   const setView = useUIStore((state) => state.setLeftNavigationView);
 
@@ -67,7 +69,8 @@ export const LeftNavigationModule = () => {
 
   const armiesWithStaminaLeft = entityArmies?.filter((entity) => {
     return (
-      getStamina({ travelingEntityId: BigInt(entity.entity_id) })?.amount >= EternumGlobalConfig.stamina.travelCost
+      getStamina({ travelingEntityId: BigInt(entity.entity_id), currentArmiesTick })?.amount >=
+      EternumGlobalConfig.stamina.travelCost
     );
   });
 


### PR DESCRIPTION
### **User description**
- update of the tick for optimistic stamina update
- bug with travel cost


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `currentArmiesTick` parameter to various interfaces and functions to ensure the current tick is considered in stamina and travel calculations.
- Fixed bug where the current tick was not being updated correctly.
- Refactored event handlers to pass the `currentArmiesTick` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useExplore.tsx</strong><dd><code>Include `currentArmiesTick` in exploration functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useExplore.tsx
<li>Added <code>currentArmiesTick</code> to <code>ExploreHexProps</code> interface.<br> <li> Updated <code>optimisticExplore</code> and <code>exploreHex</code> functions to include <br><code>currentArmiesTick</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/957/files#diff-45821874b656c15cf5d9d6a603afd6d4858df5008f6353317b5a2d75482aa9a9">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useStamina.tsx</strong><dd><code>Add `currentArmiesTick` to stamina functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useStamina.tsx
<li>Added <code>currentArmiesTick</code> parameter to <code>getStamina</code> and <br><code>optimisticStaminaUpdate</code> functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/957/files#diff-1462ae4521465368a66e185d64e149c741cf0439b84171e3946f3fa1046b8764">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useTravel.tsx</strong><dd><code>Include `currentArmiesTick` in travel functions.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useTravel.tsx
<li>Added <code>currentArmiesTick</code> to <code>TravelToHexProps</code> interface.<br> <li> Updated <code>optimisticTravelHex</code> and <code>travelToHex</code> functions to include <br><code>currentArmiesTick</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/957/files#diff-a3ae3bb7c20e0f95e121cc173b192dadd3a166fd8c2dc84cd37c28c8ed59126a">+22/-4</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>useEventHandlers.tsx</strong><dd><code>Pass `currentArmiesTick` to event handlers.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/useEventHandlers.tsx
<li>Added <code>currentArmiesTick</code> from <code>useBlockchainStore</code>.<br> <li> Updated <code>handleTravelClick</code> and <code>handleExploreClick</code> functions to include <br><code>currentArmiesTick</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/957/files#diff-774607aebdf016d6f7b9e964ad9f0426597cd4be1a10642ee27489cc29b404a4">+27/-6</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LeftNavigationModule.tsx</strong><dd><code>Include `currentArmiesTick` in navigation module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/modules/navigation/LeftNavigationModule.tsx
<li>Added <code>currentArmiesTick</code> from <code>useBlockchainStore</code>.<br> <li> Updated stamina check in <code>armiesWithStaminaLeft</code> to include <br><code>currentArmiesTick</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/957/files#diff-be9e8648ba688d13b3b68afca51d87c31cca8d9412f8c7d77edee0d71737a287">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

