### PR TITLE
allow different structrure capacity per structure type

### DIFF
--- a/client/apps/game/src/ui/components/production/buildings-list.tsx
+++ b/client/apps/game/src/ui/components/production/buildings-list.tsx
@@ -1,8 +1,8 @@
 import { BUILDING_IMAGES_PATH } from "@/ui/config";
 import { ResourceIcon } from "@/ui/elements/resource-icon";
 import { getBlockTimestamp } from "@/utils/timestamp";
-import { BuildingType, getProducedResource, RealmInfo, ResourcesIds } from "@bibliothecadao/types";
 import { useBuildings, useResourceManager } from "@bibliothecadao/react";
+import { BuildingType, getProducedResource, RealmInfo, ResourcesIds } from "@bibliothecadao/types";
 import { useMemo } from "react";
 import { ResourceChip } from "../resources/resource-chip";
 

--- a/client/apps/game/src/ui/modules/navigation/capacity-info.tsx
+++ b/client/apps/game/src/ui/modules/navigation/capacity-info.tsx
@@ -1,8 +1,8 @@
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { ResourceIcon } from "@/ui/elements/resource-icon";
 import { configManager, getRealmInfo } from "@bibliothecadao/eternum";
-import { BuildingType, ResourcesIds } from "@bibliothecadao/types";
 import { useDojo } from "@bibliothecadao/react";
+import { BuildingType, ResourcesIds } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import clsx from "clsx";

