### PR TITLE
prevent select enemy army

### DIFF
--- a/client/src/three/components/ArmyManager.ts
+++ b/client/src/three/components/ArmyManager.ts
@@ -16,7 +16,7 @@ export class ArmyManager {
   private dummy: THREE.Mesh;
   loadPromise: Promise<void>;
   private mesh: THREE.InstancedMesh;
-  private armies: Map<number, { index: number; hexCoords: HexPosition }> = new Map();
+  private armies: Map<number, { index: number; hexCoords: HexPosition; isMine: boolean }> = new Map();
   private scale: THREE.Vector3;
   private movingArmies: Map<number, { startPos: THREE.Vector3; endPos: THREE.Vector3; progress: number }> = new Map();
   private labelManager: LabelManager;
@@ -88,7 +88,9 @@ export class ArmyManager {
 
     const entityIdMap = clickedObject.userData.entityIdMap;
     if (entityIdMap) {
-      return entityIdMap[instanceId];
+      const entityId = entityIdMap[instanceId];
+      // don't return if the army is not mine
+      if (entityId && this.armies.get(entityId)?.isMine) return entityId;
     }
   }
 
@@ -109,7 +111,7 @@ export class ArmyManager {
   addArmy(entityId: ID, hexCoords: HexPosition, isMine: boolean) {
     const index = this.mesh.count;
     this.mesh.count++;
-    this.armies.set(entityId, { index, hexCoords });
+    this.armies.set(entityId, { index, hexCoords, isMine });
     const position = this.getArmyWorldPosition(entityId, hexCoords);
     this.dummy.position.copy(position);
     this.dummy.scale.copy(this.scale);
@@ -142,8 +144,8 @@ export class ArmyManager {
     }
     console.log("move army", entityId, hexCoords);
 
-    const index = armyData.index;
-    this.armies.set(entityId, { index, hexCoords });
+    const { index, isMine } = armyData;
+    this.armies.set(entityId, { index, hexCoords, isMine });
     const newPosition = this.getArmyWorldPosition(entityId, hexCoords);
     const currentPosition = new THREE.Vector3();
     this.mesh.getMatrixAt(index, this.dummy.matrix);


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a new `isMine` property to the `armies` map to track whether an army belongs to the player.
- Updated the `getClickedArmyId` method to prevent the selection of enemy armies.
- Modified the `addArmy` and `moveArmy` methods to incorporate the new `isMine` property, ensuring proper handling of army ownership.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ArmyManager.ts</strong><dd><code>Prevent selection of enemy armies and track ownership</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/three/components/ArmyManager.ts

<li>Added <code>isMine</code> property to the <code>armies</code> map to track ownership.<br> <li> Modified <code>getClickedArmyId</code> to prevent selecting enemy armies.<br> <li> Updated <code>addArmy</code> and <code>moveArmy</code> methods to handle the new <code>isMine</code> <br>property.<br>


</details>


  </td>
  <td><a href="https://github.com/BibliothecaDAO/eternum/pull/1226/files#diff-2adc7659f600cae8085de6493ee5b76a051d6efec3e7c06e8c6cd6ab82b9a2c5">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

