### PR TITLE
feat: add global pause all automation button #3

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,6 +43,7 @@ When building features, read the relevant app README:
 - Prefer composition over inheritance
 - Use functional components for React code
 - Keep components small and focused
+- **Tailwind CSS**: Always use colors defined in `client/apps/game/tailwind.config.js` rather than default Tailwind colors (e.g., use `bg-danger` instead of `bg-red-600`, `bg-green` instead of `bg-green-600`)
 
 ## Testing Guidelines
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,7 +43,8 @@ When building features, read the relevant app README:
 - Prefer composition over inheritance
 - Use functional components for React code
 - Keep components small and focused
-- **Tailwind CSS**: Always use colors defined in `client/apps/game/tailwind.config.js` rather than default Tailwind colors (e.g., use `bg-danger` instead of `bg-red-600`, `bg-green` instead of `bg-green-600`)
+- **Tailwind CSS**: Always use colors defined in `client/apps/game/tailwind.config.js` rather than default Tailwind
+  colors (e.g., use `bg-danger` instead of `bg-red-600`, `bg-green` instead of `bg-green-600`)
 
 ## Testing Guidelines
 

--- a/client/apps/game/src/hooks/store/use-automation-store.ts
+++ b/client/apps/game/src/hooks/store/use-automation-store.ts
@@ -45,6 +45,7 @@ export interface AutomationOrder {
 interface AutomationState {
   ordersByRealm: Record<string, AutomationOrder[]>;
   pausedRealms: Record<string, boolean>; // Track paused state by realm ID
+  isGloballyPaused: boolean; // Global pause state - overrides all other automation
   addOrder: (orderData: Omit<AutomationOrder, "id" | "producedAmount"> & { mode?: OrderMode }) => void;
   removeOrder: (realmEntityId: string, orderId: string) => void;
   updateOrderProducedAmount: (realmEntityId: string, orderId: string, producedThisCycle: number) => void;
@@ -55,6 +56,7 @@ interface AutomationState {
   setNextRunTimestamp: (timestamp: number) => void; // Action to set the next run timestamp
   toggleRealmPause: (realmEntityId: string) => void; // Toggle pause state for a realm
   isRealmPaused: (realmEntityId: string) => boolean; // Check if a realm is paused
+  toggleGlobalPause: () => void; // Toggle global pause state
 }
 
 export const useAutomationStore = create<AutomationState>()(
@@ -62,6 +64,7 @@ export const useAutomationStore = create<AutomationState>()(
     (set, get) => ({
       ordersByRealm: {},
       pausedRealms: {},
+      isGloballyPaused: false, // Initialize global pause state
       nextRunTimestamp: null, // Initialize nextRunTimestamp
       addOrder: (newOrderData) => {
         const newOrder: AutomationOrder = {
@@ -140,6 +143,10 @@ export const useAutomationStore = create<AutomationState>()(
       isRealmPaused: (realmEntityId: string) => {
         return get().pausedRealms[realmEntityId] || false;
       },
+      toggleGlobalPause: () =>
+        set((state) => ({
+          isGloballyPaused: !state.isGloballyPaused,
+        })),
     }),
     {
       name: "eternum-automation-orders-by-realm",

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -138,6 +138,7 @@ export const useAutomation = () => {
   const updateOrderProducedAmount = useAutomationStore((state) => state.updateOrderProducedAmount);
   const updateTransferTimestamp = useAutomationStore((state) => state.updateTransferTimestamp);
   const isRealmPaused = useAutomationStore((state) => state.isRealmPaused);
+  const isGloballyPaused = useAutomationStore((state) => state.isGloballyPaused);
   const processingRef = useRef(false);
   const ordersByRealmRef = useRef(ordersByRealm);
   const setNextRunTimestamp = useAutomationStore((state) => state.setNextRunTimestamp);
@@ -162,6 +163,12 @@ export const useAutomation = () => {
       currentTickRef.current === 0
     ) {
       console.warn("Automation: Conditions not met (signer/components/currentDefaultTick). Skipping.");
+      return;
+    }
+
+    // Check for global pause - exit early if all automation is paused
+    if (isGloballyPaused) {
+      console.log("Automation: Globally paused. Skipping all processing.");
       return;
     }
 
@@ -577,6 +584,7 @@ export const useAutomation = () => {
     burn_resource_for_labor_production,
     updateOrderProducedAmount,
     isRealmPaused,
+    isGloballyPaused,
     updateTransferTimestamp,
   ]);
 

--- a/client/apps/game/src/ui/features/infrastructure/automation/all-automations-table.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/all-automations-table.tsx
@@ -127,7 +127,7 @@ export const AllAutomationsTable: React.FC = () => {
 
       {/* Global Pause Button */}
       <Button
-        className={`mb-2 ml-2 ${isGloballyPaused ? "bg-dark-green-accent hover:bg-dark-green-accent" : "bg-danger hover:bg-danger"}`}
+        className={`mb-2 ml-2 ${isGloballyPaused ? "hover:bg-dark-green-accent" : "hover:bg-danger"}`}
         size="xs"
         onClick={toggleGlobalPause}
         title={isGloballyPaused ? "Resume all automation" : "Pause all automation"}

--- a/client/apps/game/src/ui/features/infrastructure/automation/all-automations-table.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/all-automations-table.tsx
@@ -127,7 +127,7 @@ export const AllAutomationsTable: React.FC = () => {
 
       {/* Global Pause Button */}
       <Button
-        className={`mb-2 ml-2 ${isGloballyPaused ? "bg-green-600 hover:bg-green-700" : "bg-red-600 hover:bg-red-700"}`}
+        className={`mb-2 ml-2 ${isGloballyPaused ? "bg-dark-green-accent hover:bg-dark-green-accent" : "bg-danger hover:bg-danger"}`}
         size="xs"
         onClick={toggleGlobalPause}
         title={isGloballyPaused ? "Resume all automation" : "Pause all automation"}

--- a/client/apps/game/src/ui/features/infrastructure/automation/automation-table.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/automation-table.tsx
@@ -55,7 +55,7 @@ export const AutomationTable: React.FC<AutomationTableProps> = ({ realmEntityId,
   const addOrder = useAutomationStore((state) => state.addOrder);
   const removeOrder = useAutomationStore((state) => state.removeOrder);
   const toggleRealmPause = useAutomationStore((state) => state.toggleRealmPause);
-  
+
   // Derive the values for this specific realm
   const ordersForRealm = useMemo(() => ordersByRealm[realmEntityId] || [], [ordersByRealm, realmEntityId]);
   const isRealmPaused = useMemo(() => pausedRealms[realmEntityId] || false, [pausedRealms, realmEntityId]);

--- a/client/apps/game/src/ui/features/infrastructure/automation/automation-table.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/automation-table.tsx
@@ -49,11 +49,16 @@ export const AutomationTable: React.FC<AutomationTableProps> = ({ realmEntityId,
       .filter((res) => res.id !== ResourcesIds.Fish && res.id !== ResourcesIds.Wheat);
   }, [realmInfo, availableResources]);
 
-  const ordersForRealm = useAutomationStore((state) => state.getOrdersForRealm(realmEntityId));
+  // Get the raw data and functions from the store
+  const ordersByRealm = useAutomationStore((state) => state.ordersByRealm);
+  const pausedRealms = useAutomationStore((state) => state.pausedRealms);
   const addOrder = useAutomationStore((state) => state.addOrder);
   const removeOrder = useAutomationStore((state) => state.removeOrder);
   const toggleRealmPause = useAutomationStore((state) => state.toggleRealmPause);
-  const isRealmPaused = useAutomationStore((state) => state.isRealmPaused(realmEntityId));
+  
+  // Derive the values for this specific realm
+  const ordersForRealm = useMemo(() => ordersByRealm[realmEntityId] || [], [ordersByRealm, realmEntityId]);
+  const isRealmPaused = useMemo(() => pausedRealms[realmEntityId] || false, [pausedRealms, realmEntityId]);
 
   const [showAddForm, setShowAddForm] = useState(false);
   const [newOrder, setNewOrder] = useState<Omit<AutomationOrder, "id" | "producedAmount" | "realmEntityId">>(() => ({

--- a/client/apps/game/src/ui/features/settlement/production/production-body.tsx
+++ b/client/apps/game/src/ui/features/settlement/production/production-body.tsx
@@ -1,11 +1,11 @@
 import { BuildingThumbs } from "@/ui/config";
+import { AutomationTable } from "@/ui/features/infrastructure";
 import { configManager, getEntityIdFromKeys } from "@bibliothecadao/eternum";
 import { useBuildings, useDojo } from "@bibliothecadao/react";
 import { getProducedResource, RealmInfo as RealmInfoType, ResourcesIds } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import { SparklesIcon } from "lucide-react";
 import { useMemo, useState } from "react";
-import { AutomationTable } from "@/ui/features/infrastructure";
 import { BuildingsList } from "./buildings-list";
 import { ProductionControls } from "./production-controls";
 import { RealmInfo } from "./realm-info";


### PR DESCRIPTION
Add emergency pause functionality to stop all automation when things go wrong:

- Add isGloballyPaused state and toggleGlobalPause() to automation store
- Add global pause check in useAutomation hook to skip all processing when paused
- Add prominent red/green pause/resume button in automation UI with play/pause icons
- Show "All automation paused" status instead of countdown when globally paused
- Add visual feedback with reduced opacity and "(ALL PAUSED)" labels on orders
- Global pause takes precedence over individual realm pauses
- State persists in localStorage via existing Zustand persistence

Resolves #3374

🤖 Generated with [Claude Code](https://claude.ai/code)