### PR TITLE
Fix population update and resource amount calculations

### DIFF
--- a/client/apps/game/src/ui/components/production/labor-production-controls.tsx
+++ b/client/apps/game/src/ui/components/production/labor-production-controls.tsx
@@ -103,7 +103,7 @@ export const LaborProductionControls = ({ realm, bonus }: { realm: RealmInfo; bo
   const handleMaxClick = (index: number) => {
     const resource = selectedResources[index];
     const balance = divideByPrecision(
-      Number(availableResources.find((r) => r.resourceId === resource.id)?.amount || 0),
+      Number(availableResources.find((r) => r.resourceId === resource.id)?.amount.balance || 0),
     );
     const newResources = [...selectedResources];
     newResources[index].amount = balance;
@@ -113,7 +113,7 @@ export const LaborProductionControls = ({ realm, bonus }: { realm: RealmInfo; bo
   const hasInsufficientResources = useMemo(() => {
     return selectedResources.some((resource) => {
       const availableAmount = divideByPrecision(
-        Number(availableResources.find((r) => r.resourceId === resource.id)?.amount || 0),
+        Number(availableResources.find((r) => r.resourceId === resource.id)?.amount.balance || 0),
       );
       return resource.amount > availableAmount;
     });
@@ -161,7 +161,7 @@ export const LaborProductionControls = ({ realm, bonus }: { realm: RealmInfo; bo
                       MAX
                       <span>
                         {divideByPrecision(
-                          Number(availableResources.find((r) => r.resourceId === resource.id)?.amount || 0),
+                          availableResources.find((r) => r.resourceId === resource.id)?.amount.balance || 0,
                         )
                           .toString()
                           .toLocaleString()}

--- a/client/apps/game/src/ui/modules/navigation/capacity-info.tsx
+++ b/client/apps/game/src/ui/modules/navigation/capacity-info.tsx
@@ -107,11 +107,16 @@ export const CapacityInfo = ({ structureEntityId, className }: { structureEntity
   const { setup } = useDojo();
   const setTooltip = useUIStore((state) => state.setTooltip);
 
+  // use this to trigger new realm info computation
   const resources = useComponentValue(setup.components.Resource, getEntityIdFromKeys([BigInt(structureEntityId)]));
+  const structureBuildings = useComponentValue(
+    setup.components.StructureBuildings,
+    getEntityIdFromKeys([BigInt(structureEntityId)]),
+  );
 
   const realmInfo = useMemo(
     () => getRealmInfo(getEntityIdFromKeys([BigInt(structureEntityId)]), setup.components),
-    [structureEntityId, resources],
+    [structureEntityId, resources, structureBuildings],
   );
 
   const populationPercentage = realmInfo?.capacity


### PR DESCRIPTION
Adjust calculations for resource amounts to correctly reference the balance property. Update dependencies in the realm info computation to include structure buildings for accurate population updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the display and calculation of available resource amounts in labor production controls to ensure accurate resource balances are shown and used.
  - Improved the responsiveness of realm information updates in capacity info, ensuring changes in building structures are immediately reflected in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->