### PR TITLE
feat: Add Mock MMR Token Contract for Testing

### DIFF
--- a/contracts/game/src/models/mmr.cairo
+++ b/contracts/game/src/models/mmr.cairo
@@ -5,6 +5,7 @@
 
 use core::num::traits::Zero;
 use starknet::ContractAddress;
+use crate::alias::ID;
 
 
 // ================================
@@ -37,8 +38,6 @@ pub struct MMRConfig {
     pub mean_regression_scaled: u128,
     /// Minimum players for a game to be rated (default: 6)
     pub min_players: u16,
-    /// Minimum entry fee for a game to be rated (in $LORDS wei)
-    pub min_entry_fee: u256,
 }
 
 /// Helper to get default MMR config values
@@ -60,146 +59,8 @@ pub impl MMRConfigDefaultImpl of MMRConfigDefaultTrait {
             // 0.015 scaled by 1e6 for fixed-point precision
             mean_regression_scaled: 15000,
             min_players: 6,
-            // $1 in $LORDS (18 decimals)
-            min_entry_fee: 1_000000000000000000,
         }
     }
-}
-
-
-// ================================
-// PLAYER MMR STATISTICS
-// ================================
-
-/// Tracks per-player MMR statistics
-/// Updated after each rated game
-#[derive(IntrospectPacked, Copy, Drop, Serde)]
-#[dojo::model]
-pub struct PlayerMMRStats {
-    #[key]
-    pub player: ContractAddress,
-    /// Number of rated games played
-    pub games_played: u32,
-    /// Highest MMR ever achieved
-    pub highest_mmr: u128,
-    /// Lowest MMR ever recorded
-    pub lowest_mmr: u128,
-    /// Timestamp of last rated game
-    pub last_game_timestamp: u64,
-    /// MMR change from last game (positive = gain, uses magnitude + sign flag)
-    pub last_mmr_change_magnitude: u128,
-    /// True if last_mmr_change was negative
-    pub last_mmr_change_negative: bool,
-    /// Current win streak (consecutive games with positive MMR change)
-    pub current_streak: u16,
-    /// True if current streak is wins, false if losses
-    pub streak_is_wins: bool,
-}
-
-#[generate_trait]
-pub impl PlayerMMRStatsImpl of PlayerMMRStatsTrait {
-    /// Initialize stats for a new player
-    fn new(player: ContractAddress, initial_mmr: u128) -> PlayerMMRStats {
-        PlayerMMRStats {
-            player,
-            games_played: 0,
-            highest_mmr: initial_mmr,
-            lowest_mmr: initial_mmr,
-            last_game_timestamp: 0,
-            last_mmr_change_magnitude: 0,
-            last_mmr_change_negative: false,
-            current_streak: 0,
-            streak_is_wins: true,
-        }
-    }
-
-    /// Update stats after a game
-    fn record_game(ref self: PlayerMMRStats, new_mmr: u128, old_mmr: u128, timestamp: u64) {
-        self.games_played += 1;
-        self.last_game_timestamp = timestamp;
-
-        // Calculate MMR change
-        let (magnitude, is_negative) = if new_mmr >= old_mmr {
-            (new_mmr - old_mmr, false)
-        } else {
-            (old_mmr - new_mmr, true)
-        };
-
-        self.last_mmr_change_magnitude = magnitude;
-        self.last_mmr_change_negative = is_negative;
-
-        // Update highest/lowest
-        if new_mmr > self.highest_mmr {
-            self.highest_mmr = new_mmr;
-        }
-        if new_mmr < self.lowest_mmr {
-            self.lowest_mmr = new_mmr;
-        }
-
-        // Update streak
-        let is_win = !is_negative && magnitude > 0;
-        if is_win {
-            if self.streak_is_wins {
-                self.current_streak += 1;
-            } else {
-                self.current_streak = 1;
-                self.streak_is_wins = true;
-            }
-        } else if is_negative {
-            if !self.streak_is_wins {
-                self.current_streak += 1;
-            } else {
-                self.current_streak = 1;
-                self.streak_is_wins = false;
-            }
-        }
-        // If magnitude == 0, don't change streak
-    }
-}
-
-
-// ================================
-// GAME MMR RECORD
-// ================================
-
-/// Records MMR changes for a specific player in a specific game
-/// Used for historical tracking and analytics
-#[derive(IntrospectPacked, Copy, Drop, Serde)]
-#[dojo::model]
-pub struct GameMMRRecord {
-    #[key]
-    pub trial_id: u128,
-    #[key]
-    pub player: ContractAddress,
-    /// MMR before the game
-    pub mmr_before: u128,
-    /// MMR after the game
-    pub mmr_after: u128,
-    /// Player's rank in this game (1 = winner)
-    pub rank: u16,
-    /// Total players in the game
-    pub player_count: u16,
-    /// Median MMR of all players in the game
-    pub median_mmr: u128,
-    /// Timestamp when the game ended
-    pub timestamp: u64,
-}
-
-
-// ================================
-// SERIES MMR CONFIGURATION
-// ================================
-
-/// Marks whether a specific series/trial is eligible for MMR tracking
-#[derive(IntrospectPacked, Copy, Drop, Serde)]
-#[dojo::model]
-pub struct SeriesMMRConfig {
-    #[key]
-    pub trial_id: u128,
-    /// Whether this series is ranked (MMR-eligible)
-    pub is_ranked: bool,
-    /// Whether MMR has been processed for this trial
-    pub mmr_processed: bool,
 }
 
 
@@ -212,19 +73,9 @@ pub struct SeriesMMRConfig {
 #[dojo::model]
 pub struct MMRGameMeta {
     #[key]
-    pub trial_id: u128,
+    pub world_id: ID,
     /// Total players in the game
-    pub player_count: u16,
-    /// Median MMR for this game
     pub game_median: u128,
-    /// Global median across all registered players (for split lobbies)
-    pub global_median: u128,
-    /// When the meta was committed
-    pub committed_at: u64,
-    /// Who committed the meta
-    pub committed_by: ContractAddress,
-    /// Number of players already processed
-    pub processed_count: u16,
 }
 
 /// Tracks whether a player has claimed their MMR update for a trial
@@ -232,10 +83,7 @@ pub struct MMRGameMeta {
 #[dojo::model]
 pub struct MMRClaimed {
     #[key]
-    pub trial_id: u128,
-    #[key]
-    pub player: ContractAddress,
-    pub claimed: bool,
+    pub world_id: ID,
     pub claimed_at: u64,
 }
 
@@ -246,16 +94,7 @@ pub struct MMRClaimed {
 
 #[cfg(test)]
 mod tests {
-    use starknet::ContractAddress;
-    use super::{MMRConfigDefaultImpl, PlayerMMRStatsTrait};
-
-    fn addr(val: felt252) -> ContractAddress {
-        val.try_into().unwrap()
-    }
-
-    // ================================
-    // MMRConfig Default Tests
-    // ================================
+    use super::MMRConfigDefaultImpl;
 
     #[test]
     fn test_mmr_config_default() {
@@ -271,220 +110,5 @@ mod tests {
         assert!(config.lobby_split_weight_scaled == 250000, "Split weight scaled should be 250000");
         assert!(config.mean_regression_scaled == 15000, "Lambda scaled should be 15000");
         assert!(config.min_players == 6, "Min players should be 6");
-    }
-
-    // ================================
-    // PlayerMMRStats Tests
-    // ================================
-
-    #[test]
-    fn test_player_stats_new() {
-        let player = addr('player1');
-        let initial_mmr: u128 = 1000;
-
-        let stats = PlayerMMRStatsTrait::new(player, initial_mmr);
-
-        assert!(stats.player == player, "Player should match");
-        assert!(stats.games_played == 0, "Should have 0 games");
-        assert!(stats.highest_mmr == initial_mmr, "Highest should be initial");
-        assert!(stats.lowest_mmr == initial_mmr, "Lowest should be initial");
-        assert!(stats.last_game_timestamp == 0, "Timestamp should be 0");
-        assert!(stats.last_mmr_change_magnitude == 0, "Change should be 0");
-        assert!(stats.last_mmr_change_negative == false, "Should not be negative");
-        assert!(stats.current_streak == 0, "Streak should be 0");
-        assert!(stats.streak_is_wins == true, "Streak type defaults to wins");
-    }
-
-    #[test]
-    fn test_record_game_win() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Record a win (MMR increase)
-        stats.record_game(1025, 1000, 12345);
-
-        assert!(stats.games_played == 1, "Should have 1 game");
-        assert!(stats.last_game_timestamp == 12345, "Timestamp should update");
-        assert!(stats.last_mmr_change_magnitude == 25, "Change should be 25");
-        assert!(stats.last_mmr_change_negative == false, "Should not be negative");
-        assert!(stats.highest_mmr == 1025, "Highest should update");
-        assert!(stats.lowest_mmr == 1000, "Lowest should not change");
-        assert!(stats.current_streak == 1, "Win streak should be 1");
-        assert!(stats.streak_is_wins == true, "Should be win streak");
-    }
-
-    #[test]
-    fn test_record_game_loss() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Record a loss (MMR decrease)
-        stats.record_game(975, 1000, 12345);
-
-        assert!(stats.games_played == 1, "Should have 1 game");
-        assert!(stats.last_mmr_change_magnitude == 25, "Change magnitude should be 25");
-        assert!(stats.last_mmr_change_negative == true, "Should be negative");
-        assert!(stats.highest_mmr == 1000, "Highest should not change");
-        assert!(stats.lowest_mmr == 975, "Lowest should update");
-        assert!(stats.current_streak == 1, "Loss streak should be 1");
-        assert!(stats.streak_is_wins == false, "Should be loss streak");
-    }
-
-    #[test]
-    fn test_record_game_no_change() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // First record a win to start a streak
-        stats.record_game(1025, 1000, 100);
-        assert!(stats.current_streak == 1, "Should have 1 win");
-
-        // Record a game with no change
-        stats.record_game(1025, 1025, 200);
-
-        assert!(stats.games_played == 2, "Should have 2 games");
-        assert!(stats.last_mmr_change_magnitude == 0, "Change should be 0");
-        assert!(stats.last_mmr_change_negative == false, "Should not be negative");
-        // Streak should remain unchanged when no MMR change
-        assert!(stats.current_streak == 1, "Streak should stay at 1");
-        assert!(stats.streak_is_wins == true, "Should still be win streak");
-    }
-
-    #[test]
-    fn test_win_streak_consecutive() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Record 3 consecutive wins
-        stats.record_game(1020, 1000, 100);
-        assert!(stats.current_streak == 1, "Streak should be 1");
-
-        stats.record_game(1040, 1020, 200);
-        assert!(stats.current_streak == 2, "Streak should be 2");
-
-        stats.record_game(1055, 1040, 300);
-        assert!(stats.current_streak == 3, "Streak should be 3");
-        assert!(stats.streak_is_wins == true, "Should be win streak");
-        assert!(stats.highest_mmr == 1055, "Highest should be 1055");
-    }
-
-    #[test]
-    fn test_loss_streak_consecutive() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Record 3 consecutive losses
-        stats.record_game(980, 1000, 100);
-        assert!(stats.current_streak == 1, "Streak should be 1");
-        assert!(stats.streak_is_wins == false, "Should be loss streak");
-
-        stats.record_game(960, 980, 200);
-        assert!(stats.current_streak == 2, "Streak should be 2");
-
-        stats.record_game(945, 960, 300);
-        assert!(stats.current_streak == 3, "Streak should be 3");
-        assert!(stats.streak_is_wins == false, "Should be loss streak");
-        assert!(stats.lowest_mmr == 945, "Lowest should be 945");
-    }
-
-    #[test]
-    fn test_streak_breaks_on_opposite_result() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Build a 3-win streak
-        stats.record_game(1020, 1000, 100);
-        stats.record_game(1040, 1020, 200);
-        stats.record_game(1060, 1040, 300);
-        assert!(stats.current_streak == 3, "Win streak should be 3");
-        assert!(stats.streak_is_wins == true, "Should be win streak");
-
-        // Now lose - streak should reset to 1 loss
-        stats.record_game(1035, 1060, 400);
-        assert!(stats.current_streak == 1, "Streak should reset to 1");
-        assert!(stats.streak_is_wins == false, "Should now be loss streak");
-
-        // Another loss - streak grows
-        stats.record_game(1010, 1035, 500);
-        assert!(stats.current_streak == 2, "Loss streak should be 2");
-
-        // Win again - resets to 1 win
-        stats.record_game(1030, 1010, 600);
-        assert!(stats.current_streak == 1, "Streak should reset to 1");
-        assert!(stats.streak_is_wins == true, "Should be win streak again");
-    }
-
-    #[test]
-    fn test_highest_lowest_tracking() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Go up
-        stats.record_game(1050, 1000, 100);
-        assert!(stats.highest_mmr == 1050, "Highest should be 1050");
-        assert!(stats.lowest_mmr == 1000, "Lowest should be 1000");
-
-        // Go down below initial
-        stats.record_game(950, 1050, 200);
-        assert!(stats.highest_mmr == 1050, "Highest should stay 1050");
-        assert!(stats.lowest_mmr == 950, "Lowest should be 950");
-
-        // New high
-        stats.record_game(1100, 950, 300);
-        assert!(stats.highest_mmr == 1100, "Highest should be 1100");
-        assert!(stats.lowest_mmr == 950, "Lowest should stay 950");
-
-        // New low
-        stats.record_game(900, 1100, 400);
-        assert!(stats.highest_mmr == 1100, "Highest should stay 1100");
-        assert!(stats.lowest_mmr == 900, "Lowest should be 900");
-    }
-
-    #[test]
-    fn test_games_played_increments() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        assert!(stats.games_played == 0, "Should start at 0");
-
-        for i in 1..11_u32 {
-            stats.record_game(1000, 1000, i.into() * 100);
-            assert!(stats.games_played == i, "Games should match iteration");
-        }
-
-        assert!(stats.games_played == 10, "Should have 10 games");
-    }
-
-    #[test]
-    fn test_timestamp_updates() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        stats.record_game(1000, 1000, 1000);
-        assert!(stats.last_game_timestamp == 1000, "Timestamp should be 1000");
-
-        stats.record_game(1000, 1000, 5000);
-        assert!(stats.last_game_timestamp == 5000, "Timestamp should be 5000");
-
-        stats.record_game(1000, 1000, 3000); // Earlier timestamp (shouldn't happen but test anyway)
-        assert!(stats.last_game_timestamp == 3000, "Timestamp should update to 3000");
-    }
-
-    #[test]
-    fn test_large_mmr_changes() {
-        let player = addr('player1');
-        let mut stats = PlayerMMRStatsTrait::new(player, 1000);
-
-        // Large gain
-        stats.record_game(2000, 1000, 100);
-        assert!(stats.last_mmr_change_magnitude == 1000, "Change should be 1000");
-        assert!(stats.last_mmr_change_negative == false, "Should be positive");
-        assert!(stats.highest_mmr == 2000, "Highest should be 2000");
-
-        // Large loss
-        stats.record_game(500, 2000, 200);
-        assert!(stats.last_mmr_change_magnitude == 1500, "Change should be 1500");
-        assert!(stats.last_mmr_change_negative == true, "Should be negative");
-        assert!(stats.lowest_mmr == 500, "Lowest should be 500");
     }
 }

