### PR TITLE
[fix] ui freeze bug, texture error

### DIFF
--- a/client/apps/game/src/hooks/store/use-ui-store.ts
+++ b/client/apps/game/src/hooks/store/use-ui-store.ts
@@ -125,7 +125,9 @@ export const useUIStore = create(
     isLoadingScreenEnabled: true,
     setIsLoadingScreenEnabled: (enabled) => set({ isLoadingScreenEnabled: enabled }),
     modalContent: null,
-    toggleModal: (content) => set({ modalContent: content, showModal: !get().showModal }),
+    toggleModal: (content) => {
+      set({ modalContent: content, showModal: !!content });
+    },
     showModal: false,
     battleView: null,
     setBattleView: (participants: BattleViewInfo | null) => set({ battleView: participants }),

--- a/client/apps/game/src/three/managers/resource-fx-manager.ts
+++ b/client/apps/game/src/three/managers/resource-fx-manager.ts
@@ -302,7 +302,7 @@ export class ResourceFXManager {
     const texture = this.getOrLoadTexture(resourceId);
 
     if (!texture || !texture.image) {
-      console.warn("Resource texture not loaded yet, skipping FX");
+      console.warn("Resource texture not loaded yet, skipping FX", resourceId);
       return Promise.reject("Resource texture not loaded");
     }
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -221,6 +221,9 @@ export default class WorldmapScene extends HexagonScene {
       setTimeout(() => {
         const armyPosition = this.armiesPositions.get(explorerId);
         if (armyPosition) {
+          if (resourceId === 0) {
+            return;
+          }
           const resource = findResourceById(resourceId);
           // Play the sound for the resource gain
           playResourceSound(resourceId, this.state.isSoundOn, this.state.effectsLevel);

--- a/client/apps/game/src/three/types/systems.ts
+++ b/client/apps/game/src/three/types/systems.ts
@@ -46,7 +46,7 @@ export type BuildingSystemUpdate = {
 
 export type ExplorerRewardSystemUpdate = {
   explorerId: ID;
-  resourceId: ResourcesIds;
+  resourceId: ResourcesIds | 0;
   amount: number;
 };
 export type RealmSystemUpdate = {


### PR DESCRIPTION
#3246
+ bug with console errors related to textures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved modal behavior so it only appears when content is provided, preventing accidental toggling off with the same content.
	- Fixed an issue where resource gain effects and sounds could trigger for an invalid resource (resourceId 0).

- **Other Improvements**
	- Enhanced logging for missing resource textures by including the resource ID for better troubleshooting.
	- Updated internal type definitions to support cases where no valid resource is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->