### PR TITLE
Fix BigInt crash on invalid owner addresses

### DIFF
--- a/client/apps/eternum-mobile/src/shared/lib/three/utils/utils.ts
+++ b/client/apps/eternum-mobile/src/shared/lib/three/utils/utils.ts
@@ -23,13 +23,6 @@ const normalizeAddressToBigInt = (address: unknown): bigint | undefined => {
     return address;
   }
 
-  if (typeof address === "number") {
-    if (!Number.isFinite(address) || !Number.isInteger(address)) {
-      return undefined;
-    }
-    return BigInt(address);
-  }
-
   if (typeof address === "string") {
     const normalized = address.trim();
     if (normalized.length === 0) {
@@ -45,7 +38,7 @@ const normalizeAddressToBigInt = (address: unknown): bigint | undefined => {
   return undefined;
 };
 
-export function isAddressEqualToAccount(address: bigint | string | number | null | undefined): boolean {
+export function isAddressEqualToAccount(address: bigint | string | null | undefined): boolean {
   const normalizedAddress = normalizeAddressToBigInt(address);
   if (normalizedAddress === undefined) {
     return false;

--- a/client/apps/game/src/three/utils/utils.address-equality.test.ts
+++ b/client/apps/game/src/three/utils/utils.address-equality.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getStateMock = vi.fn();
+
+vi.mock("@/hooks/store/use-account-store", () => ({
+  useAccountStore: {
+    getState: () => getStateMock(),
+  },
+}));
+
+vi.mock("three-stdlib", () => ({
+  DRACOLoader: class {
+    setDecoderPath() {}
+    preload() {}
+  },
+  GLTFLoader: class {
+    setDRACOLoader() {}
+    setMeshoptDecoder() {}
+  },
+  MeshoptDecoder: () => ({}),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  calculateDistance: () => 0,
+}));
+
+vi.mock("../constants", () => ({
+  HEX_SIZE: 1,
+}));
+
+import { isAddressEqualToAccount } from "./utils";
+
+describe("isAddressEqualToAccount", () => {
+  beforeEach(() => {
+    getStateMock.mockReset();
+    getStateMock.mockReturnValue({
+      account: { address: "123" },
+    });
+  });
+
+  it("matches bigint and string addresses", () => {
+    expect(isAddressEqualToAccount(123n)).toBe(true);
+    expect(isAddressEqualToAccount("123")).toBe(true);
+    expect(isAddressEqualToAccount(" 123 ")).toBe(true);
+    expect(isAddressEqualToAccount("0x7b")).toBe(true);
+  });
+
+  it("returns false for invalid or empty string addresses", () => {
+    expect(isAddressEqualToAccount("")).toBe(false);
+    expect(isAddressEqualToAccount("   ")).toBe(false);
+    expect(isAddressEqualToAccount("not-an-address")).toBe(false);
+  });
+
+  it("returns false for nullish values", () => {
+    expect(isAddressEqualToAccount(null)).toBe(false);
+    expect(isAddressEqualToAccount(undefined)).toBe(false);
+  });
+
+  it("returns false if a numeric value is passed at runtime", () => {
+    expect(isAddressEqualToAccount(123 as unknown as bigint)).toBe(false);
+  });
+});

--- a/client/apps/game/src/three/utils/utils.ts
+++ b/client/apps/game/src/three/utils/utils.ts
@@ -22,13 +22,6 @@ const normalizeAddressToBigInt = (address: unknown): bigint | undefined => {
     return address;
   }
 
-  if (typeof address === "number") {
-    if (!Number.isFinite(address) || !Number.isInteger(address)) {
-      return undefined;
-    }
-    return BigInt(address);
-  }
-
   if (typeof address === "string") {
     const normalized = address.trim();
     if (normalized.length === 0) {
@@ -44,7 +37,7 @@ const normalizeAddressToBigInt = (address: unknown): bigint | undefined => {
   return undefined;
 };
 
-export function isAddressEqualToAccount(address: bigint | string | number | null | undefined): boolean {
+export function isAddressEqualToAccount(address: bigint | string | null | undefined): boolean {
   const normalizedAddress = normalizeAddressToBigInt(address);
   if (normalizedAddress === undefined) {
     return false;


### PR DESCRIPTION
This hardens address comparison in game and mobile three.js utils.\n\nisAddressEqualToAccount now safely normalizes unknown inputs and returns false for invalid values instead of throwing on undefined BigInt conversion.\n\nI ran pnpm run format before preparing this PR.