### PR TITLE
[client] show total troops of each realm

### DIFF
--- a/client/src/ui/components/military/EntitiesArmyTable.tsx
+++ b/client/src/ui/components/military/EntitiesArmyTable.tsx
@@ -4,8 +4,10 @@ import useUIStore from "@/hooks/store/useUIStore";
 import Button from "@/ui/elements/Button";
 import { Headline } from "@/ui/elements/Headline";
 import { HintModalButton } from "@/ui/elements/HintModalButton";
+import { ResourceIcon } from "@/ui/elements/ResourceIcon";
 import { BattleSimulation } from "@/ui/modules/battle-simulation/BattleSimulation";
-import { ID } from "@bibliothecadao/eternum";
+import { divideByPrecision } from "@/ui/utils/utils";
+import { ID, ResourcesIds } from "@bibliothecadao/eternum";
 import { HintSection } from "../hints/HintModal";
 import { battleSimulation } from "../navigation/Config";
 import { ArmyChip } from "./ArmyChip";
@@ -47,6 +49,17 @@ const EntityArmyTable = ({ structureEntityId }: { structureEntityId: ID | undefi
   }
   const { entityArmies } = useArmiesByEntityOwner({ entity_owner_entity_id: structureEntityId });
 
+  const totalTroops = entityArmies.reduce(
+    (acc, army: ArmyInfo) => {
+      return {
+        crossbowmen: Number(acc.crossbowmen) + Number(army.troops.crossbowman_count),
+        paladins: Number(acc.paladins) + Number(army.troops.paladin_count),
+        knights: Number(acc.knights) + Number(army.troops.knight_count),
+      };
+    },
+    { crossbowmen: 0, paladins: 0, knights: 0 },
+  );
+
   if (entityArmies.length === 0) {
     return <div className="m-auto">No armies</div>;
   }
@@ -57,5 +70,25 @@ const EntityArmyTable = ({ structureEntityId }: { structureEntityId: ID | undefi
     });
   };
 
-  return <div className="flex flex-col gap-4">{armyElements()}</div>;
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-sm text-gold/80">
+        <div className="flex items-center justify-center gap-4 w-full">
+          <div className="flex items-center gap-2">
+            <ResourceIcon resource={ResourcesIds[ResourcesIds.Crossbowman]} size="sm" className="self-center" />
+            {divideByPrecision(totalTroops.crossbowmen)}
+          </div>
+          <div className="flex items-center gap-2">
+            <ResourceIcon resource={ResourcesIds[ResourcesIds.Knight]} size="sm" className="self-center" />
+            {divideByPrecision(totalTroops.knights)}
+          </div>
+          <div className="flex items-center gap-2">
+            <ResourceIcon resource={ResourcesIds[ResourcesIds.Paladin]} size="sm" className="self-center" />
+            {divideByPrecision(totalTroops.paladins)}
+          </div>
+        </div>
+      </div>
+      {armyElements()}
+    </div>
+  );
 };


### PR DESCRIPTION
Fixes #2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced total troop counts display in the Entities Army Table, enhancing visibility of troop types.
	- Added resource icons for better visual representation of associated troop resources.

- **Bug Fixes**
	- Improved rendering logic to ensure accurate display of troop totals and resource icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->