### PR TITLE
fix: resolve tile scoring case-sensitivity bug in leaderboard SQL query

### DIFF
--- a/packages/torii/src/queries/sql/leaderboard.ts
+++ b/packages/torii/src/queries/sql/leaderboard.ts
@@ -65,14 +65,12 @@ const PLAYER_LEADERBOARD_BASE = `
       points_story AS (
         SELECT
           lower(COALESCE("story.PointsRegisteredStory.owner_address", '')) AS player_address,
-          lower(
+          replace(
             replace(
-              replace(
-                replace(trim(COALESCE("story.PointsRegisteredStory.activity", '')), 'pointsactivity::', ''),
-                'pointsactivity.', ''
-              ),
-              'pointsactivity', ''
-            )
+              replace(lower(trim(COALESCE("story.PointsRegisteredStory.activity", ''))), 'pointsactivity::', ''),
+              'pointsactivity.', ''
+            ),
+            'pointsactivity', ''
           ) AS raw_activity,
           lower(trim(COALESCE("story.PointsRegisteredStory.points", '0'))) AS raw_points
         FROM "s1_eternum-StoryEvent"


### PR DESCRIPTION
The leaderboard SQL query had a case-sensitivity issue that prevented proper matching of exploration and other activity points. The enum values from PointsActivity (e.g., "PointsActivity::Exploration") were being processed with lowercase() applied AFTER the replace operations, causing mismatches.

Root cause:
- If stored as "PointsActivity::Exploration" (capitals), the case-sensitive replace('pointsactivity::', '') wouldn't match
- After lowercasing, it became 'pointsactivity::exploration'
- This never matched 'exploration' in the pivot queries, resulting in 0 points

Fix:
- Apply lower() BEFORE replace operations (line 70)
- Now: "PointsActivity::Exploration" → lowercase → "pointsactivity::exploration" → strip prefix → "exploration" → matches correctly
- Numeric format (0, 1, 2, 3, 4) continues to work via points_story_normalized mapping

This ensures both old (string) and new (numeric) event formats are properly counted in the leaderboard breakdown for exploration, relic chests, and bandit defeats.