### PR TITLE
fix: make events non-historical

### DIFF
--- a/contracts/src/models/event.cairo
+++ b/contracts/src/models/event.cairo
@@ -2,17 +2,6 @@ use eternum::models::buildings::BuildingCategory;
 use eternum::{alias::ID, models::combat::BattleSide, models::structure::StructureCategory};
 use starknet::ContractAddress;
 
-#[derive(Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
-pub struct EternumEvent {
-    #[key]
-    id: ID,
-    #[key]
-    event_id: EventType,
-    timestamp: u64,
-    // data: EventData,
-}
-
 #[derive(Introspect, Copy, Drop, Serde)]
 pub enum EventType {
     BattleStart,
@@ -33,7 +22,7 @@ pub enum EventData {
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct BattleStartData {
     #[key]
     id: ID,
@@ -54,7 +43,7 @@ pub struct BattleStartData {
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct BattleJoinData {
     #[key]
     id: ID,
@@ -72,7 +61,7 @@ pub struct BattleJoinData {
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct BattleLeaveData {
     #[key]
     id: ID,
@@ -90,7 +79,7 @@ pub struct BattleLeaveData {
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct BattleClaimData {
     #[key]
     id: ID,
@@ -108,7 +97,7 @@ pub struct BattleClaimData {
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct BattlePillageData {
     #[key]
     id: ID,
@@ -130,7 +119,7 @@ pub struct BattlePillageData {
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct SettleRealmData {
     #[key]
     id: ID,
@@ -153,7 +142,7 @@ pub struct SettleRealmData {
 }
 
 #[derive(Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct CreateGuild {
     #[key]
     guild_entity_id: ID,
@@ -162,7 +151,7 @@ pub struct CreateGuild {
 }
 
 #[derive(Copy, Drop, Serde)]
-#[dojo::event(historical: true)]
+#[dojo::event(historical: false)]
 pub struct JoinGuild {
     #[key]
     guild_entity_id: ID,

--- a/contracts/src/systems/bank/contracts/liquidity.cairo
+++ b/contracts/src/systems/bank/contracts/liquidity.cairo
@@ -31,7 +31,7 @@ mod liquidity_systems {
     use eternum::systems::bank::contracts::bank::bank_systems::{InternalBankSystemsImpl};
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct LiquidityEvent {
         #[key]
         bank_entity_id: ID,

--- a/contracts/src/systems/bank/contracts/swap.cairo
+++ b/contracts/src/systems/bank/contracts/swap.cairo
@@ -33,7 +33,7 @@ mod swap_systems {
 
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct SwapEvent {
         #[key]
         bank_entity_id: ID,

--- a/contracts/src/systems/combat/contracts/battle_systems.cairo
+++ b/contracts/src/systems/combat/contracts/battle_systems.cairo
@@ -315,8 +315,7 @@ mod battle_systems {
     };
     use eternum::models::config::{WeightConfig, WeightConfigCustomImpl};
     use eternum::models::event::{
-        EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData,
-        BattlePillageData
+        EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData, BattlePillageData
     };
 
     use eternum::models::movable::{Movable, MovableCustomTrait};
@@ -801,8 +800,7 @@ mod battle_pillage_systems {
     };
     use eternum::models::config::{WeightConfig, WeightConfigCustomImpl};
     use eternum::models::event::{
-        EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData,
-        BattlePillageData
+        EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData, BattlePillageData
     };
 
     use eternum::models::movable::{Movable, MovableCustomTrait};

--- a/contracts/src/systems/combat/contracts/battle_systems.cairo
+++ b/contracts/src/systems/combat/contracts/battle_systems.cairo
@@ -315,7 +315,7 @@ mod battle_systems {
     };
     use eternum::models::config::{WeightConfig, WeightConfigCustomImpl};
     use eternum::models::event::{
-        EternumEvent, EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData,
+        EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData,
         BattlePillageData
     };
 
@@ -801,7 +801,7 @@ mod battle_pillage_systems {
     };
     use eternum::models::config::{WeightConfig, WeightConfigCustomImpl};
     use eternum::models::event::{
-        EternumEvent, EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData,
+        EventType, EventData, BattleStartData, BattleJoinData, BattleLeaveData, BattleClaimData,
         BattlePillageData
     };
 

--- a/contracts/src/systems/hyperstructure/contracts.cairo
+++ b/contracts/src/systems/hyperstructure/contracts.cairo
@@ -57,7 +57,7 @@ mod hyperstructure_systems {
     use super::calculate_total_contributable_amount;
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct HyperstructureFinished {
         #[key]
         id: ID,
@@ -68,7 +68,7 @@ mod hyperstructure_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct HyperstructureCoOwnersChange {
         #[key]
         id: ID,
@@ -79,7 +79,7 @@ mod hyperstructure_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct HyperstructureContribution {
         #[key]
         id: ID,
@@ -91,7 +91,7 @@ mod hyperstructure_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct GameEnded {
         #[key]
         winner_address: ContractAddress,

--- a/contracts/src/systems/map/contracts.cairo
+++ b/contracts/src/systems/map/contracts.cairo
@@ -51,7 +51,7 @@ mod map_systems {
     use starknet::ContractAddress;
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct MapExplored {
         #[key]
         entity_id: ID,
@@ -68,7 +68,7 @@ mod map_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct FragmentMineDiscovered {
         #[key]
         entity_owner_id: ID,

--- a/contracts/src/systems/resources/contracts/resource_systems.cairo
+++ b/contracts/src/systems/resources/contracts/resource_systems.cairo
@@ -44,7 +44,7 @@ mod resource_systems {
     use eternum::systems::transport::contracts::travel_systems::travel_systems::{InternalTravelSystemsImpl as travel};
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct Transfer {
         #[key]
         recipient_entity_id: ID,

--- a/contracts/src/systems/trade/contracts/trade_systems.cairo
+++ b/contracts/src/systems/trade/contracts/trade_systems.cairo
@@ -62,7 +62,7 @@ mod trade_systems {
 
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct CreateOrder {
         #[key]
         taker_id: ID,
@@ -73,7 +73,7 @@ mod trade_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct AcceptOrder {
         #[key]
         taker_id: ID,
@@ -86,7 +86,7 @@ mod trade_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct AcceptPartialOrder {
         #[key]
         taker_id: ID,
@@ -97,7 +97,7 @@ mod trade_systems {
     }
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct CancelOrder {
         #[key]
         taker_id: ID,

--- a/contracts/src/systems/transport/contracts/donkey_systems.cairo
+++ b/contracts/src/systems/transport/contracts/donkey_systems.cairo
@@ -26,7 +26,7 @@ mod donkey_systems {
     use starknet::ContractAddress;
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct BurnDonkey {
         #[key]
         player_address: ContractAddress,

--- a/contracts/src/systems/transport/contracts/travel_systems.cairo
+++ b/contracts/src/systems/transport/contracts/travel_systems.cairo
@@ -33,7 +33,7 @@ mod travel_systems {
     use starknet::ContractAddress;
 
     #[derive(Copy, Drop, Serde)]
-    #[dojo::event(historical: true)]
+    #[dojo::event(historical: false)]
     struct Travel {
         #[key]
         destination_coord_x: u32,

--- a/contracts/src/utils/testing/world.cairo
+++ b/contracts/src/utils/testing/world.cairo
@@ -181,7 +181,6 @@ fn namespace_def() -> NamespaceDef {
             TestResource::Event(trade_systems::e_CancelOrder::TEST_CLASS_HASH.try_into().unwrap()),
             TestResource::Event(donkey_systems::e_BurnDonkey::TEST_CLASS_HASH.try_into().unwrap()),
             TestResource::Event(travel_systems::e_Travel::TEST_CLASS_HASH.try_into().unwrap()),
-            TestResource::Event(eternum::models::event::e_EternumEvent::TEST_CLASS_HASH.try_into().unwrap()),
             TestResource::Event(eternum::models::event::e_BattleStartData::TEST_CLASS_HASH.try_into().unwrap()),
             TestResource::Event(eternum::models::event::e_BattleJoinData::TEST_CLASS_HASH.try_into().unwrap()),
             TestResource::Event(eternum::models::event::e_BattleLeaveData::TEST_CLASS_HASH.try_into().unwrap()),


### PR DESCRIPTION
Blocked by https://github.com/dojoengine/dojo.js/pull/329 and bumping dojojs to the appropriate version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Updated various event structures to no longer track historical data, affecting how events are stored and retrieved across multiple modules, including battle, liquidity, trade, and travel systems.

- **Bug Fixes**
  - Improved checks and logic for battle mechanics, ensuring better handling of army statuses and conditions during battles.

- **Documentation**
  - Enhanced clarity in event handling and struct modifications to reflect the changes in historical tracking.

- **Chores**
  - Removed deprecated event struct imports and attributes across several modules to streamline the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->