### PR TITLE
feat: add starting biome based defense and tokenized troops to realms and villages

### DIFF
--- a/config/environments/local.ts
+++ b/config/environments/local.ts
@@ -70,8 +70,26 @@ export const LocalEternumGlobalConfig: Config = {
     delaySeconds: 0,
   },
   // starting resources x1000
-  startingResources: getAllResourcesWithAmount(1000000),
-  villageStartingResources: getAllResourcesWithAmount(1000000),
+  startingResources: getAllResourcesWithAmount(1_000_000).map((resource) => {
+    if (
+      resource.resource === ResourcesIds.Knight ||
+      resource.resource === ResourcesIds.Paladin ||
+      resource.resource === ResourcesIds.Crossbowman
+    ) {
+      return { ...resource, amount: CommonEternumGlobalConfig.troop.limit.explorerAndGuardMaxTroopCount };
+    }
+    return resource;
+  }),
+  villageStartingResources: getAllResourcesWithAmount(1_000_000).map((resource) => {
+    if (
+      resource.resource === ResourcesIds.Knight ||
+      resource.resource === ResourcesIds.Paladin ||
+      resource.resource === ResourcesIds.Crossbowman
+    ) {
+      return { ...resource, amount: CommonEternumGlobalConfig.troop.limit.explorerAndGuardMaxTroopCount };
+    }
+    return resource;
+  }),
   speed: {
     ...CommonEternumGlobalConfig.speed,
     // 1 second per km

--- a/config/environments/utils/resource.ts
+++ b/config/environments/utils/resource.ts
@@ -275,10 +275,10 @@ export const STARTING_RESOURCES: ResourceCost[] = [
   { resource: ResourcesIds.Fish, amount: 3_000_000 },
   { resource: ResourcesIds.Labor, amount: 300_000 },
   { resource: ResourcesIds.Donkey, amount: 2_000 },
-  // 2500 / 3
-  { resource: ResourcesIds.Knight, amount: 833 },
-  { resource: ResourcesIds.Crossbowman, amount: 833 },
-  { resource: ResourcesIds.Paladin, amount: 833 },
+  // 5000, + 10 tokenized. only one troop type will be selected
+  { resource: ResourcesIds.Knight, amount: 5_010 },
+  { resource: ResourcesIds.Crossbowman, amount: 5_010 },
+  { resource: ResourcesIds.Paladin, amount: 5_010 },
 ];
 
 export const VILLAGE_STARTING_RESOURCES: ResourceCost[] = [
@@ -286,10 +286,10 @@ export const VILLAGE_STARTING_RESOURCES: ResourceCost[] = [
   { resource: ResourcesIds.Fish, amount: 2_000_000 },
   { resource: ResourcesIds.Labor, amount: 200_000 },
   { resource: ResourcesIds.Donkey, amount: 500 },
-  // 400 / 3
-  { resource: ResourcesIds.Knight, amount: 133 },
-  { resource: ResourcesIds.Crossbowman, amount: 133 },
-  { resource: ResourcesIds.Paladin, amount: 133 },
+  // 1000, + 10 tokenized. only one troop type will be selected
+  { resource: ResourcesIds.Knight, amount: 1_010 },
+  { resource: ResourcesIds.Crossbowman, amount: 1_010 },
+  { resource: ResourcesIds.Paladin, amount: 1_010 },
 ];
 
 export const LABOR_PRODUCTION_OUTPUT_AMOUNTS_THROUGH_RESOURCES: ResourceOutputs = {

--- a/contracts/game/dojo_dev.toml
+++ b/contracts/game/dojo_dev.toml
@@ -26,6 +26,7 @@ website = "https://alpha-eternum.realms.world/"
     "s1_eternum-name_systems",
     "s1_eternum-ownership_systems",
     "s1_eternum-realm_systems",
+	"s1_eternum-realm_internal_systems",
     "s1_eternum-resource_bridge_systems",
     "s1_eternum-resource_systems",
     "s1_eternum-swap_systems",

--- a/contracts/game/dojo_local.toml
+++ b/contracts/game/dojo_local.toml
@@ -26,6 +26,7 @@ website = "https://alpha-eternum.realms.world/"
     "s1_eternum-name_systems",
     "s1_eternum-ownership_systems",
     "s1_eternum-realm_systems",
+	"s1_eternum-realm_internal_systems",
     "s1_eternum-resource_bridge_systems",
     "s1_eternum-resource_systems",
     "s1_eternum-swap_systems",

--- a/contracts/game/dojo_sepolia.toml
+++ b/contracts/game/dojo_sepolia.toml
@@ -26,6 +26,7 @@ website = "https://eternum.realms.world/"
     "s1_eternum-name_systems",
     "s1_eternum-ownership_systems",
     "s1_eternum-realm_systems",
+	"s1_eternum-realm_internal_systems",
     "s1_eternum-resource_bridge_systems",
     "s1_eternum-resource_systems",
     "s1_eternum-swap_systems",

--- a/contracts/game/dojo_slot.toml
+++ b/contracts/game/dojo_slot.toml
@@ -27,6 +27,7 @@ website = "https://alpha-eternum.realms.world/"
 	"s1_eternum-name_systems",
 	"s1_eternum-ownership_systems",
 	"s1_eternum-realm_systems",
+	"s1_eternum-realm_internal_systems",
 	"s1_eternum-resource_bridge_systems",
 	"s1_eternum-resource_systems",
 	"s1_eternum-swap_systems",

--- a/contracts/game/src/models/troop.cairo
+++ b/contracts/game/src/models/troop.cairo
@@ -1,7 +1,7 @@
 use core::num::traits::zero::Zero;
 use cubit::f128::types::fixed::{Fixed, FixedTrait};
 use s1_eternum::alias::ID;
-use s1_eternum::constants::RESOURCE_PRECISION;
+use s1_eternum::constants::{RESOURCE_PRECISION, ResourceTypes};
 use s1_eternum::models::config::{TroopDamageConfig, TroopStaminaConfig};
 use s1_eternum::models::position::Coord;
 use s1_eternum::models::stamina::{Stamina, StaminaImpl, StaminaTrait};
@@ -446,6 +446,32 @@ pub impl TroopsImpl of TroopsTrait {
                     TroopType::Paladin => (ADD, VALUE) // +1
                 }
             },
+        }
+    }
+
+    fn start_resource_amount() -> u128 {
+        10 * RESOURCE_PRECISION
+    }
+
+    fn start_troop_type(biome: Biome) -> (u8, (TroopType, TroopTier)) {
+        match biome {
+            Biome::None => panic!("biome is not set"),
+            Biome::DeepOcean => (ResourceTypes::KNIGHT_T1, (TroopType::Knight, TroopTier::T1)),
+            Biome::Ocean => (ResourceTypes::KNIGHT_T1, (TroopType::Knight, TroopTier::T1)),
+            Biome::Beach => (ResourceTypes::KNIGHT_T1, (TroopType::Knight, TroopTier::T1)),
+            Biome::Scorched => (ResourceTypes::KNIGHT_T1, (TroopType::Knight, TroopTier::T1)),
+            Biome::Bare => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::Tundra => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::Snow => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::TemperateDesert => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::Shrubland => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::Taiga => (ResourceTypes::CROSSBOWMAN_T1, (TroopType::Crossbowman, TroopTier::T1)),
+            Biome::Grassland => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::TemperateDeciduousForest => (ResourceTypes::CROSSBOWMAN_T1, (TroopType::Crossbowman, TroopTier::T1)),
+            Biome::TemperateRainForest => (ResourceTypes::CROSSBOWMAN_T1, (TroopType::Crossbowman, TroopTier::T1)),
+            Biome::SubtropicalDesert => (ResourceTypes::PALADIN_T1, (TroopType::Paladin, TroopTier::T1)),
+            Biome::TropicalSeasonalForest => (ResourceTypes::CROSSBOWMAN_T1, (TroopType::Crossbowman, TroopTier::T1)),
+            Biome::TropicalRainForest => (ResourceTypes::CROSSBOWMAN_T1, (TroopType::Crossbowman, TroopTier::T1)),
         }
     }
 

