### PR TITLE
contracts: dont allow labor building destruction

### DIFF
--- a/contracts/game/.tool-versions
+++ b/contracts/game/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.9.2
-dojo 1.2.1
+scarb 2.9.4
+dojo 1.4.0

--- a/contracts/game/src/models/resource/production/building.cairo
+++ b/contracts/game/src/models/resource/production/building.cairo
@@ -878,6 +878,9 @@ pub impl BuildingImpl of BuildingTrait {
             .read_model((outer_entity_coord.x, outer_entity_coord.y, inner_coord.x, inner_coord.y));
         assert!(building.entity_id != 0, "building does not exist");
 
+        // ensure labor building can't be destroyed
+        assert!(building.category.into() != BuildingCategory::ResourceLabor, "labor building can't be destroyed");
+
         // stop production related to building
         if !building.paused {
             building.stop_production(ref world, outer_structure_category);


### PR DESCRIPTION
resolves #2874 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented destruction of buildings categorized as ResourceLabor, ensuring these buildings cannot be accidentally removed.

- **Chores**
  - Updated tool versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->