### PR TITLE
contracts: allow agent ownership change

### DIFF
--- a/contracts/game/src/models.cairo
+++ b/contracts/game/src/models.cairo
@@ -1,3 +1,4 @@
+pub mod agent;
 pub mod config;
 pub mod event;
 pub mod guild;

--- a/contracts/game/src/models/agent.cairo
+++ b/contracts/game/src/models/agent.cairo
@@ -1,0 +1,36 @@
+use dojo::model::ModelStorage;
+use dojo::world::WorldStorage;
+use s1_eternum::alias::ID;
+use s1_eternum::constants::WORLD_CONFIG_ID;
+
+#[derive(IntrospectPacked, Copy, Drop, Serde)]
+#[dojo::model]
+pub struct AgentOwner {
+    #[key]
+    pub explorer_id: ID,
+    pub address: starknet::ContractAddress,
+}
+
+#[derive(IntrospectPacked, Copy, Drop, Serde)]
+#[dojo::model]
+pub struct AgentCount {
+    #[key]
+    pub id: ID,
+    pub count: u16,
+}
+
+
+#[generate_trait]
+pub impl AgentCountImpl of AgentCountTrait {
+    fn increase(ref world: WorldStorage) {
+        let mut agent_count: AgentCount = world.read_model(WORLD_CONFIG_ID);
+        agent_count.count += 1;
+        world.write_model(@agent_count);
+    }
+
+    fn decrease(ref world: WorldStorage) {
+        let mut agent_count: AgentCount = world.read_model(WORLD_CONFIG_ID);
+        agent_count.count -= 1;
+        world.write_model(@agent_count);
+    }
+}

--- a/contracts/game/src/systems/ownership/contracts.cairo
+++ b/contracts/game/src/systems/ownership/contracts.cairo
@@ -13,7 +13,7 @@ mod ownership_systems {
     use s1_eternum::alias::ID;
     use s1_eternum::constants::DEFAULT_NS;
     use s1_eternum::models::agent::AgentOwner;
-    use s1_eternum::models::config::{SeasonConfigImpl};
+    use s1_eternum::models::config::{AgentControllerConfig, SeasonConfigImpl, WorldConfigUtilImpl};
     use s1_eternum::models::owner::OwnerAddressTrait;
     use s1_eternum::models::structure::{StructureOwnerStoreImpl};
     use starknet::ContractAddress;
@@ -35,11 +35,14 @@ mod ownership_systems {
             // ensure season is open
             SeasonConfigImpl::get(world).assert_started_and_not_over();
 
-            // ensure caller owns agent
-            let mut agent_owner: AgentOwner = world.read_model(explorer_id);
-            agent_owner.address.assert_caller_owner();
+            // ensure caller is agent controller
+            let mut agent_controller_config: AgentControllerConfig = WorldConfigUtilImpl::get_member(
+                world, selector!("agent_controller_config"),
+            );
+            agent_controller_config.address.assert_caller_owner();
 
             // update agent owner
+            let mut agent_owner: AgentOwner = world.read_model(explorer_id);
             agent_owner.address = new_owner;
             world.write_model(@agent_owner);
         }

--- a/contracts/game/src/systems/ownership/contracts.cairo
+++ b/contracts/game/src/systems/ownership/contracts.cairo
@@ -3,30 +3,45 @@ use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IOwnershipSystems<T> {
-    fn transfer_ownership(ref self: T, entity_id: ID, new_owner: ContractAddress);
+    fn transfer_structure_ownership(ref self: T, structure_id: ID, new_owner: ContractAddress);
+    fn transfer_agent_ownership(ref self: T, explorer_id: ID, new_owner: ContractAddress);
 }
 
 #[dojo::contract]
 mod ownership_systems {
+    use dojo::model::ModelStorage;
     use s1_eternum::alias::ID;
-    // use s1_eternum::models::owner::{OwnerImpl};
+    use s1_eternum::constants::DEFAULT_NS;
+    use s1_eternum::models::agent::AgentOwner;
+    use s1_eternum::models::config::{SeasonConfigImpl};
+    use s1_eternum::models::owner::OwnerAddressTrait;
+    use s1_eternum::models::structure::{StructureOwnerStoreImpl};
     use starknet::ContractAddress;
 
     #[abi(embed_v0)]
     impl OwnershipSystemsImpl of super::IOwnershipSystems<ContractState> {
-        fn transfer_ownership(
-            ref self: ContractState, entity_id: ID, new_owner: ContractAddress,
-        ) { // // ensure season is not over
-        // let mut world: WorldStorage = self.world(DEFAULT_NS());
-        // SeasonImpl::assert_season_is_not_over(world);
+        fn transfer_structure_ownership(ref self: ContractState, structure_id: ID, new_owner: ContractAddress) {
+            let mut world = self.world(DEFAULT_NS());
+            // ensure season is open
+            SeasonConfigImpl::get(world).assert_started_and_not_over();
+            // ensure caller owns structure
+            StructureOwnerStoreImpl::retrieve(ref world, structure_id).assert_caller_owner();
+            // update structure owner
+            StructureOwnerStoreImpl::store(new_owner, ref world, structure_id)
+        }
 
-        // // ensure caller is the current owner
-        // let mut owner: Owner = world.read_model(entity_id);
-        // owner.assert_caller_owner();
+        fn transfer_agent_ownership(ref self: ContractState, explorer_id: ID, new_owner: ContractAddress) {
+            let mut world = self.world(DEFAULT_NS());
+            // ensure season is open
+            SeasonConfigImpl::get(world).assert_started_and_not_over();
 
-        // // transfer ownership
-        // owner.transfer(new_owner);
-        // world.write_model(@owner);
+            // ensure caller owns agent
+            let mut agent_owner: AgentOwner = world.read_model(explorer_id);
+            agent_owner.address.assert_caller_owner();
+
+            // update agent owner
+            agent_owner.address = new_owner;
+            world.write_model(@agent_owner);
         }
     }
 }

--- a/contracts/game/src/systems/utils/troop.cairo
+++ b/contracts/game/src/systems/utils/troop.cairo
@@ -293,7 +293,7 @@ pub impl iExplorerImpl of iExplorerTrait {
         AgentCountImpl::decrease(ref world);
 
         // delete agent owner
-        let agent_owner = AgentOwner{explorer_id: explorer.explorer_id, address: Zero::zero()};
+        let agent_owner = AgentOwner { explorer_id: explorer.explorer_id, address: Zero::zero() };
         world.erase_model(@agent_owner);
 
         // explorer delete


### PR DESCRIPTION
- change ownership of structure or agent by calling `ownership_systems.transfer_structure_ownership` or `ownership_systems.transfer_agent_ownership`
- added agent count model
- added more agent names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced agent management module that improves tracking of agent ownership and count.
	- Refined the ownership transfer process by splitting operations into distinct transfers for structures and agents, ensuring robust access control.
	- Added dynamic naming of agents for greater variability during creation, enhancing the overall gameplay experience.
	- Added a new public module for agent functionalities.
	- Implemented new data structures for agent management and ownership tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->