### PR TITLE
Allow bidirectional troop and resource transfer with warnings

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -29,6 +29,7 @@ import {
   StructureActionManager,
 } from "@bibliothecadao/eternum";
 import {
+  ActorType,
   BiomeType,
   ContractAddress,
   DUMMY_HYPERSTRUCTURE_ENTITY_ID,
@@ -461,12 +462,12 @@ export default class WorldmapScene extends HexagonScene {
     this.state.toggleModal(
       <CombatModal
         selected={{
-          type: selected.army ? "explorer" : "structure",
+          type: selected.army ? ActorType.Explorer : ActorType.Structure,
           id: selectedEntityId,
           hex: new Position({ x: selectedPath[0].col, y: selectedPath[0].row }).getContract(),
         }}
         target={{
-          type: target.army ? "explorer" : "structure",
+          type: target.army ? ActorType.Explorer : ActorType.Structure,
           id: target.army?.id || target.structure?.id || 0,
           hex: new Position({ x: targetHex.col, y: targetHex.row }).getContract(),
         }}
@@ -485,12 +486,12 @@ export default class WorldmapScene extends HexagonScene {
     this.state.toggleModal(
       <HelpModal
         selected={{
-          type: selected.army ? "explorer" : "structure",
+          type: selected.army ? ActorType.Explorer : ActorType.Structure,
           id: selectedEntityId,
           hex: new Position({ x: selectedHex.col, y: selectedHex.row }).getContract(),
         }}
         target={{
-          type: target.army ? "explorer" : "structure",
+          type: target.army ? ActorType.Explorer : ActorType.Structure,
           id: target.army?.id || target.structure?.id || 0,
           hex: new Position({ x: targetHex.col, y: targetHex.row }).getContract(),
         }}

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -482,6 +482,9 @@ export default class WorldmapScene extends HexagonScene {
     const selectedHex = selectedPath[0];
     const selected = this.getHexagonEntity(selectedHex);
     const target = this.getHexagonEntity(targetHex);
+    const account = ContractAddress(useAccountStore.getState().account?.address || "");
+    const isTargetMine = target.army?.owner === account || target.structure?.owner === account;
+    const isSelectedMine = selected.army?.owner === account || selected.structure?.owner === account;
 
     this.state.toggleModal(
       <HelpModal
@@ -495,6 +498,7 @@ export default class WorldmapScene extends HexagonScene {
           id: target.army?.id || target.structure?.id || 0,
           hex: new Position({ x: targetHex.col, y: targetHex.row }).getContract(),
         }}
+        allowBothDirections={isTargetMine && isSelectedMine}
       />,
     );
   }

--- a/client/apps/game/src/ui/components/military/army-chip.tsx
+++ b/client/apps/game/src/ui/components/military/army-chip.tsx
@@ -12,7 +12,7 @@ import { ViewOnMapIcon } from "@/ui/elements/view-on-map-icon";
 import { HelpModal } from "@/ui/modules/military/help-modal";
 import { armyHasTroops, getEntityIdFromKeys, StaminaManager } from "@bibliothecadao/eternum";
 import { useDojo, useQuery } from "@bibliothecadao/react";
-import { ArmyInfo, TroopTier, TroopType } from "@bibliothecadao/types";
+import { ActorType, ArmyInfo, TroopTier, TroopType } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
 import { ArrowLeftRight, CirclePlus, LucideArrowRight } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
@@ -100,12 +100,12 @@ export const ArmyChip = ({
     toggleModal(
       <HelpModal
         selected={{
-          type: "explorer",
+          type: ActorType.Explorer,
           id: army.entityId,
           hex: new Position({ x: Number(army.position.x), y: Number(army.position.y) }).getContract(),
         }}
         target={{
-          type: "structure",
+          type: ActorType.Structure,
           id: army.entity_owner_id,
           hex: new Position({ x: Number(hexPosition?.col), y: Number(hexPosition?.row) }).getContract(),
         }}

--- a/client/apps/game/src/ui/modules/military/combat-modal.tsx
+++ b/client/apps/game/src/ui/modules/military/combat-modal.tsx
@@ -1,8 +1,9 @@
 import { ModalContainer } from "@/ui/components/modal-container";
 import { LoadingAnimation } from "@/ui/elements/loading-animation";
-import { ID } from "@bibliothecadao/types";
+import { ActorType, ID } from "@bibliothecadao/types";
 import { Suspense, useState } from "react";
 import { AttackContainer } from "./attack-container";
+import { HelpContainer } from "./help-container";
 
 enum ModalTab {
   Attack = "Attack",
@@ -14,12 +15,12 @@ export const CombatModal = ({
   target,
 }: {
   selected: {
-    type: "explorer" | "structure";
+    type: ActorType;
     id: ID;
     hex: { x: number; y: number };
   };
   target: {
-    type: "explorer" | "structure";
+    type: ActorType;
     id: ID;
     hex: { x: number; y: number };
   };
@@ -32,26 +33,28 @@ export const CombatModal = ({
         {/* Tab Selection */}
         <div className="flex justify-center border-b border-gold/30">
           <div className="flex">
-            <button
-              className={`px-6 py-3 text-lg font-semibold text-gold border-b-2 border-gold`}
-              onClick={() => setActiveTab(ModalTab.Attack)}
-            >
-              {ModalTab.Attack}
-            </button>
-            <button
-              className={`px-6 py-3 text-lg font-semibold text-gold/30 cursor-not-allowed flex items-center`}
-              disabled
-            >
-              {ModalTab.Transfer}{" "}
-              <span className="ml-2 text-xs bg-gold/20 text-gold px-2 py-0.5 rounded">COMING SOON</span>
-            </button>
+            {Object.values(ModalTab).map((tab) => (
+              <button
+                key={tab}
+                className={`px-6 py-3 text-lg font-semibold ${
+                  activeTab === tab ? "text-gold border-b-2 border-gold" : "text-gold/50 hover:text-gold/70"
+                }`}
+                onClick={() => setActiveTab(tab)}
+              >
+                {tab}
+              </button>
+            ))}
           </div>
         </div>
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto overflow-x-hidden max-h-[calc(100vh-200px)]">
           <Suspense fallback={<LoadingAnimation />}>
-            <AttackContainer attackerEntityId={selected.id} targetHex={target.hex} />
+            {activeTab === ModalTab.Attack ? (
+              <AttackContainer attackerEntityId={selected.id} targetHex={target.hex} />
+            ) : (
+              <HelpContainer selected={selected} target={target} />
+            )}
           </Suspense>
         </div>
       </div>

--- a/client/apps/game/src/ui/modules/military/help-container.tsx
+++ b/client/apps/game/src/ui/modules/military/help-container.tsx
@@ -1,8 +1,24 @@
 import { useUIStore } from "@/hooks/store/use-ui-store";
-import { ID } from "@bibliothecadao/types";
+import { ActorType, ID } from "@bibliothecadao/types";
 import { useState } from "react";
 import { TransferResourcesContainer } from "./transfer-resources-container";
-import { TransferDirection, TransferTroopsContainer } from "./transfer-troops-container";
+import { TransferTroopsContainer } from "./transfer-troops-container";
+
+export enum TransferDirection {
+  ExplorerToStructure,
+  StructureToExplorer,
+  ExplorerToExplorer,
+}
+
+export const getActorTypes = (direction: TransferDirection) => {
+  if (direction === TransferDirection.ExplorerToStructure) {
+    return { selected: ActorType.Explorer, target: ActorType.Structure };
+  } else if (direction === TransferDirection.StructureToExplorer) {
+    return { selected: ActorType.Structure, target: ActorType.Explorer };
+  } else {
+    return { selected: ActorType.Explorer, target: ActorType.Explorer };
+  }
+};
 
 enum TransferType {
   Resources,
@@ -15,12 +31,12 @@ export const HelpContainer = ({
   allowBothDirections = false,
 }: {
   selected: {
-    type: "explorer" | "structure";
+    type: ActorType;
     id: ID;
     hex: { x: number; y: number };
   };
   target: {
-    type: "explorer" | "structure";
+    type: ActorType;
     id: ID;
     hex: { x: number; y: number };
   };
@@ -38,15 +54,15 @@ export const HelpContainer = ({
 
   // Determine the transfer direction based on entity types
   const transferDirection = (() => {
-    if (currentSelected.type === "explorer" && currentTarget.type === "structure") {
+    if (currentSelected.type === ActorType.Explorer && currentTarget.type === ActorType.Structure) {
       return TransferDirection.ExplorerToStructure;
     }
 
-    if (currentSelected.type === "structure" && currentTarget.type === "explorer") {
+    if (currentSelected.type === ActorType.Structure && currentTarget.type === ActorType.Explorer) {
       return TransferDirection.StructureToExplorer;
     }
 
-    if (currentSelected.type === "explorer" && currentTarget.type === "explorer") {
+    if (currentSelected.type === ActorType.Explorer && currentTarget.type === ActorType.Explorer) {
       return TransferDirection.ExplorerToExplorer;
     }
 

--- a/client/apps/game/src/ui/modules/military/help-container.tsx
+++ b/client/apps/game/src/ui/modules/military/help-container.tsx
@@ -112,7 +112,7 @@ export const HelpContainer = ({
   };
 
   return (
-    <div className="flex h-full flex-col items-center justify-center  max-w-4xl mx-auto">
+    <div className="flex h-full flex-col items-center justify-center  max-w-4xl mx-auto mb-4">
       <div className="px-6 h-full backdrop-blur-sm w-full flex flex-col">
         {/* Transfer Type Selection */}
         <div className="flex justify-center mb-6 mx-auto mt-4">

--- a/client/apps/game/src/ui/modules/military/help-modal.tsx
+++ b/client/apps/game/src/ui/modules/military/help-modal.tsx
@@ -1,6 +1,6 @@
 import { ModalContainer } from "@/ui/components/modal-container";
 import { LoadingAnimation } from "@/ui/elements/loading-animation";
-import { ID } from "@bibliothecadao/types";
+import { ActorType, ID } from "@bibliothecadao/types";
 import { Suspense } from "react";
 import { HelpContainer } from "./help-container";
 
@@ -10,12 +10,12 @@ export const HelpModal = ({
   allowBothDirections = false,
 }: {
   selected: {
-    type: "explorer" | "structure";
+    type: ActorType;
     id: ID;
     hex: { x: number; y: number };
   };
   target: {
-    type: "explorer" | "structure";
+    type: ActorType;
     id: ID;
     hex: { x: number; y: number };
   };

--- a/client/apps/game/src/ui/modules/military/transfer-resources-container.tsx
+++ b/client/apps/game/src/ui/modules/military/transfer-resources-container.tsx
@@ -103,9 +103,6 @@ export const TransferResourcesContainer = ({
   const availableResources = availableResourcesData || [];
   const availableCapacityKg = explorerCapacity ? explorerCapacity.remainingCapacityKg - selectedResourcesWeightKg : 0;
 
-  console.log({ availableResourcesData, isResourcesLoading });
-  console.log({ explorerCapacity, isExplorerCapacityLoading });
-
   useEffect(() => {
     // Calculate weight of selected resources
     const selectedResourcesWeight = selectedResources.reduce((total, { resourceId, amount }) => {

--- a/client/apps/game/src/ui/modules/military/transfer-resources-container.tsx
+++ b/client/apps/game/src/ui/modules/military/transfer-resources-container.tsx
@@ -1,11 +1,20 @@
 import Button from "@/ui/elements/button";
+import { LoadingAnimation } from "@/ui/elements/loading-animation";
 import { ResourceIcon } from "@/ui/elements/resource-icon";
 import { getBlockTimestamp } from "@/utils/timestamp";
-import { ResourceManager, configManager, divideByPrecision, getArmy } from "@bibliothecadao/eternum";
+import {
+  configManager,
+  divideByPrecision,
+  getArmyTotalCapacityInKg,
+  gramToKg,
+  ResourceManager,
+} from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
-import { ContractAddress, ID, ResourcesIds, resources } from "@bibliothecadao/types";
-import { useState } from "react";
-import { TransferDirection } from "./transfer-troops-container";
+import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@bibliothecadao/torii-client";
+import { ActorType, ID, resources, ResourcesIds } from "@bibliothecadao/types";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { getActorTypes, TransferDirection } from "./help-container";
 
 // Define the Resource type to match what the system calls expect
 interface ResourceTransfer {
@@ -28,53 +37,83 @@ export const TransferResourcesContainer = ({
 }: TransferResourcesContainerProps) => {
   const {
     account: { account },
+    network: { toriiClient },
     setup: {
       systemCalls: {
         troop_structure_adjacent_transfer,
         structure_troop_adjacent_transfer,
         troop_troop_adjacent_transfer,
       },
-      components,
     },
   } = useDojo();
 
   const [loading, setLoading] = useState(false);
   const [selectedResources, setSelectedResources] = useState<ResourceTransfer[]>([]);
   const [resourceAmounts, setResourceAmounts] = useState<Record<number, number>>({});
+  const [selectedResourcesWeightKg, setSelectedResourcesWeightKg] = useState<number>(0);
+  const [actorTypes, setActorTypes] = useState<{
+    selected: ActorType;
+    target: ActorType;
+  } | null>(null);
 
-  // Get available resources for the selected entity
-  const availableResources = (() => {
-    const { currentDefaultTick } = getBlockTimestamp();
-    if (!selectedEntityId) return [];
-    const resourceManager = new ResourceManager(components, selectedEntityId);
-    return resources
-      .map(({ id }) => ({
-        resourceId: id,
-        amount: resourceManager.balanceWithProduction(currentDefaultTick, id).balance,
-      }))
-      .filter(({ amount }) => amount > 0);
-  })();
+  useEffect(() => {
+    const { selected, target } = getActorTypes(transferDirection);
+    setActorTypes({ selected, target });
+  }, [transferDirection]);
 
-  // Explorer capacity information
-  const explorerCapacity = (() => {
-    const armyInfo = getArmy(targetEntityId, ContractAddress(account.address), components);
-    const MAX_CAPACITY = armyInfo?.totalCapacity || 0;
-    const currentLoad = armyInfo?.weight || 0;
+  // Query for available resources
+  const { data: availableResourcesData, isLoading: isResourcesLoading } = useQuery({
+    queryKey: ["availableResources", String(selectedEntityId), String(actorTypes?.selected)],
+    queryFn: async () => {
+      if (!selectedEntityId || !actorTypes?.selected) return [];
+      const { currentDefaultTick } = getBlockTimestamp();
+      const { resources: resourcesData } =
+        actorTypes.selected === ActorType.Explorer
+          ? await getExplorerFromToriiClient(toriiClient, selectedEntityId)
+          : await getStructureFromToriiClient(toriiClient, selectedEntityId);
+      if (!resourcesData) return [];
+      return resources
+        .map(({ id }) => ({
+          resourceId: id,
+          amount: ResourceManager.balanceWithProduction(resourcesData, currentDefaultTick, id).balance,
+        }))
+        .filter(({ amount }) => amount > 0);
+    },
+    staleTime: 10000, // 10 seconds
+  });
 
+  // Query for explorer capacity
+  const { data: explorerCapacity, isLoading: isExplorerCapacityLoading } = useQuery({
+    queryKey: ["explorerCapacity", String(targetEntityId), String(actorTypes?.target)],
+    queryFn: async () => {
+      if (!targetEntityId || actorTypes?.target !== ActorType.Explorer) return null;
+      const { resources: resourcesData } = await getExplorerFromToriiClient(toriiClient, targetEntityId);
+      if (!resourcesData) return null;
+      const maxCapacity = getArmyTotalCapacityInKg(resourcesData);
+      const currentLoad = gramToKg(divideByPrecision(Number(resourcesData.weight.weight)));
+      return {
+        maxCapacityKg: maxCapacity,
+        currentLoadKg: currentLoad,
+        remainingCapacityKg: maxCapacity - currentLoad,
+      };
+    },
+    staleTime: 10000, // 10 seconds
+  });
+
+  const availableResources = availableResourcesData || [];
+  const availableCapacityKg = explorerCapacity ? explorerCapacity.remainingCapacityKg - selectedResourcesWeightKg : 0;
+
+  console.log({ availableResourcesData, isResourcesLoading });
+  console.log({ explorerCapacity, isExplorerCapacityLoading });
+
+  useEffect(() => {
     // Calculate weight of selected resources
-    const selectedResourcesWeight = Object.entries(resourceAmounts).reduce((total, [resourceId, amount]) => {
-      const weight = configManager.resourceWeightsKg[parseInt(resourceId)] || 0;
+    const selectedResourcesWeight = selectedResources.reduce((total, { resourceId, amount }) => {
+      const weight = configManager.resourceWeightsKg[resourceId] || 0;
       return total + amount * weight;
     }, 0);
-
-    return {
-      maxCapacity: MAX_CAPACITY,
-      currentLoad,
-      remainingCapacity: MAX_CAPACITY - currentLoad,
-      selectedResourcesWeight,
-      availableCapacity: MAX_CAPACITY - currentLoad - selectedResourcesWeight,
-    };
-  })();
+    setSelectedResourcesWeightKg(selectedResourcesWeight);
+  }, [selectedResources]);
 
   // Handle resource selection
   const toggleResourceSelection = (resource: ResourceTransfer) => {
@@ -93,12 +132,12 @@ export const TransferResourcesContainer = ({
       let defaultAmount = divideByPrecision(resource.amount);
 
       // If transferring to explorer, limit by available capacity
-      if (transferDirection === TransferDirection.StructureToExplorer) {
+      if (actorTypes?.target === ActorType.Explorer && explorerCapacity) {
         const resourceWeight = configManager.resourceWeightsKg[resource.resourceId] || 0;
         if (resourceWeight > 0) {
           // Only limit if resource has weight
           // Use explorerCapacity.availableCapacity which accounts for other selected resources
-          const maxPossibleAmountBasedOnCapacity = Math.floor(explorerCapacity.availableCapacity / resourceWeight);
+          const maxPossibleAmountBasedOnCapacity = Math.floor(availableCapacityKg / resourceWeight);
           defaultAmount = Math.min(defaultAmount, maxPossibleAmountBasedOnCapacity);
         }
       }
@@ -114,12 +153,12 @@ export const TransferResourcesContainer = ({
   const handleResourceAmountChange = (resourceId: number, amount: number) => {
     // Ensure amount is within valid range
     const resource = availableResources.find((r) => r.resourceId === resourceId);
-    if (!resource) return;
+    if (!resource || !explorerCapacity) return;
 
     let maxAmount = divideByPrecision(resource.amount);
 
     // If transferring to explorer, limit by remaining capacity
-    if (transferDirection === TransferDirection.StructureToExplorer) {
+    if (actorTypes?.target === ActorType.Explorer) {
       const resourceWeight = configManager.resourceWeightsKg[resourceId] || 0;
 
       // Calculate how much capacity is used by other selected resources
@@ -131,7 +170,7 @@ export const TransferResourcesContainer = ({
         }, 0);
 
       const availableForThisResource =
-        explorerCapacity.maxCapacity - explorerCapacity.currentLoad - otherResourcesWeight;
+        explorerCapacity.maxCapacityKg - explorerCapacity.currentLoadKg - otherResourcesWeight;
       const maxPossibleAmount = Math.floor(availableForThisResource / resourceWeight);
       maxAmount = Math.min(divideByPrecision(resource.amount), maxPossibleAmount);
     }
@@ -157,8 +196,8 @@ export const TransferResourcesContainer = ({
 
     // If transferring to explorer, we need to calculate how much of each resource we can add
     // based on weight constraints
-    if (transferDirection === TransferDirection.StructureToExplorer) {
-      let remainingCapacity = explorerCapacity.remainingCapacity;
+    if (actorTypes?.target === ActorType.Explorer && explorerCapacity) {
+      let remainingCapacity = explorerCapacity.remainingCapacityKg;
 
       // Sort resources by weight (lightest first) to maximize the number of resources we can transfer
       const sortedResources = [...availableResources].sort((a, b) => {
@@ -249,14 +288,12 @@ export const TransferResourcesContainer = ({
 
   // Render explorer capacity information
   const renderExplorerCapacity = () => {
-    if (transferDirection !== TransferDirection.StructureToExplorer) {
+    if (actorTypes?.target !== ActorType.Explorer || !explorerCapacity) {
       return null;
     }
 
-    const currentLoadKg = explorerCapacity.currentLoad;
-    const maxCapacityKg = explorerCapacity.maxCapacity;
-    const selectedWeightKg = explorerCapacity.selectedResourcesWeight;
-    const availableCapacityKg = explorerCapacity.availableCapacity;
+    const currentLoadKg = explorerCapacity.currentLoadKg;
+    const maxCapacityKg = explorerCapacity.maxCapacityKg;
 
     let capacityPercentageForBar = 0;
     if (maxCapacityKg > 0) {
@@ -270,7 +307,7 @@ export const TransferResourcesContainer = ({
 
     let selectedPercentageForBar = 0;
     if (maxCapacityKg > 0) {
-      const rawSelectedRatio = (selectedWeightKg / maxCapacityKg) * 100;
+      const rawSelectedRatio = (selectedResourcesWeightKg / maxCapacityKg) * 100;
       // Selected part is capped by the remaining space in the bar after current load
       selectedPercentageForBar = Math.max(0, Math.min(rawSelectedRatio, 100 - capacityPercentageForBar));
     }
@@ -310,10 +347,12 @@ export const TransferResourcesContainer = ({
             <div
               className="absolute top-0 h-full bg-orange-500/70 flex items-center justify-center bg-green/30"
               style={{ width: `${selectedPercentageForBar}%`, left: `${capacityPercentageForBar}%` }}
-              title={`Selected: ${selectedWeightKg.toLocaleString()} kg`}
+              title={`Selected: ${selectedResourcesWeightKg.toLocaleString()} kg`}
             >
               {selectedPercentageForBar > 15 && (
-                <span className="text-xs text-white/90 truncate px-1">{selectedWeightKg.toLocaleString()} kg</span>
+                <span className="text-xs text-white/90 truncate px-1">
+                  {selectedResourcesWeightKg.toLocaleString()} kg
+                </span>
               )}
             </div>
             {/* Empty space indicator if not full */}
@@ -335,14 +374,16 @@ export const TransferResourcesContainer = ({
             </div>
             <div>
               <span className="text-orange-400/90">Selected:</span>
-              <span className="font-medium float-right text-white/90">{selectedWeightKg.toLocaleString()} kg</span>
+              <span className="font-medium float-right text-white/90">
+                {selectedResourcesWeightKg.toLocaleString()} kg
+              </span>
             </div>
             <div>
               <span className="text-gold/80">After Transfer:</span>
               <span
-                className={`font-medium float-right ${currentLoadKg + selectedWeightKg > maxCapacityKg ? "text-red-500" : "text-white/90"}`}
+                className={`font-medium float-right ${currentLoadKg + selectedResourcesWeightKg > maxCapacityKg ? "text-red-500" : "text-white/90"}`}
               >
-                {(currentLoadKg + selectedWeightKg).toLocaleString()} kg
+                {(currentLoadKg + selectedResourcesWeightKg).toLocaleString()} kg
               </span>
             </div>
             <div>
@@ -363,138 +404,147 @@ export const TransferResourcesContainer = ({
 
   return (
     <div className="flex flex-col h-full relative pb-32">
-      {/* Top section with capacity info */}
+      {isResourcesLoading || isExplorerCapacityLoading ? (
+        <LoadingAnimation />
+      ) : (
+        <>
+          {/* Top section with capacity info */}
 
-      {/* Add Select All / Unselect All buttons here */}
-      <div className="flex justify-end space-x-2 mb-3">
-        {transferDirection === TransferDirection.ExplorerToStructure && (
-          <Button
-            onClick={handleSelectAllResources}
-            variant="outline"
-            size="xs"
-            disabled={availableResources.length === 0}
-          >
-            Select All Available
-          </Button>
-        )}
-        <Button
-          onClick={handleUnselectAllResources}
-          variant="outline"
-          size="xs"
-          disabled={selectedResources.length === 0}
-        >
-          Unselect All
-        </Button>
-      </div>
-
-      {/* Scrollable resources section */}
-      <div className=" h-full grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <div className="sticky top-0 z-10">
-          {transferDirection === TransferDirection.StructureToExplorer && renderExplorerCapacity()}
-        </div>
-
-        <div className="grid grid-cols-1 gap-3 overflow-y-auto">
-          {availableResources.map((resource) => {
-            const isSelected = selectedResources.some((r) => r.resourceId === resource.resourceId);
-            const resourceWeight = configManager.resourceWeightsKg[resource.resourceId] || 0;
-            const displayAmount = divideByPrecision(resource.amount);
-
-            return (
-              <div
-                key={resource.resourceId}
-                className={`p-3 rounded-md border ${
-                  isSelected ? "bg-gold/20 border-gold" : "bg-dark-brown border-gold/30"
-                }`}
+          {/* Add Select All / Unselect All buttons here */}
+          <div className="flex justify-end space-x-2 mb-3">
+            {actorTypes?.target === ActorType.Structure && (
+              <Button
+                onClick={handleSelectAllResources}
+                variant="outline"
+                size="xs"
+                disabled={availableResources.length === 0}
               >
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center">
-                    <ResourceIcon resource={ResourcesIds[resource.resourceId]} size="sm" withTooltip={false} />
-                    <span className="ml-2 font-medium">{ResourcesIds[resource.resourceId]}</span>
-                  </div>
-                  <div className="text-sm text-gold/80">{resourceWeight} kg per unit</div>
-                  <button
-                    className={`px-3 py-1 rounded-md text-sm ${
-                      isSelected ? "bg-red/50 hover:bg-red/70 text-red-300" : "bg-gold/10 hover:bg-gold/20 text-gold"
+                Select All Available
+              </Button>
+            )}
+            <Button
+              onClick={handleUnselectAllResources}
+              variant="outline"
+              size="xs"
+              disabled={selectedResources.length === 0}
+            >
+              Unselect All
+            </Button>
+          </div>
+
+          {/* Scrollable resources section */}
+          <div className=" h-full grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="sticky top-0 z-10">
+              {actorTypes?.target === ActorType.Explorer && explorerCapacity && renderExplorerCapacity()}
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 overflow-y-auto">
+              {availableResources.map((resource) => {
+                const isSelected = selectedResources.some((r) => r.resourceId === resource.resourceId);
+                const resourceWeight = configManager.resourceWeightsKg[resource.resourceId] || 0;
+                const displayAmount = divideByPrecision(resource.amount);
+
+                return (
+                  <div
+                    key={resource.resourceId}
+                    className={`p-3 rounded-md border ${
+                      isSelected ? "bg-gold/20 border-gold" : "bg-dark-brown border-gold/30"
                     }`}
-                    onClick={() => toggleResourceSelection(resource)}
                   >
-                    {isSelected ? "Remove" : "Select"}
-                  </button>
-                </div>
-
-                <div className="flex items-center justify-between mb-2">
-                  <span className="text-gold/80">Available: {displayAmount.toLocaleString()}</span>
-                </div>
-
-                {isSelected && (
-                  <div className="mt-3">
-                    <div className="flex justify-between text-sm text-gold/80 mb-1">
-                      <label>Amount to Transfer:</label>
-                      <span>
-                        {resourceAmounts[resource.resourceId]?.toLocaleString() || 0} /{displayAmount.toLocaleString()}
-                      </span>
-                    </div>
-                    <div className="flex items-center space-x-2">
-                      <input
-                        type="range"
-                        min="0"
-                        max={displayAmount}
-                        value={resourceAmounts[resource.resourceId] || 0}
-                        onChange={(e) => handleResourceAmountChange(resource.resourceId, parseInt(e.target.value))}
-                        className="w-full accent-gold"
-                      />
-                      <input
-                        type="number"
-                        min="0"
-                        max={displayAmount}
-                        value={resourceAmounts[resource.resourceId] || 0}
-                        onChange={(e) => handleResourceAmountChange(resource.resourceId, parseInt(e.target.value))}
-                        className="w-20 px-2 py-1 bg-dark-brown border border-gold/30 rounded-md text-gold"
-                      />
-                    </div>
-
-                    <div className="flex justify-between mt-2">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center">
+                        <ResourceIcon resource={ResourcesIds[resource.resourceId]} size="sm" withTooltip={false} />
+                        <span className="ml-2 font-medium">{ResourcesIds[resource.resourceId]}</span>
+                      </div>
+                      <div className="text-sm text-gold/80">{resourceWeight} kg per unit</div>
                       <button
-                        className="px-2 py-1 text-xs bg-gold/10 hover:bg-gold/20 rounded-md"
-                        onClick={() => handleResourceAmountChange(resource.resourceId, 0)}
+                        className={`px-3 py-1 rounded-md text-sm ${
+                          isSelected
+                            ? "bg-red/50 hover:bg-red/70 text-red-300"
+                            : "bg-gold/10 hover:bg-gold/20 text-gold"
+                        }`}
+                        onClick={() => toggleResourceSelection(resource)}
                       >
-                        None
-                      </button>
-
-                      <button
-                        className="px-2 py-1 text-xs bg-gold/10 hover:bg-gold/20 rounded-md"
-                        onClick={() => {
-                          // Let handleResourceAmountChange handle capacity limits
-                          handleResourceAmountChange(resource.resourceId, displayAmount);
-                        }}
-                      >
-                        Max
+                        {isSelected ? "Remove" : "Select"}
                       </button>
                     </div>
+
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-gold/80">Available: {displayAmount.toLocaleString()}</span>
+                    </div>
+
+                    {isSelected && (
+                      <div className="mt-3">
+                        <div className="flex justify-between text-sm text-gold/80 mb-1">
+                          <label>Amount to Transfer:</label>
+                          <span>
+                            {resourceAmounts[resource.resourceId]?.toLocaleString() || 0} /
+                            {displayAmount.toLocaleString()}
+                          </span>
+                        </div>
+                        <div className="flex items-center space-x-2">
+                          <input
+                            type="range"
+                            min="0"
+                            max={displayAmount}
+                            value={resourceAmounts[resource.resourceId] || 0}
+                            onChange={(e) => handleResourceAmountChange(resource.resourceId, parseInt(e.target.value))}
+                            className="w-full accent-gold"
+                          />
+                          <input
+                            type="number"
+                            min="0"
+                            max={displayAmount}
+                            value={resourceAmounts[resource.resourceId] || 0}
+                            onChange={(e) => handleResourceAmountChange(resource.resourceId, parseInt(e.target.value))}
+                            className="w-20 px-2 py-1 bg-dark-brown border border-gold/30 rounded-md text-gold"
+                          />
+                        </div>
+
+                        <div className="flex justify-between mt-2">
+                          <button
+                            className="px-2 py-1 text-xs bg-gold/10 hover:bg-gold/20 rounded-md"
+                            onClick={() => handleResourceAmountChange(resource.resourceId, 0)}
+                          >
+                            None
+                          </button>
+
+                          <button
+                            className="px-2 py-1 text-xs bg-gold/10 hover:bg-gold/20 rounded-md"
+                            onClick={() => {
+                              // Let handleResourceAmountChange handle capacity limits
+                              handleResourceAmountChange(resource.resourceId, displayAmount);
+                            }}
+                          >
+                            Max
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </div>
+                );
+              })}
+            </div>
+          </div>
 
-      {/* Fixed position transfer button at the bottom */}
-      <div className="mt-10 mx-auto">
-        <Button
-          onClick={handleTransfer}
-          variant="gold"
-          disabled={
-            loading ||
-            selectedResources.length === 0 ||
-            selectedResources.every((r) => (resourceAmounts[r.resourceId] || 0) === 0)
-          }
-          isLoading={loading}
-          className="w-full sm:w-auto"
-        >
-          {loading ? "Processing..." : "Transfer Resources"}
-        </Button>
-      </div>
+          {/* Fixed position transfer button at the bottom */}
+          <div className="mt-10 mx-auto">
+            <Button
+              onClick={handleTransfer}
+              variant="gold"
+              disabled={
+                loading ||
+                selectedResources.length === 0 ||
+                selectedResources.every((r) => (resourceAmounts[r.resourceId] || 0) === 0)
+              }
+              isLoading={loading}
+              className="w-full sm:w-auto"
+            >
+              {loading ? "Processing..." : "Transfer Resources"}
+            </Button>
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
+++ b/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
@@ -221,6 +221,15 @@ export const TransferTroopsContainer = ({
         }
         return selectedTroop?.tier !== targetTroop?.tier || selectedTroop?.category !== targetTroop?.category;
       }
+    } else if (transferDirection === TransferDirection.ExplorerToExplorer) {
+      // check if selected troops is same category and tier as target troops
+      if (selectedExplorerTroops?.troops.category !== targetExplorerTroops?.troops.category) {
+        return true;
+      }
+      if (selectedExplorerTroops?.troops.tier !== targetExplorerTroops?.troops.tier) {
+        return true;
+      }
+      return false;
     }
     return troopAmount === 0;
   })();
@@ -251,6 +260,47 @@ export const TransferTroopsContainer = ({
       }
     }
 
+    return null;
+  };
+
+  const getDisabledMessage = () => {
+    if (loading) return "Processing transfer...";
+    if (troopAmount === 0) return "Please select an amount of troops to transfer";
+    if (
+      guardSlot === undefined &&
+      (transferDirection === TransferDirection.ExplorerToStructure ||
+        transferDirection === TransferDirection.StructureToExplorer)
+    ) {
+      return "Please select a guard slot";
+    }
+    if (transferDirection === TransferDirection.ExplorerToExplorer) {
+      if (selectedExplorerTroops?.troops.category !== targetExplorerTroops?.troops.category) {
+        return `Cannot transfer troops: Category mismatch (${selectedExplorerTroops?.troops.category} ≠ ${targetExplorerTroops?.troops.category})`;
+      }
+      if (selectedExplorerTroops?.troops.tier !== targetExplorerTroops?.troops.tier) {
+        return `Cannot transfer troops: Tier mismatch (Tier ${selectedExplorerTroops?.troops.tier} ≠ Tier ${targetExplorerTroops?.troops.tier})`;
+      }
+    }
+    if (transferDirection === TransferDirection.ExplorerToStructure) {
+      const selectedTroop = selectedExplorerTroops?.troops;
+      const targetTroop = targetGuards[guardSlot]?.troops;
+      if (
+        targetTroop?.count !== 0 &&
+        (selectedTroop?.tier !== targetTroop?.tier || selectedTroop?.category !== targetTroop?.category)
+      ) {
+        return `Cannot transfer troops: Type mismatch (Tier ${selectedTroop?.tier} ${selectedTroop?.category} ≠ Tier ${targetTroop?.tier} ${targetTroop?.category})`;
+      }
+    }
+    if (transferDirection === TransferDirection.StructureToExplorer) {
+      const selectedTroop = selectedGuards[guardSlot]?.troops;
+      const targetTroop = targetExplorerTroops?.troops;
+      if (
+        targetTroop?.count !== 0n &&
+        (selectedTroop?.tier !== targetTroop?.tier || selectedTroop?.category !== targetTroop?.category)
+      ) {
+        return `Cannot transfer troops: Type mismatch (Tier ${selectedTroop?.tier} ${selectedTroop?.category} ≠ Tier ${targetTroop?.tier} ${targetTroop?.category})`;
+      }
+    }
     return null;
   };
 
@@ -380,6 +430,7 @@ export const TransferTroopsContainer = ({
           )}
 
           {getTroopMismatchMessage() && <div className="text-red-500 text-sm mt-2">{getTroopMismatchMessage()}</div>}
+          {isTroopsTransferDisabled && <div className="text-red-500 text-sm mt-2">{getDisabledMessage()}</div>}
 
           <div className="flex justify-center mt-6">
             <Button

--- a/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
+++ b/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
@@ -1,17 +1,13 @@
 import Button from "@/ui/elements/button";
+import { LoadingAnimation } from "@/ui/elements/loading-animation";
 import { formatNumber } from "@/ui/utils/utils";
-import { getEntityIdFromKeys, getGuardsByStructure } from "@bibliothecadao/eternum";
+import { divideByPrecision, getGuardsByStructure, multiplyByPrecision } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
+import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@bibliothecadao/torii-client";
 import { DEFENSE_NAMES, ID, getDirectionBetweenAdjacentHexes } from "@bibliothecadao/types";
-import { useComponentValue } from "@dojoengine/react";
-import { getComponentValue } from "@dojoengine/recs";
+import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
-
-export enum TransferDirection {
-  ExplorerToStructure,
-  StructureToExplorer,
-  ExplorerToExplorer,
-}
+import { TransferDirection } from "./help-container";
 
 interface TransferTroopsContainerProps {
   selectedEntityId: ID;
@@ -32,9 +28,9 @@ export const TransferTroopsContainer = ({
 }: TransferTroopsContainerProps) => {
   const {
     account: { account },
+    network: { toriiClient },
     setup: {
       systemCalls: { explorer_explorer_swap, explorer_guard_swap, guard_explorer_swap },
-      components,
     },
   } = useDojo();
 
@@ -42,90 +38,98 @@ export const TransferTroopsContainer = ({
   const [troopAmount, setTroopAmount] = useState<number>(0);
   const [guardSlot, setGuardSlot] = useState<number>(0); // Default to first guard slot
 
-  const selected = useComponentValue(components.Structure, getEntityIdFromKeys([BigInt(selectedEntityId)]));
-  const target = useComponentValue(components.Structure, getEntityIdFromKeys([BigInt(targetEntityId)]));
+  // Query for selected entity data
+  const { data: selectedEntityData, isLoading: isSelectedLoading } = useQuery({
+    queryKey: ["selectedEntity", String(selectedEntityId)],
+    queryFn: async () => {
+      const [structureData, explorerData] = await Promise.all([
+        getStructureFromToriiClient(toriiClient, selectedEntityId),
+        getExplorerFromToriiClient(toriiClient, selectedEntityId),
+      ]);
 
-  console.log(selected, target);
+      return {
+        structure: structureData.structure,
+        explorer: explorerData.explorer,
+      };
+    },
+    staleTime: 10000, // 10 seconds
+  });
+
+  // Query for target entity data
+  const { data: targetEntityData, isLoading: isTargetLoading } = useQuery({
+    queryKey: ["targetEntity", String(targetEntityId)],
+    queryFn: async () => {
+      const [structureData, explorerData] = await Promise.all([
+        getStructureFromToriiClient(toriiClient, targetEntityId),
+        getExplorerFromToriiClient(toriiClient, targetEntityId),
+      ]);
+
+      return {
+        structure: structureData.structure,
+        explorer: explorerData.explorer,
+      };
+    },
+    staleTime: 10000, // 10 seconds
+  });
+
+  const selectedStructure = selectedEntityData?.structure;
+  const selectedExplorerTroops = selectedEntityData?.explorer;
+  const targetStructure = targetEntityData?.structure;
+  const targetExplorerTroops = targetEntityData?.explorer;
 
   const availableGuards = useMemo<number[]>(() => {
     if (transferDirection === TransferDirection.ExplorerToStructure) {
       // Guards are on the target structure
-      if (!target) return [];
-      return Array.from({ length: target.base.level + 1 }, (_, i) => i);
+      if (!targetStructure) return [];
+      return Array.from({ length: targetStructure.base.level + 1 }, (_, i) => i);
     } else if (transferDirection === TransferDirection.StructureToExplorer) {
       // Guards are on the selected structure
-      if (!selected) return [];
-      return Array.from({ length: selected.base.level + 1 }, (_, i) => i);
+      if (!selectedStructure) return [];
+      return Array.from({ length: selectedStructure.base.level + 1 }, (_, i) => i);
     } else if (transferDirection === TransferDirection.ExplorerToExplorer) {
       // Guards aren't directly involved in the same way for transfer amount calculation,
       // but the UI might use this for displaying guard slots (though it seems hidden).
       // Using selected structure's level as a fallback like the original code, with check.
-      if (!selected) return [];
-      return Array.from({ length: selected.base.level + 1 }, (_, i) => i);
+      if (!selectedStructure) return [];
+      return Array.from({ length: selectedStructure.base.level + 1 }, (_, i) => i);
     }
     // Default case or unknown direction
     return [];
-  }, [selected, target, transferDirection]);
+  }, [selectedStructure, targetStructure, transferDirection]);
 
   // list of guards
-  const targetGuards = (() => {
-    if (!targetEntityId) return [];
-    const structure = getComponentValue(components.Structure, getEntityIdFromKeys([BigInt(targetEntityId)]));
-    if (!structure) return [];
-    const guards = getGuardsByStructure(structure);
+  const targetGuards = useMemo(() => {
+    if (!targetStructure) return [];
+    const guards = getGuardsByStructure(targetStructure);
     return guards.map((guard) => ({
       ...guard,
       troops: {
         ...guard.troops,
-        count: Number(guard.troops.count) / 10 ** 9,
+        count: divideByPrecision(Number(guard.troops.count)),
       },
     }));
-  })();
-
-  // one explorer troop
-  const targetExplorerTroops = (() => {
-    if (!targetEntityId) return undefined;
-    const explorers = getComponentValue(components.ExplorerTroops, getEntityIdFromKeys([BigInt(targetEntityId)]));
-    if (!explorers?.troops) return undefined;
-    return {
-      ...explorers.troops,
-      count: Number(explorers.troops.count) / 10 ** 9,
-    };
-  })();
+  }, [targetStructure]);
 
   // list of guards
-  const selectedGuards = (() => {
-    if (!selectedEntityId) return [];
-    const structure = getComponentValue(components.Structure, getEntityIdFromKeys([BigInt(selectedEntityId)]));
-    if (!structure) return [];
-    const guards = getGuardsByStructure(structure);
+  const selectedGuards = useMemo(() => {
+    if (!selectedStructure) return [];
+    const guards = getGuardsByStructure(selectedStructure);
     return guards.map((guard) => ({
       ...guard,
       troops: {
         ...guard.troops,
-        count: Number(guard.troops.count) / 10 ** 9,
+        count: divideByPrecision(Number(guard.troops.count)),
       },
     }));
-  })();
-
-  // one explorer troop
-  const selectedExplorerTroops = (() => {
-    if (!selectedEntityId) return undefined;
-    const explorers = getComponentValue(components.ExplorerTroops, getEntityIdFromKeys([BigInt(selectedEntityId)]));
-    if (!explorers?.troops) return undefined;
-    return {
-      ...explorers.troops,
-      count: Number(explorers.troops.count) / 10 ** 9,
-    };
-  })();
+  }, [selectedStructure]);
 
   const maxTroops = (() => {
     if (transferDirection === TransferDirection.ExplorerToStructure) {
-      return Math.max(0, Number(selectedExplorerTroops?.count || 0) - 1);
+      return Math.max(0, divideByPrecision(Number(selectedExplorerTroops?.troops.count || 0)) - 1);
     } else if (transferDirection === TransferDirection.StructureToExplorer) {
-      return Number(selectedGuards[guardSlot].troops.count);
+      return Number(selectedGuards[guardSlot]?.troops.count || 0);
     } else if (transferDirection === TransferDirection.ExplorerToExplorer) {
-      return Number(selectedExplorerTroops?.count || 0);
+      return divideByPrecision(Number(selectedExplorerTroops?.troops.count || 0));
     }
     return 0;
   })();
@@ -153,7 +157,7 @@ export const TransferTroopsContainer = ({
       setLoading(true);
 
       // Apply precision to troop amount for the transaction
-      const troopAmountWithPrecision = troopAmount * 10 ** 9;
+      const troopAmountWithPrecision = multiplyByPrecision(troopAmount);
 
       if (transferDirection === TransferDirection.ExplorerToExplorer) {
         await explorer_explorer_swap({
@@ -201,18 +205,18 @@ export const TransferTroopsContainer = ({
 
       // Check if troop tier and category match between selected and target
       if (transferDirection === TransferDirection.ExplorerToStructure) {
-        const selectedTroop = selectedExplorerTroops;
-        const targetTroop = targetGuards[guardSlot].troops;
+        const selectedTroop = selectedExplorerTroops?.troops;
+        const targetTroop = targetGuards[guardSlot]?.troops;
         // If target troop count is 0, tier and category don't matter
         if (targetTroop?.count === 0) {
           return false;
         }
         return selectedTroop?.tier !== targetTroop?.tier || selectedTroop?.category !== targetTroop?.category;
       } else {
-        const selectedTroop = selectedGuards[guardSlot].troops;
-        const targetTroop = targetExplorerTroops;
+        const selectedTroop = selectedGuards[guardSlot]?.troops;
+        const targetTroop = targetExplorerTroops?.troops;
         // If target troop count is 0, tier and category don't matter
-        if (targetTroop?.count === 0) {
+        if (targetTroop?.count === 0n) {
           return false;
         }
         return selectedTroop?.tier !== targetTroop?.tier || selectedTroop?.category !== targetTroop?.category;
@@ -230,11 +234,11 @@ export const TransferTroopsContainer = ({
       let selectedTroop, targetTroop;
 
       if (transferDirection === TransferDirection.ExplorerToStructure) {
-        selectedTroop = selectedExplorerTroops;
-        targetTroop = targetGuards[guardSlot].troops;
+        selectedTroop = selectedExplorerTroops?.troops;
+        targetTroop = targetGuards[guardSlot]?.troops;
       } else {
-        selectedTroop = selectedGuards[guardSlot].troops;
-        targetTroop = targetExplorerTroops;
+        selectedTroop = selectedGuards[guardSlot]?.troops;
+        targetTroop = targetExplorerTroops?.troops;
       }
 
       // If target troop count is 0, no mismatch message needed
@@ -252,138 +256,144 @@ export const TransferTroopsContainer = ({
 
   return (
     <div className="flex flex-col space-y-4">
-      {/* Available Troops Section */}
-      <div className="flex flex-col space-y-1 p-3 border border-gold/30 rounded-md bg-dark-brown/50">
-        <h4 className="text-gold font-semibold text-lg">Available for Transfer</h4>
-        <p className="text-gold/80 text-md">{formatNumber(maxTroops, 0)} troops</p>
-        {transferDirection === TransferDirection.ExplorerToStructure && selectedExplorerTroops && (
-          <p className="text-gold/70 text-sm">
-            From Explorer: Tier {selectedExplorerTroops.tier} {selectedExplorerTroops.category}
-          </p>
-        )}
-        {transferDirection === TransferDirection.StructureToExplorer &&
-          selectedGuards.length > 0 &&
-          guardSlot !== undefined &&
-          selectedGuards[guardSlot] && (
-            <p className="text-gold/70 text-sm">
-              From Structure (Slot {guardSlot + 1} - {DEFENSE_NAMES[guardSlot as keyof typeof DEFENSE_NAMES]}): Tier{" "}
-              {selectedGuards[guardSlot].troops.tier} {selectedGuards[guardSlot].troops.category}
-            </p>
-          )}
-        {transferDirection === TransferDirection.ExplorerToExplorer && selectedExplorerTroops && (
-          <p className="text-gold/70 text-sm">
-            From Explorer: Tier {selectedExplorerTroops.tier} {selectedExplorerTroops.category}
-          </p>
-        )}
-      </div>
-
-      {/* Troop Amount Input Section */}
-      <div className="flex flex-col space-y-2">
-        <label htmlFor="troopAmountInput" className="text-gold font-semibold h6">
-          Set Amount to Transfer
-        </label>
-        <div className="flex items-center space-x-2">
-          <input
-            id="troopAmountInput"
-            type="range"
-            min="0"
-            max={maxTroops}
-            value={troopAmount}
-            onChange={handleTroopAmountChange}
-            className="w-full accent-gold"
-          />
-          <input
-            type="number"
-            min="0"
-            max={maxTroops}
-            value={troopAmount}
-            onChange={handleTroopAmountChange}
-            className="w-20 px-2 py-1 bg-dark-brown border border-gold/30 rounded-md text-gold"
-          />
-        </div>
-      </div>
-
-      {/* Transferring Details Section */}
-      {troopAmount > 0 && (
-        <div className="flex flex-col space-y-1 p-3 border border-blue-500/50 rounded-md bg-blue-900/30 mt-4">
-          <h4 className="text-blue-300 font-semibold text-lg">You will transfer:</h4>
-          <p className="text-blue-200/80 text-md">{formatNumber(troopAmount, 0)} troops</p>
-          {transferDirection === TransferDirection.ExplorerToStructure && selectedExplorerTroops && (
-            <p className="text-blue-200/70 text-sm">
-              Type: Tier {selectedExplorerTroops.tier} {selectedExplorerTroops.category}
-            </p>
-          )}
-          {transferDirection === TransferDirection.StructureToExplorer &&
-            selectedGuards.length > 0 &&
-            guardSlot !== undefined &&
-            selectedGuards[guardSlot] && (
-              <p className="text-blue-200/70 text-sm">
-                Type: Tier {selectedGuards[guardSlot].troops.tier} {selectedGuards[guardSlot].troops.category}
+      {isTargetLoading || isSelectedLoading ? (
+        <LoadingAnimation />
+      ) : (
+        <>
+          {/* Available Troops Section */}
+          <div className="flex flex-col space-y-1 p-3 border border-gold/30 rounded-md bg-dark-brown/50">
+            <h4 className="text-gold font-semibold text-lg">Available for Transfer</h4>
+            <p className="text-gold/80 text-md">{formatNumber(maxTroops, 0)} troops</p>
+            {transferDirection === TransferDirection.ExplorerToStructure && selectedExplorerTroops && (
+              <p className="text-gold/70 text-sm">
+                From Explorer: Tier {selectedExplorerTroops.troops.tier} {selectedExplorerTroops.troops.category}
               </p>
             )}
-          {transferDirection === TransferDirection.ExplorerToExplorer && selectedExplorerTroops && (
-            <p className="text-blue-200/70 text-sm">
-              Type: Tier {selectedExplorerTroops.tier} {selectedExplorerTroops.category}
-            </p>
-          )}
-        </div>
-      )}
-
-      {(transferDirection === TransferDirection.ExplorerToStructure ||
-        transferDirection === TransferDirection.StructureToExplorer) && (
-        <div className="flex flex-col space-y-2 mt-4">
-          <label className="text-gold font-semibold h6">Guard Slot</label>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {availableGuards.map((slotIndex) => {
-              const guards =
-                transferDirection === TransferDirection.ExplorerToStructure ? targetGuards : selectedGuards;
-              if (!guards[slotIndex] || !guards[slotIndex].troops) {
-                // This case should ideally not happen if guards are always initialized for 4 slots
-                return (
-                  <div
-                    key={slotIndex}
-                    className={`p-2 border rounded-md cursor-not-allowed bg-dark-brown border-danger- Glimmer text-light-pink/70`}
-                  >
-                    Slot {slotIndex + 1} - Empty/Error
-                  </div>
-                );
-              }
-              const troopInfo = guards[slotIndex].troops;
-              const isActive = guardSlot === slotIndex;
-              return (
-                <div
-                  key={slotIndex}
-                  onClick={() => setGuardSlot(slotIndex)}
-                  className={`p-3 border rounded-md cursor-pointer transition-all duration-150 ease-in-out \
-                                                ${isActive ? "bg-gold/20 border-gold ring-2 ring-gold/50" : "bg-dark-brown border-gold/30 hover:bg-gold/10"}`}
-                >
-                  <div className="font-semibold text-gold">
-                    {DEFENSE_NAMES[slotIndex as keyof typeof DEFENSE_NAMES]}
-                  </div>
-                  <div className="text-sm text-gold/80">
-                    Tier {troopInfo.tier} {troopInfo.category}
-                  </div>
-                  <div className="text-sm text-gold/60">Available: {formatNumber(troopInfo.count, 0)}</div>
-                </div>
-              );
-            })}
+            {transferDirection === TransferDirection.StructureToExplorer &&
+              selectedGuards.length > 0 &&
+              guardSlot !== undefined &&
+              selectedGuards[guardSlot] && (
+                <p className="text-gold/70 text-sm">
+                  From Structure (Slot {guardSlot + 1} - {DEFENSE_NAMES[guardSlot as keyof typeof DEFENSE_NAMES]}): Tier{" "}
+                  {selectedGuards[guardSlot].troops.tier} {selectedGuards[guardSlot].troops.category}
+                </p>
+              )}
+            {transferDirection === TransferDirection.ExplorerToExplorer && selectedExplorerTroops && (
+              <p className="text-gold/70 text-sm">
+                From Explorer: Tier {selectedExplorerTroops.troops.tier} {selectedExplorerTroops.troops.category}
+              </p>
+            )}
           </div>
-        </div>
+
+          {/* Troop Amount Input Section */}
+          <div className="flex flex-col space-y-2">
+            <label htmlFor="troopAmountInput" className="text-gold font-semibold h6">
+              Set Amount to Transfer
+            </label>
+            <div className="flex items-center space-x-2">
+              <input
+                id="troopAmountInput"
+                type="range"
+                min="0"
+                max={maxTroops}
+                value={troopAmount}
+                onChange={handleTroopAmountChange}
+                className="w-full accent-gold"
+              />
+              <input
+                type="number"
+                min="0"
+                max={maxTroops}
+                value={troopAmount}
+                onChange={handleTroopAmountChange}
+                className="w-20 px-2 py-1 bg-dark-brown border border-gold/30 rounded-md text-gold"
+              />
+            </div>
+          </div>
+
+          {/* Transferring Details Section */}
+          {troopAmount > 0 && (
+            <div className="flex flex-col space-y-1 p-3 border border-blue-500/50 rounded-md bg-blue-900/30 mt-4">
+              <h4 className="text-blue-300 font-semibold text-lg">You will transfer:</h4>
+              <p className="text-blue-200/80 text-md">{formatNumber(troopAmount, 0)} troops</p>
+              {transferDirection === TransferDirection.ExplorerToStructure && selectedExplorerTroops && (
+                <p className="text-blue-200/70 text-sm">
+                  Type: Tier {selectedExplorerTroops.troops.tier} {selectedExplorerTroops.troops.category}
+                </p>
+              )}
+              {transferDirection === TransferDirection.StructureToExplorer &&
+                selectedGuards.length > 0 &&
+                guardSlot !== undefined &&
+                selectedGuards[guardSlot] && (
+                  <p className="text-blue-200/70 text-sm">
+                    Type: Tier {selectedGuards[guardSlot].troops.tier} {selectedGuards[guardSlot].troops.category}
+                  </p>
+                )}
+              {transferDirection === TransferDirection.ExplorerToExplorer && selectedExplorerTroops && (
+                <p className="text-blue-200/70 text-sm">
+                  Type: Tier {selectedExplorerTroops.troops.tier} {selectedExplorerTroops.troops.category}
+                </p>
+              )}
+            </div>
+          )}
+
+          {(transferDirection === TransferDirection.ExplorerToStructure ||
+            transferDirection === TransferDirection.StructureToExplorer) && (
+            <div className="flex flex-col space-y-2 mt-4">
+              <label className="text-gold font-semibold h6">Guard Slot</label>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {availableGuards.map((slotIndex) => {
+                  const guards =
+                    transferDirection === TransferDirection.ExplorerToStructure ? targetGuards : selectedGuards;
+                  if (!guards[slotIndex] || !guards[slotIndex].troops) {
+                    // This case should ideally not happen if guards are always initialized for 4 slots
+                    return (
+                      <div
+                        key={slotIndex}
+                        className={`p-2 border rounded-md cursor-not-allowed bg-dark-brown border-danger- Glimmer text-light-pink/70`}
+                      >
+                        Slot {slotIndex + 1} - Empty/Error
+                      </div>
+                    );
+                  }
+                  const troopInfo = guards[slotIndex].troops;
+                  const isActive = guardSlot === slotIndex;
+                  return (
+                    <div
+                      key={slotIndex}
+                      onClick={() => setGuardSlot(slotIndex)}
+                      className={`p-3 border rounded-md cursor-pointer transition-all duration-150 ease-in-out \
+                                                ${isActive ? "bg-gold/20 border-gold ring-2 ring-gold/50" : "bg-dark-brown border-gold/30 hover:bg-gold/10"}`}
+                    >
+                      <div className="font-semibold text-gold">
+                        {DEFENSE_NAMES[slotIndex as keyof typeof DEFENSE_NAMES]}
+                      </div>
+                      <div className="text-sm text-gold/80">
+                        Tier {troopInfo.tier} {troopInfo.category}
+                      </div>
+                      <div className="text-sm text-gold/60">Available: {formatNumber(troopInfo.count, 0)}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {getTroopMismatchMessage() && <div className="text-red-500 text-sm mt-2">{getTroopMismatchMessage()}</div>}
+
+          <div className="flex justify-center mt-6">
+            <Button
+              onClick={handleTransfer}
+              variant="primary"
+              disabled={loading || isTroopsTransferDisabled}
+              isLoading={loading}
+              className="w-full sm:w-auto"
+            >
+              {loading ? "Processing..." : "Transfer Troops"}
+            </Button>
+          </div>
+        </>
       )}
-
-      {getTroopMismatchMessage() && <div className="text-red-500 text-sm mt-2">{getTroopMismatchMessage()}</div>}
-
-      <div className="flex justify-center mt-6">
-        <Button
-          onClick={handleTransfer}
-          variant="primary"
-          disabled={loading || isTroopsTransferDisabled}
-          isLoading={loading}
-          className="w-full sm:w-auto"
-        >
-          {loading ? "Processing..." : "Transfer Troops"}
-        </Button>
-      </div>
     </div>
   );
 };

--- a/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
+++ b/client/apps/game/src/ui/modules/military/transfer-troops-container.tsx
@@ -366,7 +366,7 @@ export const TransferTroopsContainer = ({
   };
 
   return (
-    <div className="flex flex-col space-y-4">
+    <div className="flex flex-col space-y-4 ">
       {isTargetLoading || isSelectedLoading ? (
         <LoadingAnimation />
       ) : (
@@ -400,7 +400,10 @@ export const TransferTroopsContainer = ({
                 </div>
               </div>
               {!isStructureOwnerOfExplorer && (
-                <div className="text-red text-sm mt-1">Cannot use balance: Explorer not owned by this structure</div>
+                <div className="text-red text-sm mt-1">
+                  Cannot use balance: Explorer not owned by this structure. You can circumvent this by first
+                  transferring the troops to a guard slot and then transferring them to the explorer.
+                </div>
               )}
               <p className="text-gold/80 text-md">
                 Available: {formatNumber(divideByPrecision(Number(structureTroopBalance.balance)), 0)} troops

--- a/packages/types/src/types/common.ts
+++ b/packages/types/src/types/common.ts
@@ -12,6 +12,11 @@ import {
 } from "../constants";
 import { ClientComponents } from "../dojo/create-client-components";
 
+export enum ActorType {
+  Explorer = "explorer",
+  Structure = "structure",
+}
+
 export enum TileOccupier {
   None = 0,
   RealmRegularLevel1 = 1,


### PR DESCRIPTION
Add functionality to enable troop and resource transfers in both directions, along with a warning message for users. Fix issues related to enemy troop and resource transfers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for transferring troops and resources between explorers and structures, with improved UI feedback and loading animations during data fetching.
  - Introduced dynamic tab selection in the combat modal, enabling access to both attack and help (transfer) functionalities.

- **Improvements**
  - Enhanced type safety and consistency by replacing string-based actor type checks with a unified enum.
  - Resource and troop transfer interfaces now respect explorer capacity and provide detailed reasons when actions are unavailable.
  - UI now dynamically reflects ownership, transfer directions, and displays relevant information based on user context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->