### PR TITLE
contracts: increase troop max explorer count during level upgrade

### DIFF
--- a/contracts/game/src/systems/structure/contracts.cairo
+++ b/contracts/game/src/systems/structure/contracts.cairo
@@ -89,6 +89,7 @@ pub mod structure_systems {
             // update structure level and troop max guard count
             structure_base.level = next_level;
             structure_base.troop_max_guard_count += 1;
+            structure_base.troop_max_explorer_count += 1;
             StructureBaseStoreImpl::store(ref structure_base, ref world, structure_id);
 
             // update structure tile


### PR DESCRIPTION
resolves #2949 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Structures now gain an additional explorer slot when leveled up, increasing both guard and explorer capacities by 1 per level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->