### PR TITLE
contracts: reset guard slots after battle claim

### DIFF
--- a/contracts/game/src/models/troop.cairo
+++ b/contracts/game/src/models/troop.cairo
@@ -135,6 +135,16 @@ pub impl GuardImpl of GuardTrait {
         }
     }
 
+    fn reset_all_slots(ref self: GuardTroops) {
+        let default_troops: Troops = Troops {
+            category: TroopType::Knight, tier: TroopTier::T1, count: 0, stamina: Default::default(),
+        };
+        self.delta = default_troops;
+        self.charlie = default_troops;
+        self.bravo = default_troops;
+        self.alpha = default_troops;
+    }
+
     fn from_slot(self: GuardTroops, slot: GuardSlot) -> (Troops, u32) {
         match slot {
             GuardSlot::Delta => (self.delta, self.delta_destroyed_tick),

--- a/contracts/game/src/systems/combat/contracts/troop_battle.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_battle.cairo
@@ -250,7 +250,10 @@ pub mod troop_battle_systems {
 
             // claim structure if there are no guard troops. it is tried again after the attack
             if guard_slot.is_none() {
-                iStructureImpl::claim(ref world, ref guarded_structure, ref explorer_aggressor, structure_id);
+                // claim structure
+                iStructureImpl::battle_claim(
+                    ref world, ref guard_defender, ref guarded_structure, ref explorer_aggressor, structure_id,
+                );
                 return;
             }
 
@@ -332,7 +335,10 @@ pub mod troop_battle_systems {
                     let guard_slot: Option<GuardSlot> = guard_defender
                         .next_attack_slot(guarded_structure.troop_max_guard_count.into());
                     if guard_slot.is_none() {
-                        iStructureImpl::claim(ref world, ref guarded_structure, ref explorer_aggressor, structure_id);
+                        // claim structure
+                        iStructureImpl::battle_claim(
+                            ref world, ref guard_defender, ref guarded_structure, ref explorer_aggressor, structure_id,
+                        );
                     }
                 }
             } else {
@@ -474,8 +480,13 @@ pub mod troop_battle_systems {
                     let guard_slot: Option<GuardSlot> = structure_guards_aggressor
                         .next_attack_slot(structure_aggressor_base.troop_max_guard_count.into());
                     if guard_slot.is_none() {
-                        iStructureImpl::claim(
-                            ref world, ref structure_aggressor_base, ref explorer_defender, structure_id,
+                        // claim structure
+                        iStructureImpl::battle_claim(
+                            ref world,
+                            ref structure_guards_aggressor,
+                            ref structure_aggressor_base,
+                            ref explorer_defender,
+                            structure_id,
                         );
                     }
                 }


### PR DESCRIPTION
resolves #2951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new method to reset all guard troop slots to default values.
	- Introduced a new battle claim action that resets guard troops and transfers structure ownership during battles.

- **Improvements**
	- Updated battle system to use the new battle claim action for more accurate guard and ownership handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->