### PR TITLE
fix: bug in top middle navigation realms

### DIFF
--- a/client/src/ui/modules/navigation/TopMiddleNavigation.tsx
+++ b/client/src/ui/modules/navigation/TopMiddleNavigation.tsx
@@ -13,8 +13,8 @@ import { useMemo } from "react";
 import { useLocation } from "wouter";
 import useBlockchainStore from "../../../hooks/store/useBlockchainStore";
 
-import { motion } from "framer-motion";
 import { useQuestStore } from "@/hooks/store/useQuestStore";
+import { motion } from "framer-motion";
 
 const slideDown = {
   hidden: { y: "-100%" },
@@ -52,7 +52,7 @@ export const TopMiddleNavigation = () => {
       if (b.category === "Realm") return 1;
       return a.category!.localeCompare(b.category!);
     });
-  }, [playerStructures().length]);
+  }, [playerStructures().length, realmEntityId]);
 
   const isHexView = useMemo(() => {
     return location.includes(`/hex`);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the import order for `motion` from `framer-motion` to resolve potential issues.
- Added `realmEntityId` as a dependency in the `useMemo` hook to ensure proper reactivity when sorting player structures.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TopMiddleNavigation.tsx</strong><dd><code>Fix import order and update dependencies in useMemo hook</code>&nbsp; </dd></summary>
<hr>

client/src/ui/modules/navigation/TopMiddleNavigation.tsx
<li>Fixed import order for <code>motion</code> from <code>framer-motion</code>.<br> <li> Added <code>realmEntityId</code> as a dependency in the <code>useMemo</code> hook for sorting <br>player structures.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1010/files#diff-98461a600ecf71fa8776ed334c66d832ea531c99b49221910e7aea02abe61b95">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

