### PR TITLE
Unify game entry loading transitions

### DIFF
--- a/client/apps/game/src/game-route.tsx
+++ b/client/apps/game/src/game-route.tsx
@@ -12,9 +12,9 @@ import { useUnifiedOnboarding } from "./hooks/context/use-unified-onboarding";
 import { useTransactionListener } from "./hooks/use-transaction-listener";
 import type { SetupResult } from "./init/bootstrap";
 import { StoryEventToastBridge } from "./ui/features/story-events";
+import { resolveOnboardingPhaseForScreen, shouldRenderOnboardingScreen } from "./ui/layouts/loading-flow";
 import { UnifiedOnboardingScreen } from "./ui/layouts/unified-onboarding";
 import { World } from "./ui/layouts/world";
-import { LoadingScreen } from "./ui/modules/loading-screen";
 
 type ReadyAppProps = {
   backgroundImage: string;
@@ -73,18 +73,18 @@ export const GameRoute = ({ backgroundImage }: { backgroundImage: string }) => {
   }, []);
 
   const state = useUnifiedOnboarding(backgroundImage);
-  const { phase, setupResult, account, bootstrap } = state;
+  const { phase, setupResult, account } = state;
+  const hasSetupResult = setupResult !== null;
+  const hasAccount = account !== null;
+  const shouldRenderOnboarding = shouldRenderOnboardingScreen(phase, hasSetupResult, hasAccount);
+  const onboardingPhase = resolveOnboardingPhaseForScreen(phase, hasSetupResult, hasAccount);
 
-  // Phases that don't need Dojo: world-select, account, loading
-  if (phase === "world-select" || phase === "account" || phase === "loading") {
-    return <UnifiedOnboardingScreen backgroundImage={backgroundImage} state={state} />;
+  if (shouldRenderOnboarding) {
+    return <UnifiedOnboardingScreen backgroundImage={backgroundImage} state={{ ...state, phase: onboardingPhase }} />;
   }
 
-  // Settlement and Ready phases both render the full game
-  // The onboarding overlay (PlayOverlayManager) handles showing settlement UI
-  // when showBlankOverlay is true in the UI store
   if (!setupResult || !account) {
-    return <LoadingScreen backgroundImage={backgroundImage} />;
+    return <UnifiedOnboardingScreen backgroundImage={backgroundImage} state={{ ...state, phase: "loading" }} />;
   }
 
   return <ReadyApp backgroundImage={backgroundImage} setupResult={setupResult} account={account} />;

--- a/client/apps/game/src/ui/layouts/loading-flow.test.ts
+++ b/client/apps/game/src/ui/layouts/loading-flow.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveOnboardingPhaseForScreen,
+  shouldRenderOnboardingScreen,
+  shouldShowTransitionLoadingOverlay,
+} from "./loading-flow";
+
+describe("loading-flow", () => {
+  describe("shouldRenderOnboardingScreen", () => {
+    it("returns true for direct onboarding phases", () => {
+      expect(shouldRenderOnboardingScreen("world-select", true, true)).toBe(true);
+      expect(shouldRenderOnboardingScreen("account", true, true)).toBe(true);
+      expect(shouldRenderOnboardingScreen("loading", true, true)).toBe(true);
+    });
+
+    it("returns true when setup or account is not ready", () => {
+      expect(shouldRenderOnboardingScreen("settlement", false, true)).toBe(true);
+      expect(shouldRenderOnboardingScreen("settlement", true, false)).toBe(true);
+      expect(shouldRenderOnboardingScreen("ready", false, false)).toBe(true);
+    });
+
+    it("returns false when setup and account are ready outside onboarding phases", () => {
+      expect(shouldRenderOnboardingScreen("settlement", true, true)).toBe(false);
+      expect(shouldRenderOnboardingScreen("ready", true, true)).toBe(false);
+    });
+  });
+
+  describe("resolveOnboardingPhaseForScreen", () => {
+    it("preserves explicit onboarding phases", () => {
+      expect(resolveOnboardingPhaseForScreen("world-select", true, true)).toBe("world-select");
+      expect(resolveOnboardingPhaseForScreen("account", true, true)).toBe("account");
+      expect(resolveOnboardingPhaseForScreen("loading", true, true)).toBe("loading");
+    });
+
+    it("bridges non-onboarding phases to loading while dependencies are not ready", () => {
+      expect(resolveOnboardingPhaseForScreen("settlement", false, true)).toBe("loading");
+      expect(resolveOnboardingPhaseForScreen("ready", true, false)).toBe("loading");
+    });
+  });
+
+  describe("shouldShowTransitionLoadingOverlay", () => {
+    it("hides transition overlay while blank onboarding overlay is visible", () => {
+      expect(shouldShowTransitionLoadingOverlay(true, true)).toBe(false);
+    });
+
+    it("shows transition overlay only when enabled and onboarding overlay is hidden", () => {
+      expect(shouldShowTransitionLoadingOverlay(false, true)).toBe(true);
+      expect(shouldShowTransitionLoadingOverlay(false, false)).toBe(false);
+    });
+  });
+});

