### PR TITLE
contracts: disallow join after battle ends

### DIFF
--- a/contracts/manifests/dev/manifest.json
+++ b/contracts/manifests/dev/manifest.json
@@ -1001,7 +1001,7 @@
     ],
     "address": "0x161b08e252b353008665e85ab5dcb0044a61186eb14b999657d14c04c94c824",
     "transaction_hash": "0x612de8b84ba9c5454887b576a17af10b7be97dab5f01bf79d1ec2d3cca3e6c5",
-    "block_number": 18,
+    "block_number": 28,
     "seed": "eternum",
     "metadata": {
       "profile_name": "dev",
@@ -1020,8 +1020,8 @@
     {
       "kind": "DojoContract",
       "address": "0x3db3213122bf078c0dc15d5f45b542ab0a03a3fae4fe9e1373fe291357f1000",
-      "class_hash": "0x2281f217a4d6994a2d4203859bb8ff70b2375898bbd5285ba0bbd27520d4b2b",
-      "original_class_hash": "0x2281f217a4d6994a2d4203859bb8ff70b2375898bbd5285ba0bbd27520d4b2b",
+      "class_hash": "0x60f537be65aa0992a5cb2feedc4af036cbb7784da94c87ed6cc3453eb84188a",
+      "original_class_hash": "0x60f537be65aa0992a5cb2feedc4af036cbb7784da94c87ed6cc3453eb84188a",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -1114,7 +1114,11 @@
                   "type": "eternum::models::position::Coord"
                 },
                 {
-                  "name": "owner_fee_scaled",
+                  "name": "owner_fee_num",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "owner_fee_denom",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1134,7 +1138,11 @@
                   "type": "core::integer::u128"
                 },
                 {
-                  "name": "new_swap_fee_unscaled",
+                  "name": "new_owner_fee_num",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "new_owner_fee_denom",
                   "type": "core::integer::u128"
                 }
               ],
@@ -1230,8 +1238,8 @@
     {
       "kind": "DojoContract",
       "address": "0x72c668dbc1e2e8dae1aa02952e3f70a7f89dfeb6648b37315c5c05bb7297754",
-      "class_hash": "0x12a85ecde2aed68fc489460bff6baab43cf03748760506e7fa196a65243429b",
-      "original_class_hash": "0x12a85ecde2aed68fc489460bff6baab43cf03748760506e7fa196a65243429b",
+      "class_hash": "0x723d625e9272bd2117192336ce207ad93d65a377c1fd6571216c76e3f0e2e63",
+      "original_class_hash": "0x723d625e9272bd2117192336ce207ad93d65a377c1fd6571216c76e3f0e2e63",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -1470,8 +1478,8 @@
     {
       "kind": "DojoContract",
       "address": "0x33868c8253a6bdd63074cb8fbdd11cfcca50af1b0f25062d5311541487edb45",
-      "class_hash": "0x78d5cf3d35b3481c4841067f63f993910fdce6c49ead3ea6106df364e90db43",
-      "original_class_hash": "0x78d5cf3d35b3481c4841067f63f993910fdce6c49ead3ea6106df364e90db43",
+      "class_hash": "0x3c9804f6b875898cd8313c7e50eb1911a21a2128ad54a70df35f950f95f43db",
+      "original_class_hash": "0x3c9804f6b875898cd8313c7e50eb1911a21a2128ad54a70df35f950f95f43db",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -1968,8 +1976,8 @@
     {
       "kind": "DojoContract",
       "address": "0xca567be002d22ad080bf3ed80d869374022ee3d215462da7b048543dd79535",
-      "class_hash": "0x52228c1f092d974bc2d67dead9ce2bb762c13b213a037d7661624bec5122229",
-      "original_class_hash": "0x52228c1f092d974bc2d67dead9ce2bb762c13b213a037d7661624bec5122229",
+      "class_hash": "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9",
+      "original_class_hash": "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -2322,8 +2330,8 @@
     {
       "kind": "DojoContract",
       "address": "0x73f0efc06b135109b40f185f2a04a3a30e317f189642958f4f6848c1bb95a8e",
-      "class_hash": "0x6d8eac87d7284c8d946d66f9d38912c3728c63e7f9e724dd0faa1b704537565",
-      "original_class_hash": "0x6d8eac87d7284c8d946d66f9d38912c3728c63e7f9e724dd0faa1b704537565",
+      "class_hash": "0x6ac03a6cf52309eb6eb3e0e2feaf789e5b5de19b106af0c8839f7ce904b9bf4",
+      "original_class_hash": "0x6ac03a6cf52309eb6eb3e0e2feaf789e5b5de19b106af0c8839f7ce904b9bf4",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -2765,7 +2773,11 @@
                   "type": "core::integer::u128"
                 },
                 {
-                  "name": "lp_fee_scaled",
+                  "name": "lp_fee_num",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "lp_fee_denom",
                   "type": "core::integer::u128"
                 }
               ],
@@ -3114,8 +3126,8 @@
     {
       "kind": "DojoContract",
       "address": "0x2b516f55f0ce07ab936099bc3c77471857170a39461adf49c67eb0f67921221",
-      "class_hash": "0x11efdc80c04daa4f2f4a2f88d153c4f3c9fbceba55240dae4cf5e32088f6ba5",
-      "original_class_hash": "0x11efdc80c04daa4f2f4a2f88d153c4f3c9fbceba55240dae4cf5e32088f6ba5",
+      "class_hash": "0x40752f21fda4bc129fa90c8a40b192acdb7982e253de18a5ad5f5ba86783425",
+      "original_class_hash": "0x40752f21fda4bc129fa90c8a40b192acdb7982e253de18a5ad5f5ba86783425",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -3204,7 +3216,11 @@
                   "type": "eternum::models::position::Coord"
                 },
                 {
-                  "name": "owner_fee_scaled",
+                  "name": "owner_fee_num",
+                  "type": "core::integer::u128"
+                },
+                {
+                  "name": "owner_fee_denom",
                   "type": "core::integer::u128"
                 }
               ],
@@ -5828,7 +5844,12 @@
           "key": true
         },
         {
-          "name": "owner_fee_scaled",
+          "name": "owner_fee_num",
+          "type": "u128",
+          "key": false
+        },
+        {
+          "name": "owner_fee_denom",
           "type": "u128",
           "key": false
         },
