### PR TITLE
fixe number input in automation

### DIFF
--- a/client/apps/game/src/ui/components/automation/automation-table.tsx
+++ b/client/apps/game/src/ui/components/automation/automation-table.tsx
@@ -267,14 +267,16 @@ export const AutomationTable: React.FC<AutomationTableProps> = ({ realmEntityId,
             <div>
               <label htmlFor="maxAmount" className="block mb-1 text-sm font-medium">
                 {newOrder.productionType === ProductionType.ResourceToLabor ? "Target Labor Amount:" : "Target Amount:"}
+                {!isInfinite && parseInt(maxAmountInput, 10) < 1000 && (
+                  <span className="text-red ml-1">(min 1000)</span>
+                )}
               </label>
               <div className="flex items-center gap-2">
                 <NumberInput
                   value={isInfinite ? 0 : parseInt(maxAmountInput, 10) || 0}
                   disabled={isInfinite}
                   onChange={(val) => handleMaxAmountChange(String(val))}
-                  min={1000}
-                  className="w-full"
+                  min={0}
                 />
                 <input
                   type="checkbox"
@@ -294,7 +296,13 @@ export const AutomationTable: React.FC<AutomationTableProps> = ({ realmEntityId,
           </div>
 
           <div className="flex justify-end gap-2">
-            <Button type="submit" variant="gold" disabled={newOrder.resourceToUse === undefined}>
+            <Button
+              type="submit"
+              variant="gold"
+              disabled={
+                newOrder.resourceToUse === undefined || (newOrder.maxAmount !== "infinite" && newOrder.maxAmount < 1000)
+              }
+            >
               Add Automation
             </Button>
             <Button onClick={() => setShowAddForm(false)} variant="default" size="md">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visual warning when the target amount is set below 1000 units in the automation order form.
- **Bug Fixes**
  - The "Add Automation" button is now disabled if the target amount is below 1000 units (unless set to "infinite") or if no resource is selected, preventing invalid submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->