### PR TITLE
add sweep and fix for transferred sp

### DIFF
--- a/client/apps/landing/package.json
+++ b/client/apps/landing/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-popover": "^1.1.2",
     "@radix-ui/react-radio-group": "^1.3.4",
     "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-slider": "^1.3.4",
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@solana/web3.js": "catalog:",

--- a/client/apps/landing/src/components/modules/animated-grid.tsx
+++ b/client/apps/landing/src/components/modules/animated-grid.tsx
@@ -53,7 +53,7 @@ const getRowSpanClass = (span: number | undefined, breakpoint: string) => {
 export const AnimatedGrid = <T,>({ items, renderItem }: AnimatedGridProps<T>) => {
   return (
     <motion.div
-      className="grid grid-cols-1 sm:grid-cols-12 gap-8 px-2"
+      className="grid grid-cols-1 sm:grid-cols-12 gap-8 px-2 pb-4"
       initial="hidden"
       animate="visible"
       variants={{

--- a/client/apps/landing/src/components/ui/slider.tsx
+++ b/client/apps/landing/src/components/ui/slider.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+import * as SliderPrimitive from "@radix-ui/react-slider";
+import * as React from "react";
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn("relative flex w-full touch-none select-none items-center", className)}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 cursor-pointer" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/client/apps/landing/src/hooks/services/index.ts
+++ b/client/apps/landing/src/hooks/services/index.ts
@@ -198,6 +198,7 @@ WITH limited_active_orders AS (
   LEFT JOIN active_orders ao
     ON ao.token_id_hex = substr(tb.token_id, instr(tb.token_id, ':') + 1)
   WHERE tb.contract_address = '{contractAddress}'
+  AND tb.balance != "0x0000000000000000000000000000000000000000000000000000000000000000"
   AND tb.account_address = '{trimmedAccountAddress}';
   `,
 };

--- a/client/apps/landing/src/hooks/use-marketplace.tsx
+++ b/client/apps/landing/src/hooks/use-marketplace.tsx
@@ -36,7 +36,7 @@ export const useMarketplace = () => {
     },
   } = useDojo();
 
-  const { account } = useAccount();
+  const { account, address } = useAccount();
 
   const { contract } = useContract({
     abi: SeasonPassAbi,
@@ -49,11 +49,11 @@ export const useMarketplace = () => {
   });
 
   // improve
-  const seasonPassApproved = useReadContract({
-    abi: SeasonPassAbi,
+  const { data: seasonPassApproved } = useReadContract({
+    abi: SeasonPassAbi as const,
     address: seasonPassAddress as `0x${string}`,
     functionName: "is_approved_for_all",
-    args: [account?.address as `0x${string}`, marketplaceAddress],
+    args: [address as `0x${string}`, marketplaceAddress],
     watch: true,
   });
 
@@ -173,7 +173,7 @@ export const useMarketplace = () => {
     cancelOrder,
     editOrder,
     approveMarketplace,
-    seasonPassApproved: seasonPassApproved.data,
+    seasonPassApproved: seasonPassApproved,
     isLoading: isCreatingOrder || isAcceptingOrder || isCancellingOrder || isEditingOrder,
     isCreatingOrder,
     isAcceptingOrder,

--- a/client/apps/landing/src/hooks/use-marketplace.tsx
+++ b/client/apps/landing/src/hooks/use-marketplace.tsx
@@ -50,7 +50,7 @@ export const useMarketplace = () => {
 
   // improve
   const { data: seasonPassApproved } = useReadContract({
-    abi: SeasonPassAbi as const,
+    abi: SeasonPassAbi,
     address: seasonPassAddress as `0x${string}`,
     functionName: "is_approved_for_all",
     args: [address as `0x${string}`, marketplaceAddress],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,6 +670,9 @@ importers:
       '@radix-ui/react-separator':
         specifier: ^1.1.0
         version: 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slider':
+        specifier: ^1.3.4
+        version: 1.3.4(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.2(@types/react@18.3.21)(react@18.3.1)
@@ -3969,6 +3972,19 @@ packages:
 
   '@radix-ui/react-separator@1.1.6':
     resolution: {integrity: sha512-Izof3lPpbCfTM7WDta+LRkz31jem890VjEvpVRoWQNKpDUMMVffuyq854XPGP1KYGWWmjmYvHvPFeocWhFCy1w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.4':
+    resolution: {integrity: sha512-Cp6hEmQtRJFci285vkdIJ+HCDLTRDk+25VhFwa1fcubywjMUE3PynBgtN5RLudOgSCYMlT4jizCXdmV+8J7Y2w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -14843,6 +14859,25 @@ snapshots:
   '@radix-ui/react-separator@1.1.6(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.2(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.21
+      '@types/react-dom': 18.3.7(@types/react@18.3.21)
+
+  '@radix-ui/react-slider@1.3.4(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collection': 1.1.6(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.21)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.21)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.21)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.2(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.21)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.21)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.21)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.21)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a slider-based "sweep" selection tool in the marketplace, allowing users to batch-select multiple season passes at once.
  - Added a new, visually styled slider component for enhanced UI interaction.

- **Enhancements**
  - The marketplace UI now displays a slider control for batch selection when sweep is active, and shows selected pass images otherwise.
  - The total price display now reflects the maximum price among selected passes.
  - Improved marketplace account handling for more reliable season pass approval status.

- **Bug Fixes**
  - Token balances with zero value are now excluded from displayed results, ensuring only relevant balances appear.

- **UI Improvements**
  - Added bottom padding to the animated grid layout for better spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->