### PR TITLE
update reward to fragments

### DIFF
--- a/sdk/packages/eternum/src/constants/resources.ts
+++ b/sdk/packages/eternum/src/constants/resources.ts
@@ -391,15 +391,15 @@ export const getLevelingCost = (newLevel: number): { resourceId: number; amount:
       ? // level 4 (resource tier 3)
         [16, 24421, 17, 20954, 18, 16733, 19, 14020, 20, 8291, 21, 5578, 22, 3467]
       : rem === 1
-        ? // level 1 (food)
-          [254, 11340000, 255, 3780000]
-        : rem === 2
-          ? // level 2 (resource tier 1)
-            [1, 756000, 2, 594097, 3, 577816, 4, 398426, 5, 334057, 6, 262452, 7, 177732]
-          : rem === 3
-            ? // level 3 (resource tier 2)
-              [8, 144266, 9, 137783, 10, 89544, 11, 45224, 12, 37235, 13, 36029, 14, 36029, 15, 25929]
-            : [];
+      ? // level 1 (food)
+        [254, 11340000, 255, 3780000]
+      : rem === 2
+      ? // level 2 (resource tier 1)
+        [1, 756000, 2, 594097, 3, 577816, 4, 398426, 5, 334057, 6, 262452, 7, 177732]
+      : rem === 3
+      ? // level 3 (resource tier 2)
+        [8, 144266, 9, 137783, 10, 89544, 11, 45224, 12, 37235, 13, 36029, 14, 36029, 15, 25929]
+      : [];
 
   const costResources = [];
   for (let i = 0; i < baseAmounts.length; i = i + 2) {
@@ -890,11 +890,11 @@ export const QUEST_RESOURCES = {
     { resource: ResourcesIds.Paladin, amount: 3 },
   ],
   [QuestType.Earthenshard]: [{ resource: ResourcesIds.Earthenshard, amount: 10 }],
-  [QuestType.Travel]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
-  [QuestType.Population]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
-  [QuestType.Market]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
-  [QuestType.Mine]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
-  [QuestType.Pillage]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
-  [QuestType.Hyperstructure]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
-  [QuestType.Contribution]: [{ resource: ResourcesIds.Wheat, amount: 1 }],
+  [QuestType.Travel]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
+  [QuestType.Population]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
+  [QuestType.Market]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
+  [QuestType.Mine]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
+  [QuestType.Pillage]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
+  [QuestType.Hyperstructure]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
+  [QuestType.Contribution]: [{ resource: ResourcesIds.Earthenshard, amount: 5 }],
 };


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Adjusted the indentation for resource tiers in the `getLevelingCost` function for better readability.
- Updated quest rewards for various quest types from `ResourcesIds.Wheat` to `ResourcesIds.Earthenshard` and increased the amount from 1 to 5.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resources.ts</strong><dd><code>Update quest rewards and adjust resource tier indentation</code></dd></summary>
<hr>

sdk/packages/eternum/src/constants/resources.ts

<li>Adjusted indentation for leveling cost resource tiers.<br> <li> Updated quest rewards from <code>ResourcesIds.Wheat</code> to <br><code>ResourcesIds.Earthenshard</code> and increased the amount.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1056/files#diff-03877f9a7de964bc35d454531a120cf998aca1a8b8ebd1d0471d35393c38ac4a">+16/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