--- a/contracts/game/src/systems/mmr/contracts.cairo
+++ b/contracts/game/src/systems/mmr/contracts.cairo
@@ -4,85 +4,55 @@
 // Uses commit + permissionless per-player claims to avoid lobby-wide loops.
 
 use starknet::ContractAddress;
-use crate::models::mmr::{GameMMRRecord, MMRGameMeta, PlayerMMRStats};
 
 /// Interface for the MMR token contract
+/// Simplified: balance_of returns INITIAL_MMR if player has never been set
 #[starknet::interface]
 pub trait IMMRToken<T> {
-    fn get_mmr(self: @T, player: ContractAddress) -> u256;
-    fn has_mmr(self: @T, player: ContractAddress) -> bool;
-    fn initialize_player(ref self: T, player: ContractAddress);
+    /// Get player's current MMR balance
+    /// Returns INITIAL_MMR (1000) if player has never been initialized
+    fn balance_of(self: @T, player: ContractAddress) -> u256;
+
+    /// Update a player's MMR to a new value
+    /// Enforces minimum MMR floor, auto-initializes if first update
     fn update_mmr(ref self: T, player: ContractAddress, new_mmr: u256);
+
+    /// Batch update multiple players' MMR
     fn update_mmr_batch(ref self: T, updates: Array<(ContractAddress, u256)>);
 }
 
 /// Interface for the MMR systems
 #[starknet::interface]
 pub trait IMMRSystems<T> {
-    /// Mark a series as ranked (MMR-eligible)
-    /// Only callable by admin
-    fn set_series_ranked(ref self: T, trial_id: u128, is_ranked: bool);
-
-    /// Check if a series is ranked
-    fn is_series_ranked(self: @T, trial_id: u128) -> bool;
-
-    /// Commit MMR metadata (medians) for a completed game
-    /// Enables permissionless per-player claims without lobby-wide loops
-    fn commit_game_mmr_meta(ref self: T, trial_id: u128, game_median: u128, global_median: u128);
-
+    /// Commit MMR metadata for a completed game with on-chain verification
+    /// Caller provides player list; contract verifies each player and calculates median
+    fn commit_game_mmr_meta(ref self: T, players: Array<ContractAddress>);
     /// Permissionless per-player MMR claim for a completed game
-    fn claim_game_mmr(ref self: T, trial_id: u128, player: ContractAddress);
-
-    /// Get a player's current MMR
-    fn get_player_mmr(self: @T, player: ContractAddress) -> u128;
-
-    /// Get a player's MMR stats
-    fn get_player_stats(self: @T, player: ContractAddress) -> PlayerMMRStats;
-
-    /// Get the MMR record for a player in a specific game
-    fn get_game_mmr_record(self: @T, trial_id: u128, player: ContractAddress) -> GameMMRRecord;
-
-    /// Get committed MMR metadata for a game
-    fn get_game_mmr_meta(self: @T, trial_id: u128) -> MMRGameMeta;
-
-    /// Check if a player has already claimed their MMR for a game
-    fn has_player_claimed_mmr(self: @T, trial_id: u128, player: ContractAddress) -> bool;
-
-    /// Check if a game is eligible for MMR updates
-    fn is_game_mmr_eligible(self: @T, trial_id: u128, player_count: u16, entry_fee: u256) -> bool;
+    fn claim_game_mmr(ref self: T, players: Array<ContractAddress>);
 }
 
 
 #[dojo::contract]
 pub mod mmr_systems {
+    use core::dict::Felt252Dict;
     use core::num::traits::Zero;
     use dojo::event::EventStorage;
     use dojo::model::ModelStorage;
     use dojo::world::{WorldStorage, WorldStorageTrait};
     use starknet::ContractAddress;
-    use crate::constants::DEFAULT_NS;
-    use crate::models::config::{BlitzRegistrationConfig, WorldConfigUtilImpl};
-    use crate::models::mmr::{
-        GameMMRRecord, MMRClaimed, MMRConfig, MMRGameMeta, PlayerMMRStats, PlayerMMRStatsTrait, SeriesMMRConfig,
-    };
-    use crate::models::rank::{PlayerRank, PlayersRankTrial};
-    use crate::systems::config::contracts::config_systems::assert_caller_is_admin;
+    use crate::constants::{DEFAULT_NS, WORLD_CONFIG_ID};
+    use crate::models::config::WorldConfigUtilImpl;
+    use crate::models::mmr::{MMRClaimed, MMRConfig, MMRGameMeta};
+    use crate::models::rank::{PlayerRank, PlayersRankFinal, PlayersRankTrial};
     use crate::systems::utils::mmr::MMRCalculatorImpl;
     use super::{IMMRSystems, IMMRTokenDispatcher, IMMRTokenDispatcherTrait};
+
+    // Token uses 18 decimals, but MMR calculator works with logical values (1000 = 1000 MMR)
+    const MMR_PRECISION: u256 = 1_000000000000000000; // 1e18
 
     // ================================
     // EVENTS
     // ================================
-
-    #[derive(Copy, Drop, Serde)]
-    #[dojo::event]
-    pub struct MMRGameProcessed {
-        #[key]
-        pub trial_id: u128,
-        pub player_count: u16,
-        pub median_mmr: u128,
-        pub timestamp: u64,
-    }
 
     #[derive(Copy, Drop, Serde)]
     #[dojo::event]
@@ -115,290 +85,184 @@ pub mod mmr_systems {
 
     #[abi(embed_v0)]
     pub impl MMRSystemsImpl of IMMRSystems<ContractState> {
-        fn set_series_ranked(ref self: ContractState, trial_id: u128, is_ranked: bool) {
+        fn commit_game_mmr_meta(ref self: ContractState, players: Array<ContractAddress>) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
 
-            // Only admin can set series as ranked
-            assert_caller_is_admin(world);
+            let player_count: u16 = players.len().try_into().unwrap();
+            assert!(player_count.is_non_zero(), "Eternum: no players");
 
-            let mut series_config: SeriesMMRConfig = world.read_model(trial_id);
-            series_config.is_ranked = is_ranked;
-            world.write_model(@series_config);
-        }
+            let players_rank_final: PlayersRankFinal = world.read_model(WORLD_CONFIG_ID);
+            assert!(players_rank_final.trial_id.is_non_zero(), "Eternum: rankings not finalized");
 
-        fn is_series_ranked(self: @ContractState, trial_id: u128) -> bool {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            let series_config: SeriesMMRConfig = world.read_model(trial_id);
-            series_config.is_ranked
-        }
-
-        fn commit_game_mmr_meta(ref self: ContractState, trial_id: u128, game_median: u128, global_median: u128) {
-            let mut world: WorldStorage = self.world(DEFAULT_NS());
+            let final_trial_id = players_rank_final.trial_id;
 
             // Get MMR config
             let mmr_config: MMRConfig = WorldConfigUtilImpl::get_member(world, selector!("mmr_config"));
 
             // Check if MMR is enabled
-            if !mmr_config.enabled {
-                return;
-            }
-
-            // Check if already processed
-            let series_config: SeriesMMRConfig = world.read_model(trial_id);
-            if series_config.mmr_processed {
-                return;
-            }
-
-            // Check if ranked
-            if !series_config.is_ranked {
-                return;
-            }
-
-            // Check minimum entry fee
-            let blitz_registration_config: BlitzRegistrationConfig = WorldConfigUtilImpl::get_member(
-                world, selector!("blitz_registration_config"),
-            );
-            if blitz_registration_config.fee_amount < mmr_config.min_entry_fee {
-                return;
-            }
+            assert!(mmr_config.enabled, "Eternum: MMR not enabled");
 
             // Read the trial data
-            let trial: PlayersRankTrial = world.read_model(trial_id);
-            if trial.total_player_count_revealed == 0 {
-                return;
-            }
-            if trial.total_player_count_revealed != trial.total_player_count_committed {
-                return;
-            }
-            if trial.last_rank == 0 {
-                return;
-            }
+            let trial: PlayersRankTrial = world.read_model(final_trial_id);
+            assert!(!trial.total_player_count_revealed.is_zero(), "Eternum: no players");
 
             // Check minimum players
-            if trial.total_player_count_revealed < mmr_config.min_players {
-                return;
-            }
+            assert!(trial.total_player_count_revealed >= mmr_config.min_players, "Eternum: not enough players");
 
             // Avoid overwriting an existing commit
-            let mut meta: MMRGameMeta = world.read_model(trial_id);
-            if meta.committed_at != 0 {
-                return;
+            let mut meta: MMRGameMeta = world.read_model(final_trial_id);
+            assert!(meta.game_median.is_zero(), "Eternum: mmr meta already committed");
+
+            // Verify player count matches trial
+            assert!(
+                player_count == trial.total_player_count_revealed,
+                "Eternum: MMR: player count mismatch - expected {}, got {}",
+                trial.total_player_count_revealed,
+                player_count,
+            );
+
+            // Check if token is configured
+            assert!(mmr_config.mmr_token_address.is_non_zero(), "MMR: zero token address");
+
+            // Verify each player and collect their MMRs
+            // Client MUST sort players by MMR ascending - we verify this on-chain
+            let mut mmrs: Array<u128> = array![];
+            let mut last_mmr: u128 = 0;
+            let mut player_address_used: Felt252Dict<bool> = Default::default();
+            let mmr_token = IMMRTokenDispatcher { contract_address: mmr_config.mmr_token_address };
+
+            for player in players {
+                assert!(!player_address_used.get(player.into()), "MMR: player address repeated");
+                player_address_used.insert(player.into(), true);
+
+                // Verify player has a valid rank in this trial
+                let player_rank: PlayerRank = world.read_model((final_trial_id, player));
+                assert!(player_rank.rank > 0, "MMR: player {:?} has no rank in trial", player);
+
+                // Get player's current MMR (balance_of returns INITIAL_MMR if uninitialized)
+                // Token stores with 18 decimals, divide to get logical value
+                let player_mmr: u128 = (mmr_token.balance_of(player) / MMR_PRECISION).try_into().unwrap();
+
+                // Verify ascending MMR order (client must sort by MMR)
+                assert!(player_mmr >= last_mmr, "MMR: players must be sorted by MMR ascending");
+                last_mmr = player_mmr;
+
+                mmrs.append(player_mmr);
             }
 
-            assert!(game_median > 0, "MMR: game median must be > 0");
-            let effective_global_median = if global_median == 0 {
-                game_median
+            // Calculate median - O(1) since client sorted by MMR
+            let mmrs_span = mmrs.span();
+            let game_median = if player_count == 1 {
+                // Single player: median is their MMR
+                *mmrs_span.at(0)
+            } else if player_count % 2 == 1 {
+                // Odd count: true middle element
+                let mid_idx: u32 = (player_count / 2).into();
+                *mmrs_span.at(mid_idx)
             } else {
-                global_median
+                // Even count: average of two middle elements
+                let upper_idx: u32 = (player_count / 2).into();
+                let lower_idx: u32 = upper_idx - 1;
+                (*mmrs_span.at(lower_idx) + *mmrs_span.at(upper_idx)) / 2
             };
+            meta.game_median = game_median;
+            world.write_model(@meta);
 
             let now = starknet::get_block_timestamp();
             let caller = starknet::get_caller_address();
 
-            meta.trial_id = trial_id;
-            meta.player_count = trial.total_player_count_revealed;
-            meta.game_median = game_median;
-            meta.global_median = effective_global_median;
-            meta.committed_at = now;
-            meta.committed_by = caller;
-            meta.processed_count = 0;
-            world.write_model(@meta);
-
             world
                 .emit_event(
                     @MMRGameCommitted {
-                        trial_id,
-                        player_count: meta.player_count,
+                        trial_id: final_trial_id,
+                        player_count,
                         game_median,
-                        global_median: effective_global_median,
+                        global_median: game_median, // Same as game_median (no split lobby support)
                         committed_by: caller,
                         timestamp: now,
                     },
                 );
         }
 
-        fn claim_game_mmr(ref self: ContractState, trial_id: u128, player: ContractAddress) {
+        fn claim_game_mmr(ref self: ContractState, players: Array<ContractAddress>) {
             let mut world: WorldStorage = self.world(DEFAULT_NS());
+
+            let players_rank_final: PlayersRankFinal = world.read_model(WORLD_CONFIG_ID);
+            assert!(players_rank_final.trial_id.is_non_zero(), "Eternum: rankings not finalized");
+
+            let final_trial_id = players_rank_final.trial_id;
+
+            let player_rank_trial_final: PlayersRankTrial = world.read_model(final_trial_id);
+            let player_count: u16 = players.len().try_into().unwrap();
+
+            // Verify player count matches trial. all claims must be made at once
+            assert!(
+                player_count == player_rank_trial_final.total_player_count_revealed,
+                "Eternum: MMR: player count mismatch - expected {}, got {}",
+                player_rank_trial_final.total_player_count_revealed,
+                player_count,
+            );
 
             // Get MMR config
             let mmr_config: MMRConfig = WorldConfigUtilImpl::get_member(world, selector!("mmr_config"));
 
             // Check if MMR is enabled
-            if !mmr_config.enabled {
-                return;
-            }
-
-            // Check if already processed
-            let mut series_config: SeriesMMRConfig = world.read_model(trial_id);
-            if series_config.mmr_processed {
-                return;
-            }
-
-            // Check if ranked
-            if !series_config.is_ranked {
-                return;
-            }
+            assert!(mmr_config.enabled, "Eternum: MMR not enabled");
 
             // Ensure meta has been committed
-            let mut meta: MMRGameMeta = world.read_model(trial_id);
-            if meta.committed_at == 0 || meta.player_count == 0 {
-                return;
-            }
+            let meta: MMRGameMeta = world.read_model(final_trial_id);
+            assert!(meta.game_median.is_non_zero(), "Eternum: mmr meta not committed");
 
-            // Ensure player hasn't already claimed
-            let mut claimed: MMRClaimed = world.read_model((trial_id, player));
-            if claimed.claimed {
-                return;
-            }
+            // Ensure claim hasnt been called previously
+            let mut claimed: MMRClaimed = world.read_model(WORLD_CONFIG_ID);
+            assert!(claimed.claimed_at.is_zero(), "Eternum: mmr already claimed");
 
-            // Read player rank
-            let player_rank: PlayerRank = world.read_model((trial_id, player));
-            if player_rank.rank == 0 {
-                return;
-            }
+            // ensure mmr token address is set
+            assert!(mmr_config.mmr_token_address.is_non_zero(), "MMR: zero token address");
 
-            // Check if token is configured (optional - we can still process records without it)
-            let has_token = !mmr_config.mmr_token_address.is_zero();
-
-            // Load current MMR
-            let current_mmr: u128 = if has_token {
-                let mmr_token = IMMRTokenDispatcher { contract_address: mmr_config.mmr_token_address };
-                if !mmr_token.has_mmr(player) {
-                    mmr_token.initialize_player(player);
-                }
-                mmr_token.get_mmr(player).try_into().unwrap()
-            } else {
-                mmr_config.initial_mmr
-            };
-
-            let new_mmr = MMRCalculatorImpl::calculate_player_mmr(
-                mmr_config, current_mmr, player_rank.rank, meta.player_count, meta.game_median, meta.global_median,
-            );
-
-            // Store game record
             let now = starknet::get_block_timestamp();
-            let record = GameMMRRecord {
-                trial_id,
-                player,
-                mmr_before: current_mmr,
-                mmr_after: new_mmr,
-                rank: player_rank.rank,
-                player_count: meta.player_count,
-                median_mmr: meta.game_median,
-                timestamp: now,
-            };
-            world.write_model(@record);
 
-            // Update player stats
-            let mut stats: PlayerMMRStats = world.read_model(player);
-            if stats.games_played == 0 {
-                stats = PlayerMMRStatsTrait::new(player, mmr_config.initial_mmr);
-            }
-            stats.record_game(new_mmr, current_mmr, now);
-            world.write_model(@stats);
-
-            // Update MMR token (if configured)
-            if has_token {
-                let mmr_token = IMMRTokenDispatcher { contract_address: mmr_config.mmr_token_address };
-                mmr_token.update_mmr(player, new_mmr.into());
-            }
-
-            // Mark claimed
-            claimed.trial_id = trial_id;
-            claimed.player = player;
-            claimed.claimed = true;
+            // Mark claimed (once, before processing)
             claimed.claimed_at = now;
             world.write_model(@claimed);
 
-            // Emit player event
-            world
-                .emit_event(
-                    @PlayerMMRChanged {
-                        player, trial_id, old_mmr: current_mmr, new_mmr, rank: player_rank.rank, timestamp: now,
-                    },
+            let mmr_token = IMMRTokenDispatcher { contract_address: mmr_config.mmr_token_address };
+            let mut player_address_used: Felt252Dict<bool> = Default::default();
+
+            for player in players {
+                assert!(!player_address_used.get(player.into()), "MMR: player address repeated");
+                player_address_used.insert(player.into(), true);
+
+                // Read player rank
+                let player_rank: PlayerRank = world.read_model((final_trial_id, player));
+                assert!(player_rank.rank.is_non_zero(), "Eternum: player zero rank");
+
+                // Load current MMR (balance_of returns INITIAL_MMR if uninitialized)
+                // Token stores with 18 decimals, divide to get logical value
+                let current_mmr: u128 = (mmr_token.balance_of(player) / MMR_PRECISION).try_into().unwrap();
+
+                // Calculate new MMR (works with logical values like 1000)
+                let new_mmr = MMRCalculatorImpl::calculate_player_mmr(
+                    mmr_config, current_mmr, player_rank.rank, player_count, meta.game_median, meta.game_median,
                 );
 
-            // Update processed count + finalize if complete
-            if meta.processed_count < meta.player_count {
-                meta.processed_count += 1;
-                world.write_model(@meta);
-            }
+                // Update MMR token - multiply by precision for token storage
+                let new_mmr_scaled: u256 = new_mmr.into() * MMR_PRECISION;
+                mmr_token.update_mmr(player, new_mmr_scaled);
 
-            if meta.processed_count == meta.player_count {
-                series_config.mmr_processed = true;
-                world.write_model(@series_config);
+                // Emit player event
                 world
                     .emit_event(
-                        @MMRGameProcessed {
-                            trial_id, player_count: meta.player_count, median_mmr: meta.game_median, timestamp: now,
+                        @PlayerMMRChanged {
+                            player,
+                            trial_id: final_trial_id,
+                            old_mmr: current_mmr,
+                            new_mmr,
+                            rank: player_rank.rank,
+                            timestamp: now,
                         },
                     );
             }
-        }
-
-        fn get_player_mmr(self: @ContractState, player: ContractAddress) -> u128 {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            let mmr_config: MMRConfig = WorldConfigUtilImpl::get_member(world, selector!("mmr_config"));
-
-            if mmr_config.mmr_token_address.is_zero() {
-                return mmr_config.initial_mmr;
-            }
-
-            let mmr_token = IMMRTokenDispatcher { contract_address: mmr_config.mmr_token_address };
-            if !mmr_token.has_mmr(player) {
-                return mmr_config.initial_mmr;
-            }
-
-            mmr_token.get_mmr(player).try_into().unwrap()
-        }
-
-        fn get_player_stats(self: @ContractState, player: ContractAddress) -> PlayerMMRStats {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            world.read_model(player)
-        }
-
-        fn get_game_mmr_record(self: @ContractState, trial_id: u128, player: ContractAddress) -> GameMMRRecord {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            world.read_model((trial_id, player))
-        }
-
-        fn get_game_mmr_meta(self: @ContractState, trial_id: u128) -> MMRGameMeta {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            world.read_model(trial_id)
-        }
-
-        fn has_player_claimed_mmr(self: @ContractState, trial_id: u128, player: ContractAddress) -> bool {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            let claimed: MMRClaimed = world.read_model((trial_id, player));
-            claimed.claimed
-        }
-
-        fn is_game_mmr_eligible(self: @ContractState, trial_id: u128, player_count: u16, entry_fee: u256) -> bool {
-            let world: WorldStorage = self.world(DEFAULT_NS());
-            let mmr_config: MMRConfig = WorldConfigUtilImpl::get_member(world, selector!("mmr_config"));
-
-            // Check if MMR is enabled
-            if !mmr_config.enabled {
-                return false;
-            }
-
-            // Check if series is ranked
-            let series_config: SeriesMMRConfig = world.read_model(trial_id);
-            if !series_config.is_ranked {
-                return false;
-            }
-
-            // Check minimum players
-            if player_count < mmr_config.min_players {
-                return false;
-            }
-
-            // Check minimum entry fee
-            if entry_fee < mmr_config.min_entry_fee {
-                return false;
-            }
-
-            true
         }
     }
 

--- a/contracts/game/src/systems/mmr/tests/test_mmr_systems.cairo
+++ b/contracts/game/src/systems/mmr/tests/test_mmr_systems.cairo
@@ -1,841 +1,758 @@
-// MMR Systems Integration Tests
-//
-// Tests the full MMR game flow including:
-// - Admin controls for ranked series
-// - MMR processing after game completion
-// - Player stats tracking
-// - Game record creation
+//! MMR Systems Integration Tests
+//!
+//! Tests for:
+//! - commit_game_mmr_meta: Commits MMR metadata (median) for a completed game
+//! - claim_game_mmr: Claims MMR updates for all players
+//!
+//! These tests use snforge with actual system calls through dispatchers.
 
-use core::num::traits::Zero;
-use dojo::model::{Model, ModelStorage, ModelStorageTest};
-use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
-use dojo_snf_test::{ContractDef, ContractDefTrait, NamespaceDef, TestResource, WorldStorageTestTrait, spawn_test_world};
-use snforge_std::{start_cheat_block_timestamp_global, start_cheat_caller_address, stop_cheat_caller_address};
-use starknet::{ContractAddress, contract_address_const};
-use crate::constants::{DEFAULT_NS, DEFAULT_NS_STR};
-use crate::models::config::{BlitzRegistrationConfig, WorldConfigUtilImpl};
-use crate::models::mmr::{GameMMRRecord, MMRConfig, MMRConfigDefaultImpl, MMRGameMeta, SeriesMMRConfig};
-use crate::models::rank::{PlayerRank, PlayersRankTrial};
-use crate::systems::mmr::contracts::{IMMRSystems, IMMRSystemsDispatcher, IMMRSystemsDispatcherTrait};
-use crate::systems::utils::mmr::MMRCalculatorImpl;
+#[cfg(test)]
+mod tests {
+    use core::num::traits::Zero;
+    use dojo::model::{ModelStorage, ModelStorageTest};
+    use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
+    use dojo_snf_test::{
+        ContractDef, ContractDefTrait, NamespaceDef, TestResource, WorldStorageTestTrait, spawn_test_world,
+    };
+    use snforge_std::{
+        ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp_global, start_cheat_caller_address,
+        stop_cheat_caller_address,
+    };
+    use starknet::ContractAddress;
+    use crate::constants::{DEFAULT_NS, DEFAULT_NS_STR, WORLD_CONFIG_ID};
+    use crate::models::config::WorldConfigUtilImpl;
+    use crate::models::mmr::{MMRClaimed, MMRConfigDefaultImpl, MMRGameMeta};
+    use crate::models::rank::{PlayerRank, PlayersRankFinal, PlayersRankTrial};
+    use crate::systems::mmr::contracts::{IMMRSystemsDispatcher, IMMRSystemsDispatcherTrait};
+    use crate::utils::testing::contracts::mmr_token_mock::{IMockMMRTokenDispatcher, IMockMMRTokenDispatcherTrait};
 
+    // ================================
+    // TEST HELPERS
+    // ================================
 
-// ================================
-// TEST HELPERS
-// ================================
+    // Token uses 18 decimals
+    const PRECISION: u256 = 1_000000000000000000; // 1e18
 
-fn ADMIN() -> ContractAddress {
-    contract_address_const::<'admin'>()
-}
-
-fn NON_ADMIN() -> ContractAddress {
-    contract_address_const::<'non_admin'>()
-}
-
-fn PLAYER1() -> ContractAddress {
-    contract_address_const::<'player1'>()
-}
-
-fn PLAYER2() -> ContractAddress {
-    contract_address_const::<'player2'>()
-}
-
-fn PLAYER3() -> ContractAddress {
-    contract_address_const::<'player3'>()
-}
-
-fn PLAYER4() -> ContractAddress {
-    contract_address_const::<'player4'>()
-}
-
-fn PLAYER5() -> ContractAddress {
-    contract_address_const::<'player5'>()
-}
-
-fn PLAYER6() -> ContractAddress {
-    contract_address_const::<'player6'>()
-}
-
-/// Create namespace definition with required models
-fn namespace_def() -> NamespaceDef {
-    NamespaceDef {
-        namespace: DEFAULT_NS_STR(),
-        resources: [
-            // Config models
-            TestResource::Model("WorldConfig"), // MMR models
-            TestResource::Model("PlayerMMRStats"),
-            TestResource::Model("GameMMRRecord"), TestResource::Model("SeriesMMRConfig"),
-            TestResource::Model("MMRGameMeta"), TestResource::Model("MMRClaimed"),
-            // Rank models (for trial data)
-            TestResource::Model("PlayersRankTrial"), TestResource::Model("PlayerRank"),
-            // MMR systems contract
-            TestResource::Contract("mmr_systems"), // MMR events
-            TestResource::Event("MMRGameProcessed"),
-            TestResource::Event("MMRGameCommitted"), TestResource::Event("PlayerMMRChanged"),
-        ]
-            .span(),
+    fn e18(val: u256) -> u256 {
+        val * PRECISION
     }
-}
 
-/// Create contract definitions with permissions
-fn contract_defs() -> Span<ContractDef> {
-    [
-        ContractDefTrait::new(DEFAULT_NS(), @"mmr_systems")
-            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
-    ]
-        .span()
-}
+    fn addr(val: felt252) -> ContractAddress {
+        val.try_into().unwrap()
+    }
 
-/// Spawn test world with MMR systems
-fn spawn_mmr_test_world() -> WorldStorage {
-    let mut world = spawn_test_world([namespace_def()].span());
-    world.sync_perms_and_inits(contract_defs());
-    world.dispatcher.uuid();
-    world
-}
-
-/// Set up world config with admin address
-fn setup_world_config(ref world: WorldStorage, admin: ContractAddress) {
-    // Set admin address in world config
-    WorldConfigUtilImpl::set_member(ref world, selector!("admin_address"), admin);
-}
-
-/// Set up MMR config (enabled with no token - for testing calculations only)
-fn setup_mmr_config(ref world: WorldStorage) {
-    let mmr_config = MMRConfig {
-        enabled: true,
-        mmr_token_address: Zero::zero(), // No token for unit tests
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000, // 0.25 * 1e6
-        mean_regression_scaled: 15000, // 0.015 * 1e6
-        min_players: 2, // Lower threshold for testing
-        min_entry_fee: 0 // No fee requirement for testing
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-}
-
-/// Set blitz registration fee (used for MMR min entry fee checks)
-fn setup_blitz_registration_fee(ref world: WorldStorage, fee_amount: u256) {
-    let blitz_registration_config = BlitzRegistrationConfig {
-        fee_amount,
-        fee_token: Zero::zero(),
-        fee_recipient: Zero::zero(),
-        entry_token_address: Zero::zero(),
-        collectibles_cosmetics_max: 0,
-        collectibles_cosmetics_address: Zero::zero(),
-        collectibles_timelock_address: Zero::zero(),
-        collectibles_lootchest_address: Zero::zero(),
-        collectibles_elitenft_address: Zero::zero(),
-        registration_count: 0,
-        registration_count_max: 0,
-        registration_start_at: 0,
-        assigned_positions_count: 0,
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("blitz_registration_config"), blitz_registration_config);
-}
-
-/// Set up a mock trial with player rankings
-fn setup_mock_trial(ref world: WorldStorage, trial_id: u128, players: Span<ContractAddress>, ranks: Span<u16>) {
-    let player_count: u16 = players.len().try_into().unwrap();
-    let mut last_rank: u16 = 0;
-
-    // Create rank entries for each player
-    let mut i: u32 = 0;
-    while i < players.len() {
-        let player = *players.at(i);
-        let rank = *ranks.at(i);
-
-        if rank > last_rank {
-            last_rank = rank;
+    fn namespace_def_mmr() -> NamespaceDef {
+        NamespaceDef {
+            namespace: DEFAULT_NS_STR(),
+            resources: [
+                // Core config
+                TestResource::Model("WorldConfig"), // MMR models
+                TestResource::Model("MMRGameMeta"),
+                TestResource::Model("MMRClaimed"), // Rank models
+                TestResource::Model("PlayersRankFinal"),
+                TestResource::Model("PlayersRankTrial"), TestResource::Model("PlayerRank"),
+                // MMR system contract
+                TestResource::Contract("mmr_systems"), // MMR events
+                TestResource::Event("MMRGameCommitted"),
+                TestResource::Event("PlayerMMRChanged"),
+            ]
+                .span(),
         }
-
-        // Create player rank entry
-        let mut player_rank: PlayerRank = world.read_model((trial_id, player));
-        player_rank.rank = rank;
-        world.write_model_test(@player_rank);
-
-        i += 1;
     }
 
-    // Create trial
-    let trial = PlayersRankTrial {
-        trial_id,
-        owner: contract_address_const::<'trial_owner'>(),
-        last_rank,
-        last_player_points: 0,
-        total_player_points: 0,
-        total_player_count_committed: player_count,
-        total_player_count_revealed: player_count,
-        total_prize_amount: 0,
-        total_prize_amount_calculated: 0,
-    };
-    world.write_model_test(@trial);
-}
-
-/// Get MMR systems dispatcher
-fn get_mmr_dispatcher(world: @WorldStorage) -> IMMRSystemsDispatcher {
-    let (addr, _) = world.dns(@"mmr_systems").unwrap();
-    IMMRSystemsDispatcher { contract_address: addr }
-}
-
-/// Get MMR systems contract address for cheat calls
-fn get_mmr_contract_address(world: @WorldStorage) -> ContractAddress {
-    let (addr, _) = world.dns(@"mmr_systems").unwrap();
-    addr
-}
-
-
-// ================================
-// SET SERIES RANKED TESTS
-// ================================
-
-#[test]
-fn test_set_series_ranked_as_admin() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 1;
-
-    // Initially not ranked
-    assert!(!mmr.is_series_ranked(trial_id), "Should not be ranked initially");
-
-    // Set as admin
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    // Now should be ranked
-    assert!(mmr.is_series_ranked(trial_id), "Should be ranked after admin sets it");
-
-    // Can also unset
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, false);
-    stop_cheat_caller_address(mmr_addr);
-    assert!(!mmr.is_series_ranked(trial_id), "Should be unranked after admin unsets it");
-}
-
-#[test]
-#[should_panic]
-fn test_set_series_ranked_as_non_admin() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-
-    // Try to set as non-admin
-    start_cheat_caller_address(mmr_addr, NON_ADMIN());
-    mmr.set_series_ranked(1, true);
-    stop_cheat_caller_address(mmr_addr);
-}
-
-
-// ================================
-// IS SERIES RANKED TESTS
-// ================================
-
-#[test]
-fn test_is_series_ranked_default() {
-    let mut world = spawn_mmr_test_world();
-    let mmr = get_mmr_dispatcher(@world);
-
-    // Any trial should default to not ranked
-    assert!(!mmr.is_series_ranked(1), "Trial 1 should not be ranked by default");
-    assert!(!mmr.is_series_ranked(999), "Trial 999 should not be ranked by default");
-}
-
-
-// ================================
-// GET PLAYER MMR TESTS
-// ================================
-
-#[test]
-fn test_get_player_mmr_uninitialized() {
-    let mut world = spawn_mmr_test_world();
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-
-    // Uninitialized player should return initial MMR
-    let player_mmr = mmr.get_player_mmr(PLAYER1());
-    assert!(player_mmr == 1000, "Uninitialized player should have initial MMR of 1000");
-}
-
-
-// ================================
-// GET PLAYER STATS TESTS
-// ================================
-
-#[test]
-fn test_get_player_stats_uninitialized() {
-    let mut world = spawn_mmr_test_world();
-    let mmr = get_mmr_dispatcher(@world);
-
-    let stats = mmr.get_player_stats(PLAYER1());
-
-    // Uninitialized stats should have zeroed values
-    assert!(stats.games_played == 0, "Should have 0 games played");
-    assert!(stats.highest_mmr == 0, "Should have 0 highest MMR");
-    assert!(stats.lowest_mmr == 0, "Should have 0 lowest MMR");
-}
-
-
-// ================================
-// IS GAME MMR ELIGIBLE TESTS
-// ================================
-
-#[test]
-fn test_is_game_mmr_eligible_disabled() {
-    let mut world = spawn_mmr_test_world();
-
-    // Set MMR config as disabled
-    let mmr_config = MMRConfig {
-        enabled: false,
-        mmr_token_address: Zero::zero(),
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000,
-        mean_regression_scaled: 15000,
-        min_players: 6,
-        min_entry_fee: 0,
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-
-    let mmr = get_mmr_dispatcher(@world);
-
-    // Should not be eligible when disabled
-    assert!(!mmr.is_game_mmr_eligible(1, 6, 0), "Should not be eligible when MMR disabled");
-}
-
-#[test]
-fn test_is_game_mmr_eligible_not_ranked() {
-    let mut world = spawn_mmr_test_world();
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let trial_id: u128 = 1;
-
-    // Series not marked as ranked
-    assert!(!mmr.is_game_mmr_eligible(trial_id, 6, 0), "Should not be eligible when series not ranked");
-}
-
-#[test]
-fn test_is_game_mmr_eligible_below_min_players() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    // Set min_players to 6
-    let mmr_config = MMRConfig {
-        enabled: true,
-        mmr_token_address: Zero::zero(),
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000,
-        mean_regression_scaled: 15000,
-        min_players: 6,
-        min_entry_fee: 0,
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 1;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    // 4 players is below min_players of 6
-    assert!(!mmr.is_game_mmr_eligible(trial_id, 4, 0), "Should not be eligible below min players");
-
-    // 6 players should be eligible
-    assert!(mmr.is_game_mmr_eligible(trial_id, 6, 0), "Should be eligible with exactly min players");
-
-    // 10 players should be eligible
-    assert!(mmr.is_game_mmr_eligible(trial_id, 10, 0), "Should be eligible above min players");
-}
-
-#[test]
-fn test_is_game_mmr_eligible_below_min_fee() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    // Set min_entry_fee to 1 LORDS
-    let mmr_config = MMRConfig {
-        enabled: true,
-        mmr_token_address: Zero::zero(),
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000,
-        mean_regression_scaled: 15000,
-        min_players: 2,
-        min_entry_fee: 1_000000000000000000 // 1 LORDS (18 decimals)
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 1;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    // 0 fee should not be eligible
-    assert!(!mmr.is_game_mmr_eligible(trial_id, 6, 0), "Should not be eligible with 0 fee");
-
-    // Below min fee should not be eligible
-    assert!(
-        !mmr.is_game_mmr_eligible(trial_id, 6, 500000000000000000), "Should not be eligible below min fee",
-    ); // 0.5 LORDS
-
-    // Exactly min fee should be eligible
-    assert!(mmr.is_game_mmr_eligible(trial_id, 6, 1_000000000000000000), "Should be eligible with exactly min fee");
-
-    // Above min fee should be eligible
-    assert!(mmr.is_game_mmr_eligible(trial_id, 6, 5_000000000000000000), "Should be eligible above min fee");
-}
-
-
-// ================================
-// COMMIT + CLAIM MMR TESTS
-// ================================
-
-#[test]
-fn test_commit_mmr_disabled() {
-    let mut world = spawn_mmr_test_world();
-
-    // Set MMR config as disabled
-    let mmr_config = MMRConfig {
-        enabled: false,
-        mmr_token_address: Zero::zero(),
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000,
-        mean_regression_scaled: 15000,
-        min_players: 2,
-        min_entry_fee: 0,
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-
-    let mmr = get_mmr_dispatcher(@world);
-
-    // Commit should no-op
-    mmr.commit_game_mmr_meta(1, 1000, 1000);
-    // Claim should no-op
-    mmr.claim_game_mmr(1, PLAYER1());
-
-    // Verify no records were created
-    let record: GameMMRRecord = world.read_model((1_u128, PLAYER1()));
-    assert!(record.timestamp == 0, "No record should be created when disabled");
-}
-
-#[test]
-fn test_commit_mmr_not_ranked() {
-    let mut world = spawn_mmr_test_world();
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-
-    // Set up trial but do NOT mark as ranked
-    let players = array![PLAYER1(), PLAYER2()].span();
-    let ranks = array![1_u16, 2].span();
-    setup_mock_trial(ref world, 1, players, ranks);
-
-    // Commit should no-op
-    mmr.commit_game_mmr_meta(1, 1000, 1000);
-    // Claim should no-op
-    mmr.claim_game_mmr(1, PLAYER1());
-
-    // Verify no records were created
-    let record: GameMMRRecord = world.read_model((1_u128, PLAYER1()));
-    assert!(record.timestamp == 0, "No record should be created when not ranked");
-}
-
-#[test]
-fn test_commit_mmr_already_processed() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 1;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    // Manually mark as processed
-    let series_config = SeriesMMRConfig { trial_id, is_ranked: true, mmr_processed: true };
-    world.write_model_test(@series_config);
-
-    // Set up trial
-    let players = array![PLAYER1(), PLAYER2()].span();
-    let ranks = array![1_u16, 2].span();
-    setup_mock_trial(ref world, trial_id, players, ranks);
-
-    // Commit should return early
-    mmr.commit_game_mmr_meta(trial_id, 1000, 1000);
-}
-
-
-// ================================
-// GET GAME MMR RECORD TESTS
-// ================================
-
-#[test]
-fn test_get_game_mmr_record_not_exists() {
-    let mut world = spawn_mmr_test_world();
-    let mmr = get_mmr_dispatcher(@world);
-
-    let record = mmr.get_game_mmr_record(1, PLAYER1());
-
-    // Should return zeroed record
-    assert!(record.mmr_before == 0, "Should have 0 mmr_before");
-    assert!(record.mmr_after == 0, "Should have 0 mmr_after");
-    assert!(record.timestamp == 0, "Should have 0 timestamp");
-}
-
-
-// ================================
-// MULTIPLE SERIES TESTS
-// ================================
-
-#[test]
-fn test_multiple_series_independent() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-
-    start_cheat_caller_address(mmr_addr, ADMIN());
-
-    // Set multiple series with different ranked status
-    mmr.set_series_ranked(1, true);
-    mmr.set_series_ranked(2, false);
-    mmr.set_series_ranked(3, true);
-
-    stop_cheat_caller_address(mmr_addr);
-
-    // Verify each series has independent status
-    assert!(mmr.is_series_ranked(1), "Series 1 should be ranked");
-    assert!(!mmr.is_series_ranked(2), "Series 2 should not be ranked");
-    assert!(mmr.is_series_ranked(3), "Series 3 should be ranked");
-
-    // Change one series
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(1, false);
-    stop_cheat_caller_address(mmr_addr);
-
-    // Others should be unaffected
-    assert!(!mmr.is_series_ranked(1), "Series 1 should now be unranked");
-    assert!(!mmr.is_series_ranked(2), "Series 2 should still not be ranked");
-    assert!(mmr.is_series_ranked(3), "Series 3 should still be ranked");
-}
-
-
-// ================================
-// COMMIT + CLAIM FLOW TESTS
-// ================================
-
-#[test]
-fn test_commit_and_claim_success() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 100;
-
-    // Mark series as ranked (admin only)
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    // Set up a complete trial with 4 players
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2(), PLAYER3(), PLAYER4()].span();
-    let ranks: Span<u16> = array![1_u16, 2, 3, 4].span();
-    setup_mock_trial(ref world, trial_id, players, ranks);
-
-    start_cheat_block_timestamp_global(1000);
-
-    // Commit meta and claim for all players
-    mmr.commit_game_mmr_meta(trial_id, 1000, 1000);
-    mmr.claim_game_mmr(trial_id, PLAYER1());
-    mmr.claim_game_mmr(trial_id, PLAYER2());
-    mmr.claim_game_mmr(trial_id, PLAYER3());
-    mmr.claim_game_mmr(trial_id, PLAYER4());
-
-    // Verify game records were created
-    let record1 = mmr.get_game_mmr_record(trial_id, PLAYER1());
-    let record4 = mmr.get_game_mmr_record(trial_id, PLAYER4());
-
-    assert!(record1.timestamp == 1000, "Record 1 should have timestamp");
-    assert!(record4.timestamp == 1000, "Record 4 should have timestamp");
-    assert!(record1.rank == 1, "Record 1 should have rank 1");
-    assert!(record4.rank == 4, "Record 4 should have rank 4");
-    assert!(record1.player_count == 4, "Record should show 4 players");
-
-    // Verify player stats were updated
-    let stats1 = mmr.get_player_stats(PLAYER1());
-    let stats4 = mmr.get_player_stats(PLAYER4());
-
-    assert!(stats1.games_played == 1, "Player 1 should have 1 game played");
-    assert!(stats4.games_played == 1, "Player 4 should have 1 game played");
-
-    // Winner should have gained, loser should have lost
-    assert!(record1.mmr_after > record1.mmr_before, "Winner should gain MMR");
-    assert!(record4.mmr_after < record4.mmr_before, "Loser should lose MMR");
-
-    // Series should be marked processed after all claims
-    let series_config: SeriesMMRConfig = world.read_model(trial_id);
-    assert!(series_config.mmr_processed, "Series should be marked processed");
-}
-
-#[test]
-fn test_claim_idempotent() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 101;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2()].span();
-    let ranks: Span<u16> = array![1_u16, 2].span();
-    setup_mock_trial(ref world, trial_id, players, ranks);
-
-    start_cheat_block_timestamp_global(2000);
-
-    mmr.commit_game_mmr_meta(trial_id, 1000, 1000);
-    mmr.claim_game_mmr(trial_id, PLAYER1());
-
-    let record_after_first = mmr.get_game_mmr_record(trial_id, PLAYER1());
-    let stats_after_first = mmr.get_player_stats(PLAYER1());
-
-    // Claim again (should be no-op)
-    start_cheat_block_timestamp_global(3000);
-    mmr.claim_game_mmr(trial_id, PLAYER1());
-
-    let record_after_second = mmr.get_game_mmr_record(trial_id, PLAYER1());
-    let stats_after_second = mmr.get_player_stats(PLAYER1());
-
-    assert!(record_after_first.timestamp == record_after_second.timestamp, "Record timestamp should not change");
-    assert!(
-        record_after_first.mmr_after == record_after_second.mmr_after, "Record MMR should not change on second call",
-    );
-    assert!(stats_after_first.games_played == stats_after_second.games_played, "Games played should not increase");
-}
-
-#[test]
-fn test_commit_below_min_entry_fee() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    // Set min_entry_fee to 1 LORDS
-    let mmr_config = MMRConfig {
-        enabled: true,
-        mmr_token_address: Zero::zero(),
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000,
-        mean_regression_scaled: 15000,
-        min_players: 2,
-        min_entry_fee: 1_000000000000000000,
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-
-    // Fee amount below min_entry_fee
-    setup_blitz_registration_fee(ref world, 0);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 102;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2()].span();
-    let ranks: Span<u16> = array![1_u16, 2].span();
-    setup_mock_trial(ref world, trial_id, players, ranks);
-
-    // Commit should no-op since entry fee below min
-    mmr.commit_game_mmr_meta(trial_id, 1000, 1000);
-
-    let meta: MMRGameMeta = mmr.get_game_mmr_meta(trial_id);
-    assert!(meta.committed_at == 0, "Meta should not be committed below min entry fee");
-}
-
-#[test]
-fn test_commit_below_min_players() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-
-    // Set up config with min_players = 4
-    let mmr_config = MMRConfig {
-        enabled: true,
-        mmr_token_address: Zero::zero(),
-        initial_mmr: 1000,
-        min_mmr: 100,
-        distribution_mean: 1500,
-        spread_factor: 450,
-        max_delta: 45,
-        k_factor: 50,
-        lobby_split_weight_scaled: 250000,
-        mean_regression_scaled: 15000,
-        min_players: 4, // Require 4 players
-        min_entry_fee: 0,
-    };
-    WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), mmr_config);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 103;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2()].span();
-    let ranks: Span<u16> = array![1_u16, 2].span();
-    setup_mock_trial(ref world, trial_id, players, ranks);
-
-    mmr.commit_game_mmr_meta(trial_id, 1000, 1000);
-
-    let meta: MMRGameMeta = mmr.get_game_mmr_meta(trial_id);
-    assert!(meta.committed_at == 0, "Meta should not be committed below min players");
-}
-
-#[test]
-fn test_claim_requires_commit() {
-    let mut world = spawn_mmr_test_world();
-    setup_world_config(ref world, ADMIN());
-    setup_mmr_config(ref world);
-
-    let mmr = get_mmr_dispatcher(@world);
-    let mmr_addr = get_mmr_contract_address(@world);
-    let trial_id: u128 = 104;
-
-    // Mark series as ranked
-    start_cheat_caller_address(mmr_addr, ADMIN());
-    mmr.set_series_ranked(trial_id, true);
-    stop_cheat_caller_address(mmr_addr);
-
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2()].span();
-    let ranks: Span<u16> = array![1_u16, 2].span();
-    setup_mock_trial(ref world, trial_id, players, ranks);
-
-    // Claim without commit should no-op
-    mmr.claim_game_mmr(trial_id, PLAYER1());
-    let record = mmr.get_game_mmr_record(trial_id, PLAYER1());
-    assert!(record.timestamp == 0, "No record should be created without commit");
-}
-
-
-// ================================
-// MMR CALCULATION LIBRARY INTEGRATION TESTS
-// ================================
-
-#[test]
-fn test_mmr_calculator_median() {
-    // Test odd count
-    let values: Span<u128> = array![1200, 1000, 1100].span();
-    let median = MMRCalculatorImpl::calculate_median(values);
-    assert!(median == 1100, "Median of [1200, 1000, 1100] should be 1100");
-
-    // Test even count
-    let values2: Span<u128> = array![1000, 1100, 1200, 1300].span();
-    let median2 = MMRCalculatorImpl::calculate_median(values2);
-    assert!(median2 == 1100, "Median of [1000, 1100, 1200, 1300] should be 1100");
-}
-
-#[test]
-fn test_mmr_calculator_full_game() {
-    let config = MMRConfigDefaultImpl::default();
-
-    // 6 players with equal MMR
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2(), PLAYER3(), PLAYER4(), PLAYER5(), PLAYER6()]
-        .span();
-    let ranks: Span<u16> = array![1_u16, 2, 3, 4, 5, 6].span();
-    let mmrs: Span<u128> = array![1000_u128, 1000, 1000, 1000, 1000, 1000].span();
-
-    // No split lobby
-    let updates = MMRCalculatorImpl::calculate_game_mmr_updates(config, players, ranks, mmrs, Option::None);
-    let updates_span = updates.span();
-
-    // Should have 6 updates
-    assert!(updates_span.len() == 6, "Should have 6 updates");
-
-    // Winner should gain, loser should lose
-    let (_, winner_new) = *updates_span.at(0);
-    let (_, loser_new) = *updates_span.at(5);
-    assert!(winner_new > 1000, "Winner should gain MMR");
-    assert!(loser_new < 1000, "Loser should lose MMR");
-}
-
-#[test]
-fn test_mmr_calculator_upset() {
-    let config = MMRConfigDefaultImpl::default();
-
-    // Low MMR player wins against high MMR players
-    let players: Span<ContractAddress> = array![PLAYER1(), PLAYER2()].span();
-    let ranks: Span<u16> = array![1_u16, 2].span();
-    let mmrs: Span<u128> = array![800_u128, 1500].span(); // Low MMR wins
-
-    // No split lobby
-    let updates = MMRCalculatorImpl::calculate_game_mmr_updates(config, players, ranks, mmrs, Option::None);
-    let updates_span = updates.span();
-
-    let (_, low_mmr_winner_new) = *updates_span.at(0);
-    let (_, high_mmr_loser_new) = *updates_span.at(1);
-
-    // Low MMR upset winner should gain significantly
-    let gain = low_mmr_winner_new - 800;
-    assert!(gain > 0, "Upset winner should gain MMR");
-
-    // High MMR loser should lose
-    let loss = 1500 - high_mmr_loser_new;
-    assert!(loss > 0, "Upset loser should lose MMR");
+    fn contract_defs_mmr() -> Span<ContractDef> {
+        [
+            ContractDefTrait::new(DEFAULT_NS(), @"mmr_systems")
+                .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ]
+            .span()
+    }
+
+    fn setup_mmr_world() -> WorldStorage {
+        let mut world = spawn_test_world([namespace_def_mmr()].span());
+        world.sync_perms_and_inits(contract_defs_mmr());
+        world.dispatcher.uuid();
+        // Set a non-zero timestamp for tests (contract uses get_block_timestamp)
+        start_cheat_block_timestamp_global(1000);
+        world
+    }
+
+    fn get_mmr_systems_dispatcher(ref world: WorldStorage) -> (ContractAddress, IMMRSystemsDispatcher) {
+        let (addr, _) = world.dns(@"mmr_systems").unwrap();
+        (addr, IMMRSystemsDispatcher { contract_address: addr })
+    }
+
+    /// Deploys the mock MMR token contract
+    fn deploy_mock_mmr_token() -> (ContractAddress, IMockMMRTokenDispatcher) {
+        let contract_class = declare("MockMMRToken").unwrap().contract_class();
+        let (token_address, _) = contract_class.deploy(@array![]).unwrap();
+        (token_address, IMockMMRTokenDispatcher { contract_address: token_address })
+    }
+
+    /// Sets up a finalized trial with ranked players
+    fn setup_finalized_trial(
+        ref world: WorldStorage, trial_id: u128, players: Span<ContractAddress>, ranks: Span<u16>,
+    ) {
+        // Set finalized trial
+        let players_rank_final = PlayersRankFinal { world_id: WORLD_CONFIG_ID.into(), trial_id };
+        world.write_model_test(@players_rank_final);
+
+        // Set trial data
+        let player_count: u16 = players.len().try_into().unwrap();
+        let trial = PlayersRankTrial {
+            trial_id,
+            owner: addr('trial_owner'),
+            last_rank: player_count,
+            last_player_points: 0,
+            total_player_points: 0,
+            total_player_count_committed: player_count,
+            total_player_count_revealed: player_count,
+            total_prize_amount: 0,
+            total_prize_amount_calculated: 0,
+        };
+        world.write_model_test(@trial);
+
+        // Set player ranks
+        let mut i: u32 = 0;
+        while i < players.len() {
+            let player_rank = PlayerRank { trial_id, player: *players.at(i), rank: *ranks.at(i), paid: false };
+            world.write_model_test(@player_rank);
+            i += 1;
+        }
+    }
+
+    /// Sets up MMR config with a mock token address
+    fn setup_mmr_config(ref world: WorldStorage, token_address: ContractAddress) {
+        let mut config = MMRConfigDefaultImpl::default();
+        config.enabled = true;
+        config.mmr_token_address = token_address;
+        WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), config);
+    }
+
+    // ================================
+    // COMMIT SUCCESS TESTS
+    // ================================
+
+    #[test]
+    fn test_commit_success_six_players_even_median() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, token) = deploy_mock_mmr_token();
+
+        // Set up players with known MMRs (sorted ascending)
+        let p1 = addr('p1');
+        let p2 = addr('p2');
+        let p3 = addr('p3');
+        let p4 = addr('p4');
+        let p5 = addr('p5');
+        let p6 = addr('p6');
+
+        // MMRs: 800, 900, 1000, 1100, 1200, 1400 (with 18 decimals)
+        // Median for even count = (1000 + 1100) / 2 = 1050
+        token.set_mmr(p1, e18(800));
+        token.set_mmr(p2, e18(900));
+        token.set_mmr(p3, e18(1000));
+        token.set_mmr(p4, e18(1100));
+        token.set_mmr(p5, e18(1200));
+        token.set_mmr(p6, e18(1400));
+
+        // Players must be provided sorted by MMR ascending
+        let players = array![p1, p2, p3, p4, p5, p6];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+
+        // Verify MMRGameMeta was written with correct median
+        let meta: MMRGameMeta = world.read_model(1_u128);
+        assert!(meta.game_median == 1050, "Median should be 1050 for even count");
+    }
+
+    #[test]
+    fn test_commit_success_seven_players_odd_median() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, token) = deploy_mock_mmr_token();
+
+        let p1 = addr('p1');
+        let p2 = addr('p2');
+        let p3 = addr('p3');
+        let p4 = addr('p4');
+        let p5 = addr('p5');
+        let p6 = addr('p6');
+        let p7 = addr('p7');
+
+        // MMRs: 700, 850, 950, 1000, 1050, 1150, 1300 (with 18 decimals)
+        // Median for odd count = middle element = 1000 (index 3)
+        token.set_mmr(p1, e18(700));
+        token.set_mmr(p2, e18(850));
+        token.set_mmr(p3, e18(950));
+        token.set_mmr(p4, e18(1000));
+        token.set_mmr(p5, e18(1050));
+        token.set_mmr(p6, e18(1150));
+        token.set_mmr(p7, e18(1300));
+
+        let players = array![p1, p2, p3, p4, p5, p6, p7];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16, 7_u16];
+
+        // Need to update min_players config since we have 7
+        let mut config = MMRConfigDefaultImpl::default();
+        config.enabled = true;
+        config.mmr_token_address = token_addr;
+        config.min_players = 6; // Keep at 6, we have 7
+        WorldConfigUtilImpl::set_member(ref world, selector!("mmr_config"), config);
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+
+        let meta: MMRGameMeta = world.read_model(1_u128);
+        assert!(meta.game_median == 1000, "Median should be 1000 for odd count");
+    }
+
+    #[test]
+    fn test_commit_success_new_players_use_initial_mmr() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        // Players with no MMR set - should use initial_mmr (1000)
+        let p1 = addr('new1');
+        let p2 = addr('new2');
+        let p3 = addr('new3');
+        let p4 = addr('new4');
+        let p5 = addr('new5');
+        let p6 = addr('new6');
+
+        // All use initial_mmr = 1000, so median = 1000
+        let players = array![p1, p2, p3, p4, p5, p6];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+
+        let meta: MMRGameMeta = world.read_model(1_u128);
+        assert!(meta.game_median == 1000, "Median should be 1000 (initial MMR for new players)");
+    }
+
+    // ================================
+    // COMMIT ERROR TESTS
+    // ================================
+
+    #[test]
+    #[should_panic(expected: "Eternum: rankings not finalized")]
+    fn test_commit_fails_no_finalized_trial() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: MMR not enabled")]
+    fn test_commit_fails_mmr_not_enabled() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        // MMR config not enabled (default)
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: no players")]
+    fn test_commit_fails_empty_players() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+
+        let players = array![addr('p1')];
+        let ranks = array![1_u16];
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, addr('mock_token'));
+
+        let empty_players: Array<ContractAddress> = array![];
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(empty_players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: MMR: player count mismatch")]
+    fn test_commit_fails_player_count_mismatch() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        // Set up trial with 6 players
+        let all_players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+        setup_finalized_trial(ref world, 1, all_players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Try to commit with only 4 players
+        let fewer_players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4')];
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(fewer_players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "MMR: players must be sorted by MMR ascending")]
+    fn test_commit_fails_players_not_sorted() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, token) = deploy_mock_mmr_token();
+
+        let p1 = addr('p1');
+        let p2 = addr('p2');
+        let p3 = addr('p3');
+        let p4 = addr('p4');
+        let p5 = addr('p5');
+        let p6 = addr('p6');
+
+        // Set MMRs (with 18 decimals)
+        token.set_mmr(p1, e18(1400)); // Highest
+        token.set_mmr(p2, e18(900));
+        token.set_mmr(p3, e18(1000));
+        token.set_mmr(p4, e18(1100));
+        token.set_mmr(p5, e18(1200));
+        token.set_mmr(p6, e18(800)); // Lowest
+
+        // Provide in wrong order (not sorted by MMR)
+        let players = array![p1, p2, p3, p4, p5, p6];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "MMR: player address repeated")]
+    fn test_commit_fails_duplicate_players() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, token) = deploy_mock_mmr_token();
+
+        let p1 = addr('p1');
+        let p2 = addr('p2');
+        let p3 = addr('p3');
+
+        token.set_mmr(p1, e18(900));
+        token.set_mmr(p2, e18(1000));
+        token.set_mmr(p3, e18(1100));
+
+        // Include p1 twice
+        let players_with_dup = array![p1, p2, p3, p1, addr('p4'), addr('p5')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players_with_dup.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players_with_dup);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "MMR: player")]
+    fn test_commit_fails_player_not_in_trial() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        // Set up trial with specific players
+        let trial_players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+        setup_finalized_trial(ref world, 1, trial_players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Try to commit with a player not in trial
+        let wrong_players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('intruder')];
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(wrong_players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: mmr meta already committed")]
+    fn test_commit_fails_already_committed() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // First commit succeeds
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players.clone());
+        stop_cheat_caller_address(system_addr);
+
+        // Second commit should fail
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: not enough players")]
+    fn test_commit_fails_not_enough_players() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        // Only 3 players, but min_players is 6
+        let players = array![addr('p1'), addr('p2'), addr('p3')];
+        let ranks = array![1_u16, 2_u16, 3_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    // ================================
+    // CLAIM SUCCESS TESTS
+    // ================================
+
+    #[test]
+    fn test_claim_success_six_players_mmr_updated() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, token) = deploy_mock_mmr_token();
+
+        let p1 = addr('p1');
+        let p2 = addr('p2');
+        let p3 = addr('p3');
+        let p4 = addr('p4');
+        let p5 = addr('p5');
+        let p6 = addr('p6');
+
+        // All start at 1000 MMR (with 18 decimals)
+        token.set_mmr(p1, e18(1000));
+        token.set_mmr(p2, e18(1000));
+        token.set_mmr(p3, e18(1000));
+        token.set_mmr(p4, e18(1000));
+        token.set_mmr(p5, e18(1000));
+        token.set_mmr(p6, e18(1000));
+
+        // Players sorted by MMR (all same, so any order works)
+        let players = array![p1, p2, p3, p4, p5, p6];
+        // Ranks: p1=1st, p2=2nd, etc.
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit first
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players.clone());
+        stop_cheat_caller_address(system_addr);
+
+        // Claim
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players);
+        stop_cheat_caller_address(system_addr);
+
+        // Verify winner gained and loser lost (values are in 18 decimals)
+        let winner_mmr: u256 = token.balance_of(p1);
+        let loser_mmr: u256 = token.balance_of(p6);
+
+        assert!(winner_mmr > e18(1000), "Rank 1 should gain MMR");
+        assert!(loser_mmr < e18(1000), "Rank 6 should lose MMR");
+
+        // Verify monotonic: better rank = higher final MMR
+        let mmr2: u256 = token.balance_of(p2);
+        let mmr3: u256 = token.balance_of(p3);
+        let mmr4: u256 = token.balance_of(p4);
+        let mmr5: u256 = token.balance_of(p5);
+
+        assert!(winner_mmr > mmr2, "Rank 1 > Rank 2");
+        assert!(mmr2 > mmr3, "Rank 2 > Rank 3");
+        assert!(mmr3 > mmr4, "Rank 3 > Rank 4");
+        assert!(mmr4 > mmr5, "Rank 4 > Rank 5");
+        assert!(mmr5 > loser_mmr, "Rank 5 > Rank 6");
+    }
+
+    #[test]
+    fn test_claim_success_marks_claimed() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players.clone());
+        stop_cheat_caller_address(system_addr);
+
+        // Verify not claimed yet
+        let claimed_before: MMRClaimed = world.read_model(WORLD_CONFIG_ID);
+        assert!(claimed_before.claimed_at == 0, "Should not be claimed yet");
+
+        // Claim
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players);
+        stop_cheat_caller_address(system_addr);
+
+        // Verify claimed
+        let claimed_after: MMRClaimed = world.read_model(WORLD_CONFIG_ID);
+        assert!(claimed_after.claimed_at > 0, "Should be marked as claimed");
+    }
+
+    // ================================
+    // CLAIM ERROR TESTS
+    // ================================
+
+    #[test]
+    #[should_panic(expected: "Eternum: rankings not finalized")]
+    fn test_claim_fails_no_finalized_trial() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: MMR not enabled")]
+    fn test_claim_fails_mmr_not_enabled() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: mmr meta not committed")]
+    fn test_claim_fails_meta_not_committed() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, addr('mock_token'));
+
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: mmr already claimed")]
+    fn test_claim_fails_already_claimed() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players.clone());
+        stop_cheat_caller_address(system_addr);
+
+        // First claim succeeds
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players.clone());
+        stop_cheat_caller_address(system_addr);
+
+        // Second claim should fail
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: MMR: player count mismatch")]
+    fn test_claim_fails_player_count_mismatch() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit with all players
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+
+        // Try to claim with fewer players
+        let fewer_players = array![addr('p1'), addr('p2'), addr('p3')];
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(fewer_players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "MMR: player address repeated")]
+    fn test_claim_fails_duplicate_players() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+
+        // Try to claim with duplicates
+        let dup_players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p1'), addr('p6')];
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(dup_players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    #[test]
+    #[should_panic(expected: "Eternum: player zero rank")]
+    fn test_claim_fails_player_no_rank() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, _token) = deploy_mock_mmr_token();
+
+        let players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('p6')];
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.commit_game_mmr_meta(players);
+        stop_cheat_caller_address(system_addr);
+
+        // Try to claim with a player not in trial
+        let wrong_players = array![addr('p1'), addr('p2'), addr('p3'), addr('p4'), addr('p5'), addr('intruder')];
+        start_cheat_caller_address(system_addr, addr('caller'));
+        dispatcher.claim_game_mmr(wrong_players);
+        stop_cheat_caller_address(system_addr);
+    }
+
+    // ================================
+    // FULL INTEGRATION TEST
+    // ================================
+
+    #[test]
+    fn test_full_commit_then_claim_flow() {
+        let mut world = setup_mmr_world();
+        let (system_addr, dispatcher) = get_mmr_systems_dispatcher(ref world);
+        let (token_addr, token) = deploy_mock_mmr_token();
+
+        // Setup: 6 players with varying MMRs
+        let p1 = addr('alice');
+        let p2 = addr('bob');
+        let p3 = addr('charlie');
+        let p4 = addr('diana');
+        let p5 = addr('eve');
+        let p6 = addr('frank');
+
+        // Set MMRs (must be sorted ascending for commit, with 18 decimals)
+        token.set_mmr(p1, e18(800)); // Low-rated underdog
+        token.set_mmr(p2, e18(900));
+        token.set_mmr(p3, e18(1000));
+        token.set_mmr(p4, e18(1100));
+        token.set_mmr(p5, e18(1200));
+        token.set_mmr(p6, e18(1400)); // High-rated favorite
+
+        // Players sorted by MMR ascending
+        let players_by_mmr = array![p1, p2, p3, p4, p5, p6];
+
+        // Ranks: p1 (800 MMR) wins! p6 (1400 MMR) loses - an upset!
+        let ranks = array![1_u16, 2_u16, 3_u16, 4_u16, 5_u16, 6_u16];
+
+        setup_finalized_trial(ref world, 1, players_by_mmr.span(), ranks.span());
+        setup_mmr_config(ref world, token_addr);
+
+        // Commit phase
+        start_cheat_caller_address(system_addr, addr('committer'));
+        dispatcher.commit_game_mmr_meta(players_by_mmr.clone());
+        stop_cheat_caller_address(system_addr);
+
+        // Verify median computed correctly: (1000 + 1100) / 2 = 1050
+        let meta: MMRGameMeta = world.read_model(1_u128);
+        assert!(meta.game_median == 1050, "Median should be 1050");
+
+        // Claim phase
+        start_cheat_caller_address(system_addr, addr('claimer'));
+        dispatcher.claim_game_mmr(players_by_mmr);
+        stop_cheat_caller_address(system_addr);
+
+        // Verify results (values are in 18 decimals)
+        let winner_new_mmr: u256 = token.balance_of(p1);
+        let loser_new_mmr: u256 = token.balance_of(p6);
+
+        // Underdog won - should gain significant MMR (was 800e18)
+        let winner_gain: u256 = winner_new_mmr - e18(800);
+        assert!(winner_gain > e18(20), "Underdog winner should gain significant MMR");
+
+        // Favorite lost - should lose MMR (was 1400e18)
+        assert!(loser_new_mmr < e18(1400), "Favorite loser should lose MMR");
+
+        // Verify claimed flag is set
+        let claimed: MMRClaimed = world.read_model(WORLD_CONFIG_ID);
+        assert!(claimed.claimed_at > 0, "Should be marked claimed");
+    }
 }

