### PR TITLE
contracts: allow explorers steal resources if they win a battle again

### DIFF
--- a/contracts/game/src/systems/combat/contracts/troop_raid.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_raid.cairo
@@ -18,7 +18,7 @@ pub mod troop_raid_systems {
 
     use dojo::model::ModelStorage;
     use s1_eternum::alias::ID;
-    use s1_eternum::constants::{DAYDREAMS_AGENT_ID, DEFAULT_NS, RESOURCE_PRECISION};
+    use s1_eternum::constants::{DAYDREAMS_AGENT_ID, DEFAULT_NS, RESOURCE_PRECISION, ResourceTypes};
     use s1_eternum::models::config::{
         BattleConfig, CombatConfigImpl, SeasonConfigImpl, TickImpl, TroopDamageConfig, TroopStaminaConfig,
         WorldConfigUtilImpl,
@@ -253,6 +253,14 @@ pub mod troop_raid_systems {
 
             // steal resources
             if raid_success {
+                // ensure lords are not raidable
+                for i in 0..steal_resources.len() {
+                    let (resource_type, _) = *steal_resources.at(i);
+                    if resource_type == ResourceTypes::LORDS {
+                        panic!("$LORDS are not raidable. Attack and conquer the realm");
+                    }
+                };
+
                 let mut structure_weight: Weight = WeightStoreImpl::retrieve(ref world, structure_id);
                 let mut explorer_weight: Weight = WeightStoreImpl::retrieve(ref world, explorer_id);
                 iResourceTransferImpl::structure_to_troop_instant(


### PR DESCRIPTION
- allow explorers steal resources if they win a battle against other explorers 
- make lords non raidable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced combat mechanics now allow victorious units to transfer resources from defeated opponents.
  - Updated raid functionality prevents the raiding of protected resource types, ensuring improved battle balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->