### PR TITLE
add activity page to marketplace

### DIFF
--- a/client/apps/landing/schema.graphql
+++ b/client/apps/landing/schema.graphql
@@ -46,7 +46,13 @@ union ERC__Token = ERC20__Token | ERC721__Token | ERC1155__Token
 
 scalar Enum
 
-union ModelUnion = marketplace_MarketFeeModel | marketplace_MarketGlobalModel | marketplace_MarketOrderEvent | marketplace_MarketOrderModel | marketplace_MarketTokenOrderModel | marketplace_MarketWhitelistModel
+union ModelUnion =
+  | marketplace_MarketFeeModel
+  | marketplace_MarketGlobalModel
+  | marketplace_MarketOrderEvent
+  | marketplace_MarketOrderModel
+  | marketplace_MarketTokenOrderModel
+  | marketplace_MarketWhitelistModel
 
 enum OrderDirection {
   ASC
@@ -264,27 +270,151 @@ type World__PageInfo {
 
 type World__Query {
   controller(id: ID!): World__Controller!
-  controllers(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int): World__ControllerConnection
-  entities(after: Cursor, before: Cursor, first: Int, keys: [String], last: Int, limit: Int, offset: Int): World__EntityConnection
+  controllers(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+  ): World__ControllerConnection
+  entities(
+    after: Cursor
+    before: Cursor
+    first: Int
+    keys: [String]
+    last: Int
+    limit: Int
+    offset: Int
+  ): World__EntityConnection
   entity(id: ID!): World__Entity!
   eventMessage(id: ID!): World__EventMessage!
-  eventMessages(after: Cursor, before: Cursor, first: Int, keys: [String], last: Int, limit: Int, offset: Int): World__EventMessageConnection
-  events(after: Cursor, before: Cursor, first: Int, keys: [String], last: Int, limit: Int, offset: Int): World__EventConnection
-  marketplaceMarketFeeModelModels(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: marketplace_MarketFeeModelOrder, where: marketplace_MarketFeeModelWhereInput): marketplace_MarketFeeModelConnection
-  marketplaceMarketGlobalModelModels(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: marketplace_MarketGlobalModelOrder, where: marketplace_MarketGlobalModelWhereInput): marketplace_MarketGlobalModelConnection
-  marketplaceMarketOrderEventModels(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: marketplace_MarketOrderEventOrder, where: marketplace_MarketOrderEventWhereInput): marketplace_MarketOrderEventConnection
-  marketplaceMarketOrderModelModels(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: marketplace_MarketOrderModelOrder, where: marketplace_MarketOrderModelWhereInput): marketplace_MarketOrderModelConnection
-  marketplaceMarketTokenOrderModelModels(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: marketplace_MarketTokenOrderModelOrder, where: marketplace_MarketTokenOrderModelWhereInput): marketplace_MarketTokenOrderModelConnection
-  marketplaceMarketWhitelistModelModels(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: marketplace_MarketWhitelistModelOrder, where: marketplace_MarketWhitelistModelWhereInput): marketplace_MarketWhitelistModelConnection
+  eventMessages(
+    after: Cursor
+    before: Cursor
+    first: Int
+    keys: [String]
+    last: Int
+    limit: Int
+    offset: Int
+  ): World__EventMessageConnection
+  events(
+    after: Cursor
+    before: Cursor
+    first: Int
+    keys: [String]
+    last: Int
+    limit: Int
+    offset: Int
+  ): World__EventConnection
+  marketplaceMarketFeeModelModels(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: marketplace_MarketFeeModelOrder
+    where: marketplace_MarketFeeModelWhereInput
+  ): marketplace_MarketFeeModelConnection
+  marketplaceMarketGlobalModelModels(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: marketplace_MarketGlobalModelOrder
+    where: marketplace_MarketGlobalModelWhereInput
+  ): marketplace_MarketGlobalModelConnection
+  marketplaceMarketOrderEventModels(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: marketplace_MarketOrderEventOrder
+    where: marketplace_MarketOrderEventWhereInput
+  ): marketplace_MarketOrderEventConnection
+  marketplaceMarketOrderModelModels(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: marketplace_MarketOrderModelOrder
+    where: marketplace_MarketOrderModelWhereInput
+  ): marketplace_MarketOrderModelConnection
+  marketplaceMarketTokenOrderModelModels(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: marketplace_MarketTokenOrderModelOrder
+    where: marketplace_MarketTokenOrderModelWhereInput
+  ): marketplace_MarketTokenOrderModelConnection
+  marketplaceMarketWhitelistModelModels(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: marketplace_MarketWhitelistModelOrder
+    where: marketplace_MarketWhitelistModelWhereInput
+  ): marketplace_MarketWhitelistModelConnection
   metadatas(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int): World__MetadataConnection
   model(id: ID!): World__Model!
-  models(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int, order: World__ModelOrder): World__ModelConnection
+  models(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+    order: World__ModelOrder
+  ): World__ModelConnection
   token(id: String!): Token!
-  tokenBalances(accountAddress: String!, after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int): Token__BalanceConnection
-  tokenTransfers(accountAddress: String!, after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int): Token__TransferConnection
-  tokens(after: Cursor, before: Cursor, contractAddress: String, first: Int, last: Int, limit: Int, offset: Int): TokenConnection!
+  tokenBalances(
+    accountAddress: String!
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+  ): Token__BalanceConnection
+  tokenTransfers(
+    accountAddress: String!
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+  ): Token__TransferConnection
+  tokens(
+    after: Cursor
+    before: Cursor
+    contractAddress: String
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+  ): TokenConnection!
   transaction(transactionHash: ID!): World__Transaction!
-  transactions(after: Cursor, before: Cursor, first: Int, last: Int, limit: Int, offset: Int): World__TransactionConnection
+  transactions(
+    after: Cursor
+    before: Cursor
+    first: Int
+    last: Int
+    limit: Int
+    offset: Int
+  ): World__TransactionConnection
 }
 
 type World__Social {

--- a/client/apps/landing/src/routeTree.gen.ts
+++ b/client/apps/landing/src/routeTree.gen.ts
@@ -16,19 +16,15 @@ import { Route as rootRoute } from './routes/__root'
 
 // Create Virtual Routes
 
-const TradeLazyImport = createFileRoute('/trade')()
 const SeasonPassesLazyImport = createFileRoute('/season-passes')()
 const MintLazyImport = createFileRoute('/mint')()
+const DataLazyImport = createFileRoute('/data')()
 const ClaimLazyImport = createFileRoute('/claim')()
 const IndexLazyImport = createFileRoute('/')()
+const TradeIndexLazyImport = createFileRoute('/trade/')()
+const TradeActivityLazyImport = createFileRoute('/trade/activity')()
 
 // Create/Update Routes
-
-const TradeLazyRoute = TradeLazyImport.update({
-  id: '/trade',
-  path: '/trade',
-  getParentRoute: () => rootRoute,
-} as any).lazy(() => import('./routes/trade.lazy').then((d) => d.Route))
 
 const SeasonPassesLazyRoute = SeasonPassesLazyImport.update({
   id: '/season-passes',
@@ -42,6 +38,12 @@ const MintLazyRoute = MintLazyImport.update({
   getParentRoute: () => rootRoute,
 } as any).lazy(() => import('./routes/mint.lazy').then((d) => d.Route))
 
+const DataLazyRoute = DataLazyImport.update({
+  id: '/data',
+  path: '/data',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() => import('./routes/data.lazy').then((d) => d.Route))
+
 const ClaimLazyRoute = ClaimLazyImport.update({
   id: '/claim',
   path: '/claim',
@@ -53,6 +55,20 @@ const IndexLazyRoute = IndexLazyImport.update({
   path: '/',
   getParentRoute: () => rootRoute,
 } as any).lazy(() => import('./routes/index.lazy').then((d) => d.Route))
+
+const TradeIndexLazyRoute = TradeIndexLazyImport.update({
+  id: '/trade/',
+  path: '/trade/',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() => import('./routes/trade/index.lazy').then((d) => d.Route))
+
+const TradeActivityLazyRoute = TradeActivityLazyImport.update({
+  id: '/trade/activity',
+  path: '/trade/activity',
+  getParentRoute: () => rootRoute,
+} as any).lazy(() =>
+  import('./routes/trade/activity.lazy').then((d) => d.Route),
+)
 
 // Populate the FileRoutesByPath interface
 
@@ -72,6 +88,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ClaimLazyImport
       parentRoute: typeof rootRoute
     }
+    '/data': {
+      id: '/data'
+      path: '/data'
+      fullPath: '/data'
+      preLoaderRoute: typeof DataLazyImport
+      parentRoute: typeof rootRoute
+    }
     '/mint': {
       id: '/mint'
       path: '/mint'
@@ -86,11 +109,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SeasonPassesLazyImport
       parentRoute: typeof rootRoute
     }
-    '/trade': {
-      id: '/trade'
+    '/trade/activity': {
+      id: '/trade/activity'
+      path: '/trade/activity'
+      fullPath: '/trade/activity'
+      preLoaderRoute: typeof TradeActivityLazyImport
+      parentRoute: typeof rootRoute
+    }
+    '/trade/': {
+      id: '/trade/'
       path: '/trade'
       fullPath: '/trade'
-      preLoaderRoute: typeof TradeLazyImport
+      preLoaderRoute: typeof TradeIndexLazyImport
       parentRoute: typeof rootRoute
     }
   }
@@ -101,51 +131,83 @@ declare module '@tanstack/react-router' {
 export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute
   '/claim': typeof ClaimLazyRoute
+  '/data': typeof DataLazyRoute
   '/mint': typeof MintLazyRoute
   '/season-passes': typeof SeasonPassesLazyRoute
-  '/trade': typeof TradeLazyRoute
+  '/trade/activity': typeof TradeActivityLazyRoute
+  '/trade': typeof TradeIndexLazyRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute
   '/claim': typeof ClaimLazyRoute
+  '/data': typeof DataLazyRoute
   '/mint': typeof MintLazyRoute
   '/season-passes': typeof SeasonPassesLazyRoute
-  '/trade': typeof TradeLazyRoute
+  '/trade/activity': typeof TradeActivityLazyRoute
+  '/trade': typeof TradeIndexLazyRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexLazyRoute
   '/claim': typeof ClaimLazyRoute
+  '/data': typeof DataLazyRoute
   '/mint': typeof MintLazyRoute
   '/season-passes': typeof SeasonPassesLazyRoute
-  '/trade': typeof TradeLazyRoute
+  '/trade/activity': typeof TradeActivityLazyRoute
+  '/trade/': typeof TradeIndexLazyRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/claim' | '/mint' | '/season-passes' | '/trade'
+  fullPaths:
+    | '/'
+    | '/claim'
+    | '/data'
+    | '/mint'
+    | '/season-passes'
+    | '/trade/activity'
+    | '/trade'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/claim' | '/mint' | '/season-passes' | '/trade'
-  id: '__root__' | '/' | '/claim' | '/mint' | '/season-passes' | '/trade'
+  to:
+    | '/'
+    | '/claim'
+    | '/data'
+    | '/mint'
+    | '/season-passes'
+    | '/trade/activity'
+    | '/trade'
+  id:
+    | '__root__'
+    | '/'
+    | '/claim'
+    | '/data'
+    | '/mint'
+    | '/season-passes'
+    | '/trade/activity'
+    | '/trade/'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute
   ClaimLazyRoute: typeof ClaimLazyRoute
+  DataLazyRoute: typeof DataLazyRoute
   MintLazyRoute: typeof MintLazyRoute
   SeasonPassesLazyRoute: typeof SeasonPassesLazyRoute
-  TradeLazyRoute: typeof TradeLazyRoute
+  TradeActivityLazyRoute: typeof TradeActivityLazyRoute
+  TradeIndexLazyRoute: typeof TradeIndexLazyRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   ClaimLazyRoute: ClaimLazyRoute,
+  DataLazyRoute: DataLazyRoute,
   MintLazyRoute: MintLazyRoute,
   SeasonPassesLazyRoute: SeasonPassesLazyRoute,
-  TradeLazyRoute: TradeLazyRoute,
+  TradeActivityLazyRoute: TradeActivityLazyRoute,
+  TradeIndexLazyRoute: TradeIndexLazyRoute,
 }
 
 export const routeTree = rootRoute
@@ -160,9 +222,11 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/claim",
+        "/data",
         "/mint",
         "/season-passes",
-        "/trade"
+        "/trade/activity",
+        "/trade/"
       ]
     },
     "/": {
@@ -171,14 +235,20 @@ export const routeTree = rootRoute
     "/claim": {
       "filePath": "claim.lazy.tsx"
     },
+    "/data": {
+      "filePath": "data.lazy.tsx"
+    },
     "/mint": {
       "filePath": "mint.lazy.tsx"
     },
     "/season-passes": {
       "filePath": "season-passes.lazy.tsx"
     },
-    "/trade": {
-      "filePath": "trade.lazy.tsx"
+    "/trade/activity": {
+      "filePath": "trade/activity.lazy.tsx"
+    },
+    "/trade/": {
+      "filePath": "trade/index.lazy.tsx"
     }
   }
 }

--- a/client/apps/landing/src/routes/data.lazy.tsx
+++ b/client/apps/landing/src/routes/data.lazy.tsx
@@ -6,7 +6,7 @@ import { usePrizePool } from "@/hooks/use-rewards";
 import { createLazyFileRoute } from "@tanstack/react-router";
 import React from "react";
 
-export const Route = createLazyFileRoute("/")({
+export const Route = createLazyFileRoute("/data")({
   component: Index,
 });
 

--- a/client/apps/landing/src/routes/trade/activity.lazy.tsx
+++ b/client/apps/landing/src/routes/trade/activity.lazy.tsx
@@ -1,0 +1,236 @@
+import { FullPageLoader } from "@/components/modules/full-page-loader";
+import { ResourceIcon } from "@/components/ui/elements/resource-icon";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { seasonPassAddress } from "@/config";
+import { fetchActiveMarketOrdersTotal, fetchMarketOrderEvents } from "@/hooks/services";
+import { useQuery } from "@tanstack/react-query";
+import { createLazyFileRoute, Link } from "@tanstack/react-router";
+import { Clock, Loader2, Pencil, ShoppingCart, Tag, X } from "lucide-react";
+import { Suspense, useState } from "react";
+import { formatUnits } from "viem";
+
+export const Route = createLazyFileRoute("/trade/activity")({
+  component: ActivityPage,
+  pendingComponent: FullPageLoader,
+});
+
+// Format relative time (e.g. "5 minutes ago", "2 hours ago", etc.)
+function formatRelativeTime(timestamp: number | string | null | undefined): string {
+  if (!timestamp) return "N/A";
+
+  // Convert to date objects for both timestamps
+  const date = new Date(timestamp);
+  const now = new Date();
+
+  // Calculate time difference in milliseconds
+  const diffMs = now.getTime() - date.getTime();
+  const seconds = Math.floor(diffMs / 1000);
+
+  if (seconds < 60) return `${seconds} seconds ago`;
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days} day${days === 1 ? "" : "s"} ago`;
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 4) return `${weeks} week${weeks === 1 ? "" : "s"} ago`;
+
+  const months = Math.floor(days / 30);
+  return `${months} month${months === 1 ? "" : "s"} ago`;
+}
+
+function ActivityPage() {
+  const [activeTab, setActiveTab] = useState("activity");
+
+  const { data: totals } = useQuery({
+    queryKey: ["activeMarketOrdersTotal", seasonPassAddress],
+    queryFn: () => fetchActiveMarketOrdersTotal(seasonPassAddress),
+    refetchInterval: 30_000,
+  });
+
+  const { data: marketEvents, isLoading } = useQuery({
+    queryKey: ["marketOrderEvents", seasonPassAddress],
+    queryFn: () => fetchMarketOrderEvents(seasonPassAddress, 50, 0),
+    refetchInterval: 30_000,
+  });
+
+  const activeOrders = totals?.[0]?.active_order_count ?? 0;
+  const totalWeiStr = BigInt(totals?.[0]?.open_orders_total_wei ?? 0);
+  const totalWei = formatUnits(totalWeiStr, 18);
+  const totalEth = totalWei ?? "0";
+
+  // Function to get display status
+  const getDisplayStatus = (status: string) => {
+    if (status === "Accepted") return "Sale";
+    if (status === "Created") return "Listed";
+    return status;
+  };
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      <div className="flex flex-col h-full overflow-y-auto">
+        <div className="text-center border-b py-6">
+          <h2 className="text-2xl sm:text-3xl font-bold mb-2">{"Season 1 Pass Marketplace"}</h2>
+          <div className="flex justify-center items-center gap-4 text-xl text-muted-foreground">
+            <span>
+              <span className="font-semibold text-foreground">{activeOrders}</span> Active Listings
+            </span>
+            <span>•</span>
+            <span className="flex items-center gap-1">
+              Volume <span className="font-semibold text-foreground">{parseFloat(totalEth).toLocaleString()}</span>{" "}
+              <ResourceIcon resource="Lords" size="sm" />
+            </span>
+          </div>
+        </div>
+
+        {/* Tabs Navigation */}
+        <div className="border-b">
+          <div className="container mx-auto py-2">
+            <Tabs defaultValue="activity" value={activeTab} onValueChange={setActiveTab} className="w-full">
+              <TabsList className="grid w-full max-w-md grid-cols-2">
+                <TabsTrigger value="items" asChild>
+                  <Link to="/trade" className="cursor-pointer">
+                    Items
+                  </Link>
+                </TabsTrigger>
+                <TabsTrigger value="activity" asChild>
+                  <Link to="/trade/activity" className="cursor-pointer">
+                    Activity
+                  </Link>
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+        </div>
+
+        {/* Activity Content */}
+        <div className="container mx-auto py-6">
+          <h3 className="text-xl font-semibold mb-4">Recent Market Activity</h3>
+
+          <Suspense
+            fallback={
+              <div className="flex-grow flex items-center justify-center min-h-[200px]">
+                <Loader2 className="w-10 h-10 animate-spin" />
+              </div>
+            }
+          >
+            {isLoading ? (
+              <div className="flex-grow flex items-center justify-center min-h-[200px]">
+                <Loader2 className="w-10 h-10 animate-spin" />
+              </div>
+            ) : marketEvents && marketEvents.length > 0 ? (
+              <div className="overflow-x-auto">
+                {/* Table header */}
+                <div className="border-b grid grid-cols-7 w-full text-xs text-muted-foreground">
+                  <div className="px-4 py-2 text-left">Status</div>
+                  <div className="px-4 py-2 text-left col-span-2">Item</div>
+                  <div className="px-4 py-2 text-left">Price</div>
+                  <div className="px-4 py-2 text-left">Resources</div>
+                  <div className="px-4 py-2 text-right col-span-2">Time</div>
+                </div>
+
+                {/* Table body */}
+                <div className="w-full">
+                  {marketEvents.map((event) => {
+                    const metadata = event.metadata;
+                    const image = metadata?.image || "";
+                    const price = event.price ? formatUnits(BigInt(event.price), 18) : "0";
+                    const displayStatus = getDisplayStatus(event.state);
+
+                    // Set status color based on state
+                    let statusColor = "text-muted-foreground";
+                    if (event.state === "Accepted") statusColor = "text-green-500";
+                    else if (event.state === "Created") statusColor = "text-amber-500";
+
+                    return (
+                      <div
+                        key={event.event_id}
+                        className="border-b hover:bg-card/80 transition-colors grid grid-cols-7 w-full"
+                      >
+                        {/* Status */}
+                        <div className="px-4 py-3">
+                          <div className="flex items-center text-lg h-full">
+                            {event.state === "Accepted" ? (
+                              <ShoppingCart className="w-5 h-5 text-green-500 mr-3" />
+                            ) : event.state === "Created" ? (
+                              <Tag className="w-5 h-5 text-amber-500 mr-3" />
+                            ) : event.state === "Cancelled" ? (
+                              <X className="w-5 h-5 text-amber-500 mr-3" />
+                            ) : (
+                              <Pencil className="w-5 h-5 text-muted-foreground mr-3" />
+                            )}
+                            <span className={`font-medium ${statusColor}`}>{displayStatus}</span>
+                          </div>
+                        </div>
+
+                        {/* Item */}
+                        <div className="px-4 py-3  col-span-2">
+                          <div className="flex items-center h-full">
+                            <div className="w-10 h-10 rounded-md overflow-hidden mr-3">
+                              {image ? (
+                                <img
+                                  src={image}
+                                  alt={`Pass #${event.token_id}`}
+                                  className="w-full h-full object-cover"
+                                />
+                              ) : (
+                                <div className="w-full h-full bg-muted flex items-center justify-center">
+                                  <span className="text-xs text-muted-foreground">No Image</span>
+                                </div>
+                              )}
+                            </div>
+                            <span className="font-medium">
+                              {event.metadata?.name} #{parseInt(event.token_id, 16)}
+                            </span>
+                          </div>
+                        </div>
+
+                        {/* Price */}
+                        <div className="px-4 py-3 text-left">
+                          <div className="flex items-center  h-full">
+                            <span className="font-semibold mr-1">{price}</span>
+                            <ResourceIcon resource="Lords" size="sm" />
+                          </div>
+                        </div>
+
+                        {/* Resources */}
+                        <div className="px-4 py-3 text-left col-span-2">
+                          <div className="flex flex-wrap gap-2 mb-2 h-full items-center">
+                            {metadata?.attributes
+                              ?.filter((attribute) => attribute.trait_type === "Resource")
+                              .map((attribute, index) => (
+                                <ResourceIcon
+                                  resource={attribute.value as string}
+                                  size="sm"
+                                  key={`${attribute.trait_type}-${index}`}
+                                />
+                              ))}
+                          </div>
+                        </div>
+
+                        {/* Time */}
+                        <div className="px-4 py-3 text-sm text-muted-foreground">
+                          <div className="flex items-center justify-end h-full">
+                            <Clock className="w-3 h-3 mr-1" />
+                            {formatRelativeTime(event.executed_at)}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <div className="text-center py-8 text-muted-foreground">No recent market activity found.</div>
+            )}
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/apps/landing/src/routes/trade/index.lazy.tsx
+++ b/client/apps/landing/src/routes/trade/index.lazy.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/pagination";
 import { ScrollHeader } from "@/components/ui/scroll-header";
 import { Slider } from "@/components/ui/slider";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { marketplaceAddress, seasonPassAddress } from "@/config";
 import { fetchActiveMarketOrdersTotal, fetchOpenOrdersByPrice, OpenOrderByPrice } from "@/hooks/services";
 import { useTraitFiltering } from "@/hooks/useTraitFiltering";
@@ -22,12 +23,12 @@ import { useSelectedPassesStore } from "@/stores/selected-passes";
 import { useDebounce } from "@bibliothecadao/react";
 import { useAccount, useConnect } from "@starknet-react/core";
 import { useSuspenseQueries } from "@tanstack/react-query";
-import { createLazyFileRoute } from "@tanstack/react-router";
+import { createLazyFileRoute, Link } from "@tanstack/react-router";
 import { Badge, Grid2X2, Grid3X3, Loader2 } from "lucide-react";
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { formatUnits } from "viem";
 
-export const Route = createLazyFileRoute("/season-passes")({
+export const Route = createLazyFileRoute("/trade/")({
   component: SeasonPasses,
   pendingComponent: FullPageLoader,
 });
@@ -40,6 +41,7 @@ function SeasonPasses() {
   const [controllerAddress] = useState<string>();
 
   const [tokenIdToTransfer, setTokenIdToTransfer] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState("items");
 
   // --- Pagination State ---
   const [currentPage, setCurrentPage] = useState(1);
@@ -282,6 +284,27 @@ function SeasonPasses() {
               </span>
             </div>
           </div>
+
+          {/* Tabs Navigation */}
+          <div className="border-b">
+            <div className="container mx-auto py-2">
+              <Tabs defaultValue="items" value={activeTab} onValueChange={setActiveTab} className="w-full">
+                <TabsList className="grid w-full max-w-md grid-cols-2">
+                  <TabsTrigger value="items" asChild>
+                    <Link to="/season-passes" className="cursor-pointer">
+                      Items
+                    </Link>
+                  </TabsTrigger>
+                  <TabsTrigger value="activity" asChild>
+                    <Link to="/trade/activity" className="cursor-pointer">
+                      Activity
+                    </Link>
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+          </div>
+
           <ScrollHeader className="flex flex-row justify-between items-center" onScrollChange={setIsHeaderScrolled}>
             {/* Filter UI */}
             {isHeaderScrolled ? (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new marketplace activity page under `/trade/activity` that displays recent market order events, active listings, and total volume with real-time updates.
  - Added a `/data` route for accessing data-related content.
  - Implemented tabbed navigation in the trade section, allowing users to switch between "Items" and "Activity" views.

- **Improvements**
  - Updated routing structure for clearer separation between trade items and activity.
  - Enhanced marketplace activity display with user-friendly status labels, icons, and formatted timestamps.

- **Bug Fixes**
  - None.

- **Style**
  - Improved formatting and readability of the GraphQL schema without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->