### PR TITLE
[client] labels fixes

### DIFF
--- a/client/src/three/components/ArmyManager.ts
+++ b/client/src/three/components/ArmyManager.ts
@@ -526,6 +526,18 @@ export class ArmyManager {
     this.entityIdLabels.set(army.entityId, label);
   }
 
+  removeLabelsFromScene() {
+    this.entityIdLabels.forEach((label) => this.scene.remove(label));
+  }
+
+  addLabelsToScene() {
+    this.entityIdLabels.forEach((label) => {
+      if (!this.scene.children.includes(label)) {
+        this.scene.add(label);
+      }
+    });
+  }
+
   private removeEntityIdLabel(entityId: ID) {
     const label = this.entityIdLabels.get(entityId);
     if (label) {

--- a/client/src/three/components/BattleManager.ts
+++ b/client/src/three/components/BattleManager.ts
@@ -7,7 +7,7 @@ import { BattleSystemUpdate } from "../systems/types";
 import { BattleModel } from "./BattleModel";
 import { LabelManager } from "./LabelManager";
 
-const LABEL_PATH = "textures/army_label.png";
+const LABEL_PATH = "textures/battle_label.png";
 
 export class BattleManager {
   private scene: THREE.Scene;
@@ -92,7 +92,10 @@ export class BattleManager {
     this.battleModel.mesh.count = this.battles.counter;
     this.battleModel.mesh.instanceMatrix.needsUpdate = true;
     this.battleModel.mesh.computeBoundingSphere();
-    const label = this.labelManager.createLabel(position, isSiege ? new THREE.Color("orange") : new THREE.Color("red"));
+    const label = this.labelManager.createLabel(
+      position,
+      isSiege ? new THREE.Color("yellow") : new THREE.Color("orange"),
+    );
 
     this.labels.set(entityId, label);
     this.scene.add(label);

--- a/client/src/three/components/Minimap.ts
+++ b/client/src/three/components/Minimap.ts
@@ -29,6 +29,7 @@ const MINIMAP_CONFIG = {
   MAX_ZOOM_RANGE: 300,
   MAP_COLS_WIDTH: 200,
   MAP_ROWS_HEIGHT: 100,
+  EXPANDED_MODIFIER: 0.5,
   COLORS: {
     ARMY: "#FF0000",
     MY_ARMY: "#00FF00",
@@ -42,7 +43,7 @@ const MINIMAP_CONFIG = {
     },
   },
   SIZES: {
-    BATTLE: 15,
+    BATTLE: 12,
     STRUCTURE: 10,
     ARMY: 10,
     CAMERA: {
@@ -171,18 +172,22 @@ class Minimap {
     }
 
     this.dragSpeed = this.mapSize.width / MINIMAP_CONFIG.MAX_ZOOM_RANGE;
+    let modifier = 1;
+    if (this.canvas.width > 300) {
+      modifier = MINIMAP_CONFIG.EXPANDED_MODIFIER;
+    }
     // Precompute sizes
     this.structureSize = {
-      width: MINIMAP_CONFIG.SIZES.STRUCTURE * this.scaleX,
-      height: MINIMAP_CONFIG.SIZES.STRUCTURE * this.scaleX,
+      width: MINIMAP_CONFIG.SIZES.STRUCTURE * this.scaleX * modifier,
+      height: MINIMAP_CONFIG.SIZES.STRUCTURE * this.scaleX * modifier,
     };
     this.armySize = {
-      width: MINIMAP_CONFIG.SIZES.ARMY * this.scaleX,
-      height: MINIMAP_CONFIG.SIZES.ARMY * this.scaleX,
+      width: MINIMAP_CONFIG.SIZES.ARMY * this.scaleX * modifier,
+      height: MINIMAP_CONFIG.SIZES.ARMY * this.scaleX * modifier,
     };
     this.battleSize = {
-      width: MINIMAP_CONFIG.SIZES.BATTLE * this.scaleX,
-      height: MINIMAP_CONFIG.SIZES.BATTLE * this.scaleX,
+      width: MINIMAP_CONFIG.SIZES.BATTLE * this.scaleX * modifier,
+      height: MINIMAP_CONFIG.SIZES.BATTLE * this.scaleX * modifier,
     };
     this.cameraSize = {
       topSideWidth: (window.innerWidth / MINIMAP_CONFIG.SIZES.CAMERA.TOP_SIDE_WIDTH_FACTOR) * this.scaleX,

--- a/client/src/three/scenes/Worldmap.ts
+++ b/client/src/three/scenes/Worldmap.ts
@@ -373,12 +373,15 @@ export default class WorldmapScene extends HexagonScene {
       const { outerCol, outerRow } = this.state.selectedBuildingHex;
       this.state.setSelectedHex({ col: outerCol, row: outerRow });
     }
+
+    this.armyManager.addLabelsToScene();
   }
 
   onSwitchOff() {
     if (!IS_MOBILE) {
       this.minimap.hideMinimap();
     }
+    this.armyManager.removeLabelsFromScene();
   }
 
   public async updateExploredHex(update: TileSystemUpdate) {


### PR DESCRIPTION
Fix for #2289 
Fix for #2295 (added size modifier for expanded map)
Changed battle label color to be similar to minimap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced label management for armies with the addition of methods to add and remove labels from the scene.
	- Improved visualization of army movements through new label additions in the Worldmap scene.
  
- **Improvements**
	- Updated color coding for battle labels to better differentiate between siege and non-siege battles.
	- Enhanced handling of explored hexes for better interaction and responsiveness in the Worldmap scene.
	- Dynamic size adjustments for structures, armies, and battles in the Minimap based on canvas width.

- **Bug Fixes**
	- Improved logic for removing explored hexes and resetting the current chunk in the Worldmap scene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->