### PR TITLE
contracts: fix battle duration bug

### DIFF
--- a/contracts/src/models/combat.cairo
+++ b/contracts/src/models/combat.cairo
@@ -67,7 +67,7 @@ impl HealthCustomImpl of HealthCustomTrait {
     }
 
     fn steps_to_die(self: @Health, mut deduction: u128) -> u128 {
-        if deduction == 0 {
+        if *self.current == 0 || deduction == 0 {
             return 0;
         };
 


### PR DESCRIPTION
resolves #1384 

- previously battle duration was always set to at least 1 second even if one army was dead. now if any army is dead, duration is 0