--- a/contracts/game/src/utils/testing.cairo
+++ b/contracts/game/src/utils/testing.cairo
@@ -1,5 +1,6 @@
 pub mod helpers;
 pub mod contracts {
     pub mod erc20mock;
+    pub mod mmr_token_mock;
     pub mod villagepassmock;
 }

--- a/contracts/game/src/utils/testing/contracts/mmr_token_mock.cairo
+++ b/contracts/game/src/utils/testing/contracts/mmr_token_mock.cairo
@@ -1,0 +1,84 @@
+//! Mock MMR Token Contract for Testing
+//!
+//! A simple mock implementation of the IMMRToken interface for testing
+//! the MMR systems without needing a full token deployment.
+//!
+//! Key behavior:
+//! - balance_of returns INITIAL_MMR (1000e18) if player has never been set
+//! - update_mmr stores the new value (with floor enforcement)
+//! - set_mmr is a test helper to set MMR directly
+
+use starknet::ContractAddress;
+
+// MMR Constants (with 18 decimals like standard ERC20)
+pub const INITIAL_MMR: u256 = 1000_000000000000000000; // 1000e18
+pub const MIN_MMR: u256 = 100_000000000000000000; // 100e18
+
+/// Mock MMR token interface for testing
+#[starknet::interface]
+pub trait IMockMMRToken<T> {
+    /// Get player's MMR balance (returns INITIAL_MMR if not set)
+    fn balance_of(self: @T, player: ContractAddress) -> u256;
+
+    /// Update a player's MMR (enforces floor)
+    fn update_mmr(ref self: T, player: ContractAddress, new_mmr: u256);
+
+    /// Batch update multiple players' MMR
+    fn update_mmr_batch(ref self: T, updates: Array<(ContractAddress, u256)>);
+
+    /// Test helper: set MMR directly (bypasses floor for testing edge cases)
+    fn set_mmr(ref self: T, player: ContractAddress, mmr: u256);
+}
+
+#[starknet::contract]
+pub mod MockMMRToken {
+    use core::num::traits::Zero;
+    use starknet::ContractAddress;
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
+    use super::{INITIAL_MMR, MIN_MMR};
+
+    #[storage]
+    struct Storage {
+        /// MMR values (0 means uninitialized, balance_of returns INITIAL_MMR)
+        mmr_values: Map<ContractAddress, u256>,
+    }
+
+    #[abi(embed_v0)]
+    impl MockMMRTokenImpl of super::IMockMMRToken<ContractState> {
+        fn balance_of(self: @ContractState, player: ContractAddress) -> u256 {
+            let stored = self.mmr_values.read(player);
+            // Return INITIAL_MMR if player has never been set
+            if stored.is_zero() {
+                INITIAL_MMR
+            } else {
+                stored
+            }
+        }
+
+        fn update_mmr(ref self: ContractState, player: ContractAddress, new_mmr: u256) {
+            // Enforce minimum floor
+            let final_mmr = if new_mmr < MIN_MMR {
+                MIN_MMR
+            } else {
+                new_mmr
+            };
+            self.mmr_values.write(player, final_mmr);
+        }
+
+        fn update_mmr_batch(ref self: ContractState, updates: Array<(ContractAddress, u256)>) {
+            for (player, new_mmr) in updates {
+                let final_mmr = if new_mmr < MIN_MMR {
+                    MIN_MMR
+                } else {
+                    new_mmr
+                };
+                self.mmr_values.write(player, final_mmr);
+            }
+        }
+
+        fn set_mmr(ref self: ContractState, player: ContractAddress, mmr: u256) {
+            // Test helper - allows setting any value including below floor for testing
+            self.mmr_values.write(player, mmr);
+        }
+    }
+}

