### PR TITLE
fix: explored hex cache bug

### DIFF
--- a/client/src/ui/containers/TopLeftContainer.tsx
+++ b/client/src/ui/containers/TopLeftContainer.tsx
@@ -1,5 +1,5 @@
 const TopLeftContainer = ({ children }: { children: React.ReactNode }) => {
-  return <div className="absolute top-0 left-0 ">{children}</div>;
+  return <div className="absolute top-0 left-0 pointer-events-auto">{children}</div>;
 };
 
 export default TopLeftContainer;


### PR DESCRIPTION
### **User description**
#1163 fix


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed and enhanced hex cache management in the `WorldmapScene` to ensure hexes are correctly added and removed based on chunk visibility.
- Added conditional checks to manage hexes within the chunk and updated the interactive hex manager accordingly.
- Cached matrices for chunks and removed cached matrices for non-visible chunks to optimize performance.
- Enabled pointer events for the `TopLeftContainer` by adding the `pointer-events-auto` class.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Worldmap.ts</strong><dd><code>Fix and enhance hex cache management in Worldmap scene</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/scenes/Worldmap.ts

<li>Added conditional checks to ensure hexes are within the chunk before <br>adding to the interactive hex manager.<br> <li> Removed and re-added border hexes for newly explored hexes.<br> <li> Cached matrices for chunks and removed cached matrices for non-visible <br>chunks.<br> <li> Added logging for debugging purposes.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1184/files#diff-39f176e11a1d117525a8de19ae6404d20179a1d8959de6b86b17a1aa9f2de4ad">+62/-32</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>TopLeftContainer.tsx</strong><dd><code>Enable pointer events for TopLeftContainer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/ui/containers/TopLeftContainer.tsx

- Added `pointer-events-auto` class to the container div.



</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1184/files#diff-08c2adc74c161ec211614f1e8955ae6c4eefaf21970d0f27f5379a60ed630119">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

