### PR TITLE
contracts: close bridge after x seconds after season ends

### DIFF
--- a/config/index.ts
+++ b/config/index.ts
@@ -83,6 +83,7 @@ setupConfig.season = {
   realmsAddress: process.env.VITE_REALMS_ADDRESS!,
   lordsAddress: process.env.VITE_LORDS_ADDRESS!,
   startAfterSeconds: 60 * 5, // 5 minutes
+  bridgeCloseAfterEndSeconds: 60 * 60 * 2, // 2 hours
 };
 
 export const config = new EternumConfig(setupConfig);

--- a/contracts/src/models/season.cairo
+++ b/contracts/src/models/season.cairo
@@ -8,7 +8,8 @@ pub struct Season {
     #[key]
     config_id: ID,
     start_at: u64,
-    is_over: bool
+    is_over: bool,
+    ended_at: u64
 }
 
 #[generate_trait]
@@ -17,6 +18,7 @@ pub impl SeasonImpl of SeasonTrait {
         // world.read_model(
         let mut season: Season = world.read_model(WORLD_CONFIG_ID);
         season.is_over = true;
+        season.ended_at = starknet::get_block_timestamp();
         world.write_model(@season);
     }
 

--- a/contracts/src/systems/config/contracts.cairo
+++ b/contracts/src/systems/config/contracts.cairo
@@ -25,6 +25,8 @@ trait ISeasonConfig<T> {
         lords_address: starknet::ContractAddress,
         start_at: u64
     );
+
+    fn set_season_bridge_config(ref self: T, close_after_end_seconds: u64);
 }
 
 #[starknet::interface]
@@ -221,7 +223,7 @@ mod config_systems {
         PopulationConfig, HyperstructureResourceConfig, HyperstructureConfig, StaminaConfig, StaminaRefillConfig,
         ResourceBridgeConfig, ResourceBridgeFeeSplitConfig, ResourceBridgeWhitelistConfig, BuildingGeneralConfig,
         MercenariesConfig, BattleConfig, TravelStaminaCostConfig, SettlementConfig, RealmLevelConfig,
-        RealmMaxLevelConfig, TravelFoodCostConfig, SeasonAddressesConfig
+        RealmMaxLevelConfig, TravelFoodCostConfig, SeasonAddressesConfig, SeasonBridgeConfig
     };
 
     use s0_eternum::models::position::{Position, PositionTrait, Coord};
@@ -329,6 +331,14 @@ mod config_systems {
                 season.start_at = start_at;
                 world.write_model(@season);
             }
+        }
+
+
+        fn set_season_bridge_config(ref self: ContractState, close_after_end_seconds: u64) {
+            let mut world: WorldStorage = self.world(DEFAULT_NS());
+            assert_caller_is_admin(world);
+
+            world.write_model(@SeasonBridgeConfig { config_id: WORLD_CONFIG_ID, close_after_end_seconds });
         }
     }
 

