### PR TITLE
season pass: upgrade to oz 0.16.0

### DIFF
--- a/season_pass/contracts/Scarb.lock
+++ b/season_pass/contracts/Scarb.lock
@@ -70,13 +70,14 @@ source = "git+https://github.com/ponderingdemocritus/graffiti?rev=bc569531791dbc
 
 [[package]]
 name = "openzeppelin"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_governance",
  "openzeppelin_introspection",
+ "openzeppelin_merkle_tree",
  "openzeppelin_presets",
  "openzeppelin_security",
  "openzeppelin_token",
@@ -86,8 +87,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -95,18 +96,17 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_introspection",
- "openzeppelin_token",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_governance"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_introspection",
@@ -114,13 +114,18 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
+
+[[package]]
+name = "openzeppelin_merkle_tree"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 
 [[package]]
 name = "openzeppelin_presets"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
@@ -131,13 +136,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_security"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 dependencies = [
  "openzeppelin_account",
  "openzeppelin_governance",
@@ -146,13 +151,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_upgrades"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.15.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.15.0#f57642960f1c8cffafefb88bfff418eca8510634"
+version = "0.16.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.16.0#ba00ce76a93dcf25c081ab2698da20690b5a1cfb"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/season_pass/contracts/Scarb.toml
+++ b/season_pass/contracts/Scarb.toml
@@ -7,7 +7,7 @@ sierra-replace-ids = true
 
 [dependencies]
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "e1b080577aaa6889116fc8be5dde72b2fd21e397" }
-openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.15.0"}
+openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.16.0"}
 graffiti = { git = "https://github.com/ponderingdemocritus/graffiti", rev = "bc569531791dbc71c6cd8d9bc154c34eedad31fe" }
 
 [dev-dependencies]

--- a/season_pass/contracts/src/contract.cairo
+++ b/season_pass/contracts/src/contract.cairo
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Compatible with OpenZeppelin Contracts for Cairo ^0.17.0
+// Compatible with OpenZeppelin Contracts for Cairo 0.16.0
 
 // Eternum Season Pass
 use starknet::ContractAddress;

--- a/season_pass/contracts/src/contract.cairo
+++ b/season_pass/contracts/src/contract.cairo
@@ -46,6 +46,8 @@ mod EternumSeasonPass {
     impl ERC721Impl = ERC721Component::ERC721Impl<ContractState>;
     #[abi(embed_v0)]
     impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    #[abi(embed_v0)]
+    impl SRC5Impl = SRC5Component::SRC5Impl<ContractState>;
 
     impl ERC721InternalImpl = ERC721Component::InternalImpl<ContractState>;
     impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;


### PR DESCRIPTION
- upgrade to openzeppelin version 0.16.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `openzeppelin` dependency to version `v0.16.0`, potentially enhancing functionality and security.
	- Introduced new `SRC5Impl` implementation in the `EternumSeasonPass` module, expanding contract capabilities with SRC5 component integration.
	- Updated storage to include `src5` substorage and modified event handling to support `SRC5Event`.

- **Bug Fixes**
	- No specific bug fixes reported in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->