### PR TITLE
Fix popup block and other url changes

### DIFF
--- a/client/apps/game/src/ui/components/quest/quest-realm-component.tsx
+++ b/client/apps/game/src/ui/components/quest/quest-realm-component.tsx
@@ -73,8 +73,6 @@ export const QuestRealm = ({
     return "Explorer Not Found";
   }, [isCompleted, reachedTargetScore, gameOver, startedQuest, expired, fullCapacity]);
 
-  console.log(questExplorerUsed);
-
   return (
     <div
       className={`h-full flex flex-col items-center gap-2 border panel-wood rounded-lg p-4 ${!questExplorerUsed ? "opacity-70 pointer-events-none grayscale-[50%]" : ""}`}
@@ -110,7 +108,7 @@ export const QuestRealm = ({
 };
 
 interface CurrentQuestProps {
-  handleStartQuest: () => void;
+  handleStartQuest: () => Promise<number | undefined>;
   loading: boolean;
   setLoading: (loading: boolean) => void;
   questLevelInfo: any;
@@ -286,7 +284,12 @@ export const CurrentQuest = ({
               className={`px-6 py-3 rounded-lg font-bold transition-colors w-1/2`}
               isLoading={loading}
               disabled={!questExplorerUsed || fullCapacity || realmExplorerStartedQuest}
-              onClick={handleStartQuest}
+              onClick={async () => {
+                const gameId = await handleStartQuest();
+                if (gameId) {
+                  window.open(`https://darkshuffle.io/play/${Number(gameId)}`, "_blank");
+                }
+              }}
             >
               {startQuestButtonMessage}
             </Button>
@@ -297,7 +300,7 @@ export const CurrentQuest = ({
                   variant="primary"
                   className={`px-6 py-3 rounded-lg font-bold transition-colors w-1/2`}
                   isLoading={loading}
-                  onClick={() => window.open(`https://darkshuffle.dev/play/${Number(game?.token_id ?? 0)}`, "_blank")}
+                  onClick={() => window.open(`https://darkshuffle.io/play/${Number(game?.token_id ?? 0)}`, "_blank")}
                 >
                   Play
                 </Button>

--- a/client/apps/game/src/ui/modules/quests/info-container.tsx
+++ b/client/apps/game/src/ui/modules/quests/info-container.tsx
@@ -93,7 +93,7 @@ export const InfoContainer = ({
                     className="flex flex-row items-center gap-2 text-[12px] relative group"
                     onClick={() =>
                       window.open(
-                        `https://darkshuffle.dev/settings/${Number(level?.value?.settings_id?.value)}`,
+                        `https://darkshuffle.io/settings/${Number(level?.value?.settings_id?.value)}`,
                         "_blank",
                       )
                     }

--- a/client/apps/game/src/ui/modules/quests/quest-container.tsx
+++ b/client/apps/game/src/ui/modules/quests/quest-container.tsx
@@ -76,7 +76,7 @@ export const QuestContainer = ({
         to_address: account?.address,
       });
 
-      window.open(`https://darkshuffle.io/play/${Number(currentGameCount + 1)}`, "_blank");
+      return currentGameCount;
     } catch (error) {
       console.error(error);
     } finally {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Start and Play!" button now starts a quest asynchronously and automatically opens the game in a new browser tab upon success.

- **Bug Fixes**
  - Updated all relevant links from darkshuffle.dev to darkshuffle.io for both game play and settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->