### PR TITLE
fix: stale write in explorer_guard_swap corrupts explorer count

### DIFF
--- a/contracts/game/src/systems/combat/contracts/troop_management.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_management.cairo
@@ -696,6 +696,10 @@ pub mod troop_management_systems {
                 world.write_model(@from_explorer);
             }
 
+            // refresh to_structure_base in case explorer_from_structure_delete
+            // modified and stored the same entity (when from_explorer.owner == to_structure_id)
+            to_structure_base = StructureBaseStoreImpl::retrieve(ref world, to_structure_id);
+
             /////////// Update Structure Guard ///////////
             /////////////////////////////////////////////
 


### PR DESCRIPTION
## Summary
- When swapping **all** troops from an explorer to a guard on the **same** owning structure, `explorer_from_structure_delete` correctly decrements and stores `troop_explorer_count`. But `to_structure_base` (read before the delete) is then stored at the end of the function, **overwriting** the decrement back to the old value.
- This permanently inflates the structure's explorer count, eventually blocking new explorer creation once the slot limit is reached.
- Fix: re-read `to_structure_base` from world after the delete path so the final store has the correct `troop_explorer_count`.

## Test plan
- [x] All 137 existing tests pass (`sozo test`)
- [ ] Manual test: create explorer, swap all troops to own guard, verify explorer count decremented correctly and new explorer can be created

🤖 Generated with [Claude Code](https://claude.com/claude-code)