### PR TITLE
feat: add global pause all automation button

### DIFF
--- a/client/apps/game/src/hooks/store/use-automation-store.ts
+++ b/client/apps/game/src/hooks/store/use-automation-store.ts
@@ -45,6 +45,7 @@ export interface AutomationOrder {
 interface AutomationState {
   ordersByRealm: Record<string, AutomationOrder[]>;
   pausedRealms: Record<string, boolean>; // Track paused state by realm ID
+  isGloballyPaused: boolean; // Global pause state for all automation
   addOrder: (orderData: Omit<AutomationOrder, "id" | "producedAmount"> & { mode?: OrderMode }) => void;
   removeOrder: (realmEntityId: string, orderId: string) => void;
   updateOrderProducedAmount: (realmEntityId: string, orderId: string, producedThisCycle: number) => void;
@@ -55,6 +56,7 @@ interface AutomationState {
   setNextRunTimestamp: (timestamp: number) => void; // Action to set the next run timestamp
   toggleRealmPause: (realmEntityId: string) => void; // Toggle pause state for a realm
   isRealmPaused: (realmEntityId: string) => boolean; // Check if a realm is paused
+  toggleGlobalPause: () => void; // Toggle global pause for all automation
 }
 
 export const useAutomationStore = create<AutomationState>()(
@@ -62,6 +64,7 @@ export const useAutomationStore = create<AutomationState>()(
     (set, get) => ({
       ordersByRealm: {},
       pausedRealms: {},
+      isGloballyPaused: false, // Initialize global pause state
       nextRunTimestamp: null, // Initialize nextRunTimestamp
       addOrder: (newOrderData) => {
         const newOrder: AutomationOrder = {
@@ -140,6 +143,10 @@ export const useAutomationStore = create<AutomationState>()(
       isRealmPaused: (realmEntityId: string) => {
         return get().pausedRealms[realmEntityId] || false;
       },
+      toggleGlobalPause: () =>
+        set((state) => ({
+          isGloballyPaused: !state.isGloballyPaused,
+        })),
     }),
     {
       name: "eternum-automation-orders-by-realm",

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -138,6 +138,7 @@ export const useAutomation = () => {
   const updateOrderProducedAmount = useAutomationStore((state) => state.updateOrderProducedAmount);
   const updateTransferTimestamp = useAutomationStore((state) => state.updateTransferTimestamp);
   const isRealmPaused = useAutomationStore((state) => state.isRealmPaused);
+  const isGloballyPaused = useAutomationStore((state) => state.isGloballyPaused);
   const processingRef = useRef(false);
   const ordersByRealmRef = useRef(ordersByRealm);
   const setNextRunTimestamp = useAutomationStore((state) => state.setNextRunTimestamp);
@@ -162,6 +163,12 @@ export const useAutomation = () => {
       currentTickRef.current === 0
     ) {
       console.warn("Automation: Conditions not met (signer/components/currentDefaultTick). Skipping.");
+      return;
+    }
+
+    // Check global pause before processing any orders
+    if (isGloballyPaused) {
+      console.log("Automation: All automation is globally paused. Skipping all processing.");
       return;
     }
 
@@ -577,6 +584,7 @@ export const useAutomation = () => {
     burn_resource_for_labor_production,
     updateOrderProducedAmount,
     isRealmPaused,
+    isGloballyPaused,
     updateTransferTimestamp,
   ]);
 

--- a/client/apps/game/src/ui/features/infrastructure/automation/all-automations-table.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/all-automations-table.tsx
@@ -39,6 +39,8 @@ export const AllAutomationsTable: React.FC = () => {
   const nextRunTimestamp = useAutomationStore((state) => state.nextRunTimestamp);
   const toggleRealmPause = useAutomationStore((state) => state.toggleRealmPause);
   const isRealmPaused = useAutomationStore((state) => state.isRealmPaused);
+  const isGloballyPaused = useAutomationStore((state) => state.isGloballyPaused);
+  const toggleGlobalPause = useAutomationStore((state) => state.toggleGlobalPause);
 
   // Realm filter state
   const [realmFilter, setRealmFilter] = useState<string>("all");
@@ -119,12 +121,34 @@ export const AllAutomationsTable: React.FC = () => {
     <div className=" ">
       <h4 className="mb-2 font-bold">Automation</h4>
 
+      {/* Global Pause Button */}
+      <Button 
+        className={`mb-2 mr-2 ${isGloballyPaused ? 'bg-green-600 hover:bg-green-700' : 'bg-red-600 hover:bg-red-700'}`}
+        size="xs" 
+        onClick={toggleGlobalPause}
+        title={isGloballyPaused ? "Resume all automation" : "Pause all automation"}
+      >
+        {isGloballyPaused ? (
+          <>
+            <PlayIcon className="w-4 h-4 mr-1" />
+            Resume All
+          </>
+        ) : (
+          <>
+            <PauseIcon className="w-4 h-4 mr-1" />
+            Pause All
+          </>
+        )}
+      </Button>
+
       <Button className="mb-2" size="xs" onClick={() => toggleModal(<ProductionModal />)}>
         Add Automation
       </Button>
 
-      {/* Display Countdown Timer */}
-      <div className="mb-2 text-xs text-gray-400">Next automation run in: {countdown}</div>
+      {/* Display Countdown Timer or Global Pause Status */}
+      <div className="mb-2 text-xs text-gray-400">
+        {isGloballyPaused ? "All automation paused" : `Next automation run in: ${countdown}`}
+      </div>
 
       {/* Realm filter */}
       <div className="mb-4 flex items-center text-sm space-x-2">
@@ -169,10 +193,11 @@ export const AllAutomationsTable: React.FC = () => {
               order.maxAmount !== "infinite" &&
               order.producedAmount >= order.maxAmount;
             const isPaused = isRealmPaused(order.realmEntityId);
+            const isEffectivelyPaused = isGloballyPaused || isPaused;
             return (
               <tr
                 key={order.id}
-                className={`border-b border-gold/10 hover:bg-gray-600/30 ${isFinished ? "bg-green-700/40" : ""} ${isPaused ? "opacity-50" : ""}`}
+                className={`border-b border-gold/10 hover:bg-gray-600/30 ${isFinished ? "bg-green-700/40" : ""} ${isEffectivelyPaused ? "opacity-50" : ""}`}
               >
                 <td className=" py-4">
                   {order.productionType === ProductionType.Transfer ? (
@@ -188,7 +213,8 @@ export const AllAutomationsTable: React.FC = () => {
                   <div className="text-xs bg-gold/20 px-2 py-1 rounded border border-gold/30">
                     <div className="h4 flex items-center gap-2">
                       {order.realmName ?? order.realmEntityId}
-                      {isPaused && <span className="text-red text-xs">(PAUSED)</span>}
+                      {isGloballyPaused && <span className="text-red text-xs">(ALL PAUSED)</span>}
+                      {!isGloballyPaused && isPaused && <span className="text-red text-xs">(PAUSED)</span>}
                     </div>
                     <div className="font-bold">Priority {order.priority}</div>
 


### PR DESCRIPTION
Add emergency pause functionality to stop all automation when things go wrong:

- Add isGloballyPaused state and toggleGlobalPause() to automation store
- Add global pause check in useAutomation hook to skip all processing when paused
- Add prominent red/green pause/resume button in automation UI with play/pause icons
- Show "All automation paused" status instead of countdown when globally paused
- Add visual feedback with reduced opacity and "(ALL PAUSED)" labels on orders
- Global pause takes precedence over individual realm pauses
- State persists in localStorage via existing Zustand persistence

Resolves #3374

🤖 Generated with [Claude Code](https://claude.ai/code)