### PR TITLE
Remove automatic hex selection

### DIFF
--- a/client/src/three/scenes/Worldmap.ts
+++ b/client/src/three/scenes/Worldmap.ts
@@ -300,7 +300,6 @@ export default class WorldmapScene extends HexagonScene {
     if (contractHexPosition.x !== this.state.selectedHex?.col || contractHexPosition.y !== this.state.selectedHex.row) {
       playSound(soundSelector.click, this.state.isSoundOn, this.state.effectsLevel);
       this.selectedHexManager.setPosition(position.x, position.z);
-      console.log("set selected hex from handlehexselection", contractHexPosition.x, contractHexPosition.y);
       this.state.setSelectedHex({
         col: contractHexPosition.x,
         row: contractHexPosition.y,

--- a/client/src/three/scenes/Worldmap.ts
+++ b/client/src/three/scenes/Worldmap.ts
@@ -300,6 +300,7 @@ export default class WorldmapScene extends HexagonScene {
     if (contractHexPosition.x !== this.state.selectedHex?.col || contractHexPosition.y !== this.state.selectedHex.row) {
       playSound(soundSelector.click, this.state.isSoundOn, this.state.effectsLevel);
       this.selectedHexManager.setPosition(position.x, position.z);
+      console.log("set selected hex from handlehexselection", contractHexPosition.x, contractHexPosition.y);
       this.state.setSelectedHex({
         col: contractHexPosition.x,
         row: contractHexPosition.y,
@@ -348,7 +349,6 @@ export default class WorldmapScene extends HexagonScene {
   }
 
   private clearEntitySelection() {
-    // this.state.setSelectedHex(null);
     this.highlightHexManager.highlightHexes([]);
     this.state.updateTravelPaths(new Map());
     this.structurePreview?.clearPreviewStructure();
@@ -368,11 +368,8 @@ export default class WorldmapScene extends HexagonScene {
       this.minimap.showMinimap();
     }
 
-    // Set the currently selected building hex as the default world map selection
-    if (this.state.selectedBuildingHex) {
-      const { outerCol, outerRow } = this.state.selectedBuildingHex;
-      this.state.setSelectedHex({ col: outerCol, row: outerRow });
-    }
+    // Close left navigation on world map load
+    useUIStore.getState().setLeftNavigationView(LeftView.None);
 
     this.armyManager.addLabelsToScene();
   }


### PR DESCRIPTION
This pull request removes a console.log statement and the automatic hex selection feature. The console.log statement has been removed from the codebase, and the automatic hex selection functionality has been removed from the Worldmap scene. Additionally, the left navigation view is now closed on world map load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness of the world map scene to user interactions.
	- Improved performance in loading visible chunks as the camera moves.

- **Bug Fixes**
	- Streamlined initial state management for the world map.

- **Refactor**
	- Simplified methods related to entity selection and explored hex management. 

- **Documentation**
	- Updated method signatures for better clarity on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->