### PR TITLE
fix set address name

### DIFF
--- a/client/apps/game/src/hooks/helpers/use-set-address-name.ts
+++ b/client/apps/game/src/hooks/helpers/use-set-address-name.ts
@@ -31,10 +31,11 @@ export const useSetAddressName = (value: SetupResult, controllerAccount: Account
       }
 
       const usernameFelt = cairoShortStringToFelt(username.slice(0, 31));
-      value.systemCalls.set_address_name({
+      const calldata = {
         signer: controllerAccount!,
         name: usernameFelt,
-      });
+      };
+      value.systemCalls.set_address_name(calldata);
       setAddressName(username);
       setIsAddressNameSet(true);
     };

--- a/client/apps/game/src/hooks/helpers/use-set-address-name.ts
+++ b/client/apps/game/src/hooks/helpers/use-set-address-name.ts
@@ -1,0 +1,62 @@
+import { useAddressStore } from "@/hooks/store/use-address-store";
+import { SetupResult } from "@bibliothecadao/dojo";
+import { useDojo } from "@bibliothecadao/react";
+import { ContractAddress } from "@bibliothecadao/types";
+import ControllerConnector from "@cartridge/connector/controller";
+import { getComponentValue } from "@dojoengine/recs";
+import { cairoShortStringToFelt } from "@dojoengine/torii-client";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { useEffect, useState } from "react";
+import { AccountInterface, shortString } from "starknet";
+
+export const useSetAddressName = (value: SetupResult, controllerAccount: AccountInterface | null, connector: any) => {
+  const {
+    setup: { components },
+  } = useDojo();
+
+  const setAddressName = useAddressStore((state) => state.setAddressName);
+  const [isAddressNameSet, setIsAddressNameSet] = useState(false);
+
+  useEffect(() => {
+    const setUserName = async () => {
+      let username;
+      try {
+        username = await (connector as unknown as ControllerConnector)?.username();
+        if (!username) {
+          username = "adventurer"; // Default to adventurer in local mode
+        }
+      } catch (error) {
+        username = "adventurer"; // If username() fails, we're in local mode
+        console.log("Using default username 'adventurer' for local mode");
+      }
+
+      const usernameFelt = cairoShortStringToFelt(username.slice(0, 31));
+      value.systemCalls.set_address_name({
+        signer: controllerAccount!,
+        name: usernameFelt,
+      });
+      setAddressName(username);
+      setIsAddressNameSet(true);
+    };
+
+    const handleAddressName = async () => {
+      if (controllerAccount) {
+        const address = ContractAddress(controllerAccount.address);
+        // can use because we have synced all address names
+        const addressName = getComponentValue(components.AddressName, getEntityIdFromKeys([address]))?.name;
+
+        if (!addressName) {
+          await setUserName();
+        } else {
+          const decodedAddressName = shortString.decodeShortString(addressName?.toString());
+          setAddressName(decodedAddressName);
+          setIsAddressNameSet(true);
+        }
+      }
+    };
+
+    handleAddressName();
+  }, [controllerAccount, connector, value, setAddressName]);
+
+  return isAddressNameSet;
+};

--- a/client/apps/game/src/ui/modules/onboarding/steps.tsx
+++ b/client/apps/game/src/ui/modules/onboarding/steps.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as Eye } from "@/assets/icons/eye.svg";
 import { ReactComponent as Sword } from "@/assets/icons/sword.svg";
 import { ReactComponent as TreasureChest } from "@/assets/icons/treasure-chest.svg";
 import { useGoToStructure, useSpectatorModeClick } from "@/hooks/helpers/use-navigate";
+import { useSetAddressName } from "@/hooks/helpers/use-set-address-name";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { Position, Position as PositionInterface } from "@/types/position";
 import {
@@ -18,6 +19,7 @@ import { getRealmsAddress, getSeasonPassAddress } from "@/utils/addresses";
 import { getMaxLayer } from "@/utils/settlement";
 import { useDojo, usePlayerOwnedRealmEntities, usePlayerOwnedVillageEntities } from "@bibliothecadao/react";
 import { getComponentValue } from "@dojoengine/recs";
+import { useAccount } from "@starknet-react/core";
 import { motion } from "framer-motion";
 import { useEffect, useMemo, useState } from "react";
 import { env } from "../../../../env";
@@ -194,9 +196,12 @@ export const LocalStepOne = () => {
 export const StepOne = () => {
   const {
     setup: { components },
+    account: { account },
+    setup,
   } = useDojo();
   const hasAcceptedToS = useUIStore((state) => state.hasAcceptedToS);
   const setShowToS = useUIStore((state) => state.setShowToS);
+  const { connector } = useAccount();
 
   const realmEntities = usePlayerOwnedRealmEntities();
   const villageEntities = usePlayerOwnedVillageEntities();
@@ -207,6 +212,9 @@ export const StepOne = () => {
 
   const isSeasonActive = env.VITE_PUBLIC_SEASON_START_TIME <= Date.now() / 1000;
   const canPlay = hasRealmsOrVillages && isSeasonActive;
+
+  // Only set address name if user has realms or villages
+  useSetAddressName(setup, hasRealmsOrVillages ? account : null, connector);
 
   const [timeRemaining, setTimeRemaining] = useState<string>("");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new hook to manage and synchronize user address names within the game client, improving user identity consistency.
- **Refactor**
  - Simplified account initialization logic by removing address name fetching and setting from the context provider.
  - Updated onboarding flow to use the new address name management hook when the user owns a realm or village.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->