### PR TITLE
client: show army troop tiers

### DIFF
--- a/client/apps/game/src/ui/components/military/compact-defense-display.tsx
+++ b/client/apps/game/src/ui/components/military/compact-defense-display.tsx
@@ -1,4 +1,5 @@
 import { ResourceIcon } from "@/ui/elements/resource-icon";
+import { getTierStyle } from "@/ui/utils/tier-styles";
 import { currencyFormat } from "@/ui/utils/utils";
 import { getTroopResourceId } from "@bibliothecadao/eternum";
 import { resources, TroopTier, TroopType } from "@bibliothecadao/types";
@@ -18,6 +19,11 @@ export const CompactDefenseDisplay = ({ troops, className = "" }: CompactDefense
           className="flex items-center bg-brown-900/90 border border-gold/20 rounded-md px-1.5 py-0.5"
           title={`Defense Slot ${defense.slot}`}
         >
+          <span
+            className={`px-1.5 py-0.5 rounded text-[11px] font-bold border relative ${getTierStyle(defense.troops.tier)}`}
+          >
+            <span className="relative z-10">{defense.troops.tier}</span>
+          </span>
           <ResourceIcon
             withTooltip={false}
             resource={

--- a/client/apps/game/src/ui/components/military/troop-chip.tsx
+++ b/client/apps/game/src/ui/components/military/troop-chip.tsx
@@ -1,4 +1,5 @@
 import { ResourceIcon } from "@/ui/elements/resource-icon";
+import { getTierStyle } from "@/ui/utils/tier-styles";
 import { currencyFormat } from "@/ui/utils/utils";
 import { getTroopResourceId } from "@bibliothecadao/eternum";
 import { resources, Troops, TroopTier, TroopType } from "@bibliothecadao/types";
@@ -43,7 +44,13 @@ export const TroopChip = ({
             {currencyFormat(Number(troops.count || 0), 0)}
           </div>
         </div>
-        <div className="text-xs text-gold/80 self-center">Tier {troops.tier}</div>
+        <span
+          className={`px-1.5 py-0.5 rounded ${
+            iconSize === "sm" ? "text-[11px]" : iconSize === "md" ? "text-xs" : "text-sm"
+          } font-bold border relative ${getTierStyle(troops.tier)}`}
+        >
+          <span className="relative z-10">{troops.tier}</span>
+        </span>
       </div>
     </div>
   );

--- a/client/apps/game/src/ui/utils/tier-styles.ts
+++ b/client/apps/game/src/ui/utils/tier-styles.ts
@@ -1,0 +1,12 @@
+export const getTierStyle = (tier: string) => {
+  switch (tier) {
+    case "T1":
+      return "bg-gradient-to-b from-blue-500/30 to-blue-500/10 border-blue-400/40 text-blue-300 shadow-blue-500/10";
+    case "T2":
+      return "bg-gradient-to-b from-emerald-500/30 to-emerald-500/10 border-emerald-400/40 text-emerald-300 shadow-emerald-500/10";
+    case "T3":
+      return "!bg-purple-600 !text-white !border-purple-400 animate-pulse";
+    default:
+      return "bg-gradient-to-b from-gold/30 to-gold/10 border-gold/40 text-gold shadow-gold/10";
+  }
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Troop tier is now visually displayed with a styled badge in both defense and troop chip displays.
  - Tier badges feature dynamic colors and styles based on the troop’s tier, improving clarity and visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->