### PR TITLE
set realmEntityId when clicking on structure not owned by us.

### DIFF
--- a/client/src/hooks/helpers/useHexPosition.tsx
+++ b/client/src/hooks/helpers/useHexPosition.tsx
@@ -5,7 +5,7 @@ import { useSearch } from "wouter/use-location";
 import { useEntityQuery } from "@dojoengine/react";
 import { Has, HasValue, getComponentValue } from "@dojoengine/recs";
 import { useDojo } from "../context/DojoContext";
-import useRealmStore, { STARTING_ENTITY_ID } from "../store/useRealmStore";
+import useRealmStore from "../store/useRealmStore";
 import useLeaderBoardStore from "../store/useLeaderBoardStore";
 
 export enum HexType {
@@ -30,7 +30,6 @@ export const useHexPosition = () => {
 
   const searchString = useSearch();
   const setRealmEntityId = useRealmStore((state) => state.setRealmEntityId);
-  const realmEntityId = useRealmStore((state) => state.realmEntityId);
 
   const hexPosition = useMemo(() => {
     const params = new URLSearchParams(searchString);
@@ -63,11 +62,7 @@ export const useHexPosition = () => {
   useEffect(() => {
     const owner = getComponentValue(Owner, structures[0]);
     if (owner) {
-      if (owner.address === BigInt(account.account.address) && realmEntityId !== owner.entity_id) {
-        setRealmEntityId(owner.entity_id);
-      } else if (owner.address !== BigInt(account.account.address)) {
-        setRealmEntityId(STARTING_ENTITY_ID);
-      }
+      setRealmEntityId(owner.entity_id);
     }
   }, [structure]);
 

--- a/client/src/ui/elements/CircleButton.tsx
+++ b/client/src/ui/elements/CircleButton.tsx
@@ -94,7 +94,7 @@ const CircleButton = ({
           className={`absolute w-[calc(100%+2px)] h-[calc(100%+2px)] clip-angled-sm ${active ? "bg-gold/40" : " "}`}
         ></div>
       </button>
-      {notification ? (
+      {notification && !disabled ? (
         <div
           className={clsx(
             "absolute animate-bounce rounded-full border border-green/30 bg-green/90 text-brown px-2 text-xxs z-[100] font-bold",

--- a/client/src/ui/modules/navigation/LeftNavigationModule.tsx
+++ b/client/src/ui/modules/navigation/LeftNavigationModule.tsx
@@ -27,6 +27,7 @@ import useBlockchainStore from "@/hooks/store/useBlockchainStore";
 import clsx from "clsx";
 import { quests as questsPopup } from "../../components/navigation/Config";
 import { QuestName, useQuestStore } from "@/hooks/store/useQuestStore";
+import { useEntities } from "@/hooks/helpers/useEntities";
 
 export const BuildingThumbs = {
   hex: "/images/buildings/thumb/question.png",
@@ -67,7 +68,7 @@ export const LeftNavigationModule = () => {
   const quests = useQuestStore((state) => state.quests);
   const currentQuest = useQuestStore((state) => state.currentQuest);
 
-  const { realmEntityId } = useRealmStore();
+  const { realmEntityId, realmId } = useRealmStore();
   const { getStamina } = useStamina();
   const { entityArmies } = useEntityArmies({ entity_id: realmEntityId });
 
@@ -81,6 +82,9 @@ export const LeftNavigationModule = () => {
       EternumGlobalConfig.stamina.travelCost
     );
   });
+
+  const { getEntityInfo } = useEntities();
+  const realmIsMine = getEntityInfo(realmEntityId).isMine;
 
   const navigation = useMemo(() => {
     const navigation = [
@@ -131,6 +135,7 @@ export const LeftNavigationModule = () => {
         name: "construction",
         button: (
           <CircleButton
+            disabled={!realmIsMine}
             className={clsx({
               "animate-pulse":
                 view != View.ConstructionView &&

--- a/client/src/ui/modules/navigation/RightNavigationModule.tsx
+++ b/client/src/ui/modules/navigation/RightNavigationModule.tsx
@@ -20,6 +20,7 @@ import { ArrowRight } from "lucide-react";
 import { BuildingThumbs } from "./LeftNavigationModule";
 import { HintModalButton } from "@/ui/elements/HintModalButton";
 import { Headline } from "@/ui/elements/Headline";
+import { useEntities } from "@/hooks/helpers/useEntities";
 
 export enum View {
   None,
@@ -38,6 +39,9 @@ export const RightNavigationModule = () => {
   const openedPopups = useUIStore((state) => state.openedPopups);
 
   const { realmEntityId } = useRealmStore();
+
+  const { getEntityInfo } = useEntities();
+  const realmIsMine = getEntityInfo(realmEntityId).isMine;
 
   const quests = useQuestStore((state) => state.quests);
   const currentQuest = useQuestStore((state) => state.currentQuest);
@@ -72,6 +76,7 @@ export const RightNavigationModule = () => {
         name: "resourceArrivals",
         button: (
           <CircleButton
+            disabled={!realmIsMine}
             className={clsx({ hidden: !quests?.find((quest) => quest.name === QuestName.CreateTrade)?.claimed })}
             image={BuildingThumbs.trade}
             tooltipLocation="top"
@@ -92,6 +97,7 @@ export const RightNavigationModule = () => {
         name: "trade",
         button: (
           <CircleButton
+            disabled={!realmIsMine}
             className={clsx({
               "animate-pulse":
                 currentQuest?.name === QuestName.CreateTrade && !currentQuest.completed && isPopupOpen(questsPopup),
@@ -109,7 +115,7 @@ export const RightNavigationModule = () => {
         ),
       },
     ];
-  }, [location, view, quests, openedPopups]);
+  }, [location, view, quests, openedPopups, getAllArrivalsWithResources]);
 
   const slideRight = {
     hidden: { x: "100%" },


### PR DESCRIPTION
### **User description**
Also disable contruction + trade menu
Closes #944

___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Simplified the logic to set `realmEntityId` in the `useHexPosition` hook by removing redundant checks.
- Disabled notifications for `CircleButton` when the button is disabled.
- Added checks to disable construction, trade, and resource buttons in navigation modules when the realm is not owned by the user.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useHexPosition.tsx</strong><dd><code>Simplify `realmEntityId` setting logic in `useHexPosition` hook</code></dd></summary>
<hr>

client/src/hooks/helpers/useHexPosition.tsx

<li>Removed <code>STARTING_ENTITY_ID</code> import.<br> <li> Simplified logic to set <code>realmEntityId</code> directly.<br> <li> Removed redundant <code>realmEntityId</code> check.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1044/files#diff-81712b959eef2273b64ed7604c358803618d3c42385a8226bde9ab639dd06883">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>LeftNavigationModule.tsx</strong><dd><code>Disable construction button for non-owned realms in </code><br><code>LeftNavigationModule</code></dd></summary>
<hr>

client/src/ui/modules/navigation/LeftNavigationModule.tsx

<li>Imported <code>useEntities</code> hook.<br> <li> Added <code>realmIsMine</code> check to disable construction button.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1044/files#diff-be9e8648ba688d13b3b68afca51d87c31cca8d9412f8c7d77edee0d71737a287">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RightNavigationModule.tsx</strong><dd><code>Disable trade and resource buttons for non-owned realms in </code><br><code>RightNavigationModule</code></dd></summary>
<hr>

client/src/ui/modules/navigation/RightNavigationModule.tsx

<li>Imported <code>useEntities</code> hook.<br> <li> Added <code>realmIsMine</code> check to disable trade and resource buttons.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1044/files#diff-8b98807e05dc7525757f9d43f5a3b1a081305f54aa3be0d5be4b2a130160bd0c">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CircleButton.tsx</strong><dd><code>Disable notification when CircleButton is disabled</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/elements/CircleButton.tsx

- Added condition to disable notification when button is disabled.



</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1044/files#diff-3fef8a5fabecc39c9767338bb3007c5d17b6fe6d449b0101dd48a31bc399e8ef">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

