### PR TITLE
Fix unnecessary rpc calls

### DIFF
--- a/client/apps/game/package.json
+++ b/client/apps/game/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21",
     "open": "catalog:",
     "platform": "^1.3.6",
-    "metagame-sdk": "0.0.18",
+    "metagame-sdk": "0.0.19",
     "postprocessing": "^6.36.2",
     "react-beautiful-dnd": "^13.1.1",
     "react-draggable": "^4.4.6",

--- a/client/apps/game/src/ui/modules/quests/quest-modal.tsx
+++ b/client/apps/game/src/ui/modules/quests/quest-modal.tsx
@@ -41,7 +41,7 @@ export const QuestModal = ({
   const [loadingQuestTile, setLoadingQuestTile] = useState(true);
   const { setScores } = useMinigameStore();
 
-  const queryAddress = useMemo(() => account?.address ?? "0x0", [account]);
+  const queryAddress = useMemo(() => account?.address, [account]);
 
   useEffect(() => {
     const fetchQuest = async () => {
@@ -59,7 +59,7 @@ export const QuestModal = ({
       QuestLevels,
       getEntityIdFromKeys([BigInt(questTileEntity?.game_address || 0)]),
     );
-    return questLevelsEntity?.game_address ?? "0x0";
+    return questLevelsEntity?.game_address ? toHexString(BigInt(questLevelsEntity?.game_address)) : undefined;
   }, [questTileEntity]);
 
   const attributeFilters = useMemo(() => {
@@ -68,7 +68,7 @@ export const QuestModal = ({
 
   const { data: questGames, loading: loadingQuests } = useOwnedGamesWithScores({
     address: queryAddress,
-    gameAddress: toHexString(BigInt(queryGameAddress)),
+    gameAddress: queryGameAddress,
     metagame: {
       namespace: "s1_eternum",
       model: "Quest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,8 +471,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       metagame-sdk:
-        specifier: 0.0.18
-        version: 0.0.18(@dojoengine/sdk@1.5.5(@tanstack/react-query@5.76.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(bufferutil@4.0.9)(encoding@0.1.13)(get-starknet-core@4.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.23.1(encoding@0.1.13))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(typescript@5.8.3)(zustand@4.5.6(@types/react@18.3.21)(immer@10.1.1)(react@18.3.1))
+        specifier: 0.0.19
+        version: 0.0.19(@dojoengine/sdk@1.5.5(@tanstack/react-query@5.76.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(bufferutil@4.0.9)(encoding@0.1.13)(get-starknet-core@4.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.23.1(encoding@0.1.13))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(typescript@5.8.3)(zustand@4.5.6(@types/react@18.3.21)(immer@10.1.1)(react@18.3.1))
       open:
         specifier: 'catalog:'
         version: 10.1.2
@@ -8463,10 +8463,10 @@ packages:
   meshoptimizer@0.18.1:
     resolution: {integrity: sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==}
 
-  metagame-sdk@0.0.18:
-    resolution: {integrity: sha512-y7P8cSKjbDc1vtPit+LV8tl3GAgQmtdRGKysYCWIS+QP9xNod9lbeo8vAjLVoji/656ZKnFOfsLphtoZkRuICw==}
+  metagame-sdk@0.0.19:
+    resolution: {integrity: sha512-iRnESZsYOU6f5knAj7gQAMbc/cOgE+YJXWaE87lEvwRYbOoAlTFDvo6sxj/mwProkOTeBkDT4I//y0WZnS0sVQ==}
     peerDependencies:
-      '@dojoengine/sdk': ^1.5.3
+      '@dojoengine/sdk': ^1.5.5
       typescript: ^5.0.0
       zustand: ^4.4.7
 
@@ -20956,7 +20956,7 @@ snapshots:
 
   meshoptimizer@0.18.1: {}
 
-  metagame-sdk@0.0.18(@dojoengine/sdk@1.5.5(@tanstack/react-query@5.76.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(bufferutil@4.0.9)(encoding@0.1.13)(get-starknet-core@4.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.23.1(encoding@0.1.13))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(typescript@5.8.3)(zustand@4.5.6(@types/react@18.3.21)(immer@10.1.1)(react@18.3.1)):
+  metagame-sdk@0.0.19(@dojoengine/sdk@1.5.5(@tanstack/react-query@5.76.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(bufferutil@4.0.9)(encoding@0.1.13)(get-starknet-core@4.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.23.1(encoding@0.1.13))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4))(typescript@5.8.3)(zustand@4.5.6(@types/react@18.3.21)(immer@10.1.1)(react@18.3.1)):
     dependencies:
       '@dojoengine/sdk': 1.5.5(@tanstack/react-query@5.76.0(react@18.3.1))(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(bufferutil@4.0.9)(encoding@0.1.13)(get-starknet-core@4.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(starknet@6.23.1(encoding@0.1.13))(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.24.4)
       typescript: 5.8.3


### PR DESCRIPTION
This is an improvement in the `metagame-sdk` to handle when the account or game address is `undefined` and not send rpc calls or perform queries. This solves the problem of producing errors in logs when the quests are being fetched and the game address isn't yet known.

Before:
<img width="731" alt="Screenshot 2025-05-14 at 09 27 50" src="https://github.com/user-attachments/assets/37ba66ff-6201-4f73-ab10-588c1f9227a8" />

After:
<img width="702" alt="Screenshot 2025-05-14 at 09 23 40" src="https://github.com/user-attachments/assets/5bec1fe0-6c76-4386-b6e1-9edb8017ce44" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or undefined addresses in the Quest modal to prevent display of placeholder values.

- **Chores**
  - Updated a dependency to the latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->