### PR TITLE
fixes #1160

### DIFF
--- a/client/src/three/systems/SystemManager.ts
+++ b/client/src/three/systems/SystemManager.ts
@@ -1,6 +1,6 @@
 import { Component, defineComponentSystem, getComponentValue } from "@dojoengine/recs";
 import { SetupResult } from "@/dojo/setup";
-import { StructureType } from "@bibliothecadao/eternum";
+import { EternumGlobalConfig, StructureType } from "@bibliothecadao/eternum";
 import { ArmySystemUpdate, StructureSystemUpdate, TileSystemUpdate } from "./types";
 
 // The SystemManager class is responsible for updating the Three.js models when there are changes in the game state.
@@ -27,6 +27,13 @@ export class SystemManager {
         this.setupSystem(this.dojo.components.Position, callback, (update: any) => {
           const army = getComponentValue(this.dojo.components.Army, update.entity);
           if (!army) return;
+
+          // filter armies that are in battle
+          if (army.battle_id !== 0) return;
+
+          // filter armies that are dead
+          const health = getComponentValue(this.dojo.components.Health, update.entity);
+          if (!health || health.current / EternumGlobalConfig.troop.healthPrecision === 0n) return;
 
           const owner = getComponentValue(this.dojo.components.Owner, update.entity);
           const isMine = this.isOwner(owner);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Imported `EternumGlobalConfig` to access global configuration values.
- Added logic to filter out armies that are currently in battle.
- Added logic to filter out armies that are dead by checking their health against `EternumGlobalConfig.troop.healthPrecision`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SystemManager.ts</strong><dd><code>Add filtering for armies in battle and dead armies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/systems/SystemManager.ts

<li>Imported <code>EternumGlobalConfig</code> from <code>@bibliothecadao/eternum</code>.<br> <li> Added filtering logic for armies in battle and dead armies.<br> <li> Used <code>EternumGlobalConfig.troop.healthPrecision</code> to check army health.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1183/files#diff-83cb4effdaed30657761a9c8562161d46d2b527b941d3fc6a7f645b2106037ac">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