@@ -5838,8 +5859,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x6ef534336e545ee79b455746d111688b7eccf03bf7a7dcbd83672fbae431b9b",
-      "original_class_hash": "0x6ef534336e545ee79b455746d111688b7eccf03bf7a7dcbd83672fbae431b9b",
+      "class_hash": "0xf37bf9908301861b36eb6ac33bb403d1165df67d66f85061b7be42275be89",
+      "original_class_hash": "0xf37bf9908301861b36eb6ac33bb403d1165df67d66f85061b7be42275be89",
       "abi": [
         {
           "type": "impl",
@@ -6187,7 +6208,11 @@
               "type": "core::integer::u128"
             },
             {
-              "name": "owner_fee_scaled",
+              "name": "owner_fee_num",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "owner_fee_denom",
               "type": "core::integer::u128"
             },
             {
@@ -10574,13 +10599,18 @@
           "key": false
         },
         {
-          "name": "lp_fee_scaled",
+          "name": "lp_fee_num",
+          "type": "u128",
+          "key": false
+        },
+        {
+          "name": "lp_fee_denom",
           "type": "u128",
           "key": false
         }
       ],
-      "class_hash": "0x73ff2ce7a723e107fa8e074c239945f2a0ed51aad3d089da0ae54ed3749127e",
-      "original_class_hash": "0x73ff2ce7a723e107fa8e074c239945f2a0ed51aad3d089da0ae54ed3749127e",
+      "class_hash": "0x2a29a61f74c4df129238a83095d15d893ff51d2ec8b59798b52776e2085394d",
+      "original_class_hash": "0x2a29a61f74c4df129238a83095d15d893ff51d2ec8b59798b52776e2085394d",
       "abi": [
         {
           "type": "impl",
@@ -10918,7 +10948,11 @@
               "type": "core::integer::u128"
             },
             {
-              "name": "lp_fee_scaled",
+              "name": "lp_fee_num",
+              "type": "core::integer::u128"
+            },
+            {
+              "name": "lp_fee_denom",
               "type": "core::integer::u128"
             }
           ]

