### PR TITLE
feat: Enhance army and structure ownership management

### DIFF
--- a/client/apps/game/src/three/types/common.ts
+++ b/client/apps/game/src/three/types/common.ts
@@ -39,6 +39,7 @@ export interface ArmyData {
   matrixIndex: number;
   hexCoords: Position;
   isMine: boolean;
+  owningStructureId: ID | null;
   owner: { address: bigint; ownerName: string; guildName: string };
   color: string;
   category: TroopType;

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -1,5 +1,11 @@
 export const latestFeatures = [
   {
+    date: "2025-09-24",
+    title: "Realm Ownership Highlights",
+    description:
+      "Selecting a structure or one of its armies now highlights the owning realm across the map. The selected structure and every army it commands pulse in the same color, letting you instantly see a realm's forces at a glance.",
+  },
+  {
     date: "2025-09-17",
     title: "Combat Directions",
     description:

--- a/packages/core/src/stores/map-data-store.ts
+++ b/packages/core/src/stores/map-data-store.ts
@@ -22,7 +22,7 @@
  * const army = mapStore.getArmyById(456);
  */
 
-import { SqlApi, StructureMapDataRaw } from "@bibliothecadao/torii";
+import { ArmyMapDataRaw, SqlApi, StructureMapDataRaw } from "@bibliothecadao/torii";
 import { BuildingType, ID, StructureType, TroopTier } from "@bibliothecadao/types";
 import { shortString } from "starknet";
 import realms from "../../../../client/public/jsons/realms.json";
@@ -83,6 +83,7 @@ export interface ArmyMapData {
   entityId: number;
   coordX: number;
   coordY: number;
+  ownerStructureId: number | null;
   category: string | null; // troop type (crossbowman, paladin, knight)
   tier: TroopTier;
   count: number;
@@ -412,7 +413,7 @@ export class MapDataStore {
     });
 
     // Transform and store armies
-    armiesRaw.forEach((army) => {
+    armiesRaw.forEach((army: ArmyMapDataRaw) => {
       const ownerName = army.owner_name
         ? BigInt(army.owner_name) === 0n
           ? ""
@@ -423,6 +424,7 @@ export class MapDataStore {
         entityId: army.entity_id,
         coordX: army.coord_x,
         coordY: army.coord_y,
+        ownerStructureId: army.owner_structure_id,
         category: this.getCategoryName(army.category),
         tier: army.tier as TroopTier,
         count: divideByPrecision(Number(this.hexToBigInt(army.count))),

--- a/packages/core/src/systems/data-enhancer.ts
+++ b/packages/core/src/systems/data-enhancer.ts
@@ -7,6 +7,7 @@ export interface EnhancedArmyData {
   currentStamina: number;
   onChainStamina?: { amount: bigint; updatedTick: number };
   owner: { address: bigint | undefined; ownerName: string; guildName: string };
+  ownerStructureId?: ID | null;
   battleData?: {
     battleCooldownEnd: number;
     latestAttackerId: number | null;
@@ -59,6 +60,8 @@ export class DataEnhancer {
 
     const currentStamina = this.calculateCurrentStamina(armyMapData || null, explorer, currentArmiesTick);
     let owner = await this.getArmyOwnerData(armyMapData || null);
+    const ownerStructureIdRaw = armyMapData?.ownerStructureId ?? structureOwnerId ?? null;
+    const ownerStructureId = ownerStructureIdRaw && ownerStructureIdRaw !== 0 ? ownerStructureIdRaw : null;
 
     // Fallback: If army owner data is missing but we have structure owner ID, get owner from structure
     if ((!owner.address || owner.address === 0n) && structureOwnerId) {
@@ -87,6 +90,7 @@ export class DataEnhancer {
           }
         : undefined,
       owner,
+      ownerStructureId,
       battleData: armyMapData?.battleData || undefined,
     };
   }

--- a/packages/core/src/systems/types.ts
+++ b/packages/core/src/systems/types.ts
@@ -25,6 +25,7 @@ export type ExplorerTroopsTileSystemUpdate = {
   guildName: string;
   troopCount?: number | undefined;
   ownerAddress: bigint;
+  ownerStructureId: ID | null;
   currentStamina?: number | undefined;
   maxStamina?: number | undefined;
   onChainStamina?:
@@ -59,6 +60,7 @@ export type ExplorerTroopsSystemUpdate = {
   };
   ownerAddress: bigint;
   ownerName: string;
+  ownerStructureId: ID | null;
   battleCooldownEnd: number;
 };
 

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -117,12 +117,15 @@ export class WorldUpdateListener {
                   console.warn(`[DEBUG] Could not get structure owner for army ${currentState.occupier_id}:`, error);
                 }
 
+                const normalizedStructureOwnerId =
+                  structureOwnerId && structureOwnerId !== 0 ? structureOwnerId : undefined;
+
                 // Use DataEnhancer to fetch all enhanced data
                 const enhancedData = await this.dataEnhancer.enhanceArmyData(
                   currentState.occupier_id,
                   explorer,
                   currentArmiesTick,
-                  structureOwnerId,
+                  normalizedStructureOwnerId,
                 );
 
                 const maxStamina = StaminaManager.getMaxStamina(explorer.troopType, explorer.troopTier);
@@ -137,6 +140,7 @@ export class WorldUpdateListener {
                   troopType: explorer.troopType as TroopType,
                   troopTier: explorer.troopTier as TroopTier,
                   isDaydreamsAgent: explorer.isDaydreamsAgent,
+                  ownerStructureId: normalizedStructureOwnerId ?? enhancedData.ownerStructureId ?? null,
                   // Enhanced data from DataEnhancer
                   troopCount: enhancedData.troopCount,
                   currentStamina: enhancedData.currentStamina,
@@ -165,6 +169,8 @@ export class WorldUpdateListener {
 
               // maybe don't use mapdatastore here since these are all available from the tile listener
               const owner = await this.dataEnhancer.getStructureOwner(currentState.owner);
+              const normalizedOwnerStructureId =
+                currentState.owner && currentState.owner !== 0 ? currentState.owner : null;
 
               return {
                 entityId: currentState.explorer_id,
@@ -173,6 +179,7 @@ export class WorldUpdateListener {
                   amount: BigInt(currentState.troops.stamina.amount),
                   updatedTick: Number(currentState.troops.stamina.updated_tick),
                 },
+                ownerStructureId: normalizedOwnerStructureId,
                 hexCoords: { col: currentState.coord.x, row: currentState.coord.y },
                 ownerAddress: owner?.address || 0n,
                 ownerName: owner?.ownerName || "",

--- a/packages/torii/src/queries/sql/structure.ts
+++ b/packages/torii/src/queries/sql/structure.ts
@@ -274,6 +274,7 @@ export const STRUCTURE_QUERIES = {
       et.explorer_id as entity_id,
       et.\`coord.x\` as coord_x,
       et.\`coord.y\` as coord_y,
+      et.owner as owner_structure_id,
       et.\`troops.category\` as category,
       et.\`troops.tier\` as tier,
       et.\`troops.count\` as count,

--- a/packages/torii/src/types/sql.ts
+++ b/packages/torii/src/types/sql.ts
@@ -255,6 +255,7 @@ export interface ArmyMapDataRaw {
   entity_id: number;
   coord_x: number;
   coord_y: number;
+  owner_structure_id: number | null;
   category: string | null;
   tier: string | null;
   count: string; // hex string


### PR DESCRIPTION
- Added `owningStructureId` to `ArmyData` and related interfaces for better tracking of army ownership.
- Implemented ownership pulse visualization in `SelectionPulseManager` to highlight structures and armies on the map.
- Updated `WorldmapScene` to manage structure ownership pulses and cache colors for better performance.
- Enhanced data handling in `DataEnhancer` and `WorldUpdateListener` to include structure ownership information.
- Updated SQL queries to retrieve `owner_structure_id` for armies.