### PR TITLE
client: disallow all troop transfer to guards and allow explorer delete

### DIFF
--- a/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
+++ b/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
@@ -121,7 +121,7 @@ export const TransferTroopsContainer = ({
 
   const maxTroops = (() => {
     if (transferDirection === TransferDirection.ExplorerToStructure) {
-      return Number(selectedExplorerTroops?.count || 0);
+      return Math.max(0, Number(selectedExplorerTroops?.count || 0) - 1);
     } else if (transferDirection === TransferDirection.StructureToExplorer) {
       return Number(selectedGuards[guardSlot].troops.count);
     } else if (transferDirection === TransferDirection.ExplorerToExplorer) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to delete their own army entities directly from the army detail view, with a confirmation spinner indicating progress.
- **Improvements**
  - Chat and delete buttons are now grouped together for better usability in the army detail view.
- **Bug Fixes**
  - Corrected user address extraction to ensure proper functionality.
  - Prevented transferring all troops from an explorer by always reserving at least one troop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->