### PR TITLE
Fix missing travel FX during army movement

### DIFF
--- a/client/apps/game/src/three/scenes/travel-effect.test.ts
+++ b/client/apps/game/src/three/scenes/travel-effect.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { getMinEffectCleanupDelayMs } from "./travel-effect";
+
+describe("getMinEffectCleanupDelayMs", () => {
+  it("returns full minimum duration when cleanup is requested immediately", () => {
+    expect(getMinEffectCleanupDelayMs(1000, 1000, 600)).toBe(600);
+  });
+
+  it("returns remaining delay when part of the minimum duration has elapsed", () => {
+    expect(getMinEffectCleanupDelayMs(1000, 1300, 600)).toBe(300);
+  });
+
+  it("returns zero when minimum duration has already elapsed", () => {
+    expect(getMinEffectCleanupDelayMs(1000, 1700, 600)).toBe(0);
+  });
+
+  it("returns zero for non-positive minimum duration", () => {
+    expect(getMinEffectCleanupDelayMs(1000, 1200, 0)).toBe(0);
+    expect(getMinEffectCleanupDelayMs(1000, 1200, -5)).toBe(0);
+  });
+});

--- a/client/apps/game/src/three/scenes/travel-effect.ts
+++ b/client/apps/game/src/three/scenes/travel-effect.ts
@@ -1,0 +1,12 @@
+export function getMinEffectCleanupDelayMs(
+  effectStartedAtMs: number,
+  nowMs: number,
+  minimumVisibleMs: number,
+): number {
+  if (minimumVisibleMs <= 0) {
+    return 0;
+  }
+
+  const elapsedMs = Math.max(0, nowMs - effectStartedAtMs);
+  return Math.max(0, minimumVisibleMs - elapsedMs);
+}


### PR DESCRIPTION
This fixes a race where the travel FX could be cleaned up immediately after starting, so the travelling icon looked like it never appeared.

It adds a minimum visible duration before cleanup and a max-lifetime safety timeout for the effect.

It also extracts the cleanup-delay calculation into a helper with focused tests.

Tests: pnpm --dir client/apps/game exec vitest run src/three/scenes/travel-effect.test.ts src/three/managers/army-manager.visibility.test.ts src/three/scenes/worldmap-chunk-transition.test.ts