### PR TITLE
fix: hide battle model

### DIFF
--- a/client/src/three/components/BattleManager.ts
+++ b/client/src/three/components/BattleManager.ts
@@ -63,9 +63,9 @@ export class BattleManager {
   async onUpdate(update: BattleSystemUpdate) {
     await this.battleModel.loadPromise;
 
-    const { entityId, hexCoords, isEmpty, deleted, isSiege } = update;
+    const { entityId, hexCoords, isEmpty, deleted, isSiege, isOngoing } = update;
 
-    if (deleted) {
+    if (deleted || !isOngoing) {
       this.removeBattle(entityId);
       return;
     }

--- a/client/src/three/systems/SystemManager.ts
+++ b/client/src/three/systems/SystemManager.ts
@@ -211,6 +211,7 @@ export class SystemManager {
               isEmpty: false,
               deleted: true,
               isSiege: false,
+              isOngoing: false,
             };
           }
 
@@ -223,6 +224,10 @@ export class SystemManager {
             battle.defence_army_health.current < healthMultiplier;
 
           const isSiege = battle.start_at > Date.now() / 1000;
+          const currentTimestamp = Math.floor(Date.now() / 1000);
+          const isOngoing =
+            battle.duration_left !== 0n &&
+            currentTimestamp - Number(battle.last_updated) < Number(battle.duration_left);
 
           return {
             entityId: battle.entity_id,
@@ -230,6 +235,7 @@ export class SystemManager {
             isEmpty,
             deleted: false,
             isSiege,
+            isOngoing,
           };
         });
       },

--- a/client/src/three/systems/types.ts
+++ b/client/src/three/systems/types.ts
@@ -33,6 +33,7 @@ export type BattleSystemUpdate = {
   isEmpty: boolean;
   deleted: boolean;
   isSiege: boolean;
+  isOngoing: boolean;
 };
 
 export type BuildingSystemUpdate = {


### PR DESCRIPTION
Hide battle model if battle is not ongoing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced battle management with the addition of an `isOngoing` property for better control of active battles.
	- Improved data structure for battle and tile updates, including a subscription method for building updates.

- **Bug Fixes**
	- Updated logic for determining battle removal conditions.

- **Documentation**
	- Updated method signatures to reflect changes in parameters and return structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->