### PR TITLE
Fix army stamina desync and move refresh

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -51,6 +51,7 @@ import { resolveMovementPath } from "./army-move-path";
 import { getIndicatorYOffset } from "../constants/indicator-constants";
 import { MAX_INSTANCES } from "../constants/army-constants";
 import { shouldArmyRemainVisibleInBounds } from "./army-visibility";
+import { resolveAuthoritativeArmyStamina } from "./army-stamina-source";
 import { shouldAcceptTransitionToken } from "../scenes/worldmap-chunk-transition";
 
 const MEMORY_MONITORING_ENABLED = env.VITE_PUBLIC_ENABLE_MEMORY_MONITORING;
@@ -1366,6 +1367,19 @@ export class ArmyManager {
       finalOwningStructureId !== null && finalOwningStructureId !== undefined
         ? finalOwningStructureId
         : (params.owningStructureId ?? null);
+
+    const { currentArmiesTick } = getBlockTimestamp();
+    const liveTroops = this.components?.ExplorerTroops
+      ? getComponentValue(this.components.ExplorerTroops, getEntityIdFromKeys([BigInt(params.entityId)]))?.troops
+      : undefined;
+    const authoritativeStamina = resolveAuthoritativeArmyStamina({
+      currentArmiesTick,
+      fallbackCurrentStamina: finalCurrentStamina,
+      fallbackOnChainStamina: finalOnChainStamina,
+      liveTroops,
+    });
+    finalCurrentStamina = authoritativeStamina.currentStamina;
+    finalOnChainStamina = authoritativeStamina.onChainStamina;
 
     if (structureIdForOwner !== null && this.components?.Structure) {
       try {

--- a/client/apps/game/src/three/managers/army-stamina-source.test.ts
+++ b/client/apps/game/src/three/managers/army-stamina-source.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { TroopTier, TroopType, type Troops } from "@bibliothecadao/types";
+
+import { resolveAuthoritativeArmyStamina } from "./army-stamina-source";
+
+const { getStaminaMock } = vi.hoisted(() => ({
+  getStaminaMock: vi.fn(),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  StaminaManager: {
+    getStamina: getStaminaMock,
+  },
+}));
+
+describe("resolveAuthoritativeArmyStamina", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getStaminaMock.mockReset();
+  });
+
+  const makeTroops = (staminaAmount: bigint, updatedTick: bigint): Troops => ({
+    category: TroopType.Knight,
+    tier: TroopTier.T1,
+    count: 100n,
+    stamina: {
+      amount: staminaAmount,
+      updated_tick: updatedTick,
+    },
+    boosts: {
+      incr_damage_dealt_percent_num: 0,
+      incr_damage_dealt_end_tick: 0,
+      decr_damage_gotten_percent_num: 0,
+      decr_damage_gotten_end_tick: 0,
+      incr_stamina_regen_percent_num: 0,
+      incr_stamina_regen_tick_count: 0,
+      incr_explore_reward_percent_num: 0,
+      incr_explore_reward_end_tick: 0,
+    },
+    battle_cooldown_end: 0,
+  });
+
+  it("prefers live ExplorerTroops stamina when it is newer than fallback", () => {
+    getStaminaMock.mockReturnValue({ amount: 10n, updated_tick: 20n });
+
+    const resolved = resolveAuthoritativeArmyStamina({
+      currentArmiesTick: 20,
+      fallbackCurrentStamina: 40,
+      fallbackOnChainStamina: { amount: 10n, updatedTick: 5 },
+      liveTroops: makeTroops(10n, 20n),
+    });
+
+    expect(resolved.currentStamina).toBe(10);
+    expect(resolved.onChainStamina).toEqual({ amount: 10n, updatedTick: 20 });
+  });
+
+  it("keeps fallback stamina when live ExplorerTroops stamina is older", () => {
+    const resolved = resolveAuthoritativeArmyStamina({
+      currentArmiesTick: 20,
+      fallbackCurrentStamina: 42,
+      fallbackOnChainStamina: { amount: 42n, updatedTick: 18 },
+      liveTroops: makeTroops(10n, 12n),
+    });
+
+    expect(resolved.currentStamina).toBe(42);
+    expect(resolved.onChainStamina).toEqual({ amount: 42n, updatedTick: 18 });
+  });
+
+  it("keeps fallback stamina when live ExplorerTroops data is missing", () => {
+    const resolved = resolveAuthoritativeArmyStamina({
+      currentArmiesTick: 20,
+      fallbackCurrentStamina: 37,
+      fallbackOnChainStamina: { amount: 37n, updatedTick: 18 },
+      liveTroops: undefined,
+    });
+
+    expect(resolved.currentStamina).toBe(37);
+    expect(resolved.onChainStamina).toEqual({ amount: 37n, updatedTick: 18 });
+  });
+});

