### PR TITLE
contracts: only give donkey breeder achievement after successful trade

### DIFF
--- a/contracts/src/systems/resources/contracts/resource_systems.cairo
+++ b/contracts/src/systems/resources/contracts/resource_systems.cairo
@@ -244,7 +244,7 @@ mod resource_systems {
 
             // create donkey that can carry weight
             donkey::create_donkey(ref world, false, donkey_to_bank_id, owner_id, owner_coord, bank_coord);
-            donkey::burn_donkey(ref world, owner_id, total_resources_weight);
+            donkey::burn_donkey(ref world, owner_id, total_resources_weight, true);
 
             // emit transfer event
             Self::emit_transfer_event(ref world, owner_id, donkey_to_bank_id, array![resource].span());
@@ -350,7 +350,7 @@ mod resource_systems {
                     ref world, is_round_trip, actual_recipient_id, recipient_id, owner_coord, recipient_coord
                 );
                 if transport_resource_burn {
-                    donkey::burn_donkey(ref world, transport_provider_id, total_resources_weight);
+                    donkey::burn_donkey(ref world, transport_provider_id, total_resources_weight, true);
                 }
             }
 

--- a/contracts/src/systems/trade/contracts/trade_systems.cairo
+++ b/contracts/src/systems/trade/contracts/trade_systems.cairo
@@ -209,7 +209,7 @@ mod trade_systems {
             };
 
             // burn enough maker donkeys to carry resources given by taker
-            donkey::burn_donkey(ref world, maker_id, taker_gives_resources_weight);
+            donkey::burn_donkey(ref world, maker_id, taker_gives_resources_weight, false);
 
             // create trade entity
             let trade_id = world.dispatcher.uuid();
@@ -522,6 +522,11 @@ mod trade_systems {
                 maker_receives_resources_hash == trade.taker_gives_resources_hash,
                 "wrong taker_gives_resources provided"
             );
+
+            // give donkey burn achievement to trade maker only after successful transfer
+            let donkey_amount = donkey::get_donkey_needed(ref world, trade.taker_gives_resources_weight);
+            let maker_owner: Owner = world.read_model(trade.maker_id);
+            donkey::give_breeder_achievement(ref world, donkey_amount, maker_owner.address);
 
             world
                 .emit_event(


### PR DESCRIPTION
- fix the issue where you could game breeder achievement by opening and closing trade orders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced resource burning logic with an option to grant achievements when burning donkeys.
	- Trade makers can now receive rewards based on resources involved in trades.

- **Bug Fixes**
	- Improved checks for ownership and status during resource returns in trade cancellations.

- **Documentation**
	- Expanded comments in the `accept_partial_order` function for better clarity on resource constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->