### PR TITLE
fix market button

### DIFF
--- a/client/src/ui/components/trading/MarketOrderPanel.tsx
+++ b/client/src/ui/components/trading/MarketOrderPanel.tsx
@@ -261,31 +261,31 @@ export const OrderRow = ({ offer, entityId, isBuy }: { offer: MarketInterface; e
           {currencyFormat(getTotalLords, 0)}
         </div>
 
-        {canAccept ? (
-          isSelf ? (
-            <Button
-              onClick={async () => {
-                setLoading(true);
-                await cancel_order({
-                  signer: account,
-                  trade_id: offer.tradeId,
-                  return_resources: returnResources,
-                });
-                setLoading(false);
-              }}
-              variant="danger"
-              size="xs"
-              className="self-center"
-            >
-              {loading ? "cancelling" : "cancel"}
-            </Button>
-          ) : (
+        {!isSelf ? (
+          canAccept ? (
             <Button isLoading={loading} onClick={onAccept} size="xs" className="self-center flex flex-grow">
               {!isBuy ? "Buy" : "Sell"}
             </Button>
+          ) : (
+            <div className="text-xs text-center">no funds</div>
           )
         ) : (
-          <div className="text-xs text-center">no funds</div>
+          <Button
+            onClick={async () => {
+              setLoading(true);
+              await cancel_order({
+                signer: account,
+                trade_id: offer.tradeId,
+                return_resources: returnResources,
+              });
+              setLoading(false);
+            }}
+            variant="danger"
+            size="xs"
+            className="self-center"
+          >
+            {loading ? "cancelling" : "cancel"}
+          </Button>
         )}
       </div>
     </div>


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the conditional rendering logic for the market order buttons in `MarketOrderPanel.tsx`.
- Ensured that the correct button (buy/sell or cancel) displays based on whether the user is the order creator and if they have sufficient funds.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MarketOrderPanel.tsx</strong><dd><code>Fix conditional rendering for market order buttons</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/components/trading/MarketOrderPanel.tsx
<li>Fixed the conditional rendering logic for the market order buttons.<br> <li> Ensured the correct button displays based on user role and order <br>status.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/991/files#diff-00bad72a59745d3d904730035fcdeaddda30f53c9212d94f35f277ef202bd0bd">+20/-20</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

