### PR TITLE
[client] change army tiers display

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -24,6 +24,11 @@ import { getWorldPositionForHex, hashCoordinates } from "../utils";
 
 const myColor = new THREE.Color(0, 1.5, 0);
 const neutralColor = new THREE.Color(0xffffff);
+const TIERS_TO_STARS = {
+  [TroopTier.T1]: "⭐",
+  [TroopTier.T2]: "⭐⭐",
+  [TroopTier.T3]: "⭐⭐⭐",
+};
 
 export class ArmyManager {
   private scene: THREE.Scene;
@@ -384,7 +389,7 @@ export class ArmyManager {
       `${army.owner.ownerName} ${army.owner.guildName ? `[${army.owner.guildName}]` : ""}`,
     );
     const line2 = document.createElement("strong");
-    line2.textContent = `${army.category} ${army.tier}`;
+    line2.textContent = `${army.category} ${TIERS_TO_STARS[army.tier]}`;
 
     textContainer.appendChild(line1);
     textContainer.appendChild(line2);


### PR DESCRIPTION
For better clarity and a nice interface, army labels T1-T3 are replaced with the corresponding number of ⭐️ emoji.
![image](https://github.com/user-attachments/assets/32acfc83-656f-4bc2-91f2-d1aebc57a6ae)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the visual representation of troop tiers. Instead of showing numeric values, the interface now displays star icons based on each troop's tier, making troop rankings clearer and more engaging for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->