### PR TITLE
contracts: validate arrival time

### DIFF
--- a/contracts/game/src/models/resource/arrivals.cairo
+++ b/contracts/game/src/models/resource/arrivals.cairo
@@ -112,6 +112,25 @@ pub impl ResourceArrivalImpl of ResourceArrivalTrait {
     }
 
 
+    // todo: verify
+    fn slot_time_has_passed(ref world: WorldStorage, day: u64, slot: u8) -> bool {
+        let (last_open_slot_day, last_open_slot_hour) = Self::previous_arrival_slot(ref world, 0);
+
+        if day < last_open_slot_day {
+            return true;
+        }
+
+        if day == last_open_slot_day {
+            if slot <= last_open_slot_hour {
+                return true;
+            } else {
+                return false;
+            }
+        }
+        return false;
+    }
+
+
     fn previous_arrival_slot(ref world: WorldStorage, travel_time: u64) -> (u64, u8) {
         let (arrival_day, arrival_slot) = Self::arrival_slot(ref world, travel_time);
         if arrival_slot == 1 {

--- a/contracts/game/src/systems/utils/resource.cairo
+++ b/contracts/game/src/systems/utils/resource.cairo
@@ -429,6 +429,9 @@ pub impl iResourceTransferImpl of iResourceTransferTrait {
             ref world, to_structure_id, day,
         );
 
+        let arrived = ResourceArrivalImpl::slot_time_has_passed(ref world, day, slot);
+        assert!(arrived, "The items have not arrived yet");
+
         // todo: delay delivery by day and slot
         let mut index_counted: u8 = 0;
         let mut total_amount_deposited: u128 = 0;


### PR DESCRIPTION
- Implemented slot_time_has_passed to check if the arrival slot time has passed based on the current day and slot.
- Integrated the new function into the resource transfer process to assert item arrival status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a check to ensure resources can only be delivered after their scheduled arrival time.

- **Bug Fixes**
  - Prevented premature delivery of resources by verifying that the arrival time has passed before allowing delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->