### PR TITLE
fix: troop transfer when transferring all troops from defensive to attacking army

### DIFF
--- a/client/src/ui/elements/ArmyCapacity.tsx
+++ b/client/src/ui/elements/ArmyCapacity.tsx
@@ -24,7 +24,8 @@ export const ArmyCapacity = ({ army, className, deductedTroops = 0n }: ArmyCapac
   const totalTroops = getArmyNumberOfTroops(army);
   const remainingTroops = totalTroops - deductedTroops;
   const capacityRatio = Math.floor(Number(remainingTroops) / Number(totalTroops));
-  const armyTotalCapacity = BigInt(Number(army.totalCapacity) * capacityRatio);
+
+  const armyTotalCapacity = isFinite(capacityRatio) ? BigInt(Number(army.totalCapacity) * capacityRatio) : 0n;
 
   const setTooltip = useUIStore((state) => state.setTooltip);
   const remainingCapacity = useMemo(() => armyTotalCapacity - army.weight, [army]);


### PR DESCRIPTION
Closes #2019 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the calculation of army total capacity by ensuring that non-finite capacity ratios result in a total capacity of zero.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->