### PR TITLE
fix click firing after drag

### DIFF
--- a/client/src/three/components/InputManager.ts
+++ b/client/src/three/components/InputManager.ts
@@ -2,7 +2,7 @@ import { SceneName } from "@/types";
 import * as THREE from "three";
 import { SceneManager } from "../SceneManager";
 
-type ListenerTypes = "click" | "mousemove" | "contextmenu" | "dblclick" | "mouseup" | "mousedown";
+type ListenerTypes = "click" | "mousemove" | "contextmenu" | "dblclick" | "mousedown";
 
 export class InputManager {
   private listeners: Array<{ event: ListenerTypes; handler: (e: MouseEvent) => void }> = [];
@@ -19,7 +19,6 @@ export class InputManager {
     private camera: THREE.Camera,
   ) {
     window.addEventListener("mousedown", this.handleMouseDown.bind(this));
-    window.addEventListener("mouseup", this.handleMouseUp.bind(this));
   }
 
   addListener(event: ListenerTypes, callback: (raycaster: THREE.Raycaster) => void): void {
@@ -75,9 +74,15 @@ export class InputManager {
   private handleMouseDown(e: MouseEvent): void {
     this.mouseX = e.clientX;
     this.mouseY = e.clientY;
-  }
+    this.isDragged = false;
 
-  private handleMouseUp(e: MouseEvent) {
-    if (this.mouseX - e.clientX > 10 || this.mouseY - e.clientY > 10) this.isDragged = true;
+    const checkDrag = (e: MouseEvent) => {
+      if (Math.abs(this.mouseX - e.clientX) > 10 || Math.abs(this.mouseY - e.clientY) > 10) {
+        this.isDragged = true;
+        window.removeEventListener("mousemove", checkDrag);
+      }
+    };
+
+    window.addEventListener("mousemove", checkDrag);
   }
 }


### PR DESCRIPTION
### **User description**
Closes #1158


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where a click event was firing after a drag operation.
- Removed the `mouseup` event listener and added drag detection logic within the `handleMouseDown` method.
- Introduced an `isDragged` flag to track whether a drag operation has occurred.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InputManager.ts</strong><dd><code>Fix click event firing after drag operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/components/InputManager.ts

<li>Removed <code>mouseup</code> event listener.<br> <li> Added <code>isDragged</code> flag to track drag state.<br> <li> Implemented drag detection logic in <code>handleMouseDown</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1192/files#diff-941b632963053fcab6c55718bef84e57ae63483ca43acafb92ffe6ba1266816f">+10/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

