### PR TITLE
fix: address code review feedback for open next chest feature

### DIFF
--- a/client/apps/game/src/ui/features/landing/chest-opening/components/reveal-stage.tsx
+++ b/client/apps/game/src/ui/features/landing/chest-opening/components/reveal-stage.tsx
@@ -384,7 +384,7 @@ export function RevealStage({
                 )}
                 {onOpenAnother && remainingChestsCount > 0 && (
                   <Button variant="primary" size="md" onClick={onOpenAnother} className="gap-2">
-                    Choose Next Chest ({remainingChestsCount} available)
+                    Open Next Chest ({remainingChestsCount} remaining)
                   </Button>
                 )}
               </div>

--- a/client/apps/game/src/ui/features/landing/chest-opening/hooks/use-owned-chests.ts
+++ b/client/apps/game/src/ui/features/landing/chest-opening/hooks/use-owned-chests.ts
@@ -9,7 +9,7 @@ interface UseOwnedChestsReturn {
   ownedChests: MergedNftData[];
   isLoading: boolean;
   error: Error | null;
-  refetch: () => void;
+  refetch: () => Promise<MergedNftData[]>;
 }
 
 /**
@@ -74,6 +74,9 @@ export function useOwnedChests(): UseOwnedChestsReturn {
     ownedChests,
     isLoading,
     error: error as Error | null,
-    refetch,
+    refetch: async () => {
+      const result = await refetch();
+      return result.data ?? [];
+    },
   };
 }

--- a/client/apps/game/src/ui/features/landing/sections/cosmetics.tsx
+++ b/client/apps/game/src/ui/features/landing/sections/cosmetics.tsx
@@ -3,6 +3,7 @@ import { Tabs } from "@/ui/design-system/atoms/tab/tabs";
 import { ChestOpeningExperience } from "@/ui/features/landing/chest-opening";
 import { ChestEpoch } from "@/ui/features/landing/chest-opening/hooks/use-chest-opening-flow";
 import { useOwnedChests } from "@/ui/features/landing/chest-opening/hooks/use-owned-chests";
+import { LandingDojoProvider } from "@/ui/features/landing/providers/landing-dojo-provider";
 import {
   COSMETIC_NAMES,
   DEFAULT_COSMETIC_MODEL_PATH,
@@ -258,11 +259,13 @@ export const LandingCosmetics = () => {
 
       {/* Chest Opening Experience Modal */}
       {showLootChestOpening && (
-        <ChestOpeningExperience
-          onClose={handleCloseChestExperience}
-          initialChestId={openingChest?.id}
-          initialEpoch={openingChest?.epoch}
-        />
+        <LandingDojoProvider>
+          <ChestOpeningExperience
+            onClose={handleCloseChestExperience}
+            initialChestId={openingChest?.id}
+            initialEpoch={openingChest?.epoch}
+          />
+        </LandingDojoProvider>
       )}
     </>
   );


### PR DESCRIPTION
Addresses review feedback on the open next chest feature:

- Fix stale chest selection race condition by properly awaiting refetch before computing next chest
- Improve getChestEpoch reliability with multiple fallback detection strategies (ID+Epoch attrs, Season/Collection attrs, name-based)
- Update refetch return type to Promise<MergedNftData[]> for proper async handling
- Wrap ChestOpeningExperience with LandingDojoProvider to provide required Dojo context

🤖 Generated with Claude Code