### PR TITLE
🐛 Fix AMM input issue

### DIFF
--- a/client/src/ui/components/bank/ResourceBar.tsx
+++ b/client/src/ui/components/bank/ResourceBar.tsx
@@ -43,7 +43,7 @@ export const ResourceBar = ({
   };
 
   const handleAmountChange = (amount: string) => {
-    !disableInput && setAmount && setAmount(parseInt(amount) || 0);
+    !disableInput && setAmount && setAmount(parseInt(amount.replaceAll(" ", "")) || 0);
   };
 
   const hasLordsFees = lordsFee > 0 && resourceId === ResourcesIds.Lords;


### PR DESCRIPTION
Cannot test it since the AMM is not initialised locally and I didnt find how but quite confident in the fix.

Actually in my browser I have numbers displayed such as every thousands is space separated such as 9 999 for. 9999, parseInt("9 999") is 9 which was my issue

Closes #1667