### PR TITLE
perf: Parallelize independent async operations

### DIFF
--- a/client/apps/game/src/pm/hooks/markets/use-market.tsx
+++ b/client/apps/game/src/pm/hooks/markets/use-market.tsx
@@ -40,15 +40,33 @@ export const useMarket = (marketId: bigint): UseMarketResult => {
 
     setIsLoading(true);
     try {
-      // Fetch market entity
+      // Build all queries upfront
       const marketQuery = new ToriiQueryBuilder()
         .withEntityModels(["pm-Market", "pm-VaultDenominator", "pm-VaultFeesDenominator"])
         .withClause(new ClauseBuilder().where("pm-Market", "market_id", "Eq", marketIdPadded).build())
         .includeHashedKeys();
 
-      const marketResponse = await sdk.getEntities({ query: marketQuery });
-      const marketItems: StandardizedQueryResult<SchemaType> = marketResponse.getItems();
+      const vaultNumeratorQuery = new ToriiQueryBuilder()
+        .withEntityModels(["pm-VaultNumerator"])
+        .withClause(new ClauseBuilder().where("pm-VaultNumerator", "market_id", "Eq", marketIdPadded).build())
+        .withLimit(100)
+        .includeHashedKeys();
 
+      const marketCreatedQuery = new ToriiQueryBuilder()
+        .withEntityModels(["pm-MarketCreated"])
+        .withClause(new ClauseBuilder().where("pm-MarketCreated", "market_id", "Eq", marketIdPadded).build())
+        .withLimit(1)
+        .includeHashedKeys();
+
+      // Execute all queries in parallel
+      const [marketResponse, vaultNumeratorResponse, marketCreatedResponse] = await Promise.all([
+        sdk.getEntities({ query: marketQuery }),
+        sdk.getEntities({ query: vaultNumeratorQuery }),
+        sdk.getEventMessages({ query: marketCreatedQuery }),
+      ]);
+
+      // Process market entity response
+      const marketItems: StandardizedQueryResult<SchemaType> = marketResponse.getItems();
       if (marketItems[0]) {
         const entity = marketItems[0];
         if (entity.models.pm?.Market) {
@@ -62,16 +80,8 @@ export const useMarket = (marketId: bigint): UseMarketResult => {
         }
       }
 
-      // Fetch vault numerators
-      const vaultNumeratorQuery = new ToriiQueryBuilder()
-        .withEntityModels(["pm-VaultNumerator"])
-        .withClause(new ClauseBuilder().where("pm-VaultNumerator", "market_id", "Eq", marketIdPadded).build())
-        .withLimit(100)
-        .includeHashedKeys();
-
-      const vaultNumeratorResponse = await sdk.getEntities({ query: vaultNumeratorQuery });
+      // Process vault numerators response
       const vaultNumeratorItems: StandardizedQueryResult<SchemaType> = vaultNumeratorResponse.getItems();
-
       const numerators = vaultNumeratorItems
         .flatMap((item) => (item.models.pm?.VaultNumerator ? [item.models.pm.VaultNumerator as VaultNumerator] : []))
         .map((n) => ({
@@ -80,19 +90,10 @@ export const useMarket = (marketId: bigint): UseMarketResult => {
           value: BigInt(n.value),
         }))
         .sort((a, b) => a.index - b.index);
-
       setVaultNumerators(numerators as VaultNumerator[]);
 
-      // Fetch market created event
-      const marketCreatedQuery = new ToriiQueryBuilder()
-        .withEntityModels(["pm-MarketCreated"])
-        .withClause(new ClauseBuilder().where("pm-MarketCreated", "market_id", "Eq", marketIdPadded).build())
-        .withLimit(1)
-        .includeHashedKeys();
-
-      const marketCreatedResponse = await sdk.getEventMessages({ query: marketCreatedQuery });
+      // Process market created event response
       const marketCreatedItems: StandardizedQueryResult<SchemaType> = marketCreatedResponse.getItems();
-
       if (marketCreatedItems[0]?.models.pm?.MarketCreated) {
         setMarketCreated(marketCreatedItems[0].models.pm.MarketCreated as MarketCreated);
       }

--- a/client/apps/game/src/ui/features/world-selector/world-selector-modal.tsx
+++ b/client/apps/game/src/ui/features/world-selector/world-selector-modal.tsx
@@ -319,8 +319,7 @@ export const WorldSelectorModal = ({
 
   const handleRefresh = useCallback(async () => {
     setPlayerRegistration({});
-    await refetchFactoryWorlds();
-    await refetchFactory();
+    await Promise.all([refetchFactoryWorlds(), refetchFactory()]);
   }, [refetchFactoryWorlds, refetchFactory]);
 
   const handleSwitchChain = useCallback(


### PR DESCRIPTION
## Summary
Converts sequential await statements to Promise.all() for independent operations across two high-traffic hooks, reducing network round-trip time by enabling concurrent execution.

**Changes:**
- `use-market.tsx`: Parallelizes 3 SDK queries (market entity, vault numerators, market created event)
- `world-selector-modal.tsx`: Parallelizes 2 independent refetch operations

**Testing:** Verify market pages and world selector refresh correctly with all data loading properly.

Fixes #4075