### PR TITLE
Fix/claim

### DIFF
--- a/contracts/manifest_prod.json
+++ b/contracts/manifest_prod.json
@@ -7738,7 +7738,7 @@
     },
     {
       "address": "0x4298a4376c9fb18bee356463f241dd958bd92d85872c71a3ae7cf63f360cd27",
-      "class_hash": "0x27494e6093f0aa1d2ff108b7d7ebe58ac4f26080031c77c89bcb8ae5f6fd33e",
+      "class_hash": "0x26314ed259fe9a0bdb9df592f9b424ae70ed926232e1846b0af1d0253f7356f",
       "abi": [
         {
           "type": "impl",

--- a/contracts/src/models/season.cairo
+++ b/contracts/src/models/season.cairo
@@ -114,7 +114,7 @@ pub impl LeaderboardEntryImpl of LeaderboardEntryTrait {
             world.write_model(@leaderboard_registered);
         }
 
-        let mut leaderboard_entry = LeaderboardEntry { address, points };
+        let mut leaderboard_entry: LeaderboardEntry = world.read_model(address);
         world.write_model(@leaderboard_entry);
         self.total_points += points;
         world.write_model(@self);

--- a/contracts/src/systems/season/contracts.cairo
+++ b/contracts/src/systems/season/contracts.cairo
@@ -159,13 +159,22 @@ mod season_systems {
                 / leaderboard.total_points.into();
             let resource_bridge_fee_split_config: ResourceBridgeFeeSplitConfig = world.read_model(WORLD_CONFIG_ID);
 
-            assert!(
-                ERC20ABIDispatcher { contract_address: token }
-                    .transfer_from(
-                        resource_bridge_fee_split_config.season_pool_fee_recipient, caller_address, player_reward
-                    ),
-                "Failed to transfer reward"
-            );
+            let sender = resource_bridge_fee_split_config.season_pool_fee_recipient;
+            let self = starknet::get_contract_address();
+            if sender == self {
+                assert!(
+                    ERC20ABIDispatcher { contract_address: token }.transfer(caller_address, player_reward),
+                    "Failed to transfer reward"
+                );
+            } else {
+                assert!(
+                    ERC20ABIDispatcher { contract_address: token }
+                        .transfer_from(
+                            resource_bridge_fee_split_config.season_pool_fee_recipient, caller_address, player_reward
+                        ),
+                    "Failed to transfer reward"
+                );
+            }
 
             // set claimed to true
             leaderboard_reward_claimed.claimed = true;


### PR DESCRIPTION
- use transfer method when transferring from self

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated contract implementation with a new class hash for enhanced functionality.
	- Improved leaderboard registration process by retrieving existing entries instead of creating new ones.
	- Enhanced reward claiming process with refined logic for fund transfers based on conditions.

- **Bug Fixes**
	- Adjusted logic in the reward distribution process to ensure correct transfer methods are used.

- **Documentation**
	- Updated method signatures to reflect changes in implementation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->