### PR TITLE
feat: show active relic effects on realm list and info panel

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -1,5 +1,6 @@
 import type { VillageIconKey } from "@/config/game-modes";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
+import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useGoToStructure } from "@/hooks/helpers/use-navigate";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
@@ -34,7 +35,6 @@ import { BaseContainer } from "@/ui/shared/containers/base-container";
 import type { getEntityInfo } from "@bibliothecadao/eternum";
 import {
   configManager,
-  getBlockTimestamp,
   getStructureArmyRelicEffects,
   getStructureRelicEffects,
   Position,
@@ -528,15 +528,15 @@ const StructureListItem = memo(
     const liveStructure = useComponentValue(components.Structure, entityKey as any);
     const liveStructureBuildings = useComponentValue(components.StructureBuildings, entityKey as any);
     const productionBoostBonus = useComponentValue(components.ProductionBoostBonus, entityKey as any);
+    const { currentArmiesTick } = useBlockTimestamp();
 
     const activeRelicEffects = useMemo(() => {
-      const { currentArmiesTick } = getBlockTimestamp();
       const structureRelics = productionBoostBonus
         ? getStructureRelicEffects(productionBoostBonus, currentArmiesTick)
         : [];
       const armyRelics = liveStructure ? getStructureArmyRelicEffects(liveStructure, currentArmiesTick) : [];
       return [...structureRelics, ...armyRelics];
-    }, [productionBoostBonus, liveStructure]);
+    }, [productionBoostBonus, liveStructure, currentArmiesTick]);
 
     const rawLevel = liveStructure?.base?.level ?? structure.structure.base?.level ?? 0;
     const normalizedLevel = typeof rawLevel === "bigint" ? Number(rawLevel) : Number(rawLevel ?? 0);

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -1,3 +1,4 @@
+import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useGoToStructure } from "@/hooks/helpers/use-navigate";
 import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
 import { useAutomationStore } from "@/hooks/store/use-automation-store";
@@ -11,7 +12,6 @@ import { StructureProductionPanel } from "@/ui/features/world/components/entitie
 import { inferRealmPreset } from "@/utils/automation-presets";
 import {
   Position,
-  getBlockTimestamp,
   getGuardsByStructure,
   getStructureArmyRelicEffects,
   getStructureRelicEffects,
@@ -174,15 +174,16 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
     structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
   );
 
+  const { currentArmiesTick } = useBlockTimestamp();
+
   const relicEffects = useMemo(() => {
     if (!structure) return [];
-    const { currentArmiesTick } = getBlockTimestamp();
     const structureRelicEffects = productionBoostBonus
       ? getStructureRelicEffects(productionBoostBonus, currentArmiesTick)
       : [];
     const armyRelicEffects = getStructureArmyRelicEffects(structure, currentArmiesTick);
     return [...structureRelicEffects, ...armyRelicEffects];
-  }, [productionBoostBonus, structure]);
+  }, [productionBoostBonus, structure, currentArmiesTick]);
 
   const activeRelicIds = useMemo(() => relicEffects.map((effect) => Number(effect.id)), [relicEffects]);
 


### PR DESCRIPTION
## Summary
- Show relic icons inline on each structure in the left sidebar selector list
- Show full active relic effects (icon, bonus %, timer) in the realm info panel (entity details view)

## Changes
- **`left-command-sidebar.tsx`**: Each `StructureListItem` now subscribes to `ProductionBoostBonus` and computes active relic effects. Relic icons display inline on the same row as the structure name, with truncation to keep everything single-line.
- **`realm-info-panel.tsx`**: Added `ActiveRelicEffects` component (compact mode) between the Balance and Armies sections, showing relic bonuses and countdown timers.

## Test plan
- [ ] Verify relic icons appear inline on structures that have active relics in the left sidebar
- [ ] Verify structures without relics render unchanged
- [ ] Verify the realm info panel shows "Active Relic Effects" section with bonus % and timer
- [ ] Verify long structure names truncate correctly when relics are present
- [ ] Verify no performance degradation when scrolling through many structures

🤖 Generated with [Claude Code](https://claude.com/claude-code)