### PR TITLE
Fixes build preview lingering when going from hex -> map view

### DIFF
--- a/client/src/ui/modules/navigation/TopMiddleNavigation.tsx
+++ b/client/src/ui/modules/navigation/TopMiddleNavigation.tsx
@@ -40,6 +40,8 @@ export const TopMiddleNavigation = () => {
   const setRealmEntityId = useRealmStore((state) => state.setRealmEntityId);
   const setIsLoadingScreenEnabled = useUIStore((state) => state.setIsLoadingScreenEnabled);
   const moveCameraToColRow = useUIStore((state) => state.moveCameraToColRow);
+  const setPreviewBuilding = useUIStore((state) => state.setPreviewBuilding);
+
 
   // realms always first
   const structures = useMemo(() => {
@@ -110,6 +112,7 @@ export const TopMiddleNavigation = () => {
             if (location !== "/map") {
               setIsLoadingScreenEnabled(true);
               setTimeout(() => {
+                setPreviewBuilding(null);
                 setLocation("/map");
                 if (hexPosition.col !== 0 && hexPosition.row !== 0) {
                   const { col, row } = hexPosition;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added `setPreviewBuilding` to reset the building preview state when switching from hex to map view.
- Ensured that the building preview is cleared to prevent it from lingering when navigating to the map view.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TopMiddleNavigation.tsx</strong><dd><code>Fix lingering build preview when switching to map view.</code>&nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/modules/navigation/TopMiddleNavigation.tsx
<li>Added <code>setPreviewBuilding</code> to reset building preview state.<br> <li> Updated map navigation logic to clear building preview when switching <br>to map view.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/969/files#diff-98461a600ecf71fa8776ed334c66d832ea531c99b49221910e7aea02abe61b95">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

