### PR TITLE
set preview building zustand state to null + add state to HexagonScene

### DIFF
--- a/client/src/three/scenes/HexagonScene.ts
+++ b/client/src/three/scenes/HexagonScene.ts
@@ -16,6 +16,7 @@ import { BiomeType } from "../components/Biome";
 import InstancedModel from "../components/InstancedModel";
 import { SystemManager } from "../systems/SystemManager";
 import { biomeModelPaths, HEX_HORIZONTAL_SPACING, HEX_SIZE, HEX_VERTICAL_SPACING } from "./constants";
+import useUIStore, { AppStore } from "@/hooks/store/useUIStore";
 
 export abstract class HexagonScene {
   protected scene: THREE.Scene;
@@ -32,6 +33,7 @@ export abstract class HexagonScene {
   protected GUIFolder: any;
   protected biomeModels: Map<BiomeType, InstancedModel> = new Map();
   protected modelLoadPromises: Promise<void>[] = [];
+  protected state: AppStore;
 
   constructor(
     protected sceneName: SceneName,
@@ -114,6 +116,8 @@ export abstract class HexagonScene {
       const clickedHex = this.interactiveHexManager.onDoubleClick(raycaster);
       clickedHex && this.onHexagonClick(clickedHex.hexCoords);
     });
+
+    this.state = useUIStore.getState();
   }
 
   protected abstract onHexagonMouseMove({

--- a/client/src/three/scenes/Hexception.ts
+++ b/client/src/three/scenes/Hexception.ts
@@ -77,6 +77,7 @@ export default class HexceptionScene extends HexagonScene {
   private clearBuildingMode() {
     this.buildingPreview?.clearPreviewBuilding();
     this.highlightHexManager.highlightHexes([]);
+    this.state.setPreviewBuilding(null);
   }
 
   private loadBuildingModels() {

--- a/client/src/three/scenes/Worldmap.ts
+++ b/client/src/three/scenes/Worldmap.ts
@@ -35,10 +35,6 @@ export default class WorldmapScene extends HexagonScene {
 
   private currentChunk: string = "null";
 
-  // Store
-  private state: AppStore;
-  private unsubscribe: () => void;
-
   private armyManager: ArmyManager;
   private structureManager: StructureManager;
   private battleManager: BattleManager;
@@ -66,7 +62,6 @@ export default class WorldmapScene extends HexagonScene {
 
     this.loadBiomeModels(this.renderChunkSize.width * this.renderChunkSize.height);
 
-    this.state = useUIStore.getState();
     this.unsubscribe = useUIStore.subscribe((state) => {
       this.state = state;
     });

--- a/client/src/three/scenes/Worldmap.ts
+++ b/client/src/three/scenes/Worldmap.ts
@@ -62,7 +62,7 @@ export default class WorldmapScene extends HexagonScene {
 
     this.loadBiomeModels(this.renderChunkSize.width * this.renderChunkSize.height);
 
-    this.unsubscribe = useUIStore.subscribe((state) => {
+    useUIStore.subscribe((state) => {
       this.state = state;
     });
 


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Added state management to `HexagonScene` using `useUIStore`.
- Fixed issue in `HexceptionScene` by setting `previewBuilding` to null in `clearBuildingMode`.
- Removed redundant state management code in `WorldmapScene`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HexagonScene.ts</strong><dd><code>Add state management to HexagonScene using useUIStore</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/scenes/HexagonScene.ts

<li>Imported <code>useUIStore</code> and <code>AppStore</code>.<br> <li> Added <code>state</code> property to <code>HexagonScene</code> class.<br> <li> Initialized <code>state</code> in the constructor.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1206/files#diff-ac6a265a418f1d7409b7f3d70707b13fd6e5ff331503f98a951b93c0393c0b4a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Worldmap.ts</strong><dd><code>Remove redundant state management in WorldmapScene</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/scenes/Worldmap.ts

<li>Removed redundant <code>state</code> property and <code>unsubscribe</code> initialization.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1206/files#diff-39f176e11a1d117525a8de19ae6404d20179a1d8959de6b86b17a1aa9f2de4ad">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Hexception.ts</strong><dd><code>Clear preview building state in HexceptionScene</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/scenes/Hexception.ts

- Set `previewBuilding` to null in `clearBuildingMode` method.



</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1206/files#diff-b2c8beb6fec08d39c5ce0494ab0980da1e3c13366e82fdd2bac790fd450293b2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

