### PR TITLE
fix: labels colors

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -369,7 +369,7 @@ export class ArmyManager {
     labelDiv.classList.add(
       "rounded-md",
       "bg-brown/50",
-      "text-gold",
+      army.isMine ? "text-order-brilliance" : "text-gold",
       "p-1",
       "-translate-x-1/2",
       "text-xs",
@@ -378,7 +378,7 @@ export class ArmyManager {
     );
     const orderName = army.order.toLowerCase();
     const img = document.createElement("img");
-    img.src = `/images/orders/${orderName}.png`;
+    img.src = `/textures/${army.isMine ? "my_army_label" : "army_label"}.png`;
     img.classList.add("w-[24px]", "h-[24px]", "inline-block", "mr-2", "object-contain");
     labelDiv.appendChild(img);
 

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -271,7 +271,7 @@ export class StructureManager {
     labelDiv.classList.add(
       "rounded-md",
       "bg-brown/50",
-      "text-gold",
+      structure.isMine ? "text-order-brilliance" : "text-gold",
       "p-1",
       "-translate-x-1/2",
       "text-xs",
@@ -286,7 +286,7 @@ export class StructureManager {
 
     // Select appropriate icon
     let iconPath = ICONS.STRUCTURES[structure.structureType];
-    if (structure.structureType === StructureType.Realm) {
+    if (structure.structureType === StructureType.Realm || structure.structureType === StructureType.Village) {
       if (structure.hasWonder) {
         iconPath = structure.isMine ? ICONS.MY_REALM_WONDER : ICONS.REALM_WONDER;
       } else {


### PR DESCRIPTION
Labels for your own units now have green color
![image](https://github.com/user-attachments/assets/2477e4e4-1424-49ab-9cb9-8b2ab61e75f5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Army labels now dynamically adjust their styling and icons based on ownership, making player-controlled units easier to recognize.
  - Structure labels feature improved styling and icon selection for various structure types, ensuring a clearer visual distinction between user-owned and other structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->