### PR TITLE
contracts: fix stamina cost

### DIFF
--- a/contracts/game/src/models/troop.cairo
+++ b/contracts/game/src/models/troop.cairo
@@ -325,7 +325,7 @@ pub impl TroopsImpl of TroopsTrait {
         }
     }
 
-    fn stamina_movement_bonus(ref self: Troops, biome: Biome, troop_stamina_config: TroopStaminaConfig) -> (bool, u16) {
+    fn stamina_travel_bonus(ref self: Troops, biome: Biome, troop_stamina_config: TroopStaminaConfig) -> (bool, u16) {
         let ZERO: u16 = 0;
         let VALUE: u16 = troop_stamina_config.stamina_bonus_value;
         let ADD: bool = true;


### PR DESCRIPTION
- only grant biome stamina bonus when traveling
- fix stamina spend calculation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the stamina bonus calculation for troop movement to improve clarity.
  - Streamlined the computation of stamina costs during exploration and travel by applying adjustments on a per-area basis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->