### PR TITLE
fix marketplace totals and refetch intervals

### DIFF
--- a/client/apps/landing/src/hooks/services/index.ts
+++ b/client/apps/landing/src/hooks/services/index.ts
@@ -133,8 +133,6 @@ WITH limited_active_orders AS (
       AND  mo."order.expiration" > strftime('%s','now')
       AND  ('{ownerAddress}' = '' OR mo."order.owner" = '{ownerAddress}')
     GROUP  BY token_id_hex
-    LIMIT {limit}
-    OFFSET {offset}
     )
 
 

--- a/client/apps/landing/src/routes/season-passes.lazy.tsx
+++ b/client/apps/landing/src/routes/season-passes.lazy.tsx
@@ -55,7 +55,7 @@ function SeasonPasses() {
                 address /*, ITEMS_PER_PAGE, (currentPage - 1) * ITEMS_PER_PAGE*/,
               )
             : null,
-        refetchInterval: 15_000,
+        refetchInterval: 8_000,
       },
     ],
   });

--- a/client/apps/landing/src/routes/trade.lazy.tsx
+++ b/client/apps/landing/src/routes/trade.lazy.tsx
@@ -51,10 +51,11 @@ function SeasonPasses() {
         queryKey: ["openOrdersByPrice", marketplaceAddress],
         queryFn: () =>
           fetchOpenOrdersByPrice(seasonPassAddress, undefined, ITEMS_PER_PAGE, (currentPage - 1) * ITEMS_PER_PAGE),
+        refetchInterval: 8_000,
       },
       {
-        queryKey: ["activeMarketOrdersTotal"],
-        queryFn: () => fetchActiveMarketOrdersTotal(),
+        queryKey: ["activeMarketOrdersTotal", seasonPassAddress],
+        queryFn: () => fetchActiveMarketOrdersTotal(seasonPassAddress),
         refetchInterval: 30_000,
       },
     ],

--- a/client/apps/landing/src/routes/trade.lazy.tsx
+++ b/client/apps/landing/src/routes/trade.lazy.tsx
@@ -372,7 +372,7 @@ function SeasonPasses() {
                       )}
                     </div>
                   ) : (
-                    <div className="flex items-center gap-4 w-52 -mt-3">
+                    <div className="flex items-center gap-4 w-32 sm:w-52 -mt-3">
                       <div className="flex-1">
                         <div className="flex items-center justify-between mb-2">
                           <span className="text-xs font-medium">Sweep Selection</span>
@@ -395,7 +395,7 @@ function SeasonPasses() {
                   </Button>
                 </div>
                 <div className="flex items-center gap-4">
-                  <div className="font-semibold">
+                  <div className="hidden sm:block font-semibold">
                     {getTotalPrice()} Lords{" "}
                     <span className="text-xs text-muted-foreground">
                       (Max Price:{" "}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic refresh every 8 seconds for open orders and season pass token balances.

- **Improvements**
  - Total active market orders and open orders queries are now scoped to specific contract addresses for more accurate data.
  - Expired market orders are now filtered out for improved data relevance.
  - Only orders with non-zero token balances are counted as active.
  - UI enhancements for trade screen: sweep selection slider width adjusts responsively, and total price display is hidden on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->