### PR TITLE
fix: subscriptions with wildcard pattern matching

### DIFF
--- a/client/src/dojo/setup.ts
+++ b/client/src/dojo/setup.ts
@@ -1,9 +1,9 @@
+import { DojoConfig } from "@dojoengine/core";
+import { getSyncEntities } from "@dojoengine/state";
 import { createClientComponents } from "./createClientComponents";
 import { createSystemCalls } from "./createSystemCalls";
-import { setupNetwork } from "./setupNetwork";
 import { createUpdates } from "./createUpdates";
-import { getSyncEntities } from "@dojoengine/state";
-import { DojoConfig } from "@dojoengine/core";
+import { setupNetwork } from "./setupNetwork";
 
 export type SetupResult = Awaited<ReturnType<typeof setup>>;
 
@@ -14,7 +14,20 @@ export async function setup({ ...config }: DojoConfig) {
   const updates = await createUpdates();
 
   // fetch all existing entities from torii
-  const sync = await getSyncEntities(network.toriiClient, network.contractComponents as any, [], 1000);
+  const sync = await getSyncEntities(
+    network.toriiClient,
+    network.contractComponents as any,
+    [
+      {
+        Keys: {
+          keys: [],
+          pattern_matching: "VariableLen",
+          models: [],
+        },
+      },
+    ],
+    1000,
+  );
 
   return {
     network,


### PR DESCRIPTION
### **User description**
Nasr helped us by giving us this quick fix. We can remove this when we switch to dojo-1.0-alpha.5


___

### **PR Type**
Bug fix


___

### **Description**
- Reordered imports in `client/src/dojo/setup.ts` for better organization.
- Fixed the subscriptions setup by modifying the `getSyncEntities` call to include wildcard pattern matching.
- Added a configuration object to the `getSyncEntities` function to support pattern matching with `VariableLen`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.ts</strong><dd><code>Fix wildcard pattern matching in subscriptions setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/dojo/setup.ts

<li>Reordered imports for better organization.<br> <li> Modified <code>getSyncEntities</code> call to include wildcard pattern matching.<br> <li> Added a configuration object for pattern matching in <code>getSyncEntities</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1152/files#diff-bcb607d42211b85fb3025faa21f66fd4f39323a2d76d02f682d7a04fef47911e">+17/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

