### PR TITLE
Season prize leftover transfer to velords

### DIFF
--- a/contracts/game/src/systems/season/contracts.cairo
+++ b/contracts/game/src/systems/season/contracts.cairo
@@ -45,6 +45,15 @@ pub trait ISeasonSystems<T> {
     /// - Fails if the player has no registered points
     /// - Fails if the token transfer fails
     fn season_prize_claim(ref self: T);
+
+
+    /// Transfers unclaimed LORDS tokens to the velords contract address
+    ///
+    /// This function can only be called when the following conditions are met:
+    /// - The season has ended
+    /// - The claiming period has started (after the registration grace period)
+    /// - A period of 3 weeks have passed since the claiming period started
+    fn season_transfer_unclaimed_lords(ref self: T);
 }
 
 #[dojo::contract]
@@ -175,6 +184,55 @@ pub mod season_systems {
             // set claimed to true
             player_points.prize_claimed = true;
             world.write_model(@player_points);
+        }
+
+
+        fn season_transfer_unclaimed_lords(ref self: ContractState) {
+            let mut world: WorldStorage = self.world(DEFAULT_NS());
+
+            // ensure the season has ended
+            // note: season.end_at must to set to avoid fatal bug
+            let season_config = SeasonConfigImpl::get(world);
+            assert!(season_config.has_ended(), "Season has not ended");
+
+            // ensure claiming period has started
+            let season_prize_registration_end_at = season_config.end_at
+                + season_config.registration_grace_seconds.into();
+            assert!(
+                season_prize_registration_end_at < starknet::get_block_timestamp(),
+                "claiming period hasn't started yet",
+            );
+
+            // ensure a period of 3 weeks have passed since the claiming period started
+            let one_day = 60 * 60 * 24;
+            let one_week = one_day * 7;
+            let three_weeks = one_week * 3;
+            assert!(
+                season_prize_registration_end_at + three_weeks < starknet::get_block_timestamp(),
+                "3 weeks haven't passed yet",
+            );
+
+            let season_addresses_config: SeasonAddressesConfig = WorldConfigUtilImpl::get_member(
+                world, selector!("season_addresses_config"),
+            );
+            let res_bridge_fee_split_config: ResourceBridgeFeeSplitConfig = WorldConfigUtilImpl::get_member(
+                world, selector!("res_bridge_fee_split_config"),
+            );
+            let lords_address = season_addresses_config.lords_address;
+            let sender = res_bridge_fee_split_config.season_pool_fee_recipient;
+            let lords_contract = ERC20ABIDispatcher { contract_address: lords_address };
+            let lords_balance = lords_contract.balance_of(sender);
+            let velords_address = res_bridge_fee_split_config.velords_fee_recipient;
+
+            let self = starknet::get_contract_address();
+            if sender == self {
+                assert!(lords_contract.transfer(velords_address, lords_balance), "Failed to transfer LORDS to velords");
+            } else {
+                assert!(
+                    lords_contract.transfer_from(sender, velords_address, lords_balance),
+                    "Failed to transfer LORDS to velords",
+                );
+            }
         }
     }
 }

--- a/contracts/game/src/systems/season/contracts.cairo
+++ b/contracts/game/src/systems/season/contracts.cairo
@@ -117,7 +117,6 @@ pub mod season_systems {
             assert!(season_config.has_ended(), "Season has not ended");
 
             // ensure claiming period has started
-            let season_config = SeasonConfigImpl::get(world);
             let season_prize_registration_end_at = season_config.end_at
                 + season_config.registration_grace_seconds.into();
             assert!(


### PR DESCRIPTION
resolves #2923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to transfer any unclaimed LORDS tokens from the season pool to the designated velords address once the season has ended and specific time conditions are met.

- **Bug Fixes**
  - Removed redundant configuration retrieval during prize claiming to streamline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->