### PR TITLE
Unify chunk render bounds cell coverage

### DIFF
--- a/client/apps/game/src/three/utils/chunk-geometry.test.ts
+++ b/client/apps/game/src/three/utils/chunk-geometry.test.ts
@@ -6,8 +6,18 @@ vi.mock("./utils", () => ({
 import { getRenderBounds, isHexWithinRenderBounds } from "./chunk-geometry";
 
 describe("getRenderBounds", () => {
-  it("returns even-sized bounds using half-window semantics", () => {
+  it("returns even-sized bounds with exact cell coverage", () => {
     const bounds = getRenderBounds(0, 0, { width: 48, height: 48 }, 24);
+    expect(bounds).toEqual({
+      minCol: -12,
+      maxCol: 35,
+      minRow: -12,
+      maxRow: 35,
+    });
+  });
+
+  it("returns odd-sized bounds with exact cell coverage", () => {
+    const bounds = getRenderBounds(0, 0, { width: 49, height: 49 }, 24);
     expect(bounds).toEqual({
       minCol: -12,
       maxCol: 36,
@@ -15,22 +25,12 @@ describe("getRenderBounds", () => {
       maxRow: 36,
     });
   });
-
-  it("returns odd-sized bounds with half-cell precision", () => {
-    const bounds = getRenderBounds(0, 0, { width: 49, height: 49 }, 24);
-    expect(bounds).toEqual({
-      minCol: -12.5,
-      maxCol: 36.5,
-      minRow: -12.5,
-      maxRow: 36.5,
-    });
-  });
 });
 
 describe("isHexWithinRenderBounds", () => {
   it("keeps max edge inclusive under half-window bounds", () => {
     expect(isHexWithinRenderBounds(35, 35, 0, 0, { width: 48, height: 48 }, 24)).toBe(true);
-    expect(isHexWithinRenderBounds(36, 35, 0, 0, { width: 48, height: 48 }, 24)).toBe(true);
+    expect(isHexWithinRenderBounds(36, 35, 0, 0, { width: 48, height: 48 }, 24)).toBe(false);
     expect(isHexWithinRenderBounds(37, 35, 0, 0, { width: 48, height: 48 }, 24)).toBe(false);
     expect(isHexWithinRenderBounds(35, 37, 0, 0, { width: 48, height: 48 }, 24)).toBe(false);
   });

--- a/client/apps/game/src/three/utils/chunk-geometry.ts
+++ b/client/apps/game/src/three/utils/chunk-geometry.ts
@@ -35,13 +35,15 @@ export function getRenderBounds(
   chunkSize: number,
 ): ChunkBounds {
   const { row: chunkCenterRow, col: chunkCenterCol } = getChunkCenter(startRow, startCol, chunkSize);
-  const halfWidth = renderSize.width / 2;
-  const halfHeight = renderSize.height / 2;
+  const width = Math.max(0, Math.floor(renderSize.width));
+  const height = Math.max(0, Math.floor(renderSize.height));
+  const minCol = chunkCenterCol - Math.floor(width / 2);
+  const minRow = chunkCenterRow - Math.floor(height / 2);
   return {
-    minCol: chunkCenterCol - halfWidth,
-    maxCol: chunkCenterCol + halfWidth,
-    minRow: chunkCenterRow - halfHeight,
-    maxRow: chunkCenterRow + halfHeight,
+    minCol,
+    maxCol: minCol + width - 1,
+    minRow,
+    maxRow: minRow + height - 1,
   };
 }
 


### PR DESCRIPTION
Unifies render bounds to exact integer cell coverage (min + size - 1) so chunk geometry, fetch windows, and boundary inclusion stay aligned.
Updates chunk-geometry tests for even and odd window sizes and max-edge behavior.
This removes the off-by-one bound mismatch that caused subtle edge pop/disappear behavior while moving across chunks.
Verified with: pnpm -C client/apps/game exec vitest run src/three/utils/chunk-geometry.test.ts src/three/scenes/worldmap-chunk-transition.test.ts src/three/scenes/worldmap-chunk-policy.test.ts.