### PR TITLE
fix: add missing currentArmiesTick dependency to army stamina display

### DIFF
--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
@@ -11,6 +11,7 @@ import { useDojo } from "@bibliothecadao/react";
 import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@bibliothecadao/torii";
 import { ArmyInfo, ContractAddress, HexPosition, ID, TroopTier, TroopType } from "@bibliothecadao/types";
 import { useQuery } from "@tanstack/react-query";
+import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useCallback, useMemo, useState } from "react";
 
 interface UseArmyEntityDetailOptions {
@@ -42,6 +43,7 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
   } = useDojo();
   const mode = useGameModeConfig();
 
+  const { currentArmiesTick } = useBlockTimestamp();
   const userAddress = ContractAddress(account.address);
   const [isLoadingDelete, setIsLoadingDelete] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(0);
@@ -104,8 +106,6 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
   const derivedData: DerivedArmyData | undefined = useMemo(() => {
     if (!explorer) return undefined;
 
-    const { currentArmiesTick } = getBlockTimestamp();
-
     const stamina = StaminaManager.getStamina(explorer.troops, currentArmiesTick);
     const maxStamina = StaminaManager.getMaxStamina(
       explorer.troops.category as TroopType,
@@ -129,7 +129,7 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
       isMine: Boolean(isMine),
       structureOwnerName,
     };
-  }, [explorer, structure, components, userAddress, armyEntityId, mode]);
+  }, [explorer, structure, components, userAddress, armyEntityId, mode, currentArmiesTick]);
 
   const alignmentBadge: AlignmentBadge | undefined = useMemo(() => {
     if (!derivedData) return undefined;

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -645,27 +645,20 @@ export class WorldUpdateListener {
           this.setup.components.StructureBuildings,
           callback,
           (update: any) => {
-            console.log("[onStructureBuildingsUpdate] Received update:", update);
-
             if (isComponentUpdate(update, this.setup.components.StructureBuildings)) {
               const [currentState, _prevState] = update.value;
 
-              console.log("[onStructureBuildingsUpdate] currentState:", currentState, "_prevState:", _prevState);
-
               if (!currentState) {
-                console.log("[onStructureBuildingsUpdate] currentState is falsy, returning.");
                 return;
               }
 
               const entityId = currentState?.entity_id;
-              console.log("[onStructureBuildingsUpdate] entityId:", entityId);
 
               if (entityId === undefined || entityId === null) {
                 this.logMissingEntityId("Structure.onStructureBuildingsUpdate", {
                   update,
                   currentState,
                 });
-                console.log("[onStructureBuildingsUpdate] entityId missing, returning.");
                 return;
               }
 
@@ -676,39 +669,27 @@ export class WorldUpdateListener {
                 currentState.packed_counts_3 ? BigInt(currentState.packed_counts_3) : 0n,
               ];
 
-              console.log("[onStructureBuildingsUpdate] packedValues:", packedValues);
-
               // Unpack the building counts
               const buildingCounts = unpackBuildingCounts(packedValues);
-
-              console.log("[onStructureBuildingsUpdate] unpacked buildingCounts:", buildingCounts);
 
               const activeProductions: ActiveProduction[] = [];
 
               // Iterate through all building types and create productions for non-zero counts
               for (let buildingType = 1; buildingType <= buildingCounts.length; buildingType++) {
                 const count = buildingCounts[buildingType - 1]; // buildingCounts is 0-indexed, buildingType is 1-indexed
-
-                console.log(`[onStructureBuildingsUpdate] Evaluating buildingType ${buildingType}: count = ${count}`);
-
                 if (count > 0) {
                   const prod = {
                     buildingCount: count,
                     buildingType: buildingType as BuildingType,
                   };
                   activeProductions.push(prod);
-                  console.log("[onStructureBuildingsUpdate] Added activeProduction:", prod);
                 }
               }
-
-              console.log("[onStructureBuildingsUpdate] Final activeProductions:", activeProductions);
 
               return {
                 entityId,
                 activeProductions,
               };
-            } else {
-              console.log("[onStructureBuildingsUpdate] Not a relevant component update:", update);
             }
           },
           false,
@@ -935,7 +916,6 @@ export class WorldUpdateListener {
                 occupierId: currentState?.occupier_id,
                 hexCoords: { col: currentState.col, row: currentState.row },
               };
-              console.log("[onChestTileUpdate] update:", result);
               return result;
             }
           },


### PR DESCRIPTION
## Summary
Army stamina display in the army detail panel was frozen until the army's on-chain data changed. The issue was a missing dependency in the `useArmyEntityDetail` hook's useMemo.

## Root Cause
The stamina calculation called `getBlockTimestamp()` to get the current armies tick, but never included it as a dependency. This meant stamina only recalculated when the explorer data changed (i.e., on on-chain events).

## Fix
- Import the reactive `useBlockTimestamp()` hook from Zustand store
- Add `currentArmiesTick` to the useMemo dependency array so stamina recalculates every 10 seconds when the poll updates

Stamina now updates automatically as time passes, matching the behavior of the Three.js army labels on the worldmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)