### PR TITLE
Add bonuses to labor production and wonders configuration

### DIFF
--- a/client/apps/game/src/ui/components/production/labor-production-controls.tsx
+++ b/client/apps/game/src/ui/components/production/labor-production-controls.tsx
@@ -47,14 +47,15 @@ export const LaborProductionControls = ({ realm }: { realm: RealmInfo }) => {
 
   const { laborAmount, ticks } = useMemo(() => {
     if (!laborConfig.length) return { laborAmount: 0, ticks: 0 };
-    const totalLaborAmount = selectedResources.reduce((acc, resource, index) => {
-      return acc + resource.amount * (laborConfig[index]?.laborProductionPerResource ?? 0);
-    }, 0);
+    const totalLaborAmount =
+      selectedResources.reduce((acc, resource, index) => {
+        return acc + resource.amount * (laborConfig[index]?.laborProductionPerResource ?? 0);
+      }, 0) * 1.2;
 
     const maxTicks = Math.max(
       ...laborConfig.map((config, index) => {
         return Math.ceil(
-          (selectedResources[index].amount * (config?.laborProductionPerResource || 0)) /
+          (selectedResources[index].amount * (config?.laborProductionPerResource || 0) * 1.2) /
             (config?.laborRatePerTick || 0),
         );
       }),

--- a/client/apps/game/src/ui/components/production/labor-resources-panel.tsx
+++ b/client/apps/game/src/ui/components/production/labor-resources-panel.tsx
@@ -1,6 +1,5 @@
 import { NumberInput } from "@/ui/elements/number-input";
 import { ResourceIcon } from "@/ui/elements/resource-icon";
-import { configManager } from "@bibliothecadao/eternum";
 import { ResourcesIds } from "@bibliothecadao/types";
 
 interface LaborResourcesPanelProps {
@@ -10,6 +9,9 @@ interface LaborResourcesPanelProps {
   resourceBalances: Record<number, number>;
   isSelected: boolean;
   onSelect: () => void;
+  laborInputResources: { resource: number; amount: number }[];
+  resourceOutputPerInputResources: number;
+  laborBurnPerResourceOutput: number;
 }
 
 export const LaborResourcesPanel = ({
@@ -19,16 +21,15 @@ export const LaborResourcesPanel = ({
   resourceBalances,
   isSelected,
   onSelect,
+  laborInputResources,
+  resourceOutputPerInputResources,
+  laborBurnPerResourceOutput,
 }: LaborResourcesPanelProps) => {
-  const laborConfig = configManager.getLaborConfig(selectedResource);
-  const laborInputResources = laborConfig?.inputResources;
-  const resourceOutputPerInputResources = laborConfig?.resourceOutputPerInputResources ?? 0;
-
   const handleInputChange = (value: number, inputResource: number) => {
     if (!laborInputResources) return;
     const resourceConfig = laborInputResources.find((r) => r.resource === inputResource);
     if (!resourceConfig) return;
-    const newAmount = (value / laborConfig.laborBurnPerResourceOutput) * laborConfig.resourceOutputPerInputResources;
+    const newAmount = (value / laborBurnPerResourceOutput) * resourceOutputPerInputResources;
     setProductionAmount(newAmount);
   };
 
@@ -37,7 +38,7 @@ export const LaborResourcesPanel = ({
 
     const maxAmounts = laborInputResources.map((input) => {
       const balance = resourceBalances[input.resource] || 0;
-      return Math.floor((balance / input.amount) * laborConfig.resourceOutputPerInputResources);
+      return Math.floor((balance / input.amount) * resourceOutputPerInputResources);
     });
 
     return Math.max(1, Math.min(...maxAmounts));

--- a/client/apps/game/src/ui/components/production/production-controls.tsx
+++ b/client/apps/game/src/ui/components/production/production-controls.tsx
@@ -1,14 +1,33 @@
+import { configManager, getEntityIdFromKeys } from "@bibliothecadao/eternum";
+import { useDojo } from "@bibliothecadao/react";
 import { RealmInfo, ResourcesIds } from "@bibliothecadao/types";
-import { useState } from "react";
+import { getComponentValue } from "@dojoengine/recs";
+import { useMemo, useState } from "react";
 import { LaborProductionControls } from "./labor-production-controls";
 import { ResourceProductionControls } from "./resource-production-controls";
 
 export const ProductionControls = ({ selectedResource, realm }: { selectedResource: number; realm: RealmInfo }) => {
+  const {
+    setup: {
+      components: { ProductionWonderBonus },
+    },
+  } = useDojo();
+
   const isLaborMode = selectedResource === ResourcesIds.Labor;
 
   const [useRawResources, setUseRawResources] = useState(true);
   const [productionAmount, setProductionAmount] = useState(1);
   const [ticks, setTicks] = useState<number | undefined>();
+
+  const bonus = useMemo(() => {
+    const productionWonderBonus = getComponentValue(
+      ProductionWonderBonus,
+      getEntityIdFromKeys([BigInt(realm.entityId)]),
+    );
+    const wonderBonusConfig = configManager.getWonderBonusConfig();
+    const hasActivatedWonderBonus = !!productionWonderBonus;
+    return hasActivatedWonderBonus ? 1 + wonderBonusConfig.bonusPercentNum / 10000 : 1;
+  }, [realm.entityId]);
 
   if (isLaborMode) {
     return <LaborProductionControls realm={realm} />;
@@ -24,6 +43,7 @@ export const ProductionControls = ({ selectedResource, realm }: { selectedResour
       realm={realm}
       ticks={ticks}
       setTicks={setTicks}
+      bonus={bonus}
     />
   );
 };

--- a/client/apps/game/src/ui/components/production/raw-resources-panel.tsx
+++ b/client/apps/game/src/ui/components/production/raw-resources-panel.tsx
@@ -11,7 +11,7 @@ interface RawResourcesPanelProps {
   resourceBalances: Record<number, number>;
   isSelected: boolean;
   onSelect: () => void;
-  outputResource: any;
+  outputResourceAmount: number;
 }
 
 export const RawResourcesPanel = ({
@@ -21,14 +21,14 @@ export const RawResourcesPanel = ({
   resourceBalances,
   isSelected,
   onSelect,
-  outputResource,
+  outputResourceAmount,
 }: RawResourcesPanelProps) => {
   const rawInputResources = useMemo(() => {
     return configManager.complexSystemResourceInputs[selectedResource].map((resource) => ({
       ...resource,
-      amount: resource.amount / outputResource.amount,
+      amount: resource.amount / outputResourceAmount,
     }));
-  }, [selectedResource, outputResource]);
+  }, [selectedResource, outputResourceAmount]);
 
   const handleInputChange = (value: number, inputResource: number) => {
     const resourceConfig = rawInputResources.find((r) => r.resource === inputResource);

--- a/client/apps/game/src/ui/components/production/resource-production-controls.tsx
+++ b/client/apps/game/src/ui/components/production/resource-production-controls.tsx
@@ -19,6 +19,7 @@ export const ResourceProductionControls = ({
   realm,
   ticks,
   setTicks,
+  bonus,
 }: {
   selectedResource: number;
   useRawResources: boolean;
@@ -28,6 +29,7 @@ export const ResourceProductionControls = ({
   realm: RealmInfo;
   ticks: number | undefined;
   setTicks: (value: number) => void;
+  bonus: number;
 }) => {
   const {
     setup: {
@@ -111,8 +113,8 @@ export const ResourceProductionControls = ({
   }, [selectedResource, resourceManager]);
 
   useEffect(() => {
-    setTicks(Math.floor(productionAmount / outputResource.amount));
-  }, [productionAmount]);
+    setTicks(Math.floor((productionAmount / outputResource.amount) * bonus));
+  }, [productionAmount, bonus]);
 
   const rawCurrentInputs = useMemo(() => {
     return configManager.complexSystemResourceInputs[selectedResource].map(({ resource, amount }) => ({
@@ -244,7 +246,7 @@ export const ResourceProductionControls = ({
           {" "}
           <div>
             <h2 className="flex items-center gap-2 mt-4">
-              {productionAmount.toLocaleString()} {ResourcesIds[selectedResource]}
+              {Math.round(productionAmount * bonus).toLocaleString()} {ResourcesIds[selectedResource]}
               <ResourceIcon resource={ResourcesIds[selectedResource]} size="sm" /> to produce
             </h2>
           </div>

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -972,6 +972,25 @@ export class ClientConfigManager {
       resourceOutputPerInputResources: simpleSystemResourceOutput.amount,
     };
   };
+
+  getWonderBonusConfig = () => {
+    return this.getValueOrDefault(
+      () => {
+        const worldConfig = getComponentValue(this.components.WorldConfig, getEntityIdFromKeys([WORLD_CONFIG_ID]));
+        if (!worldConfig) return { withinTileDistance: 0, bonusPercentNum: 0 };
+
+        const wonderBonusConfig = (worldConfig as any).wonder_production_bonus_config;
+        return {
+          withinTileDistance: Number(wonderBonusConfig?.within_tile_distance ?? 0),
+          bonusPercentNum: Number(wonderBonusConfig?.bonus_percent_num ?? 0),
+        };
+      },
+      {
+        withinTileDistance: 0,
+        bonusPercentNum: 0,
+      },
+    );
+  };
 }
 
 export const configManager = ClientConfigManager.instance();

--- a/packages/types/src/dojo/contract-components.ts
+++ b/packages/types/src/dojo/contract-components.ts
@@ -1331,6 +1331,14 @@ export function defineContractComponents(world: World) {
             token_address: RecsType.BigInt,
             mint_recipient_address: RecsType.BigInt,
           },
+          wonder_production_bonus_config: {
+            within_tile_distance: RecsType.Number,
+            bonus_percent_num: RecsType.BigInt,
+          },
+          quest_config: {
+            quest_discovery_prob: RecsType.Number,
+            quest_discovery_fail_prob: RecsType.Number,
+          },
           structure_capacity_config: {
             realm_capacity: RecsType.BigInt,
             village_capacity: RecsType.BigInt,
@@ -1442,6 +1450,10 @@ export function defineContractComponents(world: World) {
               "Span<ContractAddress>", // village controller addresses
               "ContractAddress", // village VillageTokenConfig token_address
               "ContractAddress", // village VillageTokenConfig mint_recipient_address
+              "u8", // WonderProductionBonusConfig within_tile_distance
+              "u128", // WonderProductionBonusConfig bonus_percent_num
+              "u16", // QuestConfig quest_discovery_prob
+              "u16", // QuestConfig quest_discovery_fail_prob
               "u64", // StructureCapacityConfig realm_structure_capacity
               "u64", // StructureCapacityConfig village_structure_capacity
               "u64", // StructureCapacityConfig hyperstructure_structure_capacity


### PR DESCRIPTION
Introduce bonuses for labor production and fix issues related to wonder bonuses and world configuration. Update the configuration manager to handle wonder bonus settings and adjust production calculations accordingly.

closes #3100