--- a/client/apps/game/src/three/managers/army-stamina-source.ts
+++ b/client/apps/game/src/three/managers/army-stamina-source.ts
@@ -1,0 +1,53 @@
+import { StaminaManager } from "@bibliothecadao/eternum";
+import type { Troops } from "@bibliothecadao/types";
+
+export interface ArmyStaminaSnapshot {
+  currentStamina: number;
+  onChainStamina: {
+    amount: bigint;
+    updatedTick: number;
+  };
+}
+
+interface ResolveAuthoritativeArmyStaminaInput {
+  currentArmiesTick: number;
+  fallbackCurrentStamina: number;
+  fallbackOnChainStamina: {
+    amount: bigint;
+    updatedTick: number;
+  };
+  liveTroops?: Troops;
+}
+
+export const resolveAuthoritativeArmyStamina = ({
+  currentArmiesTick,
+  fallbackCurrentStamina,
+  fallbackOnChainStamina,
+  liveTroops,
+}: ResolveAuthoritativeArmyStaminaInput): ArmyStaminaSnapshot => {
+  if (!liveTroops) {
+    return {
+      currentStamina: fallbackCurrentStamina,
+      onChainStamina: fallbackOnChainStamina,
+    };
+  }
+
+  const liveOnChainStamina = {
+    amount: BigInt(liveTroops.stamina.amount),
+    updatedTick: Number(liveTroops.stamina.updated_tick),
+  };
+
+  // Prefer the freshest stamina source to prevent stale map-data values from overriding live ECS state.
+  if (liveOnChainStamina.updatedTick >= fallbackOnChainStamina.updatedTick) {
+    const currentStamina = Number(StaminaManager.getStamina(liveTroops, currentArmiesTick).amount);
+    return {
+      currentStamina,
+      onChainStamina: liveOnChainStamina,
+    };
+  }
+
+  return {
+    currentStamina: fallbackCurrentStamina,
+    onChainStamina: fallbackOnChainStamina,
+  };
+};

--- a/client/apps/game/src/three/scenes/worldmap-action-refresh.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-action-refresh.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldRefreshSelectedArmyActionPaths } from "./worldmap-action-refresh";
+
+describe("shouldRefreshSelectedArmyActionPaths", () => {
+  it("returns true when an army is selected and armies tick advanced", () => {
+    expect(
+      shouldRefreshSelectedArmyActionPaths({
+        selectedEntityId: 123,
+        selectedEntityIsArmy: true,
+        previousArmiesTick: 99,
+        currentArmiesTick: 100,
+        isChunkTransitioning: false,
+        hasPendingMovement: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when armies tick has not advanced", () => {
+    expect(
+      shouldRefreshSelectedArmyActionPaths({
+        selectedEntityId: 123,
+        selectedEntityIsArmy: true,
+        previousArmiesTick: 100,
+        currentArmiesTick: 100,
+        isChunkTransitioning: false,
+        hasPendingMovement: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when no entity is selected", () => {
+    expect(
+      shouldRefreshSelectedArmyActionPaths({
+        selectedEntityId: null,
+        selectedEntityIsArmy: false,
+        previousArmiesTick: 99,
+        currentArmiesTick: 100,
+        isChunkTransitioning: false,
+        hasPendingMovement: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when selected entity is not an army", () => {
+    expect(
+      shouldRefreshSelectedArmyActionPaths({
+        selectedEntityId: 321,
+        selectedEntityIsArmy: false,
+        previousArmiesTick: 99,
+        currentArmiesTick: 100,
+        isChunkTransitioning: false,
+        hasPendingMovement: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false while chunk transition is running", () => {
+    expect(
+      shouldRefreshSelectedArmyActionPaths({
+        selectedEntityId: 123,
+        selectedEntityIsArmy: true,
+        previousArmiesTick: 99,
+        currentArmiesTick: 100,
+        isChunkTransitioning: true,
+        hasPendingMovement: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false while selected army has pending movement", () => {
+    expect(
+      shouldRefreshSelectedArmyActionPaths({
+        selectedEntityId: 123,
+        selectedEntityIsArmy: true,
+        previousArmiesTick: 99,
+        currentArmiesTick: 100,
+        isChunkTransitioning: false,
+        hasPendingMovement: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-action-refresh.ts
+++ b/client/apps/game/src/three/scenes/worldmap-action-refresh.ts
@@ -1,0 +1,31 @@
+interface ShouldRefreshSelectedArmyActionPathsInput {
+  selectedEntityId: number | null;
+  selectedEntityIsArmy: boolean;
+  previousArmiesTick: number;
+  currentArmiesTick: number;
+  isChunkTransitioning: boolean;
+  hasPendingMovement: boolean;
+}
+
+export const shouldRefreshSelectedArmyActionPaths = ({
+  selectedEntityId,
+  selectedEntityIsArmy,
+  previousArmiesTick,
+  currentArmiesTick,
+  isChunkTransitioning,
+  hasPendingMovement,
+}: ShouldRefreshSelectedArmyActionPathsInput): boolean => {
+  if (!selectedEntityId || !selectedEntityIsArmy) {
+    return false;
+  }
+
+  if (currentArmiesTick <= previousArmiesTick) {
+    return false;
+  }
+
+  if (isChunkTransitioning || hasPendingMovement) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
This fixes the world-map army stamina desync where labels could display stale values versus actionable stamina. Armies now prefer live ExplorerTroops stamina when it is newer than map-data fallback values. It also refreshes selected army action paths on armies-tick changes so movement unlocks immediately after regen without a reload. Added focused tests for stamina source selection and tick-based action-path refresh gating.