### PR TITLE
fix: double click bug

### DIFF
--- a/client/src/ui/components/worldmap/Flags.jsx
+++ b/client/src/ui/components/worldmap/Flags.jsx
@@ -256,7 +256,7 @@ export function Flags(props) {
               >
                 <primitive object={hitBoxInstances[index]} renderOrder={3} />
               </group>
-              <group onClick={(e) => clickHandler(e, index)}>
+              <group>
                 <primitive object={woodInstance} renderOrder={3} />
                 <primitive object={flagInstances[index]} renderOrder={3} />
               </group>

--- a/client/src/ui/components/worldmap/hexagon/HexLayers.tsx
+++ b/client/src/ui/components/worldmap/hexagon/HexLayers.tsx
@@ -269,10 +269,8 @@ export const HexagonGrid = ({ startRow, endRow, startCol, endCol, explored }: He
 
   const goToHex = useCallback(
     (e: any) => {
-      const intersect = e.intersections.find((intersect: any) => intersect.object instanceof THREE.InstancedMesh);
-      if (!intersect) return;
-      const instanceId = intersect.instanceId;
-      const mesh = intersect.object;
+      const instanceId = e.instanceId;
+      const mesh = e.object;
       const pos = getPositionsAtIndex(mesh, instanceId);
       if (!pos) return;
       const colRow = getColRowFromUIPosition(pos.x, pos.y);


### PR DESCRIPTION
### **User description**
Fix #970


___

### **PR Type**
Bug fix


___

### **Description**
- Simplified the `goToHex` function in `HexLayers.tsx` by directly using `e.instanceId` and `e.object`, removing unnecessary intersection checks.
- Removed the redundant `onClick` event handler from a nested `group` element in `Flags.jsx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HexLayers.tsx</strong><dd><code>Simplify `goToHex` function and remove intersection checks</code></dd></summary>
<hr>

client/src/ui/components/worldmap/hexagon/HexLayers.tsx
<li>Simplified the <code>goToHex</code> function by directly using <code>e.instanceId</code> and <br><code>e.object</code>.<br> <li> Removed unnecessary checks for intersections.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/980/files#diff-32d953460a4689eeda29120db48be52828dc4e94c6e6dab11277ba52ce4db0fe">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Flags.jsx</strong><dd><code>Remove redundant `onClick` handler from nested group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/worldmap/Flags.jsx
- Removed `onClick` event handler from a nested `group` element.



</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/980/files#diff-363ae1ff924f5e9c661aafb937b8548d4f7f0b0a563a5bbaa209c010cf5ffbe9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