--- a/contracts/src/systems/ownership/tests.cairo
+++ b/contracts/src/systems/ownership/tests.cairo
@@ -29,7 +29,7 @@ fn setup() -> (WorldStorage, ContractAddress, Owner) {
     world.write_model_test(@owner);
 
     // set initial season
-    let season = Season { config_id: WORLD_CONFIG_ID, is_over: false, start_at: 0 };
+    let season = Season { config_id: WORLD_CONFIG_ID, is_over: false, start_at: 0, ended_at: 0 };
     world.write_model_test(@season);
 
     (world, ownership_systems_address, owner)

--- a/contracts/src/systems/resources/contracts/resource_bridge_systems.cairo
+++ b/contracts/src/systems/resources/contracts/resource_bridge_systems.cairo
@@ -194,11 +194,11 @@ mod resource_bridge_systems {
     use s0_eternum::constants::{WORLD_CONFIG_ID, DEFAULT_NS};
     use s0_eternum::models::bank::bank::Bank;
     use s0_eternum::models::config::{ResourceBridgeWhitelistConfig, ResourceBridgeConfig, ResourceBridgeFeeSplitConfig};
+    use s0_eternum::models::config::{SeasonBridgeConfig, SeasonBridgeConfigImpl};
     use s0_eternum::models::movable::{ArrivalTime, ArrivalTimeImpl};
     use s0_eternum::models::owner::{EntityOwner, Owner, EntityOwnerTrait};
     use s0_eternum::models::position::{Position, Coord};
     use s0_eternum::models::resources::{Resource, ResourceImpl, RESOURCE_PRECISION};
-    use s0_eternum::models::season::SeasonImpl;
     use s0_eternum::models::structure::{Structure, StructureTrait, StructureCategory};
     use s0_eternum::systems::resources::contracts::resource_systems::resource_systems::{InternalResourceSystemsImpl};
     use s0_eternum::utils::math::{pow, PercentageImpl, PercentageValueImpl, min};
@@ -224,8 +224,7 @@ mod resource_bridge_systems {
             client_fee_recipient: ContractAddress
         ) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
-            SeasonImpl::assert_has_started(world);
-            SeasonImpl::assert_season_is_not_over(world);
+            SeasonBridgeConfigImpl::assert_bridge_is_open(world);
 
             // ensure this system can only be called by realms systems contract
             let caller = get_caller_address();
@@ -282,8 +281,7 @@ mod resource_bridge_systems {
             client_fee_recipient: ContractAddress
         ) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
-            SeasonImpl::assert_has_started(world);
-            SeasonImpl::assert_season_is_not_over(world);
+            SeasonBridgeConfigImpl::assert_bridge_is_open(world);
 
             // ensure through bank is a bank
             let through_bank: Structure = world.read_model(through_bank_id);
@@ -343,6 +341,8 @@ mod resource_bridge_systems {
             ref self: ContractState, through_bank_id: ID, from_realm_id: ID, token: ContractAddress, amount: u128,
         ) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
+            SeasonBridgeConfigImpl::assert_bridge_is_open(world);
+
             // ensure caller is owner of from_realm_id
             let entity_owner: EntityOwner = world.read_model(from_realm_id);
             entity_owner.assert_caller_owner(world);
@@ -381,6 +381,8 @@ mod resource_bridge_systems {
             client_fee_recipient: ContractAddress
         ) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
+            SeasonBridgeConfigImpl::assert_bridge_is_open(world);
+
             // ensure caller is owner of from_entity_id
             let entity_owner: EntityOwner = world.read_model(from_entity_id);
             entity_owner.assert_caller_owner(world);

--- a/landing/schema.graphql
+++ b/landing/schema.graphql
@@ -8400,6 +8400,7 @@ type s0_eternum_Season {
   eventMessage: World__EventMessage
   is_over: bool
   start_at: u64
+  ended_at: u64
 }
 
 type s0_eternum_SeasonAddressesConfig {
@@ -8501,6 +8502,7 @@ enum s0_eternum_SeasonOrderField {
   CONFIG_ID
   IS_OVER
   START_AT
+  ENDED_AT
 }
 
 input s0_eternum_SeasonWhereInput {
@@ -8527,6 +8529,17 @@ input s0_eternum_SeasonWhereInput {
   start_atNEQ: u64
   start_atNOTIN: [u64]
   start_atNOTLIKE: u64
+  ended_at: u64
+  ended_atEQ: u64
+  ended_atGT: u64
+  ended_atGTE: u64
+  ended_atIN: [u64]
+  ended_atLIKE: u64
+  ended_atLT: u64
+  ended_atLTE: u64
+  ended_atNEQ: u64
+  ended_atNOTIN: [u64]
+  ended_atNOTLIKE: u64
 }
 
 type s0_eternum_SettleRealmData {

--- a/landing/src/hooks/gql/graphql.ts
+++ b/landing/src/hooks/gql/graphql.ts
@@ -5170,6 +5170,7 @@ export enum S0_Eternum_SeasonOrderField {
   ConfigId = "CONFIG_ID",
   IsOver = "IS_OVER",
   StartAt = "START_AT",
+  EndedAt = "ENDED_AT",
 }
 
 export type S0_Eternum_SeasonWhereInput = {
@@ -5196,6 +5197,17 @@ export type S0_Eternum_SeasonWhereInput = {
   start_atNEQ?: InputMaybe<Scalars["u64"]["input"]>;
   start_atNOTIN?: InputMaybe<Array<InputMaybe<Scalars["u64"]["input"]>>>;
   start_atNOTLIKE?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_at?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atEQ?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atGT?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atGTE?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atIN?: InputMaybe<Array<InputMaybe<Scalars["u64"]["input"]>>>;
+  ended_atLIKE?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atLT?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atLTE?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atNEQ?: InputMaybe<Scalars["u64"]["input"]>;
+  ended_atNOTIN?: InputMaybe<Array<InputMaybe<Scalars["u64"]["input"]>>>;
+  ended_atNOTLIKE?: InputMaybe<Scalars["u64"]["input"]>;
 };
 
 export type S0_Eternum_SettleRealmDataOrder = {

--- a/sdk/packages/eternum/src/config/index.ts
+++ b/sdk/packages/eternum/src/config/index.ts
@@ -467,6 +467,12 @@ export const setSeasonConfig = async (config: Config) => {
 
   console.log(`Configuring season ${tx.statusReceipt}`);
   console.log(`Season starts at ${new Date(startAt * 1000).toISOString()}`);
+
+  const txBridge = await config.provider.set_season_bridge_config({
+    signer: config.account,
+    close_after_end_seconds: config.config.season.bridgeCloseAfterEndSeconds,
+  });
+  console.log(`Configuring season bridge ${txBridge.statusReceipt}`);
 };
 
 export const setResourceBridgeLordsWhitlelistConfig = async (config: Config) => {

--- a/sdk/packages/eternum/src/constants/global.ts
+++ b/sdk/packages/eternum/src/constants/global.ts
@@ -141,6 +141,7 @@ export const MAX_BANK_FEE_ON_WITHDRAWAL = 1000; // 10%
 // TODO: CHECKLIST
 // - [ ] Check if this is correct
 export const SEASON_START_AFTER_SECONDS = 60 * 60 * 24 * 7; // 7 days
+export const SEASON_BRIDGE_CLOSE_AFTER_END_SECONDS = 48 * 60 * 60; // 2 days
 
 export const EternumGlobalConfig: Config = {
   stamina: {
@@ -261,6 +262,7 @@ export const EternumGlobalConfig: Config = {
     realmsAddress: REALMS_ADDRESS,
     lordsAddress: LORDS_ADDRESS,
     startAfterSeconds: SEASON_START_AFTER_SECONDS,
+    bridgeCloseAfterEndSeconds: SEASON_BRIDGE_CLOSE_AFTER_END_SECONDS,
   },
   bridge: {
     velords_fee_on_dpt_percent: VELORDS_FEE_ON_DEPOSIT,

--- a/sdk/packages/eternum/src/provider/index.ts
+++ b/sdk/packages/eternum/src/provider/index.ts
@@ -1699,6 +1699,16 @@ export class EternumProvider extends EnhancedDojoProvider {
     });
   }
 
+  public async set_season_bridge_config(props: SystemProps.SetSeasonBridgeConfigProps) {
+    const { close_after_end_seconds, signer } = props;
+
+    return await this.executeAndCheckTransaction(signer, {
+      contractAddress: getContractByName(this.manifest, `${NAMESPACE}-config_systems`),
+      entrypoint: "set_season_bridge_config",
+      calldata: [close_after_end_seconds],
+    });
+  }
+
   public async set_resource_bridge_whitlelist_config(props: SystemProps.SetResourceBridgeWhitelistConfigProps) {
     const { token, resource_type, signer } = props;
 

--- a/sdk/packages/eternum/src/provider/types.ts
+++ b/sdk/packages/eternum/src/provider/types.ts
@@ -30,6 +30,7 @@ export enum TransactionType {
   CREATE_ADMIN_BANK = "create_admin_bank",
   SET_SETTLEMENT_CONFIG = "set_settlement_config",
   SET_SEASON_CONFIG = "set_season_config",
+  SET_SEASON_BRIDGE_CONFIG = "set_season_bridge_config",
   SET_RESOURCE_BRIDGE_WHITELIST_CONFIG = "set_resource_bridge_whitelist_config",
   SET_CAPACITY_CONFIG = "set_capacity_config",
   SET_SPEED_CONFIG = "set_speed_config",

--- a/sdk/packages/eternum/src/types/common.ts
+++ b/sdk/packages/eternum/src/types/common.ts
@@ -356,6 +356,7 @@ export interface Config {
     realmsAddress: string;
     lordsAddress: string;
     startAfterSeconds: number;
+    bridgeCloseAfterEndSeconds: number;
   };
   bridge: {
     velords_fee_on_dpt_percent: number;

--- a/sdk/packages/eternum/src/types/provider.ts
+++ b/sdk/packages/eternum/src/types/provider.ts
@@ -532,6 +532,10 @@ export interface SetSeasonConfigProps extends SystemSigner {
   start_at: num.BigNumberish;
 }
 
+export interface SetSeasonBridgeConfigProps extends SystemSigner {
+  close_after_end_seconds: num.BigNumberish;
+}
+
 export interface SetResourceBridgeWhitelistConfigProps extends SystemSigner {
   token: num.BigNumberish;
   resource_type: num.BigNumberish;


### PR DESCRIPTION
resolve #2249 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new property `bridgeCloseAfterEndSeconds` for season configuration, allowing for a specified duration after a season ends.
  - Added support for tracking the end time of seasons with the new `ended_at` field.
  - Enhanced GraphQL schema to include `ended_at` for improved querying and filtering of season data.
  
- **Improvements**
  - Streamlined resource bridge operations by integrating new configuration checks for season management.
  - Added various methods for configuring season bridge settings and resource fees within the EternumConfig class.

- **Bug Fixes**
  - Maintained existing error handling and control flow for environment variables and configuration setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->