### PR TITLE
army travel after raiding + hook error

### DIFF
--- a/client/src/hooks/helpers/useStructures.tsx
+++ b/client/src/hooks/helpers/useStructures.tsx
@@ -41,12 +41,9 @@ export const useStructuresPosition = ({ position }: { position: Position }) => {
     account: { account },
   } = useDojo();
 
-  // structures at position
-  const realmsAtPosition = useEntityQuery([HasValue(Position, position), HasValue(Structure, { category: "Realm" })]);
-  const structuresAtPosition = useEntityQuery([HasValue(Position, position), Has(Structure)]);
-
-  const formattedRealmAtPosition: Realm = useMemo(() => {
-    return realmsAtPosition.map((realm_entity_id: any) => {
+  const useFormattedRealmAtPosition = () => {
+    const realmsAtPosition = useEntityQuery([HasValue(Position, position), HasValue(Structure, { category: "Realm" })]);
+    const formattedRealmAtPosition: Realm = realmsAtPosition.map((realm_entity_id: any) => {
       const realm = getComponentValue(Realm as Component, realm_entity_id) as ClientComponents["Realm"]["schema"];
       const entityOwner = getComponentValue(EntityOwner, realm_entity_id);
       const owner = getComponentValue(Owner, getEntityIdFromKeys([entityOwner?.entity_owner_id || 0n]));
@@ -67,11 +64,16 @@ export const useStructuresPosition = ({ position }: { position: Position }) => {
         name: name,
       };
       return fullRealm;
-    });
-  }, [realmsAtPosition])[0];
+    })[0];
 
-  const formattedStructureAtPosition: Structure | undefined = useMemo(() => {
-    return structuresAtPosition.map((entityId: any) => {
+    return formattedRealmAtPosition;
+  };
+
+  const useFormattedStructureAtPosition = () => {
+    // structures at position
+    const structuresAtPosition = useEntityQuery([HasValue(Position, position), Has(Structure)]);
+
+    const formattedStructureAtPosition: Structure | undefined = structuresAtPosition.map((entityId: any) => {
       const structure = getComponentValue(Structure, entityId) as unknown as ClientComponents["Structure"]["schema"];
       if (!structure) {
         return;
@@ -105,17 +107,19 @@ export const useStructuresPosition = ({ position }: { position: Position }) => {
         protector: protector as ArmyInfo | undefined,
         isMine: BigInt(owner!.address) === BigInt(account.address),
       };
-    });
-  }, [structuresAtPosition])[0];
+    })[0];
 
-  const structureAtPosition = useMemo(() => {
-    return formattedStructureAtPosition?.entity_id != null;
-  }, [formattedStructureAtPosition]);
+    return formattedStructureAtPosition;
+  };
+
+  const hasStructuresAtPosition = () => {
+    return useEntityQuery([HasValue(Position, position), Has(Structure)]).length > 0;
+  };
 
   return {
-    formattedRealmAtPosition,
-    formattedStructureAtPosition,
-    structuresAtPosition: structureAtPosition,
+    useFormattedRealmAtPosition,
+    useFormattedStructureAtPosition,
+    hasStructuresAtPosition,
   };
 };
 

