### PR TITLE
[quest] improved 3d model look

### DIFF
--- a/client/apps/game/src/three/managers/instanced-biome.tsx
+++ b/client/apps/game/src/three/managers/instanced-biome.tsx
@@ -41,6 +41,9 @@ export default class InstancedModel {
         } else {
           renderOrder = 2;
         }
+        if (child?.material?.emissiveIntensity > 1) {
+          child.material.emissiveIntensity = 3;
+        }
         const tmp = new THREE.InstancedMesh(child.geometry, child.material, count);
         const biomeMesh = child;
         if (gltf.animations.length > 0) {

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -44,6 +44,15 @@ export default class InstancedModel {
           return;
         }
         let material = child.material;
+        if (name.includes("Quest")) {
+          if (!material.depthWrite) {
+            material.depthWrite = true;
+            material.alphaTest = 0.075;
+          }
+          if (material.emissiveIntensity > 1) {
+            material.emissiveIntensity = 1.5;
+          }
+        }
         if (name === StructureType[StructureType.FragmentMine] && child.material.name.includes("crystal")) {
           material = new THREE.MeshStandardMaterial(MinesMaterialsParams[ResourcesIds.AncientFragment]);
         }

--- a/client/apps/game/src/three/managers/quest-manager.ts
+++ b/client/apps/game/src/three/managers/quest-manager.ts
@@ -82,7 +82,7 @@ export class QuestManager {
         loader.load(
           modelPath,
           (gltf) => {
-            const instancedModel = new InstancedModel(gltf, MAX_INSTANCES, false, QuestType[questType]);
+            const instancedModel = new InstancedModel(gltf, MAX_INSTANCES, false, "Quest" + QuestType[questType]);
             resolve(instancedModel);
           },
           undefined,

--- a/client/apps/game/src/three/scenes/constants.ts
+++ b/client/apps/game/src/three/scenes/constants.ts
@@ -297,9 +297,9 @@ export const MinesMaterialsParams: Record<
     emissiveIntensity: 4,
   },
   [ResourcesIds.AncientFragment]: {
-    color: new THREE.Color(0.43, 0.85, 0.16),
-    emissive: new THREE.Color(0.0, 3.25, 0.03),
-    emissiveIntensity: 1.2,
+    color: new THREE.Color(0.25, 0.45, 0.15),
+    emissive: new THREE.Color(0.0, 0.5, 0.03),
+    emissiveIntensity: 0.8,
   },
 };
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -872,9 +872,9 @@ export default class WorldmapScene extends HexagonScene {
           dummyObject.position.copy(pos);
 
           const isStructure = this.structureManager.structureHexCoords.get(globalCol)?.has(globalRow) || false;
-
+          const isQuest = this.questManager.questHexCoords.get(globalCol)?.has(globalRow) || false;
           const isExplored = this.exploredTiles.get(globalCol)?.get(globalRow) || false;
-          if (isStructure) {
+          if (isStructure || isQuest) {
             dummyObject.scale.set(0, 0, 0);
           } else {
             dummyObject.scale.set(HEX_SIZE, HEX_SIZE, HEX_SIZE);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved visual consistency for quest and structure tiles by hiding quest tiles on the world map.
	- Adjusted material properties for certain meshes to enhance rendering, including capping emissive intensity and updating transparency settings.
	- Updated the appearance of Ancient Fragment resources with darker colors and reduced emissive effects for a more balanced look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->