--- a/contracts/manifests/dev/manifest.json
+++ b/contracts/manifests/dev/manifest.json
@@ -1976,8 +1976,8 @@
     {
       "kind": "DojoContract",
       "address": "0xca567be002d22ad080bf3ed80d869374022ee3d215462da7b048543dd79535",
-      "class_hash": "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9",
-      "original_class_hash": "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9",
+      "class_hash": "0x72d03b34f40b7cfc8fc04117d877cacef2efdbd7552b4051caf3e9e032b6a56",
+      "original_class_hash": "0x72d03b34f40b7cfc8fc04117d877cacef2efdbd7552b4051caf3e9e032b6a56",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {

--- a/contracts/manifests/dev/manifest.toml
+++ b/contracts/manifests/dev/manifest.toml
@@ -5,7 +5,7 @@ original_class_hash = "0x3f63cecdc4964acafb921ba2934c6507d1b3c344edb64c2762cf080
 abi = "manifests/dev/abis/deployments/dojo_world_world.json"
 address = "0x161b08e252b353008665e85ab5dcb0044a61186eb14b999657d14c04c94c824"
 transaction_hash = "0x612de8b84ba9c5454887b576a17af10b7be97dab5f01bf79d1ec2d3cca3e6c5"
-block_number = 18
+block_number = 28
 seed = "eternum"
 name = "dojo::world::world"
 
@@ -22,8 +22,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x3db3213122bf078c0dc15d5f45b542ab0a03a3fae4fe9e1373fe291357f1000"
-class_hash = "0x2281f217a4d6994a2d4203859bb8ff70b2375898bbd5285ba0bbd27520d4b2b"
-original_class_hash = "0x2281f217a4d6994a2d4203859bb8ff70b2375898bbd5285ba0bbd27520d4b2b"
+class_hash = "0x60f537be65aa0992a5cb2feedc4af036cbb7784da94c87ed6cc3453eb84188a"
+original_class_hash = "0x60f537be65aa0992a5cb2feedc4af036cbb7784da94c87ed6cc3453eb84188a"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_bank_contracts_bank_bank_systems.json"
 reads = []
@@ -35,8 +35,8 @@ name = "eternum::systems::bank::contracts::bank::bank_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x72c668dbc1e2e8dae1aa02952e3f70a7f89dfeb6648b37315c5c05bb7297754"
-class_hash = "0x12a85ecde2aed68fc489460bff6baab43cf03748760506e7fa196a65243429b"
-original_class_hash = "0x12a85ecde2aed68fc489460bff6baab43cf03748760506e7fa196a65243429b"
+class_hash = "0x723d625e9272bd2117192336ce207ad93d65a377c1fd6571216c76e3f0e2e63"
+original_class_hash = "0x723d625e9272bd2117192336ce207ad93d65a377c1fd6571216c76e3f0e2e63"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_bank_contracts_liquidity_liquidity_systems.json"
 reads = []
@@ -48,8 +48,8 @@ name = "eternum::systems::bank::contracts::liquidity::liquidity_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x33868c8253a6bdd63074cb8fbdd11cfcca50af1b0f25062d5311541487edb45"
-class_hash = "0x78d5cf3d35b3481c4841067f63f993910fdce6c49ead3ea6106df364e90db43"
-original_class_hash = "0x78d5cf3d35b3481c4841067f63f993910fdce6c49ead3ea6106df364e90db43"
+class_hash = "0x3c9804f6b875898cd8313c7e50eb1911a21a2128ad54a70df35f950f95f43db"
+original_class_hash = "0x3c9804f6b875898cd8313c7e50eb1911a21a2128ad54a70df35f950f95f43db"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_bank_contracts_swap_swap_systems.json"
 reads = []
@@ -74,8 +74,8 @@ name = "eternum::systems::buildings::contracts::building_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0xca567be002d22ad080bf3ed80d869374022ee3d215462da7b048543dd79535"
-class_hash = "0x52228c1f092d974bc2d67dead9ce2bb762c13b213a037d7661624bec5122229"
-original_class_hash = "0x52228c1f092d974bc2d67dead9ce2bb762c13b213a037d7661624bec5122229"
+class_hash = "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9"
+original_class_hash = "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_combat_contracts_combat_systems.json"
 reads = []
@@ -87,8 +87,8 @@ name = "eternum::systems::combat::contracts::combat_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x73f0efc06b135109b40f185f2a04a3a30e317f189642958f4f6848c1bb95a8e"
-class_hash = "0x6d8eac87d7284c8d946d66f9d38912c3728c63e7f9e724dd0faa1b704537565"
-original_class_hash = "0x6d8eac87d7284c8d946d66f9d38912c3728c63e7f9e724dd0faa1b704537565"
+class_hash = "0x6ac03a6cf52309eb6eb3e0e2feaf789e5b5de19b106af0c8839f7ce904b9bf4"
+original_class_hash = "0x6ac03a6cf52309eb6eb3e0e2feaf789e5b5de19b106af0c8839f7ce904b9bf4"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_config_contracts_config_systems.json"
 reads = []
@@ -100,8 +100,8 @@ name = "eternum::systems::config::contracts::config_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0x2b516f55f0ce07ab936099bc3c77471857170a39461adf49c67eb0f67921221"
-class_hash = "0x11efdc80c04daa4f2f4a2f88d153c4f3c9fbceba55240dae4cf5e32088f6ba5"
-original_class_hash = "0x11efdc80c04daa4f2f4a2f88d153c4f3c9fbceba55240dae4cf5e32088f6ba5"
+class_hash = "0x40752f21fda4bc129fa90c8a40b192acdb7982e253de18a5ad5f5ba86783425"
+original_class_hash = "0x40752f21fda4bc129fa90c8a40b192acdb7982e253de18a5ad5f5ba86783425"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_dev_contracts_bank_dev_bank_systems.json"
 reads = []
@@ -268,8 +268,8 @@ name = "eternum::systems::transport::contracts::travel_systems::travel_systems"
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x6ef534336e545ee79b455746d111688b7eccf03bf7a7dcbd83672fbae431b9b"
-original_class_hash = "0x6ef534336e545ee79b455746d111688b7eccf03bf7a7dcbd83672fbae431b9b"
+class_hash = "0xf37bf9908301861b36eb6ac33bb403d1165df67d66f85061b7be42275be89"
+original_class_hash = "0xf37bf9908301861b36eb6ac33bb403d1165df67d66f85061b7be42275be89"
 abi = "manifests/dev/abis/deployments/models/eternum_models_bank_bank_bank.json"
 name = "eternum::models::bank::bank::bank"
 
@@ -279,7 +279,12 @@ type = "u128"
 key = true
 
 [[models.members]]
-name = "owner_fee_scaled"
+name = "owner_fee_num"
+type = "u128"
+key = false
+
+[[models.members]]
+name = "owner_fee_denom"
 type = "u128"
 key = false
 
@@ -595,8 +600,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x73ff2ce7a723e107fa8e074c239945f2a0ed51aad3d089da0ae54ed3749127e"
-original_class_hash = "0x73ff2ce7a723e107fa8e074c239945f2a0ed51aad3d089da0ae54ed3749127e"
+class_hash = "0x2a29a61f74c4df129238a83095d15d893ff51d2ec8b59798b52776e2085394d"
+original_class_hash = "0x2a29a61f74c4df129238a83095d15d893ff51d2ec8b59798b52776e2085394d"
 abi = "manifests/dev/abis/deployments/models/eternum_models_config_bank_config.json"
 name = "eternum::models::config::bank_config"
 
@@ -611,7 +616,12 @@ type = "u128"
 key = false
 
 [[models.members]]
-name = "lp_fee_scaled"
+name = "lp_fee_num"
+type = "u128"
+key = false
+
+[[models.members]]
+name = "lp_fee_denom"
 type = "u128"
 key = false
 

--- a/contracts/manifests/dev/manifest.toml
+++ b/contracts/manifests/dev/manifest.toml
@@ -74,8 +74,8 @@ name = "eternum::systems::buildings::contracts::building_systems"
 [[contracts]]
 kind = "DojoContract"
 address = "0xca567be002d22ad080bf3ed80d869374022ee3d215462da7b048543dd79535"
-class_hash = "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9"
-original_class_hash = "0x1ef8391291abe1678e533b62964f028c9a7d64a6a6326f5f5bc70052d5b08d9"
+class_hash = "0x72d03b34f40b7cfc8fc04117d877cacef2efdbd7552b4051caf3e9e032b6a56"
+original_class_hash = "0x72d03b34f40b7cfc8fc04117d877cacef2efdbd7552b4051caf3e9e032b6a56"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/eternum_systems_combat_contracts_combat_systems.json"
 reads = []

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -113,6 +113,8 @@ trait ICombatContract<TContractState> {
     /// # Preconditions:
     /// - The caller must own the `attacking_army_id`.
     /// - Both `attacking_army_id` and `defending_army_id` must not already be in battle.
+    ///   If the attacked army is in a battle that has ended, it is automatically forced 
+    ///   to leave the battle.
     /// - Both armies must be at the same location.
     ///
     /// # Arguments:
@@ -125,8 +127,7 @@ trait ICombatContract<TContractState> {
     ///     - Verifies the attacking and defending armies are not already in battle.
     ///     - Ensures the caller owns the attacking army.
     ///     - Checks that both armies are at the same position.
-    ///     - Ensure that attacking army is alive
-    ///     - Defending Army does not need to be alive
+    ///     - Ensure that both armies are alive
     /// 2. **Battle ID Assignment**:
     ///     - Generates a new unique battle ID and assigns it to both armies.
     ///     - Sets the battle side for each army (attack or defense).
@@ -170,7 +171,7 @@ trait ICombatContract<TContractState> {
     /// - The specified `battle_side` must be either `BattleSide::Attack` or `BattleSide::Defence`.
     /// - The caller must own the `army_id`.
     /// - The battle must be ongoing.
-    /// - The army must not already be in a battle.
+    /// - The army must not already be in a battle. 
     /// - The army must be at the same location as the battle.
     ///
     /// # Arguments:
@@ -187,6 +188,7 @@ trait ICombatContract<TContractState> {
     ///     - Updates the battle state before performing any other actions.
     ///     - Ensures the battle is still ongoing.
     /// 3. **Army Validations**:
+    ///     - Ensures both armies are alive
     ///     - Ensures the army is not already in a battle.
     ///     - Checks that the army is at the same location as the battle.
     /// 4. **Army Assignment to Battle**:

--- a/contracts/src/systems/combat/contracts.cairo
+++ b/contracts/src/systems/combat/contracts.cairo
@@ -686,9 +686,8 @@ mod combat_systems {
             let mut battle: Battle = get!(world, battle_id, Battle);
             battle.update_state();
 
-            if battle.has_ended() {
-                panic!("Battle has ended");
-            }
+            // ensure battle has not ended
+            assert!(!battle.has_ended(), "Battle has ended");
 
             // ensure caller army is not in battle
             let mut caller_army: Army = get!(world, army_id, Army);


### PR DESCRIPTION
### **User description**
- disallow battle join after battle ends
- if `battle_start` is called against an army that is still in battle and the battle has ended, the army is automatically forced to leave the old battle so that it can join the new one


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added logic to disallow armies from joining a battle after it has ended.
- Implemented updates to defending army's battle status to remove it from ended battles.
- Added health invariant checks for both attacking and defending armies to ensure they are at full health before starting a battle.
- Ensured both armies are alive and in the same location before initiating a battle.
- Added a panic to handle cases where a battle has already ended.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>contracts.cairo</strong><dd><code>Disallow joining battles after they have ended and add health checks</code></dd></summary>
<hr>

contracts/src/systems/combat/contracts.cairo

<li>Added checks to disallow joining a battle after it has ended.<br> <li> Updated defending army's battle status to remove it from ended <br>battles.<br> <li> Added health invariant checks for both attacking and defending armies.<br> <li> Ensured both armies are alive and in the same location before starting <br>a battle.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1118/files#diff-4bdcda25a764215afd907449c2bb112a726bf3281fc1a7e6b9f7f0d4351ddb52">+36/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

