### PR TITLE
update battle time calculations

### DIFF
--- a/client/src/dojo/contractComponents.ts
+++ b/client/src/dojo/contractComponents.ts
@@ -1210,12 +1210,13 @@ export function defineContractComponents(world: World) {
           army_max_per_structure: RecsType.Number,
           battle_leave_slash_num: RecsType.Number,
           battle_leave_slash_denom: RecsType.Number,
+          battle_time_reduction_scale: RecsType.Number,
         },
         {
           metadata: {
             namespace: "eternum",
             name: "TroopConfig",
-            types: ["u32", "u32", "u8", "u8", "u16", "u16", "u16", "u8", "u8", "u8", "u8", "u8", "u8"],
+            types: ["u32", "u32", "u8", "u8", "u16", "u16", "u16", "u8", "u8", "u8", "u8", "u8", "u8", "u16"],
             customTypes: [],
           },
         },

--- a/client/src/dojo/contractComponents.ts
+++ b/client/src/dojo/contractComponents.ts
@@ -1210,7 +1210,7 @@ export function defineContractComponents(world: World) {
           army_max_per_structure: RecsType.Number,
           battle_leave_slash_num: RecsType.Number,
           battle_leave_slash_denom: RecsType.Number,
-          battle_time_reduction_scale: RecsType.Number,
+          battle_time_scale: RecsType.Number,
         },
         {
           metadata: {

--- a/contracts/src/models/combat.cairo
+++ b/contracts/src/models/combat.cairo
@@ -25,7 +25,7 @@ use eternum::models::structure::{Structure, StructureCustomImpl};
 use eternum::models::weight::Weight;
 use eternum::models::weight::WeightCustomTrait;
 use eternum::systems::resources::contracts::resource_systems::{InternalResourceSystemsImpl};
-use eternum::utils::math::{PercentageImpl, PercentageValueImpl, min, max};
+use eternum::utils::math::{PercentageImpl, PercentageValueImpl, min, max, cap_minus};
 use eternum::utils::number::NumberTrait;
 
 const STRENGTH_PRECISION: u256 = 10_000;
@@ -222,157 +222,200 @@ impl TroopsImpl of TroopsTrait {
     fn delta(
         self: @Troops, self_health: @Health, enemy_troops: @Troops, enemy_health: @Health, troop_config: TroopConfig
     ) -> (u64, u64) {
-
         let self = *self;
         let self_health = *self_health;
         let enemy_troops = *enemy_troops;
         let enemy_health = *enemy_health;
 
+        let self_total_strength: u64 = self.strength_against(@self_health, @enemy_troops, @enemy_health, troop_config);
+        let enemy_total_strength: u64 = enemy_troops.strength_against(@enemy_health, @self, @self_health, troop_config);
+        if self_total_strength.is_zero() || enemy_total_strength.is_zero() {
+            return (1, 1);
+        }
 
-        /// 
-        /// ARMY 1 = 12.7 * 0.1, TD dealt = 1.27 ps, TD received = 1.259 so  120 / 1.259 = 95.31 time till death
-        /// ARMY 2 = 12.59 * 0.1, TD dealt = 1.259 ps , TD received ps = 1.27, so 120 / 1.27  = 94.48 time till death
-        /// 
-        /// ARMY 1 = 1_270_000 * 0.1, TD dealt = 127_000 ps, TD received = 125_900 = 95.31 time till death
-        /// ARMY 2 = 1_259_000 * 0.1, TD dealt = 125_900 ps , TD received ps = 127_000, so 120 / 1.27  = 94.48 time till death
-        /// 
-        /// // 10_000 * 0.1 = 1_000 * 95.31 = 953_100 seconds = 23.82 hours
-        ///  we use logs to make time plateau. 
-        /// 
-        /// // ask loaf if small army vs small army should take long vs big vs big
-        /// 
-        /// 
-        let self_total_strength: u64 = self.strength_against(@self_health, @enemy_troops, @enemy_health, troop_config) + 1;
-        let enemy_total_strength: u64 = enemy_troops.strength_against(@enemy_health, @self, @self_health, troop_config) + 1;
-        
-        let self_damage_per_second: u64 = (self.count() / (enemy_total_strength * 10 / 100)) + 1;
-        let self_seconds_till_death: u64 = ((self.count() * self_damage_per_second * 1) / 1_00) + 1;
-        let self_delta: u64 = (self_health.current / self_seconds_till_death.into() + 1).try_into().unwrap();
+        /// the damage received is calculated as the number of self troops divided
+        /// by a percentage of the enemy's strength
+        /// i.e `self_count / (x / 100 * the enemy's strength)`
+        /// we add 1 to prevent division by 0 errors
+        let self_seconds_till_death: u64 = 1 + ((100 * self.count()) / 10 / enemy_total_strength);
+        /// scale seconds_till_death by a percentage (e.g 1/1000) of `self_count`
+        /// we add 1 to prevent division by 0 errors
+        let self_seconds_till_death_scaled: u64 = 1
+            + ((self.count() * self_seconds_till_death) / troop_config.battle_time_reduction_scale.into());
+        /// calculate damage received based on seconds till death
+        /// we add 1 to prevent division by 0 errors
+        let self_damage_received: u64 = 1
+            + (self_health.current / self_seconds_till_death_scaled.into()).try_into().unwrap();
 
-        let enemy_damage_per_second: u64 = (enemy_troops.count() / (self_total_strength * 10 / 100)) + 1;
-        let enemy_seconds_till_death: u64 = ((enemy_troops.count() * enemy_damage_per_second * 1) / 1_00) + 1;
-        let enemy_delta: u64 = (enemy_health.current / enemy_seconds_till_death.into() + 1).try_into().unwrap();
+        /// the damage received is calculated as the number of enemy troops divided
+        /// by a percentage of self's strength
+        /// i.e `enemy_count / (x / 100 * self's strength)`
+        /// we add 1 to prevent division by 0 errors
+        let enemy_seconds_till_death: u64 = 1 + ((100 * enemy_troops.count()) / 10 / self_total_strength);
+        /// scale seconds_till_death by a percentage (1/1000) of `enemy_count`
+        /// we add 1 to prevent division by 0 errors
+        let enemy_seconds_till_death_scaled: u64 = 1
+            + ((enemy_troops.count() * enemy_seconds_till_death) / troop_config.battle_time_reduction_scale.into());
+        /// calculate damage received based on seconds till death
+        /// we add 1 to prevent division by 0 errors
+        let enemy_damage_received: u64 = 1
+            + (enemy_health.current / enemy_seconds_till_death_scaled.into()).try_into().unwrap();
 
-        return (enemy_delta, self_delta);
+        return (enemy_damage_received, self_damage_received);
     }
 
-    /// @dev Calculates the net combat strength of one troop against another, factoring in
-    /// troop-specific strengths and advantages/disadvantages.
-    /// @param self Reference to the instance of the Troops struct representing the attacking
-    /// troops.
-    /// @param enemy_troops Reference to the instance of the Troops struct representing the
-    /// defending troops.
-    /// @param troop_config Configuration object containing strength and advantage/disadvantage
-    /// percentages for each troop type.
-    /// @return The net combat strength as an integer, where a positive number indicates a strength
-    /// advantage for the attacking troops.
+    /// Calculate the combat strength of one troop against the other
     fn strength_against(
         self: @Troops, self_health: @Health, enemy_troops: @Troops, enemy_health: @Health, troop_config: TroopConfig
     ) -> u64 {
         let (self, enemy_troops) = (*self, *enemy_troops);
 
-        /// 
-        /// KNIGHT
-        /// 
         let mut self_knight_strength: u64 = self.actual_type_count(TroopType::Knight, self_health).into()
             * troop_config.knight_strength.into();
-        let mut enemy_knight_strength: u64 = enemy_troops.actual_type_count(TroopType::Knight, enemy_health).into()
-            * troop_config.knight_strength.into();
-        
-        let self_knight_strength_with_bonus_a 
-            = self_knight_strength + (enemy_knight_strength * troop_config.advantage_percent.into() / self_knight_strength / PercentageValueImpl::_100());
-        let self_knight_strength_with_bonus_b 
-            = self_knight_strength + PercentageImpl::get(self_knight_strength.into(), troop_config.advantage_percent.into());
-        let self_knight_strength_with_bonus = min(self_knight_strength_with_bonus_a, self_knight_strength_with_bonus_b);
-
-        /// 
-        /// PALADIN
-        /// 
         let mut self_paladin_strength: u64 = self.actual_type_count(TroopType::Paladin, self_health).into()
             * troop_config.paladin_strength.into();
-        let mut enemy_paladin_strength: u64 = enemy_troops.actual_type_count(TroopType::Paladin, enemy_health).into()
-            * troop_config.paladin_strength.into();
-        
-        let self_paladin_strength_with_bonus_a 
-            = self_paladin_strength + (enemy_paladin_strength * troop_config.advantage_percent.into() / self_paladin_strength / PercentageValueImpl::_100());
-        let self_paladin_strength_with_bonus_b 
-            = self_paladin_strength + PercentageImpl::get(self_paladin_strength.into(), troop_config.advantage_percent.into());
-        let self_paladin_strength_with_bonus = min(self_paladin_strength_with_bonus_a, self_paladin_strength_with_bonus_b);
-
-
-        /// 
-        /// CROSSBOWMAN
-        /// 
         let mut self_crossbowman_strength: u64 = self.actual_type_count(TroopType::Crossbowman, self_health).into()
             * troop_config.crossbowman_strength.into();
-        let mut enemy_crossbowman_strength: u64 = enemy_troops.actual_type_count(TroopType::Crossbowman, enemy_health).into()
+
+        let mut enemy_knight_strength: u64 = enemy_troops.actual_type_count(TroopType::Knight, enemy_health).into()
+            * troop_config.knight_strength.into();
+        let mut enemy_paladin_strength: u64 = enemy_troops.actual_type_count(TroopType::Paladin, enemy_health).into()
+            * troop_config.paladin_strength.into();
+        let mut enemy_crossbowman_strength: u64 = enemy_troops
+            .actual_type_count(TroopType::Crossbowman, enemy_health)
+            .into()
             * troop_config.crossbowman_strength.into();
-        
-        let self_crossbowman_strength_with_bonus_a 
-            = self_crossbowman_strength + (enemy_crossbowman_strength * troop_config.advantage_percent.into() / self_crossbowman_strength / PercentageValueImpl::_100());
-        let self_crossbowman_strength_with_bonus_b 
-            = self_crossbowman_strength + PercentageImpl::get(self_crossbowman_strength.into(), troop_config.advantage_percent.into());
-        let self_crossbowman_strength_with_bonus = min(self_crossbowman_strength_with_bonus_a, self_crossbowman_strength_with_bonus_b);
 
-        let self_total_strength  
-            = self_knight_strength_with_bonus 
-                + self_paladin_strength_with_bonus 
-                    + self_crossbowman_strength_with_bonus;
+        // Prevent division by 0 errors
+        self_knight_strength += 1;
+        self_crossbowman_strength += 1;
+        self_paladin_strength += 1;
 
-       return self_total_strength;
+        enemy_knight_strength += 1;
+        enemy_crossbowman_strength += 1;
+        enemy_paladin_strength += 1;
 
-        
+        ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// assuming troop percent is 10/100 = 0.1
+        /// The advantage formula is self + min(0.1 * self, 0.1 * enemy /self)
+        /// The disadvantage formula is self - max(0.1 * self, 0.1 * enemy /self)
+        ///
+        ///////////////////////////////////////////////////////////////////////////////
 
-                 
-        // 1k, 10c, 1p,  = 12 * 10 hp 
-        // 1(1.1) = 1.1 knight, 10(1.05) = 10.5 crossbowman, 1(1.1) = 1.1  paladin, 
-        //  original sum  = 12
-        //  with bonus = 12.7
-        //
-        // 5, 3, 4
-        // 5(1.02) = 5.1 knights, 3(1.03) = 3.09 crossbowman, 4(1.1) = 4.4 paladin
-        // o = 12
-        // b = 12.59
-        //
-        //
-        /// assume, paladin > crossbowman, 
-        ///         crossbowman > knights, 
-        ///         knights > paladin
-        /// 
-        /// paladin bonus = 3 / 1 * 0.1 = min(0.3, 0.1)
-        /// 
-        /// crossbowman bonus = 5 / 10 * 0.1 = min(0.05, 0.1)
-        /// 
-        /// k bonus = 4 / 1 *  10 / 100  = 0.4 so min(0.4, 0.1)
-        /// 
-        /// 
-        /// ARMY 2
-        ///  p = 10/ 4 * 0.1 = 0.1
-        ///  c = 1 / 3 * 0.1 = 0.03
-        ///  k = 1 / 5 * 0.1 = 0.02
-        /// 
-        /// 
-        /// 
-        /// ARMY 1 = 12.7 * 0.1, TD dealt = 1.27 ps, TD received = 1.259 so  120 / 1.259 = 95.31 time till death
-        /// ARMY 2 = 12.59 * 0.1, TD dealt = 1.259 ps , TD received ps = 1.27, so 120 / 1.27  = 94.48 time till death
-        /// 
-        /// ARMY 1 = 1_270_000 * 0.1, TD dealt = 127_000 ps, TD received = 125_900 = 95.31 time till death
-        /// ARMY 2 = 1_259_000 * 0.1, TD dealt = 125_900 ps , TD received ps = 127_000, so 120 / 1.27  = 94.48 time till death
-        /// 
-        /// // 10_000 * 0.1 = 1_000 * 95.31 = 953_100 seconds = 23.82 hours
-        ///  we use logs to make time plateau. 
-        /// 
-        /// // ask loaf if small army vs small army should take long vs big vs big
-        /// 
-        /// 
-        /// 
-        /// 
-        /// 
-        /// 
+        ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// KNIGHT ADVANTAGE CALCULATION AGAINST ENEMY'S PALADIN
+        ///
+        ///
+        let self_knight_strength_with_advantage = self_knight_strength
+            + (enemy_paladin_strength
+                * troop_config.advantage_percent.into()
+                / self_knight_strength
+                / PercentageValueImpl::_100());
+        let self_knight_strength_with_advantage_max = self_knight_strength
+            + PercentageImpl::get(self_knight_strength.into(), troop_config.advantage_percent.into());
+        let self_knight_strength_with_advantage = min(
+            self_knight_strength_with_advantage, self_knight_strength_with_advantage_max
+        );
 
+        ///
+        /// KNIGHT DISADVANTAGE CALCULATION AGAINST ENEMY'S CROSSBOWMAN
+        ///
+        let self_knight_strength_with_disadvantage = cap_minus(
+            self_knight_strength,
+            (enemy_crossbowman_strength
+                * troop_config.disadvantage_percent.into()
+                / self_knight_strength
+                / PercentageValueImpl::_100())
+        );
+        let self_knight_strength_with_disadvantage_max = self_knight_strength
+            - PercentageImpl::get(self_knight_strength.into(), troop_config.disadvantage_percent.into());
+        let self_knight_strength_with_disadvantage = max(
+            self_knight_strength_with_disadvantage, self_knight_strength_with_disadvantage_max
+        );
 
-        ///////////////         Calculate the strength of the Attacker      //////////////////////
-        //////////////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////////////
+
+        ///
+        /// CROSSBOWMAN ADVANTAGE CALCULATION AGAINST ENEMY'S KNIGHT
+        ///
+        let self_crossbowman_strength_with_advantage = self_crossbowman_strength
+            + (enemy_knight_strength
+                * troop_config.advantage_percent.into()
+                / self_crossbowman_strength
+                / PercentageValueImpl::_100());
+        let self_crossbowman_strength_with_advantage_max = self_crossbowman_strength
+            + PercentageImpl::get(self_crossbowman_strength.into(), troop_config.advantage_percent.into());
+        let self_crossbowman_strength_with_advantage = min(
+            self_crossbowman_strength_with_advantage, self_crossbowman_strength_with_advantage_max
+        );
+
+        ///
+        /// CROSSBOWMAN DISADVANTAGE CALCULATION AGAINST ENEMY'S PALADIN
+        ///
+        let self_crossbowman_strength_with_disadvantage = cap_minus(
+            self_crossbowman_strength,
+            (enemy_paladin_strength
+                * troop_config.disadvantage_percent.into()
+                / self_crossbowman_strength
+                / PercentageValueImpl::_100())
+        );
+        let self_crossbowman_strength_with_disadvantage_max = self_crossbowman_strength
+            - PercentageImpl::get(self_crossbowman_strength.into(), troop_config.disadvantage_percent.into());
+        let self_crossbowman_strength_with_disadvantage = max(
+            self_crossbowman_strength_with_disadvantage, self_crossbowman_strength_with_disadvantage_max
+        );
+
+        ///////////////////////////////////////////////////////////////////////////////
+
+        ///
+        /// PALADIN ADVANTAGE CALCULATION AGAINST ENEMY'S CROSSBOWMAN
+        ///
+        let self_paladin_strength_with_advantage = self_paladin_strength
+            + (enemy_crossbowman_strength
+                * troop_config.advantage_percent.into()
+                / self_paladin_strength
+                / PercentageValueImpl::_100());
+        let self_paladin_strength_with_advantage_max = self_paladin_strength
+            + PercentageImpl::get(self_paladin_strength.into(), troop_config.advantage_percent.into());
+        let self_paladin_strength_with_advantage = min(
+            self_paladin_strength_with_advantage, self_paladin_strength_with_advantage_max
+        );
+
+        ///
+        /// PALADIN DISADVANTAGE CALCULATION AGAINST ENEMY'S KNIGHT
+        ///
+        let self_paladin_strength_with_disadvantage = cap_minus(
+            self_paladin_strength,
+            (enemy_knight_strength
+                * troop_config.disadvantage_percent.into()
+                / self_paladin_strength
+                / PercentageValueImpl::_100())
+        );
+        let self_paladin_strength_with_disadvantage_max = self_paladin_strength
+            - PercentageImpl::get(self_paladin_strength.into(), troop_config.disadvantage_percent.into());
+        let self_paladin_strength_with_disadvantage = max(
+            self_paladin_strength_with_disadvantage, self_paladin_strength_with_disadvantage_max
+        );
+
+        ///////////////////////////////////////////////////////////////////////////////
+
+        let self_total_knight_strength = self_knight_strength
+            + (self_knight_strength_with_advantage - self_knight_strength)
+            - (self_knight_strength - self_knight_strength_with_disadvantage);
+        let self_total_crossbowman_strength = self_crossbowman_strength
+            + (self_crossbowman_strength_with_advantage - self_crossbowman_strength)
+            - (self_crossbowman_strength - self_crossbowman_strength_with_disadvantage);
+        let self_total_paladin_strength = self_paladin_strength
+            + (self_paladin_strength_with_advantage - self_paladin_strength)
+            - (self_paladin_strength - self_paladin_strength_with_disadvantage);
+
+        let self_total_strength = self_total_knight_strength
+            + self_total_paladin_strength
+            + self_total_crossbowman_strength;
+
+        return self_total_strength;
     }
 
     fn count(self: Troops) -> u64 {
@@ -1063,7 +1106,8 @@ mod health_model_tests {
             army_extra_per_building: 0,
             army_max_per_structure: 0,
             battle_leave_slash_num: 0,
-            battle_leave_slash_denom: 0
+            battle_leave_slash_denom: 0,
+            battle_time_reduction_scale: 0
         }
     }
 
@@ -1146,7 +1190,7 @@ mod tests {
     fn mock_troop_config() -> TroopConfig {
         TroopConfig {
             config_id: 0,
-            health: 7_200,
+            health: 1,
             knight_strength: 1,
             paladin_strength: 1,
             crossbowman_strength: 1,
@@ -1158,7 +1202,8 @@ mod tests {
             army_extra_per_building: 100,
             army_max_per_structure: 200,
             battle_leave_slash_num: 25,
-            battle_leave_slash_denom: 100
+            battle_leave_slash_denom: 100,
+            battle_time_reduction_scale: 1000
         }
     }
 
@@ -1202,15 +1247,6 @@ mod tests {
         battle.reset_delta(mock_troop_config());
 
         battle
-    }
-
-    #[test]
-    fn test_fabio() {
-        let attack_troop_each = 1 ;
-        let defence_troop_each = 30_000 * 1_000;
-        let mut battle = mock_battle(attack_troop_each, defence_troop_each);
-        print!("\n\n battle duration: {}\n\n", battle.duration_left);
-
     }
 
     #[test]

--- a/contracts/src/models/combat.cairo
+++ b/contracts/src/models/combat.cairo
@@ -241,7 +241,7 @@ impl TroopsImpl of TroopsTrait {
         /// scale seconds_till_death by a percentage (e.g 1/1000) of `self_count`
         /// we add 1 to prevent division by 0 errors
         let self_seconds_till_death_scaled: u64 = 1
-            + ((self.count() * self_seconds_till_death) / troop_config.battle_time_reduction_scale.into());
+            + ((self.count() * self_seconds_till_death) / troop_config.battle_time_scale.into());
         /// calculate damage received based on seconds till death
         /// we add 1 to prevent division by 0 errors
         let self_damage_received: u64 = 1
@@ -255,7 +255,7 @@ impl TroopsImpl of TroopsTrait {
         /// scale seconds_till_death by a percentage (1/1000) of `enemy_count`
         /// we add 1 to prevent division by 0 errors
         let enemy_seconds_till_death_scaled: u64 = 1
-            + ((enemy_troops.count() * enemy_seconds_till_death) / troop_config.battle_time_reduction_scale.into());
+            + ((enemy_troops.count() * enemy_seconds_till_death) / troop_config.battle_time_scale.into());
         /// calculate damage received based on seconds till death
         /// we add 1 to prevent division by 0 errors
         let enemy_damage_received: u64 = 1
@@ -1107,7 +1107,7 @@ mod health_model_tests {
             army_max_per_structure: 0,
             battle_leave_slash_num: 0,
             battle_leave_slash_denom: 0,
-            battle_time_reduction_scale: 0
+            battle_time_scale: 0
         }
     }
 
@@ -1203,7 +1203,7 @@ mod tests {
             army_max_per_structure: 200,
             battle_leave_slash_num: 25,
             battle_leave_slash_denom: 100,
-            battle_time_reduction_scale: 1000
+            battle_time_scale: 1000
         }
     }
 

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -412,7 +412,10 @@ pub struct TroopConfig {
     // percentage to slash army by if they leave early
     // e.g num = 25, denom = 100 // represents 25%
     battle_leave_slash_num: u8,
-    battle_leave_slash_denom: u8
+    battle_leave_slash_denom: u8,
+    // 1_000. multiply this number by 2 to reduce battle time by 2x,
+    // and reduce by 2x to increase battle time by 2x, etc
+    battle_time_reduction_scale: u16
 }
 
 

--- a/contracts/src/models/config.cairo
+++ b/contracts/src/models/config.cairo
@@ -415,7 +415,7 @@ pub struct TroopConfig {
     battle_leave_slash_denom: u8,
     // 1_000. multiply this number by 2 to reduce battle time by 2x,
     // and reduce by 2x to increase battle time by 2x, etc
-    battle_time_reduction_scale: u16
+    battle_time_scale: u16
 }
 
 

--- a/contracts/src/systems/combat/tests/battle_leave_test.cairo
+++ b/contracts/src/systems/combat/tests/battle_leave_test.cairo
@@ -277,7 +277,7 @@ fn test_battle_leave_by_winner() {
 
     // ensure player_1's army troop count is correct
     let player_1_army: Army = get!(world, player_1_army_id, Army);
-    assert_eq!(player_1_army.troops.count(), 8_745_000);
+    assert_eq!(player_1_army.troops.count(), 8_997_000);
 
     // ensure the battle was updated correctly
     let battle: Battle = get!(world, battle_id, Battle);

--- a/contracts/src/systems/combat/tests/battle_pillage_test.cairo
+++ b/contracts/src/systems/combat/tests/battle_pillage_test.cairo
@@ -125,9 +125,9 @@ fn test_battle_pillage__near_max_capacity() {
 
     starknet::testing::set_block_timestamp(DEFAULT_BLOCK_TIMESTAMP * 2);
 
-    let army_quantity = get!(world, attacker_realm_army_unit_id, Quantity);
+    let _army_quantity = get!(world, attacker_realm_army_unit_id, Quantity);
 
-    let capacity_config = get!(world, 3, CapacityConfig);
+    let _capacity_config = get!(world, 3, CapacityConfig);
 
     combat_system_dispatcher.battle_pillage(attacker_realm_army_unit_id, defender_realm_entity_id);
 

--- a/contracts/src/systems/map/tests.cairo
+++ b/contracts/src/systems/map/tests.cairo
@@ -99,9 +99,11 @@ fn test_map_explore() {
 
     // ensure that the right amount of food was burnt
     let expected_wheat_balance = INITIAL_WHEAT_BALANCE
-        - (MAP_EXPLORE_EXPLORATION_WHEAT_BURN_AMOUNT * INITIAL_KNIGHT_BALANCE);
+        - (MAP_EXPLORE_EXPLORATION_WHEAT_BURN_AMOUNT
+            * (INITIAL_KNIGHT_BALANCE + INITIAL_PALADIN_BALANCE + INITIAL_CROSSBOWMAN_BALANCE));
     let expected_fish_balance = INITIAL_FISH_BALANCE
-        - (MAP_EXPLORE_EXPLORATION_FISH_BURN_AMOUNT * INITIAL_KNIGHT_BALANCE);
+        - (MAP_EXPLORE_EXPLORATION_FISH_BURN_AMOUNT
+            * (INITIAL_KNIGHT_BALANCE + INITIAL_PALADIN_BALANCE + INITIAL_CROSSBOWMAN_BALANCE));
     let (realm_wheat, realm_fish) = ResourceFoodImpl::get(world, realm_entity_id);
     assert_eq!(realm_wheat.balance, expected_wheat_balance, "wrong wheat balance");
     assert_eq!(realm_fish.balance, expected_fish_balance, "wrong wheat balance");

--- a/contracts/src/systems/map/tests.cairo
+++ b/contracts/src/systems/map/tests.cairo
@@ -135,8 +135,9 @@ fn test_map_explore__mine_mercenaries_protector() {
     );
 
     let battle_entity_id = combat_systems_dispatcher.battle_start(realm_army_unit_id, mercenary_entity_id);
-
-    starknet::testing::set_block_timestamp(99999);
+    let battle = get!(world, battle_entity_id, Battle);
+    let current_ts = starknet::get_block_timestamp();
+    starknet::testing::set_block_timestamp(current_ts + battle.duration_left);
 
     combat_systems_dispatcher.battle_leave(battle_entity_id, realm_army_unit_id);
     combat_systems_dispatcher.battle_claim(realm_army_unit_id, mine_entity_id);

--- a/contracts/src/systems/map/tests.cairo
+++ b/contracts/src/systems/map/tests.cairo
@@ -7,7 +7,9 @@ use eternum::constants::{ResourceTypes, WORLD_CONFIG_ID, TickIds};
 
 use eternum::models::combat::{Battle};
 use eternum::models::combat::{Health, Troops};
-use eternum::models::config::{TickConfig, TickImpl, StaminaConfig, TravelStaminaCostConfig};
+use eternum::models::config::{
+    TickConfig, TickImpl, StaminaConfig, TravelStaminaCostConfig, CapacityConfig, CapacityConfigCategory
+};
 use eternum::models::map::Tile;
 use eternum::models::movable::{Movable};
 use eternum::models::owner::{EntityOwner, Owner};
@@ -58,9 +60,11 @@ use eternum::utils::testing::{
 
 use starknet::contract_address_const;
 
-const INITIAL_WHEAT_BALANCE: u128 = 10_000_000;
-const INITIAL_FISH_BALANCE: u128 = 10_000_000;
+const INITIAL_WHEAT_BALANCE: u128 = 500_000_000;
+const INITIAL_FISH_BALANCE: u128 = 500_000_000;
 const INITIAL_KNIGHT_BALANCE: u128 = 10_000_000;
+const INITIAL_PALADIN_BALANCE: u128 = 10_000_000;
+const INITIAL_CROSSBOWMAN_BALANCE: u128 = 10_000_000;
 
 const TIMESTAMP: u64 = 10_000;
 
@@ -191,6 +195,8 @@ fn setup() -> (IWorldDispatcher, ID, ID, IMapSystemsDispatcher, ICombatContractD
     set_mine_production_config(config_systems_address);
     set_travel_and_explore_stamina_cost_config(config_systems_address);
 
+    set!(world, CapacityConfig { category: CapacityConfigCategory::Storehouse, weight_gram: 1_000_000_000 });
+
     starknet::testing::set_contract_address(contract_address_const::<'realm_owner'>());
     starknet::testing::set_account_contract_address(contract_address_const::<'realm_owner'>());
 
@@ -207,13 +213,17 @@ fn setup() -> (IWorldDispatcher, ID, ID, IMapSystemsDispatcher, ICombatContractD
             array![
                 (ResourceTypes::WHEAT, INITIAL_WHEAT_BALANCE),
                 (ResourceTypes::FISH, INITIAL_FISH_BALANCE),
-                (ResourceTypes::KNIGHT, INITIAL_KNIGHT_BALANCE)
+                (ResourceTypes::KNIGHT, INITIAL_KNIGHT_BALANCE),
+                (ResourceTypes::PALADIN, INITIAL_PALADIN_BALANCE),
+                (ResourceTypes::CROSSBOWMAN, INITIAL_CROSSBOWMAN_BALANCE)
             ]
                 .span()
         );
 
     let troops = Troops {
-        knight_count: INITIAL_KNIGHT_BALANCE.try_into().unwrap(), paladin_count: 0, crossbowman_count: 0
+        knight_count: INITIAL_KNIGHT_BALANCE.try_into().unwrap(),
+        paladin_count: INITIAL_PALADIN_BALANCE.try_into().unwrap(),
+        crossbowman_count: INITIAL_CROSSBOWMAN_BALANCE.try_into().unwrap()
     };
     let realm_army_unit_id: ID = create_army_with_troops(
         world, combat_systems_dispatcher, realm_entity_id, troops, false

--- a/contracts/src/utils/math.cairo
+++ b/contracts/src/utils/math.cairo
@@ -30,6 +30,16 @@ pub fn max<T, impl TPartialOrd: PartialOrd<T>, impl TCopy: Copy<T>, impl TDrop: 
     };
 }
 
+pub fn cap_minus<T, impl TPartialOrd: PartialOrd<T>, impl TSub: Sub<T>, impl TCopy: Copy<T>, impl TDrop: Drop<T>>(
+    a: T, b: T
+) -> T {
+    return if (a < b) {
+        return a - a; // 0 
+    } else {
+        return a - b;
+    };
+}
+
 
 ///////// U32 Bit Manipulation /////////
 

--- a/contracts/src/utils/testing/config.cairo
+++ b/contracts/src/utils/testing/config.cairo
@@ -62,7 +62,7 @@ fn set_map_config(config_systems_address: ContractAddress) {
 fn get_combat_config() -> TroopConfig {
     return TroopConfig {
         config_id: WORLD_CONFIG_ID,
-        health: 7_200,
+        health: 1,
         knight_strength: 1,
         paladin_strength: 1,
         crossbowman_strength: 1,
@@ -74,7 +74,8 @@ fn get_combat_config() -> TroopConfig {
         army_extra_per_building: 100,
         army_max_per_structure: 200,
         battle_leave_slash_num: 25,
-        battle_leave_slash_denom: 100
+        battle_leave_slash_denom: 100,
+        battle_time_reduction_scale: 1000,
     };
 }
 

--- a/contracts/src/utils/testing/config.cairo
+++ b/contracts/src/utils/testing/config.cairo
@@ -75,7 +75,7 @@ fn get_combat_config() -> TroopConfig {
         army_max_per_structure: 200,
         battle_leave_slash_num: 25,
         battle_leave_slash_denom: 100,
-        battle_time_reduction_scale: 1000,
+        battle_time_scale: 1000,
     };
 }
 

--- a/sdk/packages/eternum/src/config/index.ts
+++ b/sdk/packages/eternum/src/config/index.ts
@@ -256,6 +256,7 @@ export const setCombatConfig = async (config: Config) => {
     maxArmiesPerStructure: max_armies_per_structure,
     battleLeaveSlashNum: battle_leave_slash_num,
     battleLeaveSlashDenom: battle_leave_slash_denom,
+    battleTimeReductionScale: battle_time_reduction_scale,
   } = config.config.troop;
 
   const tx = await config.provider.set_troop_config({
@@ -274,6 +275,7 @@ export const setCombatConfig = async (config: Config) => {
     army_max_per_structure: max_armies_per_structure,
     battle_leave_slash_num,
     battle_leave_slash_denom,
+    battle_time_reduction_scale,
   });
 
   console.log(`Configuring combat config ${tx.statusReceipt}...`);

--- a/sdk/packages/eternum/src/config/index.ts
+++ b/sdk/packages/eternum/src/config/index.ts
@@ -256,7 +256,7 @@ export const setCombatConfig = async (config: Config) => {
     maxArmiesPerStructure: max_armies_per_structure,
     battleLeaveSlashNum: battle_leave_slash_num,
     battleLeaveSlashDenom: battle_leave_slash_denom,
-    battleTimeReductionScale: battle_time_reduction_scale,
+    battleTimeReductionScale: battle_time_scale,
   } = config.config.troop;
 
   const tx = await config.provider.set_troop_config({
@@ -275,7 +275,7 @@ export const setCombatConfig = async (config: Config) => {
     army_max_per_structure: max_armies_per_structure,
     battle_leave_slash_num,
     battle_leave_slash_denom,
-    battle_time_reduction_scale,
+    battle_time_scale,
   });
 
   console.log(`Configuring combat config ${tx.statusReceipt}...`);

--- a/sdk/packages/eternum/src/constants/global.ts
+++ b/sdk/packages/eternum/src/constants/global.ts
@@ -51,11 +51,7 @@ export const EternumGlobalConfig = {
     delaySeconds: 8 * 60 * 60,
   },
   troop: {
-    // The 7,200 health value makes battles last up to 20hours at a maximum.
-    // This max will be reached if both armies are very similar in strength and health
-    // To reduce max battle time by 4x for example, change the health to (7,200 / 4)
-    // which will make the max battle time = 5 hours.
-    health: 7_200,
+    health: 1,
     knightStrength: 1,
     paladinStrength: 1,
     crossbowmanStrength: 1,
@@ -79,6 +75,9 @@ export const EternumGlobalConfig = {
     // 25%
     battleLeaveSlashNum: 25,
     battleLeaveSlashDenom: 100,
+    // 1_000. multiply this number by 2 to reduce battle time by 2x,
+    // and reduce by 2x to increase battle time by 2x, etc
+    battleTimeReductionScale: 1_000,
   },
   mercenaries: {
     troops: {

--- a/sdk/packages/eternum/src/provider/index.ts
+++ b/sdk/packages/eternum/src/provider/index.ts
@@ -829,7 +829,7 @@ export class EternumProvider extends EnhancedDojoProvider {
       army_max_per_structure,
       battle_leave_slash_num,
       battle_leave_slash_denom,
-      battle_time_reduction_scale,
+      battle_time_scale,
     } = props;
 
     return await this.executeAndCheckTransaction(signer, {
@@ -850,7 +850,7 @@ export class EternumProvider extends EnhancedDojoProvider {
         army_max_per_structure,
         battle_leave_slash_num,
         battle_leave_slash_denom,
-        battle_time_reduction_scale,
+        battle_time_scale,
       ],
     });
   }

--- a/sdk/packages/eternum/src/provider/index.ts
+++ b/sdk/packages/eternum/src/provider/index.ts
@@ -829,6 +829,7 @@ export class EternumProvider extends EnhancedDojoProvider {
       army_max_per_structure,
       battle_leave_slash_num,
       battle_leave_slash_denom,
+      battle_time_reduction_scale,
     } = props;
 
     return await this.executeAndCheckTransaction(signer, {
@@ -849,6 +850,7 @@ export class EternumProvider extends EnhancedDojoProvider {
         army_max_per_structure,
         battle_leave_slash_num,
         battle_leave_slash_denom,
+        battle_time_reduction_scale,
       ],
     });
   }

--- a/sdk/packages/eternum/src/types/common.ts
+++ b/sdk/packages/eternum/src/types/common.ts
@@ -303,6 +303,8 @@ export interface Config {
     // 25%
     battleLeaveSlashNum: number;
     battleLeaveSlashDenom: number;
+    // 1_000. multiply this number by 2 to reduce battle time by 2x, etc.
+    battleTimeReductionScale: number;
   };
   mercenaries: {
     troops: {

--- a/sdk/packages/eternum/src/types/provider.ts
+++ b/sdk/packages/eternum/src/types/provider.ts
@@ -438,6 +438,7 @@ export interface SetTroopConfigProps extends SystemSigner {
   army_max_per_structure: num.BigNumberish;
   battle_leave_slash_num: num.BigNumberish;
   battle_leave_slash_denom: num.BigNumberish;
+  battle_time_reduction_scale: num.BigNumberish;
 }
 
 export interface SetBuildingCategoryPopConfigProps extends SystemSigner {

--- a/sdk/packages/eternum/src/types/provider.ts
+++ b/sdk/packages/eternum/src/types/provider.ts
@@ -438,7 +438,7 @@ export interface SetTroopConfigProps extends SystemSigner {
   army_max_per_structure: num.BigNumberish;
   battle_leave_slash_num: num.BigNumberish;
   battle_leave_slash_denom: num.BigNumberish;
-  battle_time_reduction_scale: num.BigNumberish;
+  battle_time_scale: num.BigNumberish;
 }
 
 export interface SetBuildingCategoryPopConfigProps extends SystemSigner {


### PR DESCRIPTION
make the battle time calculations more sane
- there's now a config to increase and reduce battle time more directly through `battle_time_scale`
- battle time goes up with the number of troops in battle and there is no upper time limit
- the smaller army now loses troops quicker than the bigger army