### PR TITLE
fix pillage successful bug

### DIFF
--- a/client/src/ui/components/military/Battle.tsx
+++ b/client/src/ui/components/military/Battle.tsx
@@ -7,7 +7,7 @@ import Button from "@/ui/elements/Button";
 import { Headline } from "@/ui/elements/Headline";
 import { ResourceCost } from "@/ui/elements/ResourceCost";
 import { divideByPrecision } from "@/ui/utils/utils";
-import { BuildingType, Resource } from "@bibliothecadao/eternum";
+import { BattleSide, BuildingType, Resource } from "@bibliothecadao/eternum";
 import { useEffect, useRef, useState } from "react";
 import { Subscription } from "rxjs";
 import { BUILDING_IMAGES_PATH } from "../construction/SelectPreviewBuilding";
@@ -74,7 +74,6 @@ export const PillageHistory = ({
         if (event) {
           const newPillage = formatPillageEvent(event);
           // todo: add battle sound
-          // Check if component is still mounted
           setPillageHistory((prev) => [newPillage, ...prev]);
         }
       });
@@ -90,7 +89,7 @@ export const PillageHistory = ({
   }, [structureId, attackerRealmEntityId, eventUpdates]);
 
   const isPillageSucess = (history: any) => {
-    return history.pillagedResources.length > 0 || history.destroyedBuildingType !== "None";
+    return history.winner === BattleSide[BattleSide.Attack];
   };
 
   return (
@@ -160,6 +159,7 @@ const formatPillageEvent = (event: Event) => {
   const owner = BigInt(event.keys[4]);
 
   const winner = Number(event.data[0]);
+
   const pillagedResources: Resource[] = [];
   for (let i = 0; i < Number(event.data[1]); i++) {
     pillagedResources.push({ resourceId: Number(event.data[2 + i * 2]), amount: Number(event.data[3 + i * 2]) });
@@ -171,7 +171,7 @@ const formatPillageEvent = (event: Event) => {
     attackerRealmEntityId,
     armyId,
     owner,
-    winner,
+    winner: BattleSide[winner],
     pillagedResources,
     destroyedBuildingType,
   };


### PR DESCRIPTION
### **User description**
small fix


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the logic to determine if a pillage was successful by checking if the winner is the attacker.
- Updated the `formatPillageEvent` function to correctly map the winner to the `BattleSide` enum.
- Added the `BattleSide` import to ensure proper type checking and usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Battle.tsx</strong><dd><code>Fix pillage success determination logic in Battle component</code></dd></summary>
<hr>

client/src/ui/components/military/Battle.tsx
<li>Added <code>BattleSide</code> import from <code>@bibliothecadao/eternum</code>.<br> <li> Updated <code>isPillageSucess</code> function to check if the winner is the <br>attacker.<br> <li> Modified <code>formatPillageEvent</code> function to map the winner to <code>BattleSide</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/978/files#diff-9f3726f9bbcb484108a0b6184660bcd0f0c5ffcdbffaf734ceb72ee17f95ed75">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

