### PR TITLE
fix: tooltip displayed top instead of bottom

### DIFF
--- a/client/src/ui/components/military/ArmyChip.tsx
+++ b/client/src/ui/components/military/ArmyChip.tsx
@@ -46,7 +46,7 @@ export const NavigateToPositionIcon = ({
         if (hideTooltip) return;
         setTooltip({
           content: "Navigate to Army",
-          position: "bottom",
+          position: "top",
         });
       }}
       onMouseLeave={() => {

--- a/client/src/ui/components/military/ArmyManagementCard.tsx
+++ b/client/src/ui/components/military/ArmyManagementCard.tsx
@@ -27,7 +27,7 @@ import { useQuery } from "@/hooks/helpers/useQuery";
 import { useStructuresFromPosition } from "@/hooks/helpers/useStructures";
 import { Position as PositionInterface } from "@/types/Position";
 import { ResourceIcon } from "@/ui/elements/ResourceIcon";
-import { EternumGlobalConfig, resources } from "@bibliothecadao/eternum";
+import { resources } from "@bibliothecadao/eternum";
 import clsx from "clsx";
 import { LucideArrowRight } from "lucide-react";
 
@@ -390,7 +390,7 @@ export const ViewOnMapIcon = ({
         if (hideTooltip) return;
         setTooltip({
           content: "View on Map",
-          position: "bottom",
+          position: "top",
         });
       }}
       onMouseLeave={() => {


### PR DESCRIPTION
The two tooltips are displayed under the mouse cursor whereas the others are on top.
(I had to draw the cursor because it was not in the screenshot)
<img width="205" alt="image" src="https://github.com/user-attachments/assets/6c4567f2-c503-43ab-a27e-f05f13835b60">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tooltip position updated to display above icons for improved visibility in both the `NavigateToPositionIcon` and `ViewOnMapIcon` components.
  
- **Bug Fixes**
  - Enhanced state management during army deletion and troop purchasing processes in the `ArmyManagementCard` component.
  
- **Improvements**
  - Clarified tooltip content for the `Swap` icon to indicate swapping is only possible on the same hex.
  - Adjusted rendering logic for the "Reinforce army" button to accurately reflect the army's position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->