--- a/client/src/ui/components/hyperstructures/StructureCard.tsx
+++ b/client/src/ui/components/hyperstructures/StructureCard.tsx
@@ -24,7 +24,11 @@ export const StructureCard = ({
   ownArmySelected: ArmyInfo | undefined;
 }) => {
   const [showMergeTroopsPopup, setShowMergeTroopsPopup] = useState<boolean>(false);
-  const { formattedRealmAtPosition, formattedStructureAtPosition } = useStructuresPosition({ position });
+  const { useFormattedRealmAtPosition, useFormattedStructureAtPosition } = useStructuresPosition({ position });
+
+  const formattedRealmAtPosition = useFormattedRealmAtPosition();
+  const formattedStructureAtPosition = useFormattedStructureAtPosition();
+
   const setBattleView = useUIStore((state) => state.setBattleView);
 
   const button = useMemo(() => {

--- a/client/src/ui/components/worldmap/armies/useArmyAnimation.tsx
+++ b/client/src/ui/components/worldmap/armies/useArmyAnimation.tsx
@@ -29,9 +29,13 @@ export const useArmyAnimation = (position: Position, offset: Position, isMine: b
     if (prevPositionRef.current.x !== x || prevPositionRef.current.y !== y) {
       const startPos = { x: prevPositionRef.current.x, y: prevPositionRef.current.y };
       const endPos = { x, y };
-      const uiPath = findShortestPathBFS(startPos, endPos, exploredHexes).map((pos) =>
+      let uiPath = findShortestPathBFS(startPos, endPos, exploredHexes).map((pos) =>
         getUIPositionFromColRow(pos.x, pos.y),
       );
+      // in case that there is no path, we will just move to the end position, can apply for pillage for example
+      if (uiPath.length === 0) {
+        uiPath = [getUIPositionFromColRow(startPos.x, startPos.y), getUIPositionFromColRow(endPos.x, endPos.y)];
+      }
       setAnimationPath(uiPath.map((pos) => applyOffset(pos, offset)));
       prevPositionRef.current = { x, y };
       isMine && playMarchingSound(); // Play marching sound when animation starts

--- a/client/src/ui/components/worldmap/hexagon/HexagonInformationPanel.tsx
+++ b/client/src/ui/components/worldmap/hexagon/HexagonInformationPanel.tsx
@@ -27,7 +27,8 @@ export const HexagonInformationPanel = () => {
 
   const battle = useBattlesByPosition(hexPosition || { x: 0, y: 0 });
 
-  const { formattedStructureAtPosition } = useStructuresPosition({ position: hexPosition || { x: 0, y: 0 } });
+  const { useFormattedStructureAtPosition } = useStructuresPosition({ position: hexPosition || { x: 0, y: 0 } });
+  const formattedStructureAtPosition = useFormattedStructureAtPosition();
 
   const { userAttackingArmies, enemyArmies } = usePositionArmies({
     position: { x: hexPosition?.x || 0, y: hexPosition?.y || 0 },

--- a/client/src/ui/components/worldmap/hexagon/utils.tsx
+++ b/client/src/ui/components/worldmap/hexagon/utils.tsx
@@ -1,6 +1,12 @@
 import { Color } from "three";
-import { Position, getNeighborHexes, neighborOffsetsEven, neighborOffsetsOdd } from "@bibliothecadao/eternum";
-import { Hexagon } from "../../../../types";
+import {
+  EternumGlobalConfig,
+  Position,
+  TROOPS_STAMINAS,
+  getNeighborHexes,
+  neighborOffsetsEven,
+  neighborOffsetsOdd,
+} from "@bibliothecadao/eternum";
 
 const matrix = new Matrix4();
 const positions = new Vector3();
@@ -35,7 +41,19 @@ export const getPositionsAtIndex = (mesh: InstancedMesh<any, any>, index: number
   return positions;
 };
 
+const getMaxSteps = () => {
+  const staminaCosts = Object.values(EternumGlobalConfig.stamina);
+  const minCost = Math.min(...staminaCosts);
+
+  const staminaValues = Object.values(TROOPS_STAMINAS);
+  const maxStamina = Math.max(...staminaValues);
+
+  return Math.floor(maxStamina / minCost);
+};
+
 export const findShortestPathBFS = (startPos: Position, endPos: Position, exploredHexes: Map<number, Set<number>>) => {
+  const maxHex = getMaxSteps();
+
   const queue: { position: Position; distance: number }[] = [{ position: startPos, distance: 0 }];
   const visited = new Set<string>();
   const path = new Map<string, Position>();
@@ -54,6 +72,10 @@ export const findShortestPathBFS = (startPos: Position, endPos: Position, explor
         temp = path.get(posKey(temp)); // Move backwards through the path
       }
       return result;
+    }
+
+    if (distance > maxHex) {
+      break; // Stop processing if the current distance exceeds maxHex
     }
 
     const currentKey = posKey(current);


### PR DESCRIPTION
### **User description**
- fixes #965 
- fixes hook warnings/errors when clicking on combat


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored `useStructuresPosition` to split logic into separate hooks (`useFormattedRealmAtPosition`, `useFormattedStructureAtPosition`, `hasStructuresAtPosition`).
- Updated `StructureCard` and `HexagonInformationPanel` components to use the new hooks.
- Added fallback path logic in `useArmyAnimation` for cases where no path is found.
- Enhanced pathfinding in `findShortestPathBFS` by introducing a stamina-based step limit.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useStructures.tsx</strong><dd><code>Refactor and enhance structure position hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/hooks/helpers/useStructures.tsx
<li>Refactored <code>useStructuresPosition</code> to split logic into separate hooks.<br> <li> Added <code>useFormattedRealmAtPosition</code> and <code>useFormattedStructureAtPosition</code> <br>hooks.<br> <li> Introduced <code>hasStructuresAtPosition</code> function.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/976/files#diff-396eaa9679c616f55b4078861124f09fe1125e62921747c6e600b2d803948261">+22/-18</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StructureCard.tsx</strong><dd><code>Integrate new structure position hooks in StructureCard</code>&nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/hyperstructures/StructureCard.tsx
<li>Updated <code>StructureCard</code> to use new hooks from <code>useStructuresPosition</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/976/files#diff-dc87a3d6de7675f4a22a24979bc532796ebef68a9ac4cc8ed2d64217038fecdd">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HexagonInformationPanel.tsx</strong><dd><code>Integrate new structure position hooks in HexagonInformationPanel</code></dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/HexagonInformationPanel.tsx
<li>Updated <code>HexagonInformationPanel</code> to use new hooks from <br><code>useStructuresPosition</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/976/files#diff-9db373339d3521390ef906ccde8d7948d4c82fe8ee55d03c8a654968272a832a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.tsx</strong><dd><code>Enhance pathfinding with stamina-based step limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/utils.tsx
<li>Added <code>getMaxSteps</code> function to calculate maximum steps based on <br>stamina.<br> <li> Updated <code>findShortestPathBFS</code> to use <code>getMaxSteps</code> and limit pathfinding.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/976/files#diff-770c44daa009ae4d3637fe48f885dfddf3ed664920aca4d4367177be3a83bcb0">+24/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useArmyAnimation.tsx</strong><dd><code>Add fallback path logic in army animation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/worldmap/armies/useArmyAnimation.tsx
<li>Added fallback path logic in <code>useArmyAnimation</code> for cases with no path.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/976/files#diff-ce247ef03061209e44162c6a4f2a687d3ad45f5b3843f3f16253cd738cf64335">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