--- a/contracts/game/src/systems.cairo
+++ b/contracts/game/src/systems.cairo
@@ -92,6 +92,7 @@ pub mod utils {
     pub mod hyperstructure;
     pub mod map;
     pub mod mine;
+    pub mod realm;
     pub mod resource;
     pub mod structure;
     pub mod troop;

--- a/contracts/game/src/systems/combat/contracts/troop_management.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_management.cairo
@@ -61,6 +61,7 @@ pub mod troop_management_systems {
     use core::num::traits::zero::Zero;
     use dojo::model::ModelStorage;
     use dojo::world::{IWorldDispatcherTrait};
+    use dojo::world::{WorldStorageTrait};
     use s1_eternum::alias::ID;
     use s1_eternum::constants::DEFAULT_NS;
     use s1_eternum::constants::{RESOURCE_PRECISION};
@@ -104,8 +105,12 @@ pub mod troop_management_systems {
             // ensure season is open
             SeasonConfigImpl::get(world).assert_started_and_not_over();
 
-            // ensure caller owns structure
-            StructureOwnerStoreImpl::retrieve(ref world, for_structure_id).assert_caller_owner();
+            // ensure caller owns structure or is realms_systems
+            let (realms_systems_address, _) = world.dns(@"realm_internal_systems").unwrap();
+            let caller_address: starknet::ContractAddress = starknet::get_caller_address();
+            if caller_address != realms_systems_address {
+                StructureOwnerStoreImpl::retrieve(ref world, for_structure_id).assert_caller_owner();
+            }
 
             // deduct resources used to create guard
             iTroopImpl::make_payment(ref world, for_structure_id, amount, category, tier);

--- a/contracts/game/src/systems/realm/contracts.cairo
+++ b/contracts/game/src/systems/realm/contracts.cairo
@@ -101,11 +101,7 @@ pub mod realm_systems {
                 world, selector!("season_addresses_config"),
             );
 
-            iRealmImpl::collect_season_pass(
-                ref world,
-                season_addresses_config.season_pass_address,
-                realm_id,
-            );
+            iRealmImpl::collect_season_pass(ref world, season_addresses_config.season_pass_address, realm_id);
 
             // retrieve realm metadata
             let (realm_name, regions, cities, harbors, rivers, wonder, order, resources) =
@@ -194,16 +190,13 @@ pub mod realm_internal_systems {
             wonder: u8,
             coord: Coord,
         ) -> ID {
-
-            
             // ensure caller is the realm systems
             let mut world: WorldStorage = self.world(DEFAULT_NS());
             let (realm_systems, _) = world.dns(@"realm_systems").unwrap();
             assert!(starknet::get_caller_address() == realm_systems, "caller must be the realm_systems");
 
             // create realm
-            let structure_id = iRealmImpl::create_realm(
-                ref world, owner, realm_id, resources, order, 0, wonder, coord);
+            let structure_id = iRealmImpl::create_realm(ref world, owner, realm_id, resources, order, 0, wonder, coord);
             structure_id.into()
         }
     }

--- a/contracts/game/src/systems/utils/realm.cairo
+++ b/contracts/game/src/systems/utils/realm.cairo
@@ -44,7 +44,6 @@ pub impl iRealmImpl of iRealmTrait {
         wonder: u8,
         coord: Coord,
     ) -> ID {
-        
         // create structure
         let has_wonder = RealmReferenceImpl::wonder_mapping(wonder.into()) != "None";
         let structure_id = world.dispatcher.uuid();
@@ -113,35 +112,34 @@ pub impl iRealmImpl of iRealmTrait {
         let (name_and_attrs, _urla, _urlb) = season_pass.get_encoded_metadata(realm_id.try_into().unwrap());
         RealmNameAndAttrsDecodingImpl::decode(name_and_attrs)
     }
-
     // fn collect_lords_from_season_pass(season_pass_address: ContractAddress, realm_id: ID) -> u256 {
-    //     // detach lords from season pass
-    //     let season_pass = ISeasonPassDispatcher { contract_address: season_pass_address };
-    //     let token_lords_balance: u256 = season_pass.lords_balance(realm_id.into());
-    //     season_pass.detach_lords(realm_id.into(), token_lords_balance);
-    //     assert!(season_pass.lords_balance(realm_id.into()).is_zero(), "lords amount attached to realm should be
-    //     0");
+//     // detach lords from season pass
+//     let season_pass = ISeasonPassDispatcher { contract_address: season_pass_address };
+//     let token_lords_balance: u256 = season_pass.lords_balance(realm_id.into());
+//     season_pass.detach_lords(realm_id.into(), token_lords_balance);
+//     assert!(season_pass.lords_balance(realm_id.into()).is_zero(), "lords amount attached to realm should be
+//     0");
 
     //     // at this point, this contract's lords balance must have increased by
-    //     // `token_lords_balance`
-    //     token_lords_balance
-    // }
+//     // `token_lords_balance`
+//     token_lords_balance
+// }
 
     // fn bridge_lords_into_realm(
-    //     ref world: WorldStorage,
-    //     lords_address: ContractAddress,
-    //     realm_structure_id: ID,
-    //     amount: u256,
-    //     frontend: ContractAddress,
-    // ) {
-    //     // get bridge systems address
-    //     let (bridge_systems_address, _) = world.dns(@"resource_bridge_systems").unwrap();
-    //     // approve bridge to spend lords
-    //     IERC20Dispatcher { contract_address: lords_address }.approve(bridge_systems_address, amount);
+//     ref world: WorldStorage,
+//     lords_address: ContractAddress,
+//     realm_structure_id: ID,
+//     amount: u256,
+//     frontend: ContractAddress,
+// ) {
+//     // get bridge systems address
+//     let (bridge_systems_address, _) = world.dns(@"resource_bridge_systems").unwrap();
+//     // approve bridge to spend lords
+//     IERC20Dispatcher { contract_address: lords_address }.approve(bridge_systems_address, amount);
 
     //     // deposit lords
-    //     IResourceBridgeSystemsDispatcher { contract_address: bridge_systems_address }
-    //         .deposit(lords_address, realm_structure_id, amount, frontend);
-    // }
+//     IResourceBridgeSystemsDispatcher { contract_address: bridge_systems_address }
+//         .deposit(lords_address, realm_structure_id, amount, frontend);
+// }
 }
 

--- a/contracts/game/src/systems/utils/realm.cairo
+++ b/contracts/game/src/systems/utils/realm.cairo
@@ -1,0 +1,147 @@
+use dojo::model::ModelStorage;
+use dojo::world::{IWorldDispatcherTrait};
+use dojo::world::{WorldStorage};
+
+use s1_eternum::alias::ID;
+use s1_eternum::models::config::{
+    SeasonConfigImpl, SettlementConfigImpl, WonderProductionBonusConfig, WorldConfigUtilImpl,
+};
+use s1_eternum::models::map::{TileImpl, TileOccupier};
+use s1_eternum::models::position::{Coord};
+use s1_eternum::models::realm::{RealmNameAndAttrsDecodingImpl, RealmReferenceImpl};
+use s1_eternum::models::resource::production::building::{BuildingCategory, BuildingImpl};
+use s1_eternum::models::resource::production::production::{ProductionWonderBonus};
+use s1_eternum::models::resource::resource::{ResourceImpl};
+use s1_eternum::models::resource::resource::{
+    ResourceWeightImpl, SingleResourceImpl, SingleResourceStoreImpl, WeightStoreImpl,
+};
+use s1_eternum::models::structure::{
+    StructureBaseStoreImpl, StructureCategory, StructureImpl, StructureMetadata, StructureMetadataStoreImpl,
+    StructureOwnerStoreImpl, Wonder,
+};
+use s1_eternum::systems::utils::structure::iStructureImpl;
+use starknet::ContractAddress;
+
+#[starknet::interface]
+pub trait ISeasonPass<TState> {
+    fn get_encoded_metadata(self: @TState, token_id: u16) -> (felt252, felt252, felt252);
+    fn transfer_from(self: @TState, from: ContractAddress, to: ContractAddress, token_id: u256);
+    fn approve(self: @TState, to: ContractAddress, token_id: u256);
+    fn lords_balance(self: @TState, token_id: u256) -> u256;
+    fn detach_lords(self: @TState, token_id: u256, amount: u256);
+}
+
+
+#[generate_trait]
+pub impl iRealmImpl of iRealmTrait {
+    fn create_realm(
+        ref world: WorldStorage,
+        owner: ContractAddress,
+        realm_id: ID,
+        resources: Array<u8>,
+        order: u8,
+        level: u8,
+        wonder: u8,
+        coord: Coord,
+    ) -> ID {
+        
+        // create structure
+        let has_wonder = RealmReferenceImpl::wonder_mapping(wonder.into()) != "None";
+        let structure_id = world.dispatcher.uuid();
+        let mut tile_occupier = TileOccupier::RealmRegularLevel1;
+        if has_wonder {
+            tile_occupier = TileOccupier::RealmWonderLevel1;
+            world
+                .write_model(
+                    @Wonder { structure_id: structure_id, realm_id: realm_id.try_into().unwrap(), coord: coord },
+                );
+
+            // grant wonder production bonus
+            let wonder_production_bonus_config: WonderProductionBonusConfig = WorldConfigUtilImpl::get_member(
+                world, selector!("wonder_production_bonus_config"),
+            );
+            let production_wonder_bonus = ProductionWonderBonus {
+                structure_id: structure_id, bonus_percent_num: wonder_production_bonus_config.bonus_percent_num,
+            };
+            world.write_model(@production_wonder_bonus);
+        }
+
+        // create structure
+        iStructureImpl::create(
+            ref world,
+            coord,
+            owner,
+            structure_id,
+            StructureCategory::Realm,
+            resources.span(),
+            StructureMetadata {
+                realm_id: realm_id.try_into().unwrap(), order, has_wonder, villages_count: 0, village_realm: 0,
+            },
+            tile_occupier.into(),
+        );
+
+        // grant starting resources
+        iStructureImpl::grant_starting_resources(ref world, structure_id, coord);
+
+        // place castle building
+        BuildingImpl::create(
+            ref world,
+            structure_id,
+            StructureCategory::Realm.into(),
+            coord,
+            BuildingCategory::ResourceLabor,
+            BuildingImpl::center(),
+        );
+
+        structure_id
+    }
+
+    fn collect_season_pass(ref world: WorldStorage, season_pass_address: ContractAddress, realm_id: ID) {
+        let caller = starknet::get_caller_address();
+        let this = starknet::get_contract_address();
+        let season_pass = ISeasonPassDispatcher { contract_address: season_pass_address };
+
+        // transfer season pass from caller to this
+        season_pass.transfer_from(caller, this, realm_id.into());
+    }
+
+
+    fn collect_season_pass_metadata(
+        season_pass_address: ContractAddress, realm_id: ID,
+    ) -> (felt252, u8, u8, u8, u8, u8, u8, Array<u8>) {
+        let season_pass = ISeasonPassDispatcher { contract_address: season_pass_address };
+        let (name_and_attrs, _urla, _urlb) = season_pass.get_encoded_metadata(realm_id.try_into().unwrap());
+        RealmNameAndAttrsDecodingImpl::decode(name_and_attrs)
+    }
+
+    // fn collect_lords_from_season_pass(season_pass_address: ContractAddress, realm_id: ID) -> u256 {
+    //     // detach lords from season pass
+    //     let season_pass = ISeasonPassDispatcher { contract_address: season_pass_address };
+    //     let token_lords_balance: u256 = season_pass.lords_balance(realm_id.into());
+    //     season_pass.detach_lords(realm_id.into(), token_lords_balance);
+    //     assert!(season_pass.lords_balance(realm_id.into()).is_zero(), "lords amount attached to realm should be
+    //     0");
+
+    //     // at this point, this contract's lords balance must have increased by
+    //     // `token_lords_balance`
+    //     token_lords_balance
+    // }
+
+    // fn bridge_lords_into_realm(
+    //     ref world: WorldStorage,
+    //     lords_address: ContractAddress,
+    //     realm_structure_id: ID,
+    //     amount: u256,
+    //     frontend: ContractAddress,
+    // ) {
+    //     // get bridge systems address
+    //     let (bridge_systems_address, _) = world.dns(@"resource_bridge_systems").unwrap();
+    //     // approve bridge to spend lords
+    //     IERC20Dispatcher { contract_address: lords_address }.approve(bridge_systems_address, amount);
+
+    //     // deposit lords
+    //     IResourceBridgeSystemsDispatcher { contract_address: bridge_systems_address }
+    //         .deposit(lords_address, realm_structure_id, amount, frontend);
+    // }
+}
+

--- a/contracts/game/src/systems/utils/structure.cairo
+++ b/contracts/game/src/systems/utils/structure.cairo
@@ -178,7 +178,6 @@ pub impl iStructureImpl of IStructureTrait {
 
 
     fn grant_starting_resources(ref world: WorldStorage, structure_id: ID, structure_coord: Coord) {
-
         let biome: Biome = get_biome(structure_coord.x.into(), structure_coord.y.into());
         let mut structure_weight: Weight = WeightStoreImpl::retrieve(ref world, structure_id);
         let structure_metadata: StructureMetadata = StructureMetadataStoreImpl::retrieve(ref world, structure_id);

--- a/contracts/game/src/systems/village/contracts.cairo
+++ b/contracts/game/src/systems/village/contracts.cairo
@@ -116,7 +116,7 @@ pub mod village_systems {
             );
 
             // grant starting resources
-            iStructureImpl::grant_starting_resources(ref world, village_id);
+            iStructureImpl::grant_starting_resources(ref world, village_id, village_coord);
 
             // place castle building
             BuildingImpl::create(

--- a/contracts/game/src/utils/testing/helpers.cairo
+++ b/contracts/game/src/utils/testing/helpers.cairo
@@ -23,7 +23,7 @@ use s1_eternum::models::troop::{ExplorerTroops, TroopTier, TroopType, Troops};
 use s1_eternum::models::weight::{Weight};
 use s1_eternum::systems::quest::constants::{QUEST_REWARD_BASE_MULTIPLIER};
 use s1_eternum::systems::quest::contracts::{IQuestSystemsDispatcher, IQuestSystemsDispatcherTrait};
-use s1_eternum::systems::realm::contracts::realm_systems::{InternalRealmLogicImpl};
+use s1_eternum::systems::utils::realm::iRealmImpl;
 use s1_eternum::utils::testing::contracts::villagepassmock::EternumVillagePassMock;
 use starknet::ContractAddress;
 
@@ -206,9 +206,7 @@ pub fn tspawn_simple_realm(
     tstore_production_config(ref world, ResourceTypes::EARTHEN_SHARD);
 
     // create realm
-    let realm_entity_id = InternalRealmLogicImpl::create_realm(
-        ref world, owner, realm_id, array![], 1, 0, 1, coord.into(),
-    );
+    let realm_entity_id = iRealmImpl::create_realm(ref world, owner, realm_id, array![], 1, 0, 1, coord.into());
 
     realm_entity_id
 }
@@ -239,7 +237,7 @@ pub fn tspawn_realm(
     coord: Coord,
 ) -> ID {
     // create realm
-    let realm_entity_id = InternalRealmLogicImpl::create_realm(
+    let realm_entity_id = iRealmImpl::create_realm(
         ref world, owner, realm_id, produced_resources, order, level, wonder, coord.into(),
     );
 

--- a/contracts/village_pass/ext/scripts/deployment/libs/commands.js
+++ b/contracts/village_pass/ext/scripts/deployment/libs/commands.js
@@ -22,7 +22,7 @@ export const deployVillagePassContract = async () => {
 
   let VILLAGE_PASS_ADMIN = BigInt(process.env.SEASON_PASS_ADMIN);
   let VILLAGE_PASS_UPGRADER = VILLAGE_PASS_ADMIN;
-  let VILLAGE_PASS_MINTER = await getContractByNameFromManifest("realm_systems");
+  let VILLAGE_PASS_MINTER = await getContractByNameFromManifest("realm_internal_systems");
   let VILLAGE_PASS_DISTRIBUTORS = [
     await getContractByNameFromManifest("village_systems"),
     BigInt(process.env.VILLAGE_PASS_DISTRIBUTOR),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated internal system for realm creation, improving modularity and authorization for realm-related actions.
  - Added new configuration entries to support the internal realm system across multiple environments.

- **Improvements**
  - Updated starting resources logic to grant specific troop types based on biome, enhancing initial troop distribution and gameplay variety.
  - Adjusted troop resource starting amounts for more balanced game starts.
  - Refined authorization, allowing internal systems to perform certain actions previously restricted to structure owners.

- **Refactor**
  - Centralized realm creation logic into a new internal contract, simplifying and streamlining the main realm systems.

- **Other**
  - Updated deployment scripts and configuration files to align with new internal system changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->