### PR TITLE
Fix exploring w/ army owned by structure that isnt a realm

### DIFF
--- a/contracts/manifests/dev/manifest.json
+++ b/contracts/manifests/dev/manifest.json
@@ -4102,8 +4102,8 @@
     {
       "kind": "DojoContract",
       "address": "0x1723599f44e8b02ac7893a4bcc993a9aa55729f0a91ee94bc5d57589a5276b5",
-      "class_hash": "0x1d73c368c6c5e8b3c5de88451592ae0e0fc633742680d23cbe77469e0dc024a",
-      "original_class_hash": "0x1d73c368c6c5e8b3c5de88451592ae0e0fc633742680d23cbe77469e0dc024a",
+      "class_hash": "0x8eb052dd827624d1455aee21140c66d5411294cab36a399635bb59ca1d0785",
+      "original_class_hash": "0x8eb052dd827624d1455aee21140c66d5411294cab36a399635bb59ca1d0785",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {

--- a/contracts/manifests/dev/manifest.toml
+++ b/contracts/manifests/dev/manifest.toml
@@ -165,8 +165,8 @@ name = "eternum::systems::leveling::contracts::leveling_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x1723599f44e8b02ac7893a4bcc993a9aa55729f0a91ee94bc5d57589a5276b5"
-class_hash = "0x1d73c368c6c5e8b3c5de88451592ae0e0fc633742680d23cbe77469e0dc024a"
-original_class_hash = "0x1d73c368c6c5e8b3c5de88451592ae0e0fc633742680d23cbe77469e0dc024a"
+class_hash = "0x8eb052dd827624d1455aee21140c66d5411294cab36a399635bb59ca1d0785"
+original_class_hash = "0x8eb052dd827624d1455aee21140c66d5411294cab36a399635bb59ca1d0785"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_map_contracts_map_systems.json"
 reads = []

--- a/contracts/src/systems/map/contracts.cairo
+++ b/contracts/src/systems/map/contracts.cairo
@@ -63,11 +63,9 @@ mod map_systems {
             // ensure unit is alive
             get!(world, unit_id, Health).assert_alive("Army");
 
-            // check that entity owner is a realm
-            // TODO: Do we need this?
+            // check that caller is owner of entityOwner
             let unit_entity_owner = get!(world, unit_id, EntityOwner);
-            let unit_realm = get!(world, unit_entity_owner.entity_owner_id, Realm);
-            assert(unit_realm.realm_id != 0, 'not owned by realm');
+            unit_entity_owner.assert_caller_owner(world);
 
             // ensure unit can move
             get!(world, unit_id, Movable).assert_moveable();


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Updated `class_hash` and `original_class_hash` values for `DojoContract` in both `manifest.json` and `manifest.toml`.
- Fixed ownership validation in `map_systems` contract by removing the realm ownership check and adding a caller ownership check.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>Update class hashes for DojoContract in manifest.json</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.json

<li>Updated <code>class_hash</code> and <code>original_class_hash</code> values for <code>DojoContract</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1081/files#diff-bc6816b30ea64e261f152a070b6e767d29d900fcbacb95c684f1c14a82dff5a8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.toml</strong><dd><code>Update class hashes for DojoContract in manifest.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/manifests/dev/manifest.toml

<li>Updated <code>class_hash</code> and <code>original_class_hash</code> values for <code>DojoContract</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1081/files#diff-43499a9633d551acabe80100dc29d8995890cd62b12169122658233caea498b3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts.cairo</strong><dd><code>Fix ownership validation in map systems contract</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

contracts/src/systems/map/contracts.cairo

<li>Removed check for entity owner being a realm.<br> <li> Added check to ensure caller is the owner of <code>entityOwner</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1081/files#diff-a528fe53201c1be92bb1839e5e7c3d527f4af1d99a8302a38788aa858cec8314">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

