### PR TITLE
Change 'prettier' call from write to check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
         run: pnpm i
 
       - name: Run Prettier
-        run: pnpm run prettier --check .
+        run: pnpm run prettier-check .

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@
 
 # ignore node_modules
 **/node_modules
+
+# ignore manifests
+*manifest.json

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -218,11 +218,10 @@ h6 {
   border-image: url("/border-2.png") 30 30 round;
 }
 
-
 .ornate-borders-y {
   border-top: none;
-  border-left: 15px solid transparent;;
-  border-right: 15px solid transparent;;
+  border-left: 15px solid transparent;
+  border-right: 15px solid transparent;
   border-bottom: none;
   -moz-border-image: url("/border-2.png") 30 30 round; /* Old firefox */
   -webkit-border-image: url("/border-2.png") 30 30 round; /* Safari */

--- a/client/src/ui/modules/military/battle-view/BattleProgressBar.tsx
+++ b/client/src/ui/modules/military/battle-view/BattleProgressBar.tsx
@@ -27,8 +27,8 @@ export const BattleProgressBar = ({
   const defenderName = structure
     ? `${structure!.name} ${ownArmySide === "Defence" ? "(⚔️)" : ""}`
     : defenderArmies?.length > 0
-    ? `Defenders ${ownArmySide === "Defence" ? "(⚔️)" : ""}`
-    : "Empty";
+      ? `Defenders ${ownArmySide === "Defence" ? "(⚔️)" : ""}`
+      : "Empty";
 
   const totalHealth = useMemo(
     () => (attackingHealth?.current || 0) + (defendingHealth?.current || 0),


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the Prettier command in the CI configuration file to use `pnpm run prettier-check` instead of `pnpm run prettier --check .`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lint.yml</strong><dd><code>Update Prettier command in CI configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint.yml
<li>Changed the Prettier command from <code>pnpm run prettier --check .</code> to <code>pnpm </code><br><code>run prettier-check</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1011/files#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

