### PR TITLE
Allow anyone resolve a battle that has ended

### DIFF
--- a/client/src/dojo/createSystemCalls.ts
+++ b/client/src/dojo/createSystemCalls.ts
@@ -194,6 +194,10 @@ export function createSystemCalls({ provider }: SetupNetworkResult) {
     await provider.battle_start(props);
   };
 
+  const battle_resolve = async (props: SystemProps.BattleResolveProps) => {
+    await provider.battle_resolve(props);
+  };
+
   const battle_force_start = async (props: SystemProps.BattleForceStartProps) => {
     await provider.battle_force_start(props);
   };
@@ -287,6 +291,7 @@ export function createSystemCalls({ provider }: SetupNetworkResult) {
 
     battle_start,
     battle_force_start,
+    battle_resolve,
     battle_leave,
     battle_join,
     battle_claim,

--- a/client/src/hooks/context/policies.tsx
+++ b/client/src/hooks/context/policies.tsx
@@ -37,6 +37,10 @@ export const policies = [
   },
   {
     target: "0x18658254d1d1602ad1e1672819d8736d0e691af97c215294c57e2efa6ea5c58",
+    method: "battle_resolve",
+  },
+  {
+    target: "0x18658254d1d1602ad1e1672819d8736d0e691af97c215294c57e2efa6ea5c58",
     method: "battle_force_start",
   },
   {

--- a/sdk/packages/eternum/src/provider/index.ts
+++ b/sdk/packages/eternum/src/provider/index.ts
@@ -1549,6 +1549,18 @@ export class EternumProvider extends EnhancedDojoProvider {
     return await this.promiseQueue.enqueue(call);
   }
 
+  public async battle_resolve(props: SystemProps.BattleResolveProps) {
+    const { battle_id, army_id, signer } = props;
+
+    const call = this.createProviderCall(signer, {
+      contractAddress: getContractByName(this.manifest, `${NAMESPACE}-battle_systems`),
+      entrypoint: "battle_resolve",
+      calldata: [battle_id, army_id],
+    });
+
+    return await this.promiseQueue.enqueue(call);
+  }
+
   public async battle_force_start(props: SystemProps.BattleForceStartProps) {
     const { battle_id, defending_army_id, signer } = props;
 

--- a/sdk/packages/eternum/src/provider/types.ts
+++ b/sdk/packages/eternum/src/provider/types.ts
@@ -13,6 +13,7 @@ export enum TransactionType {
   ARMY_BUY_TROOPS = "army_buy_troops",
   ARMY_MERGE_TROOPS = "army_merge_troops",
   BATTLE_START = "battle_start",
+  BATTLE_RESOLVE = "battle_resolve",
   BATTLE_FORCE_START = "battle_force_start",
   BATTLE_JOIN = "battle_join",
   BATTLE_LEAVE = "battle_leave",

--- a/sdk/packages/eternum/src/types/provider.ts
+++ b/sdk/packages/eternum/src/types/provider.ts
@@ -341,6 +341,11 @@ export interface BattleForceStartProps extends SystemSigner {
   defending_army_id: num.BigNumberish;
 }
 
+export interface BattleResolveProps extends SystemSigner {
+  battle_id: num.BigNumberish;
+  army_id: num.BigNumberish;
+}
+
 export interface BattleJoinProps extends SystemSigner {
   battle_id: num.BigNumberish;
   battle_side: num.BigNumberish;


### PR DESCRIPTION
- allow anyone force any entity out of a battle that has ended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for resolving battles within the game mechanics.
	- Added a new policy for invoking battle resolution for a specific target.
	- Enhanced resource swapping process by integrating battle resolution checks.

- **Bug Fixes**
	- Improved event handling for armies leaving battles, ensuring accurate state management.

- **Documentation**
	- Expanded the transaction types to include battle resolution.

- **Chores**
	- Added a new interface for battle resolution properties to streamline data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->