--- a/client/apps/game/src/ui/layouts/loading-flow.ts
+++ b/client/apps/game/src/ui/layouts/loading-flow.ts
@@ -1,0 +1,37 @@
+import type { OnboardingPhase } from "@/hooks/context/use-unified-onboarding";
+
+const ONBOARDING_SCREEN_PHASES: ReadonlySet<OnboardingPhase> = new Set(["world-select", "account", "loading"]);
+
+/**
+ * Keep the onboarding shell mounted until all world dependencies are ready.
+ * This prevents fallback screen swaps that cause visible flashes.
+ */
+export const shouldRenderOnboardingScreen = (
+  phase: OnboardingPhase,
+  hasSetupResult: boolean,
+  hasAccount: boolean,
+): boolean => ONBOARDING_SCREEN_PHASES.has(phase) || !hasSetupResult || !hasAccount;
+
+/**
+ * When the shell is mounted only as a dependency bridge (not a true onboarding phase),
+ * force the loading phase so the panel always has stable content.
+ */
+export const resolveOnboardingPhaseForScreen = (
+  phase: OnboardingPhase,
+  hasSetupResult: boolean,
+  hasAccount: boolean,
+): OnboardingPhase => {
+  if (ONBOARDING_SCREEN_PHASES.has(phase)) {
+    return phase;
+  }
+
+  return !hasSetupResult || !hasAccount ? "loading" : phase;
+};
+
+/**
+ * The transition fade overlay should not stack on top of the onboarding/game-entry overlay.
+ */
+export const shouldShowTransitionLoadingOverlay = (
+  showBlankOverlay: boolean,
+  isLoadingScreenEnabled: boolean,
+): boolean => isLoadingScreenEnabled && !showBlankOverlay;

--- a/client/apps/game/src/ui/layouts/play-overlay-manager.tsx
+++ b/client/apps/game/src/ui/layouts/play-overlay-manager.tsx
@@ -2,6 +2,7 @@ import type { PointerEvent } from "react";
 import { useCallback, useEffect } from "react";
 
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import { shouldShowTransitionLoadingOverlay } from "@/ui/layouts/loading-flow";
 import { LoadingOroborus } from "@/ui/modules/loading-oroborus";
 import { BlankOverlayContainer } from "@/ui/shared/containers/blank-overlay-container";
 import { GameLoadingOverlay } from "@/ui/layouts/game-loading-overlay";
@@ -21,6 +22,7 @@ export const PlayOverlayManager = ({
   const toggleModal = useUIStore((state) => state.toggleModal);
   const showBlankOverlay = useUIStore((state) => state.showBlankOverlay);
   const isLoadingScreenEnabled = useUIStore((state) => state.isLoadingScreenEnabled);
+  const showTransitionLoadingOverlay = shouldShowTransitionLoadingOverlay(showBlankOverlay, isLoadingScreenEnabled);
 
   const handleModalOverlayPointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
@@ -58,7 +60,7 @@ export const PlayOverlayManager = ({
 
       {enableOnboarding && showBlankOverlay ? <GameLoadingOverlay /> : null}
 
-      <LoadingOroborus loading={isLoadingScreenEnabled} />
+      <LoadingOroborus loading={showTransitionLoadingOverlay} />
     </>
   );
 };

--- a/client/apps/game/src/ui/layouts/unified-onboarding/loading-panel.tsx
+++ b/client/apps/game/src/ui/layouts/unified-onboarding/loading-panel.tsx
@@ -6,17 +6,7 @@ import RefreshCw from "lucide-react/dist/esm/icons/refresh-cw";
 
 import type { BootstrapTask } from "@/hooks/context/use-unified-onboarding";
 import Button from "@/ui/design-system/atoms/button";
-
-const DEFAULT_LOADING_STATEMENTS = [
-  "Gathering your armies...",
-  "Forging alliances...",
-  "Building strongholds...",
-  "Mustering forces...",
-  "Preparing the realm...",
-  "Awakening ancient powers...",
-  "Charting territories...",
-  "Summoning heroes...",
-] as const;
+import { DEFAULT_LOADING_STATEMENTS } from "../onboarding/constants";
 
 const STATEMENT_INTERVAL_MS = 3000;
 


### PR DESCRIPTION
This unifies game entry loading state decisions so onboarding stays on a single shell until world dependencies are ready. It removes the fallback swap to the legacy loading screen and prevents the transition overlay from stacking on top of the blank onboarding overlay. It also consolidates loading statements for the unified onboarding panel and adds tests for loading-flow behavior.