### PR TITLE
Remove unused QuestManager references from worldmap

### DIFF
--- a/client/apps/eternum-mobile/src/shared/lib/three/entity-managers/army-manager.ts
+++ b/client/apps/eternum-mobile/src/shared/lib/three/entity-managers/army-manager.ts
@@ -6,8 +6,8 @@ import {
   configManager,
   ExplorerTroopsSystemUpdate,
   ExplorerTroopsTileSystemUpdate,
-  getBlockTimestamp,
   FELT_CENTER,
+  getBlockTimestamp,
   Position,
   StaminaManager,
 } from "@bibliothecadao/eternum";
@@ -749,7 +749,6 @@ export class ArmyManager extends EntityManager<ArmyObject> {
   public selectArmy(
     armyId: number,
     structureHexes: Map<number, Map<number, HexEntityInfo>>,
-    questHexes: Map<number, Map<number, HexEntityInfo>>,
     chestHexes: Map<number, Map<number, HexEntityInfo>>,
   ): ActionPaths | null {
     if (!this.dojo) {
@@ -804,7 +803,6 @@ export class ArmyManager extends EntityManager<ArmyObject> {
     row: number,
     store: any,
     structureHexes: Map<number, Map<number, HexEntityInfo>>,
-    questHexes: Map<number, Map<number, HexEntityInfo>>,
     chestHexes: Map<number, Map<number, HexEntityInfo>>,
   ): { shouldSelect: boolean; actionPaths?: ActionPaths } {
     const isDoubleClick = store.handleObjectClick(armyId, "army", col, row);
@@ -813,7 +811,7 @@ export class ArmyManager extends EntityManager<ArmyObject> {
       return { shouldSelect: false };
     }
 
-    const actionPaths = this.selectArmy(armyId, structureHexes, questHexes, chestHexes);
+    const actionPaths = this.selectArmy(armyId, structureHexes, chestHexes);
     return { shouldSelect: true, actionPaths: actionPaths || undefined };
   }
 


### PR DESCRIPTION
Removes unused QuestManager imports, properties, and system event handlers from HexagonMap and ArmyManager after recent quest system updates.

Cleans up 32 lines of dead code across entity managers.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>