### PR TITLE
Add model to BuildingType.none to fix model loading

### DIFF
--- a/client/src/three/scenes/constants.ts
+++ b/client/src/three/scenes/constants.ts
@@ -15,7 +15,7 @@ export const structureTypeToBuildingType: Record<StructureType, BuildingType> = 
 };
 
 export const buildingModelPaths: Record<BuildingType, string> = {
-  [BuildingType.None]: "",
+  [BuildingType.None]: "/models/buildings/farm.glb", //Needs to have a model to load
   [BuildingType.Bank]: "/models/buildings/bank.glb",
   [BuildingType.ArcheryRange]: "/models/buildings/archer_range.glb",
   [BuildingType.Barracks]: "/models/buildings/barracks.glb",


### PR DESCRIPTION
### **PR Type**
bug fix


___

### **Description**
- Fixed an issue where `BuildingType.None` did not have a valid model path, causing model loading problems.
- Updated the `BuildingType.None` model path to `/models/buildings/farm.glb` in `buildingModelPaths`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Fix model loading for `BuildingType.None` by adding valid path</code></dd></summary>
<hr>

client/src/three/scenes/constants.ts

<li>Updated the <code>BuildingType.None</code> model path to a valid model file.<br> <li> Changed the path from an empty string to <code>/models/buildings/farm.glb</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1217/files#diff-1f49c55dac9ff065a9c6f5456b4c6bb0577d190dc08d19d8266719e7c91c4425">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

