### PR TITLE
clarify army movement

### DIFF
--- a/docs/pages/mechanics/military/units.mdx
+++ b/docs/pages/mechanics/military/units.mdx
@@ -68,5 +68,5 @@ import { STAMINA_REFILL_PER_TICK } from "@bibliothecadao/eternum";
 - Three attacking armies can be created to start but increases as realm upgrades
 - Explores map, can initiate battle and can join a side in an existing battle
 - Can only transfer military to armies on the same hex
-- Armies have limited storage and cannot move if storage is full, stamina is depleted or there is not enough food at the
-  home realm
+- Armies can't move if their stamina is depleted or there is not enough food at the home realm
+- Armies have limited storage and cannot explore if storage is full, but they can retrace back to the home realm to unload


### PR DESCRIPTION
```diff
- Armies have limited storage and cannot move if storage is full, stamina is depleted or there is not enough food at the
  home realm
+++- Armies can't move if their stamina is depleted or there is not enough food at the home realm
+++- Armies have limited storage and cannot explore if storage is full, but they can retrace back to the home realm to unload
```