### PR TITLE
[contracts]: wonders update

### DIFF
--- a/contracts/src/constants.cairo
+++ b/contracts/src/constants.cairo
@@ -29,6 +29,10 @@ const MAX_REALMS_PER_ADDRESS: u16 = 8_000;
 // resource precision
 const RESOURCE_PRECISION: u128 = 1_000;
 
+
+// WONDER QUEST REWARD BOOST
+const WONDER_QUEST_REWARD_BOOST: u128 = 3;
+
 // pillage config
 // TODO: Move to Onchain config
 const MAX_PILLAGE_TRIAL_COUNT: u8 = 7;

--- a/contracts/src/models/buildings.cairo
+++ b/contracts/src/models/buildings.cairo
@@ -169,18 +169,21 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                 }
 
                 let production_input: ProductionInput = world.read_model((produced_resource_type, count));
-                let (input_resource_type, input_resource_amount) = (
+                let (input_resource_type, mut input_resource_amount) = (
                     production_input.input_resource_type, production_input.input_resource_amount
                 );
 
-                /// lords will not be consumed during production of donkey
+                /// only 10% of lords cost will be consumed during production of donkey
                 /// if the realm has a wonder
                 if input_resource_type == ResourceTypes::LORDS {
                     if resource_production.resource_type == ResourceTypes::DONKEY {
                         let realm: Realm = world.read_model(self.outer_entity_id);
                         if realm.has_wonder {
-                            count += 1;
-                            continue;
+                            input_resource_amount =
+                                ((input_resource_amount.into() * PercentageValueImpl::_10())
+                                    / PercentageValueImpl::_100())
+                                .try_into()
+                                .unwrap();
                         }
                     }
                 }
@@ -244,18 +247,21 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                 }
 
                 let production_input: ProductionInput = world.read_model((produced_resource_type, count));
-                let (input_resource_type, input_resource_amount) = (
+                let (input_resource_type, mut input_resource_amount) = (
                     production_input.input_resource_type, production_input.input_resource_amount
                 );
 
-                /// lords will not be consumed during production of donkey
+                /// only 10% of lords cost will be consumed during production of donkey
                 /// if the realm has a wonder
                 if input_resource_type == ResourceTypes::LORDS {
                     if resource_production.resource_type == ResourceTypes::DONKEY {
                         let realm: Realm = world.read_model(self.outer_entity_id);
                         if realm.has_wonder {
-                            count += 1;
-                            continue;
+                            input_resource_amount =
+                                ((input_resource_amount.into() * PercentageValueImpl::_10())
+                                    / PercentageValueImpl::_100())
+                                .try_into()
+                                .unwrap();
                         }
                     }
                 }

--- a/contracts/src/models/buildings.cairo
+++ b/contracts/src/models/buildings.cairo
@@ -180,8 +180,8 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                         let realm: Realm = world.read_model(self.outer_entity_id);
                         if realm.has_wonder {
                             input_resource_amount =
-                                ((input_resource_amount.into() * PercentageValueImpl::_10())
-                                    / PercentageValueImpl::_100())
+                                ((input_resource_amount * PercentageValueImpl::_10().into())
+                                    / PercentageValueImpl::_100().into())
                                 .try_into()
                                 .unwrap();
                         }
@@ -258,8 +258,8 @@ impl BuildingProductionImpl of BuildingProductionTrait {
                         let realm: Realm = world.read_model(self.outer_entity_id);
                         if realm.has_wonder {
                             input_resource_amount =
-                                ((input_resource_amount.into() * PercentageValueImpl::_10())
-                                    / PercentageValueImpl::_100())
+                                ((input_resource_amount * PercentageValueImpl::_10().into())
+                                    / PercentageValueImpl::_100().into())
                                 .try_into()
                                 .unwrap();
                         }

--- a/contracts/src/systems/realm/contracts.cairo
+++ b/contracts/src/systems/realm/contracts.cairo
@@ -32,7 +32,7 @@ mod realm_systems {
 
     use s0_eternum::alias::ID;
     use s0_eternum::constants::REALM_ENTITY_TYPE;
-    use s0_eternum::constants::{WORLD_CONFIG_ID, REALM_FREE_MINT_CONFIG_ID, DEFAULT_NS};
+    use s0_eternum::constants::{WORLD_CONFIG_ID, REALM_FREE_MINT_CONFIG_ID, DEFAULT_NS, WONDER_QUEST_REWARD_BOOST};
     use s0_eternum::models::capacity::{CapacityCategory};
     use s0_eternum::models::config::{CapacityConfigCategory, RealmLevelConfig, SettlementConfig, SettlementConfigImpl};
     use s0_eternum::models::config::{QuestRewardConfig, QuestConfig, SeasonAddressesConfig, ProductionConfig};
@@ -243,6 +243,10 @@ mod realm_systems {
 
                         jndex += 1;
                     }
+                }
+
+                if realm.has_wonder {
+                    reward_resource_amount *= WONDER_QUEST_REWARD_BOOST.into();
                 }
 
                 let mut realm_resource = ResourceImpl::get(ref world, (entity_id.into(), reward_resource_type));


### PR DESCRIPTION
- wonders pay only 10% of lords cost during donkey production
- wonders get 3x more quest reward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new constant, `WONDER_QUEST_REWARD_BOOST`, enhancing reward mechanics for quests.
	- Added a `paused` state to buildings, allowing for better control over production management.

- **Improvements**
	- Updated reward calculation logic in quest claims to consider whether the realm has a wonder.
	- Enhanced building production methods to respect the paused state and optimize resource consumption.

These changes improve user experience by providing more strategic options in gameplay and refining resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->