### PR TITLE
feat: bump to cairo v1.5.0

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.9.4"
+          scarb-version: "2.10.1"
       - name: Download Dojo release artifact
         run: |
-          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v1.4.0/dojo_v1.4.0_linux_amd64.tar.gz
+          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v1.5.0/dojo_v1.4.0_linux_amd64.tar.gz
           tar -xzf dojo-linux-x86_64.tar.gz
           sudo mv sozo /usr/local/bin/
       - name: Run Dojo Test for ${{ matrix.test }}
@@ -51,6 +51,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.9.4"
+          scarb-version: "2.10.1"
       - name: Run scarb fmt check
         run: cd contracts/game && scarb fmt --check

--- a/contracts/game/.tool-versions
+++ b/contracts/game/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.9.4
-dojo 1.4.0
+scarb 2.10.1
+dojo 1.5.0

--- a/contracts/game/Scarb.toml
+++ b/contracts/game/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
-cairo-version = "=2.9.4"
+cairo-version = "=2.10.1"
 name = "s1_eternum"
 version = "1.0.0"
 edition = "2024_07"
@@ -8,16 +8,16 @@ edition = "2024_07"
 sierra-replace-ids = true
 
 [dependencies]
-starknet = "2.9.4"
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.4.0" }
+starknet = "2.10.1"
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.5.0" }
 alexandria_math = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
 alexandria_data_structures = { git = "https://github.com/keep-starknet-strange/alexandria.git", rev = "162bed1" }
-achievement = { git = "https://github.com/cartridge-gg/arcade", tag = "v1.4.0" }
+achievement = { git = "https://github.com/cartridge-gg/arcade", tag = "v1.5.0" }
 cubit = { git = "https://github.com/edisontim/cubit.git", branch = "feat/cairo-2.9.2" }
 tournaments = { git = "https://github.com/Provable-Games/tournaments.git", tag = "v0.1.5" }
 
 [dev-dependencies]
-dojo_cairo_test = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.4.0" }
+dojo_cairo_test = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.5.0" }
 openzeppelin_token = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v1.0.0" }
 openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v1.0.0" }
 

--- a/contracts/marketplace/.tool-versions
+++ b/contracts/marketplace/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.9.4
-dojo 1.4.0
+scarb 2.10.1
+dojo 1.5.0

--- a/contracts/marketplace/Scarb.lock
+++ b/contracts/marketplace/Scarb.lock
@@ -3,8 +3,8 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "1.4.0"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
+version = "1.5.0"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.5.0#812f17c9c57fd057d0bf1e648a591ea0ca9ea718"
 dependencies = [
  "dojo_plugin",
 ]
@@ -12,15 +12,15 @@ dependencies = [
 [[package]]
 name = "dojo_cairo_test"
 version = "1.0.12"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.5.0#812f17c9c57fd057d0bf1e648a591ea0ca9ea718"
 dependencies = [
  "dojo",
 ]
 
 [[package]]
 name = "dojo_plugin"
-version = "2.9.4"
-source = "git+https://github.com/dojoengine/dojo?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
+version = "2.10.1"
+source = "git+https://github.com/dojoengine/dojo?tag=v1.5.0#812f17c9c57fd057d0bf1e648a591ea0ca9ea718"
 
 [[package]]
 name = "marketplace"

--- a/contracts/marketplace/Scarb.toml
+++ b/contracts/marketplace/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
-cairo-version = "=2.9.4"
+cairo-version = "=2.10.1"
 name = "marketplace"
 version = "1.0.0"
 edition = "2024_07"
@@ -8,12 +8,12 @@ edition = "2024_07"
 sierra-replace-ids = true
 
 [dependencies]
-starknet = "2.9.4"
-dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.4.0" }
-openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v1.0.0"}
+starknet = "2.10.1"
+dojo = { git = "https://github.com/dojoengine/dojo", tag = "v1.5.0" }
+openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v1.0.0" }
 
 [dev-dependencies]
-dojo_cairo_test = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.4.0" }
+dojo_cairo_test = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.5.0" }
 
 [[target.starknet-contract]]
 casm = true


### PR DESCRIPTION
This doesn't compile but is needed nonetheless for the Eternum loader to use the correct Torii version


```
[16/05/25 5:52:20] ➜  game git:(feat/bump-dojo) ✗ sozo build
    Updating git repository https://github.com/cartridge-gg/arcade
    Updating git repository https://github.com/dojoengine/dojo
⠁ git fetch --force --update-head-ok https://github.com/dojoengine/dojo +refs/tags/v1.5.0:refs/remotes/origin/tags/v1.5.0                                                                                                                                     0s
⠁ git clone --local --config core.autocrlf=false --recurse-submodules /Users/timothyedison/Library/Caches/com.swmansion.scarb/registry/git/db/dojo-dvdc4757v8eai.git /Users/timothyedison/Library/Caches/com.swmansion.scarb/registry/git/checkouts/dojo-dvdc 0s
[1]    45814 segmentation fault  sozo build
```