### PR TITLE
feat: Add name field to StructureOwnerStats and update name setting logic

### DIFF
--- a/contracts/game/src/models/structure.cairo
+++ b/contracts/game/src/models/structure.cairo
@@ -36,6 +36,7 @@ pub struct StructureOwnerStats {
     #[key]
     pub owner: ContractAddress,
     pub structures_num: u32,
+    pub name: felt252,
 }
 
 #[generate_trait]

--- a/contracts/game/src/systems/name/contracts.cairo
+++ b/contracts/game/src/systems/name/contracts.cairo
@@ -18,18 +18,25 @@ pub mod name_systems {
         fn set_address_name(ref self: ContractState, name: felt252) {
             // todo: limit this to only realm/village owners else it can be spammed
             let mut world: WorldStorage = self.world(DEFAULT_NS());
-            SeasonConfigImpl::get(world).assert_started_and_not_over();
+
+            // we can bypass this check because no user would own a structure
+            // until the season starts
+            // SeasonConfigImpl::get(world).assert_started_and_not_over();
 
             let caller = starknet::get_caller_address();
-            let structure_owner_stats: StructureOwnerStats = world.read_model(caller);
+            let mut structure_owner_stats: StructureOwnerStats = world.read_model(caller);
             assert!(structure_owner_stats.structures_num > 0, "Caller does not own any structure");
 
             // assert that name not set
             let mut address_name: AddressName = world.read_model(caller);
             assert!(address_name.name == 0, "Name already set");
-            address_name.name = name;
 
+            // set name
+            address_name.name = name;
             world.write_model(@address_name);
+
+            structure_owner_stats.name = name;
+            world.write_model(@structure_owner_stats);
         }
     }
 }


### PR DESCRIPTION

- Introduced a new `name` field in the `StructureOwnerStats` struct.
- Modified the `set_address_name` function to update both the `address_name` and `structure_owner_stats` with the provided name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visible name field to structure owner statistics, allowing users to set and view a name associated with their owned structures.

- **Bug Fixes**
  - Ensured that setting a name updates both the address and the structure owner statistics for consistency across user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->