--- a/config/deployer/config.ts
+++ b/config/deployer/config.ts
@@ -928,7 +928,11 @@ export const setVillageControllersConfig = async (config: Config) => {
 export const setCapacityConfig = async (config: Config) => {
   const calldata = {
     signer: config.account,
-    structure_capacity: config.config.carryCapacityGram[CapacityConfig.Structure],
+    realm_capacity: config.config.carryCapacityGram[CapacityConfig.RealmStructure],
+    village_capacity: config.config.carryCapacityGram[CapacityConfig.VillageStructure],
+    hyperstructure_capacity: config.config.carryCapacityGram[CapacityConfig.HyperstructureStructure],
+    fragment_mine_capacity: config.config.carryCapacityGram[CapacityConfig.FragmentMineStructure],
+    bank_structure_capacity: config.config.carryCapacityGram[CapacityConfig.BankStructure],
     troop_capacity: config.config.carryCapacityGram[CapacityConfig.Army],
     donkey_capacity: config.config.carryCapacityGram[CapacityConfig.Donkey],
     storehouse_boost_capacity: config.config.carryCapacityGram[CapacityConfig.Storehouse],
@@ -941,7 +945,11 @@ export const setCapacityConfig = async (config: Config) => {
   );
 
   const capacities = [
-    { name: "Structure", value: calldata.structure_capacity },
+    { name: "Realm", value: calldata.realm_capacity },
+    { name: "Village", value: calldata.village_capacity },
+    { name: "Hyperstructure", value: calldata.hyperstructure_capacity },
+    { name: "Fragment Mine", value: calldata.fragment_mine_capacity },
+    { name: "Bank", value: calldata.bank_structure_capacity },
     { name: "Troops", value: calldata.troop_capacity },
     { name: "Donkeys", value: calldata.donkey_capacity },
     {

--- a/config/environments/_shared_.ts
+++ b/config/environments/_shared_.ts
@@ -227,7 +227,11 @@ export const EternumGlobalConfig: Config = {
   },
   carryCapacityGram: {
     [CapacityConfig.None]: 0,
-    [CapacityConfig.Structure]: 400_000_000_000, // 400m kg
+    [CapacityConfig.RealmStructure]: 400_000_000_000, // 400m kg
+    [CapacityConfig.VillageStructure]: 200_000_000_000, // 200m kg
+    [CapacityConfig.HyperstructureStructure]: 1_800_000_000, // 1.8m kg
+    [CapacityConfig.BankStructure]: 400_000_000_000, // 400m kg
+    [CapacityConfig.FragmentMineStructure]: 100_000_000, // 100k kg
     [CapacityConfig.Donkey]: 500_000,
     // 10_000 gr per army
     [CapacityConfig.Army]: 10_000,

--- a/contracts/game/src/models/config.cairo
+++ b/contracts/game/src/models/config.cairo
@@ -226,7 +226,7 @@ pub struct StructureCapacityConfig {
     pub village_capacity: u64, // grams
     pub hyperstructure_capacity: u64, // grams
     pub fragment_mine_capacity: u64, // grams
-    pub bank_structure_capacity: u64 // grams
+    pub bank_structure_capacity: u64,
 }
 
 // speed

--- a/contracts/game/src/models/config.cairo
+++ b/contracts/game/src/models/config.cairo
@@ -45,6 +45,7 @@ pub struct WorldConfig {
     pub village_pass_config: VillageTokenConfig,
     pub wonder_production_bonus_config: WonderProductionBonusConfig,
     pub quest_config: QuestConfig,
+    pub structure_capacity_config: StructureCapacityConfig,
 }
 
 #[derive(Introspect, Copy, Drop, Serde)]
@@ -213,10 +214,19 @@ pub struct HyperstructureCostConfig {
 
 #[derive(IntrospectPacked, Copy, Drop, Serde)]
 pub struct CapacityConfig {
-    pub structure_capacity: u128, // grams
+    pub structure_capacity: u128, // grams // deprecated
     pub troop_capacity: u32, // grams
     pub donkey_capacity: u32, // grams
     pub storehouse_boost_capacity: u32,
+}
+
+#[derive(IntrospectPacked, Copy, Drop, Serde)]
+pub struct StructureCapacityConfig {
+    pub realm_capacity: u64, // grams
+    pub village_capacity: u64, // grams
+    pub hyperstructure_capacity: u64, // grams
+    pub fragment_mine_capacity: u64, // grams
+    pub bank_structure_capacity: u64 // grams
 }
 
 // speed

--- a/contracts/game/src/systems/config/contracts.cairo
+++ b/contracts/game/src/systems/config/contracts.cairo
@@ -1,7 +1,7 @@
 use s1_eternum::models::config::{
     BattleConfig, CapacityConfig, HyperstructureConstructConfig, MapConfig, QuestConfig, ResourceBridgeConfig,
-    ResourceBridgeFeeSplitConfig, ResourceBridgeWhitelistConfig, TradeConfig, TroopDamageConfig, TroopLimitConfig,
-    TroopStaminaConfig, VillageTokenConfig,
+    ResourceBridgeFeeSplitConfig, ResourceBridgeWhitelistConfig, StructureCapacityConfig, TradeConfig,
+    TroopDamageConfig, TroopLimitConfig, TroopStaminaConfig, VillageTokenConfig,
 };
 use s1_eternum::models::resource::production::building::BuildingCategory;
 
@@ -76,7 +76,9 @@ pub trait IWeightConfig<T> {
 
 #[starknet::interface]
 pub trait ICapacityConfig<T> {
-    fn set_capacity_config(ref self: T, capacity_config: CapacityConfig);
+    fn set_capacity_config(
+        ref self: T, non_structure_capacity_config: CapacityConfig, structure_capacity_config: StructureCapacityConfig,
+    );
 }
 
 #[starknet::interface]
@@ -207,8 +209,8 @@ pub mod config_systems {
         HyperstructureConfig, HyperstructureConstructConfig, HyperstructureCostConfig, MapConfig, QuestConfig,
         ResourceBridgeConfig, ResourceBridgeFeeSplitConfig, ResourceBridgeWhitelistConfig, ResourceFactoryConfig,
         ResourceRevBridgeWhtelistConfig, SeasonAddressesConfig, SeasonConfig, SettlementConfig, SpeedConfig,
-        StartingResourcesConfig, StructureLevelConfig, StructureMaxLevelConfig, TickConfig, TradeConfig,
-        TroopDamageConfig, TroopLimitConfig, TroopStaminaConfig, VillageTokenConfig, WeightConfig,
+        StartingResourcesConfig, StructureCapacityConfig, StructureLevelConfig, StructureMaxLevelConfig, TickConfig,
+        TradeConfig, TroopDamageConfig, TroopLimitConfig, TroopStaminaConfig, VillageTokenConfig, WeightConfig,
         WonderProductionBonusConfig, WorldConfig, WorldConfigUtilImpl,
     };
     use s1_eternum::models::name::AddressName;
@@ -471,11 +473,18 @@ pub mod config_systems {
 
     #[abi(embed_v0)]
     impl CapacityConfigImpl of super::ICapacityConfig<ContractState> {
-        fn set_capacity_config(ref self: ContractState, capacity_config: CapacityConfig) {
+        fn set_capacity_config(
+            ref self: ContractState,
+            non_structure_capacity_config: CapacityConfig,
+            structure_capacity_config: StructureCapacityConfig,
+        ) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
             assert_caller_is_admin(world);
 
-            WorldConfigUtilImpl::set_member(ref world, selector!("capacity_config"), capacity_config);
+            WorldConfigUtilImpl::set_member(ref world, selector!("capacity_config"), non_structure_capacity_config);
+            WorldConfigUtilImpl::set_member(
+                ref world, selector!("structure_capacity_config"), structure_capacity_config,
+            );
         }
     }
 

--- a/contracts/game/src/systems/utils/structure.cairo
+++ b/contracts/game/src/systems/utils/structure.cairo
@@ -3,7 +3,9 @@ use dojo::model::ModelStorage;
 use dojo::world::{WorldStorage, WorldStorageTrait};
 use s1_eternum::alias::ID;
 use s1_eternum::constants::{DAYDREAMS_AGENT_ID, RESOURCE_PRECISION, ResourceTypes};
-use s1_eternum::models::config::{CapacityConfig, StartingResourcesConfig, VillageTokenConfig, WorldConfigUtilImpl};
+use s1_eternum::models::config::{
+    StartingResourcesConfig, StructureCapacityConfig, VillageTokenConfig, WorldConfigUtilImpl,
+};
 use s1_eternum::models::map::{Tile, TileImpl, TileOccupier};
 use s1_eternum::models::position::{Coord, CoordImpl, Direction};
 use s1_eternum::models::resource::resource::{
@@ -155,8 +157,18 @@ pub impl iStructureImpl of IStructureTrait {
         IMapImpl::occupy(ref world, ref tile, tile_occupier, structure_id);
 
         // set structure capacity
-        let capacity_config: CapacityConfig = WorldConfigUtilImpl::get_member(world, selector!("capacity_config"));
-        let capacity: u128 = capacity_config.structure_capacity.into() * RESOURCE_PRECISION;
+        let structure_capacity_config: StructureCapacityConfig = WorldConfigUtilImpl::get_member(
+            world, selector!("structure_capacity_config"),
+        );
+        let capacity: u64 = match category {
+            StructureCategory::None => 0,
+            StructureCategory::Realm => structure_capacity_config.realm_capacity,
+            StructureCategory::Village => structure_capacity_config.village_capacity,
+            StructureCategory::Hyperstructure => structure_capacity_config.hyperstructure_capacity,
+            StructureCategory::FragmentMine => structure_capacity_config.fragment_mine_capacity,
+            StructureCategory::Bank => structure_capacity_config.bank_structure_capacity,
+        };
+        let capacity: u128 = capacity.into() * RESOURCE_PRECISION;
         let structure_weight: Weight = Weight { capacity, weight: 0 };
         ResourceImpl::initialize(ref world, structure_id);
         ResourceImpl::write_weight(ref world, structure_id, structure_weight);

--- a/contracts/game/src/utils/testing/helpers.cairo
+++ b/contracts/game/src/utils/testing/helpers.cairo
@@ -7,8 +7,8 @@ use dojo_cairo_test::{ContractDef, NamespaceDef, WorldStorageTestTrait, spawn_te
 use s1_eternum::alias::ID;
 use s1_eternum::constants::{RESOURCE_PRECISION, ResourceTypes};
 use s1_eternum::models::config::{
-    CapacityConfig, MapConfig, QuestConfig, TickConfig, TroopDamageConfig, TroopLimitConfig, TroopStaminaConfig,
-    VillageTokenConfig, WeightConfig, WorldConfigUtilImpl,
+    CapacityConfig, MapConfig, QuestConfig, StructureCapacityConfig, TickConfig, TroopDamageConfig, TroopLimitConfig,
+    TroopStaminaConfig, VillageTokenConfig, WeightConfig, WorldConfigUtilImpl,
 };
 use s1_eternum::models::config::{CombatConfigImpl, TickImpl};
 use s1_eternum::models::config::{ResourceFactoryConfig};
@@ -122,6 +122,16 @@ pub fn MOCK_CAPACITY_CONFIG() -> CapacityConfig {
     }
 }
 
+pub fn MOCK_STRUCTURE_CAPACITY_CONFIG() -> StructureCapacityConfig {
+    StructureCapacityConfig {
+        realm_capacity: 1000000000000000, // grams
+        village_capacity: 1000000000000000, // grams
+        hyperstructure_capacity: 1000000000000000, // grams
+        fragment_mine_capacity: 1000000000000000, // grams
+        bank_structure_capacity: 1000000000000000 // grams
+    }
+}
+
 pub fn MOCK_WEIGHT_CONFIG(resource_type: u8) -> WeightConfig {
     WeightConfig { resource_type, weight_gram: 100 }
 }
@@ -140,6 +150,10 @@ pub fn tstore_map_config(ref world: WorldStorage, config: MapConfig) {
 
 pub fn tstore_capacity_config(ref world: WorldStorage, capacity_config: CapacityConfig) {
     WorldConfigUtilImpl::set_member(ref world, selector!("capacity_config"), capacity_config);
+}
+
+pub fn tstore_structure_capacity_config(ref world: WorldStorage, structure_capacity_config: StructureCapacityConfig) {
+    WorldConfigUtilImpl::set_member(ref world, selector!("structure_capacity_config"), structure_capacity_config);
 }
 
 pub fn tstore_weight_config(ref world: WorldStorage, weight_configs: Span<WeightConfig>) {
@@ -301,6 +315,7 @@ pub fn tspawn_explorer(ref world: WorldStorage, owner: ID, coord: Coord) -> ID {
 
 pub fn init_config(ref world: WorldStorage) {
     tstore_capacity_config(ref world, MOCK_CAPACITY_CONFIG());
+    tstore_structure_capacity_config(ref world, MOCK_STRUCTURE_CAPACITY_CONFIG());
     tstore_tick_config(ref world, MOCK_TICK_CONFIG());
     tstore_troop_limit_config(ref world, MOCK_TROOP_LIMIT_CONFIG());
     tstore_troop_stamina_config(ref world, MOCK_TROOP_STAMINA_CONFIG());

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -679,24 +679,41 @@ export class ClientConfigManager {
 
   getCapacityConfigKg(category: CapacityConfig) {
     return this.getValueOrDefault(() => {
-      const capacityConfig = getComponentValue(
+      const nonStructureCapacityConfig = getComponentValue(
         this.components.WorldConfig,
         getEntityIdFromKeys([WORLD_CONFIG_ID]),
       )?.capacity_config;
 
+      const structureCapacityConfig = getComponentValue(
+        this.components.WorldConfig,
+        getEntityIdFromKeys([WORLD_CONFIG_ID]),
+      )?.structure_capacity_config;
+
       let capacityInGrams = 0;
       switch (category) {
-        case CapacityConfig.Structure:
-          capacityInGrams = Number(capacityConfig?.structure_capacity ?? 0);
+        case CapacityConfig.RealmStructure:
+          capacityInGrams = Number(structureCapacityConfig?.realm_structure_capacity ?? 0);
+          break;
+        case CapacityConfig.VillageStructure:
+          capacityInGrams = Number(structureCapacityConfig?.village_structure_capacity ?? 0);
+          break;
+        case CapacityConfig.HyperstructureStructure:
+          capacityInGrams = Number(structureCapacityConfig?.hyperstructure_structure_capacity ?? 0);
+          break;
+        case CapacityConfig.FragmentMineStructure:
+          capacityInGrams = Number(structureCapacityConfig?.fragment_mine_structure_capacity ?? 0);
+          break;
+        case CapacityConfig.BankStructure:
+          capacityInGrams = Number(structureCapacityConfig?.bank_structure_capacity ?? 0);
           break;
         case CapacityConfig.Donkey:
-          capacityInGrams = Number(capacityConfig?.donkey_capacity ?? 0);
+          capacityInGrams = Number(nonStructureCapacityConfig?.donkey_capacity ?? 0);
           break;
         case CapacityConfig.Army:
-          capacityInGrams = Number(capacityConfig?.troop_capacity ?? 0);
+          capacityInGrams = Number(nonStructureCapacityConfig?.troop_capacity ?? 0);
           break;
         case CapacityConfig.Storehouse:
-          capacityInGrams = Number(capacityConfig?.storehouse_boost_capacity ?? 0);
+          capacityInGrams = Number(nonStructureCapacityConfig?.storehouse_boost_capacity ?? 0);
           break;
         case CapacityConfig.None:
           return 0;

--- a/packages/core/src/managers/resource-manager.ts
+++ b/packages/core/src/managers/resource-manager.ts
@@ -639,7 +639,6 @@ export class ResourceManager {
   }
 
   public getStoreCapacityKg(): { capacityKg: number; quantity: number } {
-
     const resource = this._getResource()!;
     const structureBuildings = getComponentValue(
       this.components.StructureBuildings,

--- a/packages/core/src/managers/resource-manager.ts
+++ b/packages/core/src/managers/resource-manager.ts
@@ -1,9 +1,9 @@
 // import { getEntityIdFromKeys, gramToKg, multiplyByPrecision } from "@/ui/utils/utils";
-import { BuildingType, CapacityConfig, ClientComponents, ID, Resource, ResourcesIds } from "@bibliothecadao/types";
+import { BuildingType, ClientComponents, ID, Resource, RESOURCE_PRECISION, ResourcesIds } from "@bibliothecadao/types";
 import { ComponentValue, getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { uuid } from "@latticexyz/utils";
-import { getBuildingCount, kgToGram, multiplyByPrecision } from "../utils";
+import { getBuildingCount, gramToKg, kgToGram, multiplyByPrecision } from "../utils";
 import { configManager } from "./config-manager";
 
 export class ResourceManager {
@@ -639,14 +639,12 @@ export class ResourceManager {
   }
 
   public getStoreCapacityKg(): { capacityKg: number; quantity: number } {
-    const storehouseCapacityKg = configManager.getCapacityConfigKg(CapacityConfig.Storehouse);
+
+    const resource = this._getResource()!;
     const structureBuildings = getComponentValue(
       this.components.StructureBuildings,
       getEntityIdFromKeys([BigInt(this.entityId || 0)]),
     );
-
-    const structureCapacityKg = configManager.getCapacityConfigKg(CapacityConfig.Structure);
-
     const packBuildingCounts = [
       structureBuildings?.packed_counts_1 || 0n,
       structureBuildings?.packed_counts_2 || 0n,
@@ -655,7 +653,7 @@ export class ResourceManager {
     const quantity = getBuildingCount(BuildingType.Storehouse, packBuildingCounts) || 0;
 
     return {
-      capacityKg: Number(quantity) * storehouseCapacityKg + structureCapacityKg,
+      capacityKg: gramToKg(Number(resource.weight.capacity) / RESOURCE_PRECISION),
       quantity,
     };
   }

--- a/packages/core/src/utils/entities.ts
+++ b/packages/core/src/utils/entities.ts
@@ -1,15 +1,15 @@
-import { ComponentValue, getComponentValue } from "@dojoengine/recs";
-import { getEntityIdFromKeys } from "@dojoengine/utils";
-import { shortString } from "starknet";
-import { configManager } from "../managers/config-manager";
 import {
   CapacityConfig,
-  StructureType,
   ClientComponents,
   ContractAddress,
   EntityType,
   ID,
+  StructureType,
 } from "@bibliothecadao/types";
+import { ComponentValue, getComponentValue } from "@dojoengine/recs";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { shortString } from "starknet";
+import { configManager } from "../managers/config-manager";
 import { getRealmNameById } from "./realm";
 
 export const getEntityInfo = (entityId: ID, playerAccount: ContractAddress, components: ClientComponents) => {
@@ -32,13 +32,16 @@ export const getEntityInfo = (entityId: ID, playerAccount: ContractAddress, comp
     owner = structure.owner;
   }
 
-  const capacityCategoryId = explorer
-    ? CapacityConfig.Army
-    : structure
-      ? CapacityConfig.Storehouse
-      : structure
-        ? CapacityConfig.Structure
-        : CapacityConfig.None;
+  let capacityCategoryId: CapacityConfig;
+  if (explorer) {
+      capacityCategoryId = CapacityConfig.Army;
+  } else if (structure) {
+      // hmm
+      capacityCategoryId = CapacityConfig.Storehouse;
+  } else {
+      capacityCategoryId = CapacityConfig.None;
+  }
+
   const capacityKg = configManager.getCapacityConfigKg(capacityCategoryId);
 
   return {

--- a/packages/core/src/utils/entities.ts
+++ b/packages/core/src/utils/entities.ts
@@ -34,12 +34,12 @@ export const getEntityInfo = (entityId: ID, playerAccount: ContractAddress, comp
 
   let capacityCategoryId: CapacityConfig;
   if (explorer) {
-      capacityCategoryId = CapacityConfig.Army;
+    capacityCategoryId = CapacityConfig.Army;
   } else if (structure) {
-      // hmm
-      capacityCategoryId = CapacityConfig.Storehouse;
+    // hmm
+    capacityCategoryId = CapacityConfig.Storehouse;
   } else {
-      capacityCategoryId = CapacityConfig.None;
+    capacityCategoryId = CapacityConfig.None;
   }
 
   const capacityKg = configManager.getCapacityConfigKg(capacityCategoryId);

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -2005,12 +2005,32 @@ export class EternumProvider extends EnhancedDojoProvider {
   }
 
   public async set_capacity_config(props: SystemProps.SetCapacityConfigProps) {
-    const { troop_capacity, donkey_capacity, storehouse_boost_capacity, realm_capacity, village_capacity, hyperstructure_capacity, fragment_mine_capacity, bank_structure_capacity, signer } = props;
+    const {
+      troop_capacity,
+      donkey_capacity,
+      storehouse_boost_capacity,
+      realm_capacity,
+      village_capacity,
+      hyperstructure_capacity,
+      fragment_mine_capacity,
+      bank_structure_capacity,
+      signer,
+    } = props;
 
     return await this.executeAndCheckTransaction(signer, {
       contractAddress: getContractByName(this.manifest, `${NAMESPACE}-config_systems`),
       entrypoint: "set_capacity_config",
-      calldata: [0, troop_capacity, donkey_capacity, storehouse_boost_capacity, realm_capacity, village_capacity, hyperstructure_capacity, fragment_mine_capacity, bank_structure_capacity],
+      calldata: [
+        0,
+        troop_capacity,
+        donkey_capacity,
+        storehouse_boost_capacity,
+        realm_capacity,
+        village_capacity,
+        hyperstructure_capacity,
+        fragment_mine_capacity,
+        bank_structure_capacity,
+      ],
     });
   }
 

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -2005,12 +2005,12 @@ export class EternumProvider extends EnhancedDojoProvider {
   }
 
   public async set_capacity_config(props: SystemProps.SetCapacityConfigProps) {
-    const { structure_capacity, troop_capacity, donkey_capacity, storehouse_boost_capacity, signer } = props;
+    const { troop_capacity, donkey_capacity, storehouse_boost_capacity, realm_capacity, village_capacity, hyperstructure_capacity, fragment_mine_capacity, bank_structure_capacity, signer } = props;
 
     return await this.executeAndCheckTransaction(signer, {
       contractAddress: getContractByName(this.manifest, `${NAMESPACE}-config_systems`),
       entrypoint: "set_capacity_config",
-      calldata: [structure_capacity, troop_capacity, donkey_capacity, storehouse_boost_capacity],
+      calldata: [0, troop_capacity, donkey_capacity, storehouse_boost_capacity, realm_capacity, village_capacity, hyperstructure_capacity, fragment_mine_capacity, bank_structure_capacity],
     });
   }
 

--- a/packages/types/src/constants/structures.ts
+++ b/packages/types/src/constants/structures.ts
@@ -262,10 +262,14 @@ export function getProducedResource(category: BuildingType): ResourcesIds | unde
 
 export enum CapacityConfig {
   None = 0,
-  Structure = 1,
+  RealmStructure = 1,
   Donkey = 2,
   Army = 3,
   Storehouse = 4,
+  VillageStructure = 5,
+  HyperstructureStructure = 6,
+  BankStructure = 7,
+  FragmentMineStructure = 8,
 }
 
 export const CAPACITY_CONFIG_CATEGORY_STRING_MAP: { [key: string]: number } = {

--- a/packages/types/src/dojo/contract-components.ts
+++ b/packages/types/src/dojo/contract-components.ts
@@ -1270,6 +1270,13 @@ export function defineContractComponents(world: World) {
             token_address: RecsType.BigInt,
             mint_recipient_address: RecsType.BigInt,
           },
+          structure_capacity_config: {
+            realm_structure_capacity: RecsType.BigInt,
+            village_structure_capacity: RecsType.BigInt,
+            hyperstructure_structure_capacity: RecsType.BigInt,
+            fragment_mine_structure_capacity: RecsType.BigInt,
+            bank_structure_capacity: RecsType.BigInt,
+          },
         },
         {
           metadata: {
@@ -1374,6 +1381,11 @@ export function defineContractComponents(world: World) {
               "Span<ContractAddress>", // village controller addresses
               "ContractAddress", // village VillageTokenConfig token_address
               "ContractAddress", // village VillageTokenConfig mint_recipient_address
+              "u64", // StructureCapacityConfig realm_structure_capacity
+              "u64", // StructureCapacityConfig village_structure_capacity
+              "u64", // StructureCapacityConfig hyperstructure_structure_capacity
+              "u64", // StructureCapacityConfig fragment_mine_structure_capacity
+              "u64", // StructureCapacityConfig bank_structure_capacity
             ],
             customTypes: [],
           },

--- a/packages/types/src/types/provider.ts
+++ b/packages/types/src/types/provider.ts
@@ -355,10 +355,15 @@ export interface SetTravelFoodCostConfigProps extends SystemSigner {
 }
 
 export interface SetCapacityConfigProps extends SystemSigner {
-  structure_capacity: num.BigNumberish; // grams
   troop_capacity: num.BigNumberish; // grams
   donkey_capacity: num.BigNumberish; // grams
   storehouse_boost_capacity: num.BigNumberish; // grams
+
+  realm_capacity: num.BigNumberish; // grams
+  village_capacity: num.BigNumberish; // grams
+  hyperstructure_capacity: num.BigNumberish; // grams
+  fragment_mine_capacity: num.BigNumberish; // grams
+  bank_structure_capacity: num.BigNumberish; // grams
 }
 
 export interface SetAgentConfigProps extends SystemSigner {


### PR DESCRIPTION
- Updated capacity configuration to separate structure capacities into a new StructureCapacityConfig.
- Modified related components and contracts to accommodate the new structure capacity settings for realms, villages, hyperstructures, fragment mines, and banks.
- Adjusted resource management logic to utilize the new structure capacity configurations.
- Cleaned up imports and improved type definitions for better clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring and managing separate capacity limits for different structure types, including realm, village, hyperstructure, bank, and fragment mine structures.

- **Refactor**
  - Updated terminology and configuration to replace a single generic structure capacity with more specific capacity categories.
  - Improved capacity calculations and configuration management to use these new categories across the app.

- **Style**
  - Minor reordering of import statements for improved code clarity.

- **Documentation**
  - Deprecated the old generic structure capacity in favor of the new specific categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->