### PR TITLE
only remove override when catch error

### DIFF
--- a/packages/core/src/managers/army-action-manager.ts
+++ b/packages/core/src/managers/army-action-manager.ts
@@ -513,9 +513,9 @@ export class ArmyActionManager {
         explore: false,
       });
     } catch (e) {
-      console.log({ e });
-    } finally {
+      // only remove overrides if the move failed
       removeOverrides();
+      console.log({ e });
     }
   };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for army movement actions to ensure overrides are only removed when a move operation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->