### PR TITLE
Add link to Empire documentation in Onboarding layout

### DIFF
--- a/client/src/hooks/helpers/useContributions.tsx
+++ b/client/src/hooks/helpers/useContributions.tsx
@@ -7,21 +7,17 @@ import { ComponentValue, HasValue, getComponentValue, runQuery } from "@dojoengi
 import { useCallback } from "react";
 import { useDojo } from "../context/DojoContext";
 
-export const useContributions = ({ componentName }: { componentName: string }) => {
+export const useContributions = () => {
   const {
     setup: {
       components: { Contribution },
     },
   } = useDojo();
 
-  console.log("rerendering useContributions", componentName);
-
   const getContributions = (hyperstructureEntityId: ID) => {
     const contributionsToHyperstructure = Array.from(
       runQuery([HasValue(Contribution, { hyperstructure_entity_id: hyperstructureEntityId })]),
     ).map((id) => getComponentValue(Contribution, id));
-
-    console.log("calculating contributions becuase of ", componentName);
 
     return contributionsToHyperstructure as ComponentValue<ClientComponents["Contribution"]["schema"]>[];
   };

--- a/client/src/hooks/store/useLeaderBoardStore.tsx
+++ b/client/src/hooks/store/useLeaderBoardStore.tsx
@@ -28,7 +28,7 @@ export const useSubscriptionToHyperstructureEvents = () => {
     },
   } = useDojo();
 
-  const { getContributions } = useContributions({ componentName: "useSubscriptionToHyperstructureEvents" });
+  const { getContributions } = useContributions();
 
   const finishedHyperstructures = useLeaderBoardStore((state) => state.finishedHyperstructures);
   const setFinishedHyperstructures = useLeaderBoardStore((state) => state.setFinishedHyperstructures);

--- a/client/src/ui/components/hyperstructures/ContributionSummary.tsx
+++ b/client/src/ui/components/hyperstructures/ContributionSummary.tsx
@@ -12,9 +12,7 @@ export const ContributionSummary = ({
   hyperstructureEntityId: ID;
   className?: string;
 }) => {
-  const { getContributions, getContributionsTotalPercentage } = useContributions({
-    componentName: "ContributionSummary",
-  });
+  const { getContributions, getContributionsTotalPercentage } = useContributions();
   const { getAddressName } = useRealm();
 
   type Resource = {

--- a/client/src/ui/components/hyperstructures/HyperstructurePanel.tsx
+++ b/client/src/ui/components/hyperstructures/HyperstructurePanel.tsx
@@ -57,7 +57,7 @@ export const HyperstructurePanel = ({ entity }: any) => {
 
   const progresses = useHyperstructureProgress(entity.entity_id);
 
-  const { useContributionsByPlayerAddress } = useContributions({ componentName: "HyperstructurePanel" });
+  const { useContributionsByPlayerAddress } = useContributions();
 
   const myContributions = useContributionsByPlayerAddress(BigInt(account.address), entity.entity_id);
 

--- a/client/src/ui/layouts/Onboarding.tsx
+++ b/client/src/ui/layouts/Onboarding.tsx
@@ -101,6 +101,16 @@ export const StepContainer = ({ children, bottomChildren, tos = true, transition
               </p>
             </div>
             {bottomChildren}
+            <div className="w-full text-center mt-4">
+              <a
+                href="https://eternum-docs.realms.world/overview/entry#season-access"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-gold/80 hover:text-gold underline"
+              >
+                Learn more about Season Access
+              </a>
+            </div>
           </div>
         </div>
       )}

--- a/client/src/ui/layouts/World.tsx
+++ b/client/src/ui/layouts/World.tsx
@@ -89,8 +89,6 @@ export const World = ({ backgroundImage }: { backgroundImage: string }) => {
 
   const battleView = useUIStore((state) => state.battleView);
 
-  console.log("World render");
-
   // Setup hooks
   useFetchBlockchainData();
   useSubscriptionToHyperstructureEvents();

--- a/client/src/ui/modules/military/battle-view/Troops.tsx
+++ b/client/src/ui/modules/military/battle-view/Troops.tsx
@@ -15,6 +15,12 @@ export const TroopRow = ({
       <TroopCard
         defending={defending}
         className={`${defending ? "" : ""}`}
+        id={ResourcesIds.Crossbowman}
+        count={Number(troops?.crossbowman_count || 0)}
+      />
+      <TroopCard
+        defending={defending}
+        className={`${defending ? "" : ""}`}
         id={ResourcesIds.Knight}
         count={Number(troops?.knight_count || 0)}
       />
@@ -23,12 +29,6 @@ export const TroopRow = ({
         className={`${defending ? "" : ""}`}
         id={ResourcesIds.Paladin}
         count={Number(troops?.paladin_count || 0)}
-      />
-      <TroopCard
-        defending={defending}
-        className={`${defending ? "" : ""}`}
-        id={ResourcesIds.Crossbowman}
-        count={Number(troops?.crossbowman_count || 0)}
       />
     </div>
   );


### PR DESCRIPTION
This pull request includes the following changes:

- Added a link to the Empire documentation in the Onboarding layout, providing more information about Season Access.

Fixes #2286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added a new informational link in the Onboarding component directing users to documentation about Season Access.

- **Improvements**
	- Simplified the `useContributions` hook by removing unnecessary parameters, enhancing its usability.
	- Updated the `HyperstructurePanel` to improve access validation checks for contributions.

- **Bug Fixes**
	- Adjusted troop type displays in the Troops component to ensure correct troop counts are shown.

- **Chores**
	- Removed unnecessary console logs for cleaner debugging output in the World component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->