### PR TITLE
Only realm settler can claim quests

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -3,6 +3,7 @@ name: knip
 on:
   pull_request:
     paths-ignore:
+      - "eliza/**"
       - "contracts/**"
       - "**/manifest.json"
       - "discord-bot/**"

--- a/.knip.json
+++ b/.knip.json
@@ -1,6 +1,8 @@
 {
   "entry": ["eternum-docs/**/*.mdx", "eternum-docs/**/*.tsx"],
   "ignore": [
+    "eliza/**",
+
     ".trunk/**",
     "**/*.js",
     "bot/**",
@@ -12,6 +14,9 @@
     "config/bank/index.ts",
     "**/**__test__**/**",
     "**/**__tests__**/**",
+
+    "season_resources/scripts/deployment/config/index.ts",
+    "season_resources/scripts/deployment/config/provider/index.ts",
 
     "client/src/three/components/FogManager.ts",
     "client/src/hooks/useUISound.tsx",

--- a/client/src/dojo/contractComponents.ts
+++ b/client/src/dojo/contractComponents.ts
@@ -969,12 +969,13 @@ export function defineContractComponents(world: World) {
           order: RecsType.Number,
           level: RecsType.Number,
           has_wonder: RecsType.Boolean,
+          settler_address: RecsType.BigInt,
         },
         {
           metadata: {
             namespace: "s0_eternum",
             name: "Realm",
-            types: ["u32", "u32", "u128", "u8", "u8", "bool"],
+            types: ["u32", "u32", "u128", "u8", "u8", "bool", "contractaddress"],
             customTypes: [],
           },
         },

--- a/client/src/dojo/modelManager/__tests__/__BattleManagerMock__.ts
+++ b/client/src/dojo/modelManager/__tests__/__BattleManagerMock__.ts
@@ -120,6 +120,7 @@ export const generateMockArmyInfo = (
       level: 1,
       order: 1,
       has_wonder: false,
+      settler_address: 0n,
     },
     homePosition: { entity_id: ARMY_ENTITY_ID, x: 0, y: 0 },
   };

--- a/client/src/hooks/helpers/useQuests.tsx
+++ b/client/src/hooks/helpers/useQuests.tsx
@@ -270,10 +270,14 @@ const useQuestDependencies = (setup: SetupResult, account: Account | AccountInte
 export const useQuestClaimStatus = () => {
   const {
     setup: {
-      components: { Quest },
+      components: { Quest, Realm },
     },
+    account: { account },
   } = useDojo();
   const structureEntityId = useUIStore((state) => state.structureEntityId);
+
+  const realmSettler = getComponentValue(Realm, getEntityIdFromKeys([BigInt(structureEntityId)]))?.settler_address;
+  const isNotSettler = realmSettler !== ContractAddress(account.address);
 
   const prizeUpdate = useEntityQuery([HasValue(Quest, { entity_id: structureEntityId || 0 })]);
 
@@ -288,7 +292,7 @@ export const useQuestClaimStatus = () => {
     return Array.from(questDetails.keys()).reduce(
       (acc, questName) => ({
         ...acc,
-        [questName]: checkPrizesClaimed(questDetails.get(questName)?.prizes || []),
+        [questName]: isNotSettler || checkPrizesClaimed(questDetails.get(questName)?.prizes || []),
       }),
       {} as Record<QuestId, boolean>,
     );

--- a/contracts/src/models/owner.cairo
+++ b/contracts/src/models/owner.cairo
@@ -77,7 +77,15 @@ mod tests {
 
         world
             .write_model_test(
-                @Realm { entity_id: 1, realm_id: 3, produced_resources: 0, order: 0, level: 0, settler_address: 0x1 }
+                @Realm {
+                    entity_id: 1,
+                    realm_id: 3,
+                    produced_resources: 0,
+                    order: 0,
+                    level: 0,
+                    has_wonder: false,
+                    settler_address: contract_address_const::<'Settler'>()
+                }
             );
         world.write_model_test(@EntityOwner { entity_id: 2, entity_owner_id: 1 });
 

--- a/contracts/src/models/owner.cairo
+++ b/contracts/src/models/owner.cairo
@@ -77,7 +77,7 @@ mod tests {
 
         world
             .write_model_test(
-                @Realm { entity_id: 1, realm_id: 3, produced_resources: 0, order: 0, level: 0, has_wonder: false }
+                @Realm { entity_id: 1, realm_id: 3, produced_resources: 0, order: 0, level: 0, settler_address: 0x1 }
             );
         world.write_model_test(@EntityOwner { entity_id: 2, entity_owner_id: 1 });
 

--- a/contracts/src/models/realm.cairo
+++ b/contracts/src/models/realm.cairo
@@ -329,6 +329,7 @@ mod test_realm_name_and_attrs_decode_impl {
 
 #[cfg(test)]
 mod test_realm_resources_impl {
+    use starknet::contract_address_const;
     use super::{RealmResourcesImpl, RealmResourcesTrait, Realm};
 
     fn mock_realm() -> Realm {
@@ -339,7 +340,7 @@ mod test_realm_resources_impl {
             level: 0,
             produced_resources: 0,
             has_wonder: false,
-            settler_address: 0x1
+            settler_address: contract_address_const::<'Settler'>(),
         }
     }
 

--- a/contracts/src/models/realm.cairo
+++ b/contracts/src/models/realm.cairo
@@ -18,7 +18,8 @@ pub struct Realm {
     produced_resources: u128,
     order: u8,
     level: u8,
-    has_wonder: bool
+    has_wonder: bool,
+    settler_address: ContractAddress,
 }
 
 
@@ -331,7 +332,15 @@ mod test_realm_resources_impl {
     use super::{RealmResourcesImpl, RealmResourcesTrait, Realm};
 
     fn mock_realm() -> Realm {
-        Realm { entity_id: 1, realm_id: 1, order: 0, level: 0, produced_resources: 0, has_wonder: false }
+        Realm {
+            entity_id: 1,
+            realm_id: 1,
+            order: 0,
+            level: 0,
+            produced_resources: 0,
+            has_wonder: false,
+            settler_address: 0x1
+        }
     }
 
 

--- a/contracts/src/systems/realm/contracts.cairo
+++ b/contracts/src/systems/realm/contracts.cairo
@@ -199,6 +199,8 @@ mod realm_systems {
             let mut quest: Quest = world.read_model((entity_id, quest_id));
             assert(!quest.completed, 'quest already completed');
 
+            assert(realm.settler_address == starknet::get_caller_address(), 'Caller not settler');
+
             // ensure quest has rewards
             let quest_config: QuestConfig = world.read_model(WORLD_CONFIG_ID);
             let quest_reward_config: QuestRewardConfig = world.read_model(quest_id);
@@ -306,7 +308,8 @@ mod realm_systems {
                         produced_resources: realm_produced_resources_packed,
                         order,
                         level,
-                        has_wonder
+                        has_wonder,
+                        settler_address: owner,
                     }
                 );
             world.write_model(@Position { entity_id: entity_id.into(), x: coord.x, y: coord.y, });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -708,6 +708,31 @@ importers:
         specifier: 3.1.1
         version: 3.1.1
 
+  season_resources/scripts/deployment:
+    dependencies:
+      '@dojoengine/core':
+        specifier: 1.0.0-alpha.24
+        version: 1.0.0-alpha.24(starknet@6.11.0(encoding@0.1.13))(typescript@5.6.3)
+      colors:
+        specifier: ^1.4.0
+        version: 1.4.0
+      dotenv:
+        specifier: ^16.3.1
+        version: 16.4.5
+      eventemitter3:
+        specifier: ^5.0.1
+        version: 5.0.1
+      starknet:
+        specifier: ^6.8.0
+        version: 6.11.0(encoding@0.1.13)
+      vitest:
+        specifier: ^2.0.5
+        version: 2.1.3(@types/node@22.8.1)(@vitest/ui@2.1.3)(jsdom@24.1.3)(terser@5.36.0)
+    devDependencies:
+      prettier:
+        specifier: 3.1.1
+        version: 3.1.1
+
 packages:
 
   '@0no-co/graphql.web@1.0.9':
@@ -14323,6 +14348,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.10(@types/node@20.17.1)(terser@5.36.0)
 
+  '@vitest/mocker@2.1.3(@vitest/spy@2.1.3)(vite@5.4.10(@types/node@22.8.1)(terser@5.36.0))':
+    dependencies:
+      '@vitest/spy': 2.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.12
+    optionalDependencies:
+      vite: 5.4.10(@types/node@22.8.1)(terser@5.36.0)
+
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -20098,6 +20131,23 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.3(@types/node@22.8.1)(terser@5.36.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.7
+      pathe: 1.1.2
+      vite: 5.4.10(@types/node@22.8.1)(terser@5.36.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-mkcert@1.17.6(vite@5.4.10(@types/node@20.17.1)(terser@5.36.0)):
     dependencies:
       '@octokit/rest': 20.1.1
@@ -20267,6 +20317,42 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.1
+      '@vitest/ui': 2.1.3(vitest@2.1.3)
+      jsdom: 24.1.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@2.1.3(@types/node@22.8.1)(@vitest/ui@2.1.3)(jsdom@24.1.3)(terser@5.36.0):
+    dependencies:
+      '@vitest/expect': 2.1.3
+      '@vitest/mocker': 2.1.3(@vitest/spy@2.1.3)(vite@5.4.10(@types/node@22.8.1)(terser@5.36.0))
+      '@vitest/pretty-format': 2.1.3
+      '@vitest/runner': 2.1.3
+      '@vitest/snapshot': 2.1.3
+      '@vitest/spy': 2.1.3
+      '@vitest/utils': 2.1.3
+      chai: 5.1.2
+      debug: 4.3.7
+      magic-string: 0.30.12
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.1
+      tinypool: 1.0.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.10(@types/node@22.8.1)(terser@5.36.0)
+      vite-node: 2.1.3(@types/node@22.8.1)(terser@5.36.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.8.1
       '@vitest/ui': 2.1.3(vitest@2.1.3)
       jsdom: 24.1.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,5 @@ packages:
   - "balancing"
   - "landing"
   - "season_pass/scripts/deployment"
+  - "season_resources/scripts/deployment"
   # - "eliza/packages/*"


### PR DESCRIPTION
Closes #2097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `settler_address` to the `Realm` component, enhancing its data structure.
	- Updated quest claiming logic to validate if the caller is the settler of the realm, improving security.
	- Expanded the workspace to include `season_resources/scripts/deployment` for deployment scripts.

- **Bug Fixes**
	- Adjusted quest claim status determination to account for settler conditions.

- **Documentation**
	- Updated test cases to reflect changes in the `Realm` structure and ensure correct functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->