### PR TITLE
Show building cards depending on quests cleared

### DIFF
--- a/client/src/ui/components/construction/SelectPreviewBuilding.tsx
+++ b/client/src/ui/components/construction/SelectPreviewBuilding.tsx
@@ -43,6 +43,7 @@ export const SelectPreviewBuildingMenu = () => {
   const isPopupOpen = useUIStore((state) => state.isPopupOpen);
 
   const realmEntityId = useRealmStore((state) => state.realmEntityId);
+  const quests = useQuestStore((state) => state.quests);
   const selectedQuest = useQuestStore((state) => state.selectedQuest);
 
   const { realm } = useGetRealm(realmEntityId);
@@ -89,6 +90,11 @@ export const SelectPreviewBuildingMenu = () => {
     }
   };
 
+  const isQuestClaimedByName = (questName: QuestName) => {
+    const quest = quests?.find((q) => q.name === questName);
+    return quest?.claimed ?? false;
+  };
+
   const tabs = useMemo(
     () => [
       {
@@ -122,7 +128,7 @@ export const SelectPreviewBuildingMenu = () => {
               return (
                 <BuildingCard
                   className={clsx({
-                    hidden: selectedQuest?.name === QuestName.BuildFarm,
+                    hidden: !isQuestClaimedByName(QuestName.BuildFarm),
                   })}
                   key={resourceId}
                   buildingId={BuildingType.Resource}
@@ -178,9 +184,7 @@ export const SelectPreviewBuildingMenu = () => {
                 return (
                   <BuildingCard
                     className={clsx({
-                      hidden:
-                        (!isFarm && selectedQuest?.name === QuestName.BuildFarm) ||
-                        selectedQuest?.name === QuestName.BuildResource,
+                      hidden: !isFarm && !isQuestClaimedByName(QuestName.BuildResource),
                       "animate-pulse":
                         (isFarm && selectedQuest?.name === QuestName.BuildFarm) ||
                         (isWorkersHut && selectedQuest?.name === QuestName.BuildWorkersHut) ||
@@ -239,8 +243,7 @@ export const SelectPreviewBuildingMenu = () => {
                 return (
                   <BuildingCard
                     className={clsx({
-                      hidden:
-                        selectedQuest?.name === QuestName.BuildFarm || selectedQuest?.name === QuestName.BuildResource,
+                      hidden: !isQuestClaimedByName(QuestName.BuildResource),
                     })}
                     key={index}
                     buildingId={building}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added a new state `quests` from `useQuestStore` to track quests.
- Implemented `isQuestClaimedByName` function to determine if a quest is claimed.
- Modified the visibility conditions for `BuildingCard` components to depend on the quest completion status instead of the selected quest.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectPreviewBuilding.tsx</strong><dd><code>Update building card visibility based on quest completion</code></dd></summary>
<hr>

client/src/ui/components/construction/SelectPreviewBuilding.tsx

<li>Added <code>quests</code> state from <code>useQuestStore</code>.<br> <li> Introduced <code>isQuestClaimedByName</code> function to check if a quest is <br>claimed.<br> <li> Updated visibility logic for <code>BuildingCard</code> components based on quest <br>status.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1049/files#diff-c6a222463602fe87932fbbc060d2d99cdd1b151dcb9fcd9be42b602a77f18d97">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

