### PR TITLE
Refactor quest tile sync

### DIFF
--- a/client/apps/game/src/three/managers/quest-manager.ts
+++ b/client/apps/game/src/three/managers/quest-manager.ts
@@ -1,6 +1,6 @@
 import InstancedModel from "@/three/managers/instanced-model";
 import { Position } from "@/types/position";
-import { ContractAddress, FELT_CENTER, ID, QuestType } from "@bibliothecadao/types";
+import { FELT_CENTER, ID, QuestType } from "@bibliothecadao/types";
 import * as THREE from "three";
 import { CSS2DObject } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 import { gltfLoader } from "../helpers/utils";
@@ -106,11 +106,11 @@ export class QuestManager {
   }
 
   async onUpdate(update: QuestSystemUpdate) {
-    const { entityId, id, game_address, hexCoords, level, resource_type, amount, capacity, participant_count } = update;
+    const { entityId, occupierId, hexCoords } = update;
     const normalizedCoord = { col: hexCoords.col - FELT_CENTER, row: hexCoords.row - FELT_CENTER };
     // Add the quest to the map with the complete owner info
     const position = new Position({ x: hexCoords.col, y: hexCoords.row });
-    const structureType = QuestType.DarkShuffle;
+    const questType = QuestType.DarkShuffle;
 
     if (!this.questHexCoords.has(normalizedCoord.col)) {
       this.questHexCoords.set(normalizedCoord.col, new Set());
@@ -119,18 +119,7 @@ export class QuestManager {
       this.questHexCoords.get(normalizedCoord.col)!.add(normalizedCoord.row);
     }
 
-    this.quests.addQuest(
-      entityId,
-      structureType,
-      id,
-      game_address,
-      position,
-      level,
-      resource_type,
-      amount,
-      capacity,
-      participant_count,
-    );
+    this.quests.addQuest(entityId, questType, occupierId, position);
 
     // SPAG Re-render if we have a current chunk
     if (this.currentChunkKey) {
@@ -171,14 +160,9 @@ export class QuestManager {
       })
       .map((quest) => ({
         entityId: quest.entityId,
-        id: quest.id,
-        game_address: quest.game_address,
+        questType: quest.questType,
+        occupierId: quest.occupierId,
         hexCoords: quest.hexCoords,
-        level: quest.level,
-        resource_type: quest.resource_type,
-        amount: quest.amount,
-        capacity: quest.capacity,
-        participant_count: quest.participant_count,
       }));
 
     return visibleQuests;
@@ -296,11 +280,8 @@ export class QuestManager {
     const line1 = document.createElement("span");
     line1.textContent = `Quest`;
     line1.style.color = "inherit";
-    const line2 = document.createElement("strong");
-    line2.textContent = `Level: ${quest.level + 1}`;
 
     textContainer.appendChild(line1);
-    textContainer.appendChild(line2);
     labelDiv.appendChild(textContainer);
 
     const label = new CSS2DObject(labelDiv);
@@ -358,31 +339,15 @@ export class QuestManager {
 class Quests {
   private quests: Map<QuestType, Map<ID, QuestData>> = new Map();
 
-  addQuest(
-    entityId: ID,
-    questType: QuestType,
-    id: ID,
-    game_address: ContractAddress,
-    hexCoords: Position,
-    level: number,
-    resource_type: number,
-    amount: bigint,
-    capacity: number,
-    participant_count: number,
-  ) {
+  addQuest(entityId: ID, questType: QuestType, occupierId: ID, hexCoords: Position) {
     if (!this.quests.has(questType)) {
       this.quests.set(questType, new Map());
     }
     this.quests.get(questType)!.set(entityId, {
       entityId,
-      id,
-      game_address,
+      questType,
+      occupierId,
       hexCoords,
-      level,
-      resource_type,
-      amount,
-      capacity,
-      participant_count,
     });
   }
 

--- a/client/apps/game/src/three/systems/system-manager.ts
+++ b/client/apps/game/src/three/systems/system-manager.ts
@@ -397,23 +397,14 @@ export class SystemManager {
 
               if (!currentState) return;
 
-              const questTile = getComponentValue(
-                this.setup.components.QuestTile,
-                getEntityIdFromKeys([BigInt(currentState?.occupier_id)]),
-              );
+              const quest = currentState.occupier_type === TileOccupier.Quest;
 
-              if (!questTile) return;
+              if (!quest) return;
 
               return {
                 entityId: update.entity,
-                id: questTile.id,
-                gameAddress: questTile.game_address,
-                hexCoords: { col: questTile.coord.x, row: questTile.coord.y },
-                capacity: questTile.capacity,
-                level: questTile.level,
-                resourceType: questTile.resource_type,
-                amount: questTile.amount,
-                participantCount: questTile.participant_count,
+                occupierId: currentState?.occupier_id,
+                hexCoords: { col: currentState.col, row: currentState.row },
               };
             }
           },

--- a/client/apps/game/src/three/types/common.ts
+++ b/client/apps/game/src/three/types/common.ts
@@ -1,5 +1,5 @@
 import { Position } from "@/types/position";
-import { ContractAddress, ID, StructureType, TroopTier, TroopType } from "@bibliothecadao/types";
+import { ID, QuestType, StructureType, TroopTier, TroopType } from "@bibliothecadao/types";
 
 export enum SceneName {
   WorldMap = "map",
@@ -45,14 +45,9 @@ export interface ArmyData {
 
 export interface QuestData {
   entityId: ID;
-  id: ID;
-  game_address: ContractAddress;
+  questType: QuestType;
+  occupierId: ID;
   hexCoords: Position;
-  level: number;
-  resource_type: number;
-  amount: bigint;
-  capacity: number;
-  participant_count: number;
 }
 
 export interface RenderChunkSize {

--- a/client/apps/game/src/three/types/systems.ts
+++ b/client/apps/game/src/three/types/systems.ts
@@ -1,13 +1,4 @@
-import {
-  BiomeType,
-  BuildingType,
-  ContractAddress,
-  HexPosition,
-  ID,
-  StructureType,
-  TroopTier,
-  TroopType,
-} from "@bibliothecadao/types";
+import { BiomeType, BuildingType, HexPosition, ID, StructureType, TroopTier, TroopType } from "@bibliothecadao/types";
 import { StructureProgress } from "./common";
 
 export type ArmySystemUpdate = {
@@ -51,12 +42,6 @@ export type RealmSystemUpdate = {
 
 export type QuestSystemUpdate = {
   entityId: ID;
-  id: ID;
-  game_address: ContractAddress;
+  occupierId: ID;
   hexCoords: HexPosition;
-  level: number;
-  resource_type: number;
-  amount: bigint;
-  capacity: number;
-  participant_count: number;
 };

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -5,7 +5,7 @@ import { LoadingStateKey } from "@/hooks/store/use-world-loading";
 import { LoadingOroborus } from "@/ui/modules/loading-oroborus";
 import { LoadingScreen } from "@/ui/modules/loading-screen";
 import { getEntityInfo } from "@bibliothecadao/eternum";
-import { useDojo, usePlayerStructures, useQuests } from "@bibliothecadao/react";
+import { useDojo, usePlayerStructures } from "@bibliothecadao/react";
 import { getAllStructuresFromToriiClient } from "@bibliothecadao/torii-client";
 import { ContractAddress } from "@bibliothecadao/types";
 import { Leva } from "leva";
@@ -133,7 +133,6 @@ export const World = ({ backgroundImage }: { backgroundImage: string }) => {
   const minigameStore = useMinigameStore.getState();
   const { setup, account } = useDojo();
   const playerStructures = usePlayerStructures();
-  const quests = useQuests();
   const setLoading = useUIStore((state) => state.setLoading);
 
   // Consolidated subscription logic into a single function

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -1,4 +1,4 @@
-import { getQuestTilesFromTorii, getStructuresDataFromTorii } from "@/dojo/queries";
+import { getStructuresDataFromTorii } from "@/dojo/queries";
 import { useMinigameStore } from "@/hooks/store/use-minigame-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { LoadingStateKey } from "@/hooks/store/use-world-loading";
@@ -7,7 +7,7 @@ import { LoadingScreen } from "@/ui/modules/loading-screen";
 import { getEntityInfo } from "@bibliothecadao/eternum";
 import { useDojo, usePlayerStructures, useQuests } from "@bibliothecadao/react";
 import { getAllStructuresFromToriiClient } from "@bibliothecadao/torii-client";
-import { ContractAddress, Tile } from "@bibliothecadao/types";
+import { ContractAddress } from "@bibliothecadao/types";
 import { Leva } from "leva";
 import { useGameSettingsMetadata, useMiniGames } from "metagame-sdk";
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -258,38 +258,6 @@ export const World = ({ backgroundImage }: { backgroundImage: string }) => {
 
     syncUnsyncedStructures();
   }, [account.account, playerStructures, fetchedStructures, syncStructures, setSyncedStructures]);
-
-  const syncQuestTiles = useCallback(
-    async ({ questTiles }: { questTiles: Tile[] }) => {
-      if (!questTiles.length) return;
-
-      try {
-        const start = performance.now();
-        setLoading(LoadingStateKey.Quests, true);
-        await getQuestTilesFromTorii(
-          setup.network.toriiClient,
-          setup.network.contractComponents as any,
-          questTiles.map((q) => q.occupier_id),
-        );
-        const end = performance.now();
-        console.log(
-          `[sync] quest tiles query questTiles ${questTiles.map((q) => `${q.occupier_id}(${q.col},${q.row})`)}`,
-          end - start,
-        );
-      } catch (error) {
-        console.error("Failed to sync quest tiles:", error);
-      } finally {
-        setLoading(LoadingStateKey.Quests, false);
-      }
-    },
-    [setup.network.toriiClient, setup.network.contractComponents],
-  );
-
-  useEffect(() => {
-    if (quests.length > 0) {
-      syncQuestTiles({ questTiles: quests });
-    }
-  }, [quests?.length, syncQuestTiles]);
 
   const { data: minigames } = useMiniGames({});
 

--- a/client/apps/game/src/ui/modules/quests/info-container.tsx
+++ b/client/apps/game/src/ui/modules/quests/info-container.tsx
@@ -2,7 +2,8 @@ import { useMinigameStore } from "@/hooks/store/use-minigame-store";
 import { BuildingThumbs } from "@/ui/config";
 import { formatTime, getEntityIdFromKeys } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
-import { getComponentValue } from "@dojoengine/recs";
+import { ClientComponents } from "@bibliothecadao/types";
+import { ComponentValue, getComponentValue } from "@dojoengine/recs";
 import { useMemo } from "react";
 
 const formatAmount = (amount: number) => {
@@ -12,16 +13,18 @@ const formatAmount = (amount: number) => {
   }).format(amount);
 };
 
-export const InfoContainer = ({ targetHex }: { targetHex: { x: number; y: number } }) => {
+export const InfoContainer = ({
+  questTileEntity,
+}: {
+  questTileEntity: ComponentValue<ClientComponents["QuestTile"]["schema"]> | undefined;
+}) => {
   const {
     setup: {
-      components: { QuestTile, QuestLevels, Tile },
+      components: { QuestLevels },
     },
   } = useDojo();
   const { minigames, settingsMetadata } = useMinigameStore();
 
-  const targetEntity = getComponentValue(Tile, getEntityIdFromKeys([BigInt(targetHex.x), BigInt(targetHex.y)]));
-  const questTileEntity = getComponentValue(QuestTile, getEntityIdFromKeys([BigInt(targetEntity?.occupier_id || 0)]));
   const questLevelsEntity = getComponentValue(
     QuestLevels,
     getEntityIdFromKeys([BigInt(questTileEntity?.game_address || 0)]),

--- a/client/apps/game/src/ui/modules/quests/quest-container.tsx
+++ b/client/apps/game/src/ui/modules/quests/quest-container.tsx
@@ -7,9 +7,9 @@ import { ResourceIcon } from "@/ui/elements/resource-icon";
 import { currencyFormat } from "@/ui/utils/utils";
 import { getArmy, getRemainingCapacityInKg, toHexString } from "@bibliothecadao/eternum";
 import { useDojo, useExplorersByStructure, useGetQuestForExplorer, usePlayerStructures } from "@bibliothecadao/react";
-import { ContractAddress, type ID, ResourcesIds, StructureType } from "@bibliothecadao/types";
+import { ClientComponents, ContractAddress, type ID, ResourcesIds, StructureType } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
-import { getComponentValue } from "@dojoengine/recs";
+import { ComponentValue, getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useSubscribeScores } from "metagame-sdk";
 import { useMemo, useState } from "react";
@@ -17,19 +17,19 @@ import gameImage from "../../../assets/games/dark-shuffle.png";
 
 export const QuestContainer = ({
   explorerEntityId,
-  targetHex,
   loadingQuests,
+  questTileEntity,
 }: {
   explorerEntityId: ID;
-  targetHex: { x: number; y: number };
   loadingQuests: boolean;
+  questTileEntity: ComponentValue<ClientComponents["QuestTile"]["schema"]> | undefined;
 }) => {
   const {
     account: { account },
     setup: {
       systemCalls: { start_quest, get_game_count },
       components,
-      components: { QuestTile, Tile, QuestLevels },
+      components: { QuestLevels },
     },
   } = useDojo();
   const playerStructures = usePlayerStructures();
@@ -40,8 +40,6 @@ export const QuestContainer = ({
 
   const selectedHex = useUIStore((state) => state.selectedHex);
 
-  const targetEntity = getComponentValue(Tile, getEntityIdFromKeys([BigInt(targetHex.x), BigInt(targetHex.y)]));
-  const questTileEntity = getComponentValue(QuestTile, getEntityIdFromKeys([BigInt(targetEntity?.occupier_id || 0)]));
   const questLevelsEntity = getComponentValue(
     QuestLevels,
     getEntityIdFromKeys([BigInt(questTileEntity?.game_address || 0)]),
@@ -177,7 +175,7 @@ export const QuestContainer = ({
         <div className="flex flex-col items-center gap-2 w-1/3">
           <span className="text-gold/80">Reward</span>
           <span className="flex flex-row gap-2 items-center text-2xl font-bold text-gold">
-            <ResourceIcon resource={ResourcesIds[questTileEntity?.resource_type ?? 0]} size="lg" />
+            <ResourceIcon resource={ResourcesIds[questTileEntity?.resource_type ?? 1]} size="lg" />
             <span>{currencyFormat(Number(rewardAmount), 0)}</span>
           </span>
         </div>

--- a/client/apps/game/src/ui/modules/quests/realms-container.tsx
+++ b/client/apps/game/src/ui/modules/quests/realms-container.tsx
@@ -3,32 +3,27 @@ import { QuestRealm } from "@/ui/components/quest/quest-realm-component";
 import { useGetQuests } from "@/ui/components/quest/quest-utils";
 import { getArmy, getEntityIdFromKeys } from "@bibliothecadao/eternum";
 import { useDojo, usePlayerStructures } from "@bibliothecadao/react";
-import { ContractAddress, ID, StructureType } from "@bibliothecadao/types";
-import { getComponentValue } from "@dojoengine/recs";
+import { ClientComponents, ContractAddress, ID, StructureType } from "@bibliothecadao/types";
+import { ComponentValue, getComponentValue } from "@dojoengine/recs";
 import { useMemo } from "react";
 
 export const RealmsContainer = ({
   explorerEntityId,
-  targetHex,
   loadingQuests,
+  questTileEntity,
 }: {
   explorerEntityId: ID;
-  targetHex: { x: number; y: number };
   loadingQuests: boolean;
+  questTileEntity: ComponentValue<ClientComponents["QuestTile"]["schema"]> | undefined;
 }) => {
   const {
     account: { account },
     setup: {
       components,
-      components: { Tile, QuestTile, QuestLevels },
+      components: { QuestLevels },
     },
   } = useDojo();
   const playerStructures = usePlayerStructures();
-
-  const questTileEntity = useMemo(() => {
-    const targetEntity = getComponentValue(Tile, getEntityIdFromKeys([BigInt(targetHex.x), BigInt(targetHex.y)]));
-    return getComponentValue(QuestTile, getEntityIdFromKeys([BigInt(targetEntity?.occupier_id || 0)]));
-  }, [targetHex]);
 
   const questLevelsEntity = useMemo(() => {
     return getComponentValue(QuestLevels, getEntityIdFromKeys([BigInt(questTileEntity?.game_address || 0)]));


### PR DESCRIPTION
## Key Features

- Remove quest tile syncing for fetching on demand.
- Remove getting quest tile data in `system-manager` for just looking at `occupier_type`. This solves the rendering issue of quest tiles in the world view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified quest data throughout the application by removing detailed quest properties and focusing on a minimal set: quest type, occupier ID, entity ID, and coordinates.
  - Updated quest-related UI components to accept and use quest tile entities directly, streamlining data flow and reducing complexity.
  - Shifted quest modal logic to use asynchronous data fetching for quest tile information, improving data handling and rendering reliability.
  - Removed outdated quest syncing logic from the world layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->