### PR TITLE
feat: single global immunity cloak period

### DIFF
--- a/config/deployer/config.ts
+++ b/config/deployer/config.ts
@@ -596,8 +596,7 @@ export const setBattleConfig = async (config: Config) => {
   console.log(
     chalk.cyan(`
     ┌─ ${chalk.yellow("Battle Parameters")}
-    │  ${chalk.gray("Regular Immunity:")}      ${chalk.white(calldata.regular_immunity_ticks + " ticks")}
-    │  ${chalk.gray("Structure Immunity:")}    ${chalk.white(calldata.hyperstructure_immunity_ticks + " ticks")}
+    │  ${chalk.gray(" Immunity Period:")}      ${chalk.white(calldata.regular_immunity_ticks + " ticks")}
     └────────────────────────────────`),
   );
 

--- a/config/environments/_shared_.ts
+++ b/config/environments/_shared_.ts
@@ -117,8 +117,6 @@ export const ARMY_SPEED = 1;
 
 // ----- Battle ----- //
 export const BATTLE_GRACE_TICK_COUNT = 24;
-export const BATTLE_GRACE_TICK_COUNT_HYPERSTRUCTURES = 1;
-export const BATTLE_DELAY_SECONDS = 8 * 60 * 60;
 
 // ----- Settlement ----- //
 export const SETTLEMENT_CENTER = 2147483646;
@@ -241,8 +239,8 @@ export const EternumGlobalConfig: Config = {
   },
   battle: {
     graceTickCount: BATTLE_GRACE_TICK_COUNT,
-    graceTickCountHyp: BATTLE_GRACE_TICK_COUNT_HYPERSTRUCTURES,
-    delaySeconds: BATTLE_DELAY_SECONDS,
+    graceTickCountHyp: 0,
+    delaySeconds: 0,
   },
   troop: {
     damage: {

--- a/contracts/game/src/systems/utils/troop.cairo
+++ b/contracts/game/src/systems/utils/troop.cairo
@@ -202,6 +202,10 @@ pub impl iExplorerImpl of iExplorerTrait {
         return explorer;
     }
 
+    fn is_daydreams_agent(ref self: ExplorerTroops) -> bool {
+        self.owner == DAYDREAMS_AGENT_ID
+    }
+
     fn assert_caller_structure_or_agent_owner(ref self: ExplorerTroops, ref world: WorldStorage) {
         if self.owner == DAYDREAMS_AGENT_ID {
             let agent_owner: AgentOwner = world.read_model(self.explorer_id);

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -564,14 +564,7 @@ export class ClientConfigManager {
         this.components.WorldConfig,
         getEntityIdFromKeys([WORLD_CONFIG_ID]),
       )?.battle_config;
-      switch (category) {
-        case StructureType.Hyperstructure:
-          return Number(battleConfig?.hyperstructure_immunity_ticks ?? 0);
-        case StructureType.FragmentMine:
-          return 0;
-        default:
-          return Number(battleConfig?.regular_immunity_ticks ?? 0);
-      }
+      return Number(battleConfig?.regular_immunity_ticks ?? 0);
     }, 0);
   }
 


### PR DESCRIPTION
resolves #2878 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed immunity period calculations so that all structures now use the same regular immunity duration, regardless of category.
  - Updated immunity and cloaking messages to display remaining duration in seconds for improved clarity.

- **New Features**
  - Added a check to prevent attacks from or against cloaked structures, enhancing gameplay fairness.
  - Introduced a method to identify special "daydreams agents" for more precise attack validations.

- **Chores**
  - Updated configuration to disable certain battle timing parameters, streamlining the battle system setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->