### PR TITLE
Fix worldmap far-view shadow policy

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap-shadow-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-shadow-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { shouldCastWorldmapDirectionalShadow } from "./worldmap-shadow-policy";
+
+describe("shouldCastWorldmapDirectionalShadow", () => {
+  it("disables shadows in far view", () => {
+    expect(shouldCastWorldmapDirectionalShadow(true, true)).toBe(false);
+  });
+
+  it("disables shadows when quality disables them", () => {
+    expect(shouldCastWorldmapDirectionalShadow(false, false)).toBe(false);
+  });
+
+  it("enables shadows for non-far view when quality allows", () => {
+    expect(shouldCastWorldmapDirectionalShadow(true, false)).toBe(true);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-shadow-policy.ts
+++ b/client/apps/game/src/three/scenes/worldmap-shadow-policy.ts
@@ -1,0 +1,3 @@
+export function shouldCastWorldmapDirectionalShadow(shadowsEnabledByQuality: boolean, isFarView: boolean): boolean {
+  return shadowsEnabledByQuality && !isFarView;
+}

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -99,6 +99,7 @@ import { openStructureContextMenu } from "./context-menu/structure-context-menu"
 import { getMinEffectCleanupDelayMs } from "./travel-effect";
 import { resolveChunkSwitchActions, shouldRunManagerUpdate } from "./worldmap-chunk-transition";
 import { insertPrefetchQueueItem, type PrefetchQueueItem } from "./worldmap-prefetch-queue";
+import { shouldCastWorldmapDirectionalShadow } from "./worldmap-shadow-policy";
 
 interface CachedMatrixEntry {
   matrices: InstancedBufferAttribute | null;
@@ -907,7 +908,10 @@ export default class WorldmapScene extends HexagonScene {
     if (!this.mainDirectionalLight) {
       return;
     }
-    this.mainDirectionalLight.castShadow = true;
+    this.mainDirectionalLight.castShadow = shouldCastWorldmapDirectionalShadow(
+      this.getShadowsEnabledByQuality(),
+      this.getCurrentCameraView() === CameraView.Far,
+    );
     this.mainDirectionalLight.shadow.mapSize.set(1024, 1024);
     this.mainDirectionalLight.shadow.camera.left = -60;
     this.mainDirectionalLight.shadow.camera.right = 60;


### PR DESCRIPTION
This updates WorldmapScene shadow casting to respect both quality settings and far camera view, instead of always forcing directional shadows on. It introduces a small policy helper and targeted unit tests for far view and quality-disabled cases. The change keeps worldmap shadow configuration values intact while correcting the castShadow decision. Tests run: pnpm --dir client/apps/game test src/three/scenes/worldmap-shadow-policy.test.ts.