### PR TITLE
[client] show all my trades in history

### DIFF
--- a/client/src/ui/components/trading/MarketTradingHistory.tsx
+++ b/client/src/ui/components/trading/MarketTradingHistory.tsx
@@ -48,6 +48,9 @@ export const MarketTradingHistory = () => {
         const takerOwner = getComponentValue(components.Owner, getEntityIdFromKeys([BigInt(event.taker_id)]));
         if (!takerOwner) return;
 
+        const makerOwner = getComponentValue(components.Owner, getEntityIdFromKeys([BigInt(event.maker_id)]));
+        if (!makerOwner) return;
+
         const { makerGets, takerGets } = getTradeResources(trade.trade_id);
 
         setTradeEvents((prevTradeEvents) => {
@@ -58,7 +61,7 @@ export const MarketTradingHistory = () => {
               event: {
                 takerId: event.taker_id,
                 makerId: event.maker_id,
-                isYours: takerOwner.address === BigInt(address),
+                isYours: takerOwner.address === BigInt(address) || makerOwner.address === BigInt(address),
                 resourceGiven: makerGets[0],
                 resourceTaken: takerGets[0],
                 eventTime: new Date(event.timestamp * 1000),

--- a/client/src/ui/components/trading/TradeHistoryEvent.tsx
+++ b/client/src/ui/components/trading/TradeHistoryEvent.tsx
@@ -2,7 +2,6 @@ import { useEntitiesUtils } from "@/hooks/helpers/useEntities";
 import { ResourceIcon } from "@/ui/elements/ResourceIcon";
 import { currencyIntlFormat, divideByPrecision } from "@/ui/utils/utils";
 import { Resource, ResourcesIds } from "@bibliothecadao/eternum";
-import { Crown } from "lucide-react";
 import { TradeEvent } from "./MarketTradingHistory";
 
 export enum EventType {
@@ -35,10 +34,7 @@ export const TradeHistoryEvent = ({ trade }: { trade: TradeEvent }) => {
         className={`text-xs my-auto`}
       >{`${trade.event.eventTime.toLocaleDateString()} ${trade.event.eventTime.toLocaleTimeString()}`}</div>
       <div className={`text-sm my-auto`}>{trade.type}</div>
-      <div className={`text-sm my-auto flex flex-row items-center justify-start`}>
-        {taker}
-        {trade.event.isYours && <Crown className="h-4" />}
-      </div>
+      <div className={`text-sm my-auto flex flex-row items-center justify-start`}>{taker}</div>
       <div className="text-sm my-auto flex flex-row">
         <div>{"bought"}</div>
         <ResourceIcon resource={ResourcesIds[Number(trade.event.resourceTaken.resourceId)]} size={"sm"} />


### PR DESCRIPTION
Fixes #2041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `MarketTradingHistory` component to accurately reflect trades involving the current user as both maker and taker.
  
- **Bug Fixes**
	- Simplified rendering logic in the `TradeHistoryEvent` component by removing the conditional display of the `Crown` icon next to the taker name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->