### PR TITLE
fix: pin metagame-sdk version to 0.0.16

### DIFF
--- a/client/apps/game/package.json
+++ b/client/apps/game/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21",
     "open": "catalog:",
     "platform": "^1.3.6",
-    "metagame-sdk": "^0.0.16",
+    "metagame-sdk": "0.0.16",
     "postprocessing": "^6.36.2",
     "react-beautiful-dnd": "^13.1.1",
     "react-draggable": "^4.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,7 +471,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       metagame-sdk:
-        specifier: ^0.0.16
+        specifier: 0.0.16
         version: 0.0.16(@dojoengine/sdk@1.5.3(@tanstack/react-query@5.75.4(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(bufferutil@4.0.9)(encoding@0.1.13)(get-starknet-core@4.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.23.1(encoding@0.1.13))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(typescript@5.8.3)(zustand@4.5.6(@types/react@18.3.21)(immer@10.1.1)(react@18.3.1))
       open:
         specifier: 'catalog:'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency version for "metagame-sdk" to use an exact version instead of a version range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->