### PR TITLE
contracts: ensure defense deosnt lose troops and update attacker stamina loss

### DIFF
--- a/contracts/game/src/models/troop.cairo
+++ b/contracts/game/src/models/troop.cairo
@@ -716,7 +716,7 @@ mod tests {
 
         assert_eq!(alpha.count, 0);
         assert_eq!(bravo.count, 499_999 * RESOURCE_PRECISION);
-        assert_eq!(bravo.stamina.amount, 100);
+        assert_eq!(bravo.stamina.amount, 130);
     }
 
     #[test]
@@ -738,6 +738,6 @@ mod tests {
 
         assert_eq!(alpha.count, 0);
         assert_eq!(bravo.count, 2_052 * RESOURCE_PRECISION);
-        assert_eq!(bravo.stamina.amount, 100);
+        assert_eq!(bravo.stamina.amount, 130);
     }
 }

--- a/contracts/game/src/models/troop.cairo
+++ b/contracts/game/src/models/troop.cairo
@@ -738,6 +738,6 @@ mod tests {
 
         assert_eq!(alpha.count, 0);
         assert_eq!(bravo.count, 2_052 * RESOURCE_PRECISION);
-        assert_eq!(bravo.stamina.amount, 130);
+        assert_eq!(bravo.stamina.amount, 120);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Attack stamina cost for troops is now dynamically calculated based on damage potential, providing more accurate stamina usage during battles.

- **Bug Fixes**
  - Defender troops no longer lose stamina during attacks, ensuring only attackers expend stamina as intended.
  - Stamina deduction for explorer troops in raids now correctly uses the highest stamina loss incurred, improving raid outcome accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->