### PR TITLE
fix build

### DIFF
--- a/client/src/dojo/modelManager/types.ts
+++ b/client/src/dojo/modelManager/types.ts
@@ -63,18 +63,18 @@ export type BattleType = {
   entity_id: RecsType.BigInt;
   attack_army: {
     troops: {
-      knight_count: RecsType.Number;
-      paladin_count: RecsType.Number;
-      crossbowman_count: RecsType.Number;
+      knight_count: RecsType.BigInt;
+      paladin_count: RecsType.BigInt;
+      crossbowman_count: RecsType.BigInt;
     };
     battle_id: RecsType.BigInt;
     battle_side: RecsType.String;
   };
   defence_army: {
     troops: {
-      knight_count: RecsType.Number;
-      paladin_count: RecsType.Number;
-      crossbowman_count: RecsType.Number;
+      knight_count: RecsType.BigInt;
+      paladin_count: RecsType.BigInt;
+      crossbowman_count: RecsType.BigInt;
     };
     battle_id: RecsType.BigInt;
     battle_side: RecsType.String;

--- a/client/src/ui/components/hyperstructures/StructureCard.tsx
+++ b/client/src/ui/components/hyperstructures/StructureCard.tsx
@@ -122,11 +122,11 @@ type TroopsProps = {
   structureEntityId: bigint;
 };
 
-const troopsToFormat = (troops: { knight_count: number; paladin_count: number; crossbowman_count: number }) => {
+const troopsToFormat = (troops: { knight_count: bigint; paladin_count: bigint; crossbowman_count: bigint }) => {
   return {
-    [ResourcesIds.Crossbowmen]: troops.crossbowman_count,
-    [ResourcesIds.Knight]: troops.knight_count,
-    [ResourcesIds.Paladin]: troops.paladin_count,
+    [ResourcesIds.Crossbowmen]: Number(troops.crossbowman_count),
+    [ResourcesIds.Knight]: Number(troops.knight_count),
+    [ResourcesIds.Paladin]: Number(troops.paladin_count),
   };
 };
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated `knight_count`, `paladin_count`, and `crossbowman_count` types from `RecsType.Number` to `RecsType.BigInt` in `BattleType` to fix type issues.
- Modified `troopsToFormat` function in `StructureCard.tsx` to accept `bigint` types and convert them to `number` for UI display.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>types.ts</strong><dd><code>Update troop count types to BigInt in BattleType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/dojo/modelManager/types.ts
<li>Changed <code>knight_count</code>, <code>paladin_count</code>, and <code>crossbowman_count</code> types from <br><code>RecsType.Number</code> to <code>RecsType.BigInt</code> in <code>attack_army</code> and <code>defence_army</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/963/files#diff-8bc1f4b6d8a5a666b9ae46ca8639e42d7d9d0cc4eb981a9c4f6f4f6ad3da9bdc">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StructureCard.tsx</strong><dd><code>Convert troop count types from bigint to number in UI</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/hyperstructures/StructureCard.tsx
<li>Changed <code>troopsToFormat</code> function parameter types from <code>number</code> to <code>bigint</code>.<br> <li> Converted <code>bigint</code> values to <code>number</code> within <code>troopsToFormat</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/963/files#diff-dc87a3d6de7675f4a22a24979bc532796ebef68a9ac4cc8ed2d64217038fecdd">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