--- a/contracts/mmr/Scarb.lock
+++ b/contracts/mmr/Scarb.lock
@@ -117,13 +117,15 @@ source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.20.0#7756fd
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.31.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.31.0#72ea785ca354e9e506de3e5d687da9fb2c1b3c67"
+version = "0.51.2"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:7b94edb0a94b93915200275076c29ef8266f4b870ffda04360cf36bc3b5e67cc"
 
 [[package]]
 name = "snforge_std"
-version = "0.31.0"
-source = "git+https://github.com/foundry-rs/starknet-foundry.git?tag=v0.31.0#72ea785ca354e9e506de3e5d687da9fb2c1b3c67"
+version = "0.51.2"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:d7287b7e9c826ee560788a7a9b808a2a0454977ac4111bd3c1bcb3c7c5f01040"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/contracts/mmr/Scarb.toml
+++ b/contracts/mmr/Scarb.toml
@@ -1,15 +1,17 @@
 [package]
 name = "mmr"
 version = "1.0.0"
+edition = "2024_07"
 
 [cairo]
 sierra-replace-ids = true
 
 [dependencies]
+starknet = "2.13.1"
 openzeppelin = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.20.0" }
 
 [dev-dependencies]
-snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry.git", tag = "v0.31.0" }
+snforge_std = "0.51.2"
 
 [[target.starknet-contract]]
 sierra = true

--- a/contracts/mmr/src/lib.cairo
+++ b/contracts/mmr/src/lib.cairo
@@ -1,1 +1,4 @@
 pub mod contract;
+
+#[cfg(test)]
+mod tests;


### PR DESCRIPTION
- Introduced a new mock contract `MockMMRToken` for testing purposes, implementing the `IMockMMRToken` interface.
- Updated the main MMR token contract to utilize the new balance logic, returning `INITIAL_MMR` for uninitialized players.
- Refactored MMR update logic to auto-initialize players and enforce a minimum MMR floor.
- Enhanced tests to cover new functionality, including balance checks and total supply calculations.
- Updated dependencies in `Scarb.toml` and modified the `Scarb.lock` file accordingly.