### PR TITLE
Fit bottom-right panel on laptop viewports

### DIFF
--- a/client/apps/game/public/mockups/bottom-right-panel-laptop/README.md
+++ b/client/apps/game/public/mockups/bottom-right-panel-laptop/README.md
@@ -1,0 +1,16 @@
+# Bottom-right Panel Laptop Mockups
+
+Static mockup entry:
+- `client/apps/game/public/mockups/bottom-right-panel-laptop/index.html`
+
+Use query params:
+- `state=local-structure|world-structure|world-army|world-biome`
+- `variant=before|after`
+
+Examples:
+- `file:///.../index.html?state=local-structure&variant=before`
+- `file:///.../index.html?state=world-army&variant=after`
+
+Screenshot set generated for the requested matrix is in:
+- `.context/panel-screenshots/before`
+- `.context/panel-screenshots/after`

--- a/client/apps/game/public/mockups/bottom-right-panel-laptop/index.html
+++ b/client/apps/game/public/mockups/bottom-right-panel-laptop/index.html
@@ -1,0 +1,592 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bottom Right Panel Laptop Mockup</title>
+    <style>
+      :root {
+        --bg-1: #0a1118;
+        --bg-2: #151a24;
+        --gold: #f2c66d;
+        --gold-muted: rgba(242, 198, 109, 0.68);
+        --panel-border: rgba(242, 198, 109, 0.22);
+        --panel-bg: rgba(4, 5, 7, 0.78);
+        --chip-bg: rgba(16, 18, 24, 0.72);
+        --danger: #f37f7f;
+        --good: #99d6a6;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        font-family: "SF Mono", "Menlo", "Consolas", monospace;
+      }
+
+      body {
+        position: relative;
+        overflow: hidden;
+        color: var(--gold);
+        background:
+          radial-gradient(circle at 82% 82%, rgba(230, 166, 73, 0.16), transparent 40%),
+          radial-gradient(circle at 18% 18%, rgba(64, 103, 161, 0.2), transparent 44%),
+          linear-gradient(180deg, var(--bg-2), var(--bg-1));
+      }
+
+      body::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image:
+          linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+        background-size: 26px 26px;
+        opacity: 0.22;
+        pointer-events: none;
+      }
+
+      .meta {
+        position: absolute;
+        left: 16px;
+        top: 14px;
+        z-index: 2;
+        display: inline-flex;
+        gap: 10px;
+        align-items: center;
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.86);
+      }
+
+      .meta span {
+        display: inline-flex;
+        align-items: center;
+        height: 24px;
+        border: 1px solid rgba(255, 255, 255, 0.26);
+        border-radius: 999px;
+        padding: 0 10px;
+        background: rgba(0, 0, 0, 0.3);
+      }
+
+      .hud-root {
+        position: absolute;
+        inset: 0;
+        padding: 0;
+        display: flex;
+        align-items: flex-end;
+        justify-content: flex-end;
+        pointer-events: none;
+      }
+
+      .panel-shell {
+        position: relative;
+        pointer-events: auto;
+      }
+
+      .tab-strip {
+        position: absolute;
+        right: 8px;
+        bottom: calc(100% + 8px);
+        display: flex;
+        gap: 8px;
+      }
+
+      .tab {
+        width: 40px;
+        height: 40px;
+        border-radius: 8px;
+        border: 1px solid rgba(242, 198, 109, 0.35);
+        background: rgba(0, 0, 0, 0.62);
+        color: var(--gold-muted);
+        display: grid;
+        place-items: center;
+        font-size: 15px;
+        line-height: 1;
+      }
+
+      .tab.active {
+        border-color: rgba(242, 198, 109, 0.85);
+        color: var(--gold);
+        box-shadow: 0 4px 14px rgba(242, 198, 109, 0.22);
+      }
+
+      .panel {
+        border: 1px solid var(--panel-border);
+        border-radius: 12px 12px 0 0;
+        overflow: hidden;
+        width: var(--panel-width);
+        height: var(--panel-height);
+        background: var(--panel-bg);
+        box-shadow: 0 16px 36px rgba(0, 0, 0, 0.44);
+        display: flex;
+        flex-direction: column;
+      }
+
+      .panel-header {
+        height: 36px;
+        border-bottom: 1px solid var(--panel-border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 12px;
+      }
+
+      .panel-title {
+        margin: 0;
+        font-size: 10px;
+        letter-spacing: 0.32em;
+        text-transform: uppercase;
+        color: var(--gold-muted);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .panel-action {
+        border: 1px solid rgba(242, 198, 109, 0.52);
+        border-radius: 999px;
+        padding: 0 10px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        font-size: 11px;
+        color: var(--gold);
+        background: rgba(0, 0, 0, 0.45);
+      }
+
+      .panel-content {
+        flex: 1;
+        min-height: 0;
+        padding: 8px;
+      }
+
+      .before .tab {
+        width: 40px;
+        height: 40px;
+      }
+
+      .after .tab {
+        width: 44px;
+        height: 44px;
+      }
+
+      .before .panel-content {
+        overflow-y: auto;
+        overflow-x: hidden;
+      }
+
+      .after .panel-content {
+        overflow: hidden;
+      }
+
+      .card {
+        border: 1px solid rgba(242, 198, 109, 0.18);
+        border-radius: 9px;
+        background: rgba(14, 16, 20, 0.7);
+        padding: 8px;
+      }
+
+      .card-title {
+        margin: 0 0 6px;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        color: var(--gold-muted);
+      }
+
+      .split {
+        display: grid;
+        gap: 8px;
+      }
+
+      .split.two {
+        grid-template-columns: 1.15fr 0.85fr;
+      }
+
+      .chip-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .chip {
+        border-radius: 7px;
+        border: 1px solid rgba(242, 198, 109, 0.2);
+        background: var(--chip-bg);
+        padding: 3px 6px;
+        font-size: 10px;
+        line-height: 1.2;
+      }
+
+      .chip.danger {
+        border-color: rgba(243, 127, 127, 0.42);
+        color: #ffd6d6;
+      }
+
+      .chip.good {
+        border-color: rgba(153, 214, 166, 0.42);
+        color: #d7f4dc;
+      }
+
+      .stat-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        margin-bottom: 5px;
+      }
+
+      .label {
+        color: var(--gold-muted);
+      }
+
+      .value {
+        color: var(--gold);
+        font-weight: 700;
+      }
+
+      .value.good {
+        color: var(--good);
+      }
+
+      .value.danger {
+        color: var(--danger);
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .btn {
+        height: 32px;
+        border-radius: 8px;
+        border: 1px solid rgba(242, 198, 109, 0.28);
+        background: rgba(25, 26, 30, 0.8);
+        color: var(--gold);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        padding: 0 10px;
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .btn.warn {
+        border-color: rgba(243, 127, 127, 0.48);
+        color: #ffd5d5;
+      }
+
+      .before.local .state-body {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .after.local .state-body {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+
+      .after.local .full {
+        grid-column: 1 / -1;
+      }
+
+      .before.world-structure .state-body,
+      .before.world-army .state-body {
+        display: grid;
+        grid-template-columns: 1.15fr 0.85fr;
+        gap: 8px;
+        min-height: 0;
+      }
+
+      .after.world-structure .state-body,
+      .after.world-army .state-body {
+        display: grid;
+        grid-template-columns: 1.15fr 0.85fr;
+        gap: 8px;
+        min-height: 0;
+      }
+
+      .before.world-biome .state-body,
+      .after.world-biome .state-body {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .tab-footer {
+        margin-top: 8px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 6px;
+      }
+
+      .tab-btn {
+        height: 36px;
+        border: 1px solid rgba(242, 198, 109, 0.3);
+        border-radius: 8px;
+        display: grid;
+        place-items: center;
+        background: rgba(20, 22, 26, 0.72);
+        font-size: 13px;
+      }
+
+      .after .tab-btn {
+        min-height: 44px;
+      }
+
+      .warning-banner {
+        border: 1px solid rgba(243, 127, 127, 0.46);
+        background: rgba(120, 25, 25, 0.35);
+        border-radius: 8px;
+        padding: 6px 8px;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="meta">
+      <span id="metaVariant"></span>
+      <span id="metaState"></span>
+      <span id="metaSize"></span>
+    </div>
+    <main class="hud-root">
+      <div id="mock" class="panel-shell"></div>
+    </main>
+
+    <script>
+      const params = new URLSearchParams(window.location.search);
+      const variant = params.get("variant") === "before" ? "before" : "after";
+      const state = params.get("state") || "local-structure";
+
+      const stateClass = state
+        .replace("local-structure", "local")
+        .replace("world-structure", "world-structure")
+        .replace("world-army", "world-army")
+        .replace("world-biome", "world-biome");
+
+      const root = document.getElementById("mock");
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+
+      const beforePanelWidth =
+        viewportWidth >= 1024 ? Math.round(viewportWidth * 0.27) : Math.round(viewportWidth * 0.37);
+      const afterPanelWidth =
+        viewportWidth >= 1280
+          ? Math.round(viewportWidth * 0.32)
+          : viewportWidth >= 1024
+            ? Math.round(viewportWidth * 0.36)
+            : Math.round(viewportWidth * 0.44);
+
+      const beforePanelHeight = Math.round(viewportHeight * 0.35);
+      const afterPanelHeight = Math.max(320, Math.min(430, Math.round(viewportHeight * 0.48)));
+
+      document.documentElement.style.setProperty(
+        "--panel-width",
+        `${variant === "before" ? beforePanelWidth : afterPanelWidth}px`,
+      );
+      document.documentElement.style.setProperty(
+        "--panel-height",
+        `${variant === "before" ? beforePanelHeight : afterPanelHeight}px`,
+      );
+
+      const metaVariant = document.getElementById("metaVariant");
+      const metaState = document.getElementById("metaState");
+      const metaSize = document.getElementById("metaSize");
+      metaVariant.textContent = variant === "before" ? "Before" : "After";
+      metaState.textContent = state.replace(/-/g, " ");
+      metaSize.textContent = `${viewportWidth}x${viewportHeight}`;
+
+      const biomeCard = (compact) => `
+        <div class="card">
+          <p class="card-title">Biome</p>
+          <div class="stat-row"><span class="label">Type</span><span class="value">Taiga</span></div>
+          <div class="chip-row" style="margin-bottom:${compact ? "6px" : "10px"}">
+            <span class="chip good">Knights +15%</span>
+            <span class="chip">Crossbowmen 0%</span>
+            <span class="chip danger">Paladins -10%</span>
+          </div>
+          <button class="btn" style="${compact ? "height:44px;" : ""}">Battle Sim</button>
+        </div>
+      `;
+
+      const localBefore = `
+        <div class="state-body">
+          <div class="warning-banner">Production Paused</div>
+          <div class="card">
+            <p class="card-title">Produces Per Sec</p>
+            <div class="stat-row"><span class="label">Wood</span><span class="value good">+42</span></div>
+            <div class="chip-row"><span class="chip">Consumed by: Armory</span><span class="chip">Workshop</span><span class="chip">Siege Forge</span></div>
+          </div>
+          <div class="card">
+            <p class="card-title">Population</p>
+            <div class="chip-row"><span class="chip">Cost +12</span><span class="chip">Capacity +24</span><span class="chip">Labor +8%</span></div>
+          </div>
+          <div class="card">
+            <p class="card-title">Consumes Per Sec</p>
+            <div class="chip-row"><span class="chip danger">-7 Stone</span><span class="chip danger">-5 Wheat</span><span class="chip danger">-2 Fish</span><span class="chip danger">-2 Ore</span><span class="chip danger">-1 Essence</span></div>
+          </div>
+          <div class="card">
+            <p class="card-title">Build Cost</p>
+            <div class="chip-row"><span class="chip">2.4k/2.4k Wood</span><span class="chip danger">1.1k/1.3k Stone</span><span class="chip">740/740 Iron</span><span class="chip">250/250 Wheat</span><span class="chip">90/90 Fish</span><span class="chip">50/50 Essence</span></div>
+          </div>
+          <div class="actions">
+            <button class="btn">+ Production</button>
+            <button class="btn">Resume</button>
+            <button class="btn warn">Delete</button>
+          </div>
+        </div>
+      `;
+
+      const localAfter = `
+        <div class="state-body">
+          <div class="card full">
+            <p class="card-title">Tile Output + Population</p>
+            <div class="split two">
+              <div>
+                <div class="stat-row"><span class="label">Produces</span><span class="value good">+42 Wood/s</span></div>
+                <div class="chip-row"><span class="chip">Armory</span><span class="chip">Workshop</span></div>
+              </div>
+              <div>
+                <div class="stat-row"><span class="label">Population</span><span class="value">+24 cap</span></div>
+                <div class="chip-row"><span class="chip">Cost +12</span></div>
+              </div>
+            </div>
+          </div>
+          <div class="card">
+            <p class="card-title">Consumes</p>
+            <div class="chip-row"><span class="chip danger">-7 Stone</span><span class="chip danger">-5 Wheat</span><span class="chip danger">-2 Fish</span></div>
+          </div>
+          <div class="card">
+            <p class="card-title">Build Cost</p>
+            <div class="chip-row"><span class="chip">2.4k/2.4k Wood</span><span class="chip danger">1.1k/1.3k Stone</span><span class="chip">740/740 Iron</span></div>
+          </div>
+          <div class="actions full">
+            <button class="btn">+ Production</button>
+            <button class="btn">Pause</button>
+            <button class="btn warn">Delete</button>
+          </div>
+        </div>
+      `;
+
+      const worldStructureBefore = `
+        <div class="state-body">
+          <div class="card">
+            <p class="card-title">Structure #9921</p>
+            <div class="stat-row"><span class="label">Owner</span><span class="value">Delabrousse</span></div>
+            <div class="stat-row"><span class="label">Type</span><span class="value">Realm</span></div>
+            <div class="chip-row"><span class="chip">Guards 6/8</span><span class="chip">Relics 5 active</span><span class="chip">Inventory 14/14</span><span class="chip">Food 1.5k</span><span class="chip">Ore 980</span><span class="chip">Wood 3.4k</span><span class="chip">Stone 2.1k</span><span class="chip">Labor 550</span></div>
+            <div class="tab-footer"><div class="tab-btn">🛡️</div><div class="tab-btn">🏭</div><div class="tab-btn">🪙</div></div>
+          </div>
+          ${biomeCard(false)}
+        </div>
+      `;
+
+      const worldStructureAfter = `
+        <div class="state-body">
+          <div class="card">
+            <p class="card-title">Structure #9921</p>
+            <div class="stat-row"><span class="label">Owner</span><span class="value">Delabrousse</span></div>
+            <div class="stat-row"><span class="label">Type</span><span class="value">Realm</span></div>
+            <div class="chip-row"><span class="chip">Guards 6/8</span><span class="chip">Relics 2 active</span><span class="chip">Inv 10 shown</span></div>
+            <div class="chip-row"><span class="chip">Food 1.5k</span><span class="chip">Ore 980</span><span class="chip">Wood 3.4k</span><span class="chip">Stone 2.1k</span></div>
+            <div class="tab-footer"><div class="tab-btn">🛡️</div><div class="tab-btn">🏭</div><div class="tab-btn">🪙</div></div>
+          </div>
+          ${biomeCard(true)}
+        </div>
+      `;
+
+      const worldArmyBefore = `
+        <div class="state-body">
+          <div class="card">
+            <p class="card-title">Army #4512</p>
+            <div class="stat-row"><span class="label">Owner</span><span class="value">Delabrousse</span></div>
+            <div class="stat-row"><span class="label">Status</span><span class="value">You</span></div>
+            <div class="chip-row"><span class="chip">Knights 340</span><span class="chip">Crossbowmen 220</span><span class="chip">Paladins 90</span></div>
+            <div class="chip-row"><span class="chip danger">⚠ Missing 130 Wheat</span><span class="chip danger">⚠ Missing 50 Fish</span><span class="chip">Stamina 112/180</span><span class="chip">Relics 6 attached</span><span class="chip">Damage +12%</span><span class="chip">Reduction +8%</span></div>
+            <button class="btn warn" style="margin-top:8px">Delete Army</button>
+          </div>
+          ${biomeCard(false)}
+        </div>
+      `;
+
+      const worldArmyAfter = `
+        <div class="state-body">
+          <div class="card">
+            <p class="card-title">Army #4512</p>
+            <div class="stat-row"><span class="label">Owner</span><span class="value">Delabrousse</span></div>
+            <div class="stat-row"><span class="label">Troops</span><span class="value">340 / 220 / 90</span></div>
+            <div class="chip-row"><span class="chip">Stamina 112/180</span><span class="chip danger">Missing 130 Wheat</span><span class="chip">2 active effects</span></div>
+            <div class="chip-row"><span class="chip">Relic slots 10 shown</span></div>
+            <button class="btn warn" style="margin-top:6px">Delete Army</button>
+          </div>
+          ${biomeCard(true)}
+        </div>
+      `;
+
+      const worldBiomeBefore = `
+        <div class="state-body">
+          ${biomeCard(false)}
+          <div class="card">
+            <p class="card-title">Tile Intel</p>
+            <div class="chip-row"><span class="chip">Quadrant A: Snow ridge</span><span class="chip">Quadrant B: Frozen lake</span><span class="chip">Quadrant C: Pine line</span><span class="chip">Quadrant D: Cliff choke</span><span class="chip">Travel cost +2</span><span class="chip">Scout risk: medium</span></div>
+          </div>
+        </div>
+      `;
+
+      const worldBiomeAfter = `
+        <div class="state-body">
+          ${biomeCard(true)}
+          <div class="card">
+            <p class="card-title">Tile Intel</p>
+            <div class="chip-row"><span class="chip">Travel +2</span><span class="chip">Risk medium</span><span class="chip">4 tactical quadrants known</span></div>
+          </div>
+        </div>
+      `;
+
+      const stateMap = {
+        "local-structure": { before: localBefore, after: localAfter, title: "Structure Tile · (7, 4)" },
+        "world-structure": {
+          before: worldStructureBefore,
+          after: worldStructureAfter,
+          title: "Structure Tile · (128, -73)",
+        },
+        "world-army": { before: worldArmyBefore, after: worldArmyAfter, title: "Army Tile · (42, 9)" },
+        "world-biome": { before: worldBiomeBefore, after: worldBiomeAfter, title: "Biome Tile · (15, -21)" },
+      };
+
+      const content = stateMap[state]?.[variant] || localAfter;
+      const title = stateMap[state]?.title || "Tile";
+
+      root.className = `panel-shell ${variant} ${stateClass}`;
+      root.innerHTML = `
+        <div class="tab-strip">
+          <div class="tab active">?</div>
+          <div class="tab">⬢</div>
+        </div>
+        <section class="panel">
+          <header class="panel-header">
+            <p class="panel-title">${title}</p>
+            <span class="panel-action">Re-sync</span>
+          </header>
+          <div class="panel-content">
+            <div class="state-body-wrap">${content}</div>
+          </div>
+        </section>
+      `;
+    </script>
+  </body>
+</html>

--- a/client/apps/game/src/ui/design-system/atoms/tab/tab-panel.tsx
+++ b/client/apps/game/src/ui/design-system/atoms/tab/tab-panel.tsx
@@ -2,11 +2,17 @@ import { Tab } from "@headlessui/react";
 import clsx from "clsx";
 import type { ComponentProps } from "react";
 
-type TabPanelProps = ComponentProps<typeof Tab.Panel>;
+type TabPanelProps = ComponentProps<typeof Tab.Panel> & {
+  scrollable?: boolean;
+};
 
-export const TabPanel = ({ className, children, unmount = false, ...props }: TabPanelProps) => {
+export const TabPanel = ({ className, children, unmount = false, scrollable = true, ...props }: TabPanelProps) => {
   return (
-    <Tab.Panel className={clsx("outline-none w-full overflow-auto", className)} unmount={unmount} {...props}>
+    <Tab.Panel
+      className={clsx("outline-none w-full", scrollable ? "overflow-auto" : "overflow-hidden", className)}
+      unmount={unmount}
+      {...props}
+    >
       {children}
     </Tab.Panel>
   );

--- a/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
@@ -93,42 +93,42 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
 
   return (
     <div
-      className="grid h-full min-h-0 grid-cols-1 gap-2 overflow-auto"
+      className="grid h-full min-h-0 grid-cols-1 gap-2 overflow-hidden"
       style={{ gridTemplateColumns, gridTemplateRows, gridAutoRows }}
     >
       {isStructure ? (
-        <div className="grid h-full min-h-0 gap-2 overflow-auto sm:grid-cols-[1.1fr_0.9fr]">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
           <StructureBannerEntityDetail
             structureEntityId={occupierEntityId}
             maxInventory={14}
             showButtons={false}
-            className="h-full"
+            className="h-full min-h-0"
             {...sharedDetailProps}
           />
-          <EntityDetailSection compact tone="highlight" className="h-full flex">
+          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
             <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
           </EntityDetailSection>
         </div>
       ) : isChest ? (
-        <div className="grid h-full min-h-0 gap-2 overflow-auto sm:grid-cols-[1.1fr_0.9fr]">
-          <EntityDetailSection compact tone="highlight" className="h-full flex">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
+          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
             <RelicCrateSummaryPanel crateEntityId={occupierEntityId} />
           </EntityDetailSection>
-          <EntityDetailSection compact tone="highlight" className="h-full flex">
+          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
             <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
           </EntityDetailSection>
         </div>
       ) : isQuest ? (
-        <QuestEntityDetail questEntityId={occupierEntityId} className="h-full" {...sharedDetailProps} />
+        <QuestEntityDetail questEntityId={occupierEntityId} className="h-full min-h-0" {...sharedDetailProps} />
       ) : (
-        <div className="grid h-full min-h-0 gap-2 overflow-auto sm:grid-cols-[1.1fr_0.9fr]">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
           <ArmyBannerEntityDetail
             armyEntityId={occupierEntityId}
             showButtons={false}
-            className="h-full"
+            className="h-full min-h-0"
             {...sharedDetailProps}
           />
-          <EntityDetailSection compact tone="highlight" className="h-full flex">
+          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
             <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
           </EntityDetailSection>
         </div>

--- a/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
@@ -88,15 +88,15 @@ export const BiomeSummaryCard = ({ biome, onSimulateBattle, showSimulateAction =
   );
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="flex flex-col gap-1">
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div className="flex flex-col gap-0.5">
         <div className="flex items-center justify-between gap-2">
           <span className="text-xxs uppercase tracking-[0.3em] text-gold/60">Biome</span>
           {showSimulateAction && onSimulateBattle ? (
             <Button
               variant="outline"
               size="xs"
-              className="gap-2 rounded-full border-gold/60 px-3 py-1 text-[11px]"
+              className="h-11 min-w-[90px] gap-2 rounded-full border-gold/60 px-3 text-[11px]"
               forceUppercase={false}
               onClick={onSimulateBattle}
               withoutSound
@@ -106,23 +106,23 @@ export const BiomeSummaryCard = ({ biome, onSimulateBattle, showSimulateAction =
             </Button>
           ) : null}
         </div>
-        <span className="text-sm font-semibold text-gold truncate" title={formatQuadrantBiomeLabel(biome)}>
+        <span className="truncate text-xs font-semibold text-gold" title={formatQuadrantBiomeLabel(biome)}>
           {formatQuadrantBiomeLabel(biome)}
         </span>
       </div>
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1.5">
         <span className="text-xxs uppercase tracking-[0.3em] text-gold/60">Army bonuses</span>
-        <div className="grid grid-cols-1 gap-1.5">
+        <div className="grid grid-cols-1 gap-1">
           {troopBonuses.map(({ troopType, config, bonus, styles }) => (
             <div
               key={troopType}
-              className={`flex items-center justify-between rounded-lg border px-3 py-2 shadow-sm ${styles.containerClass}`}
+              className={`flex items-center justify-between rounded-lg border px-2 py-1.5 shadow-sm ${styles.containerClass}`}
             >
               <div className="flex items-center gap-2">
                 <ResourceIcon resource={config.resourceName} size="sm" withTooltip={false} />
-                <span className="text-[11px] font-semibold text-gold/90">{config.label}</span>
+                <span className="text-[10px] font-semibold text-gold/90">{config.label}</span>
               </div>
-              <span className={`text-sm font-semibold ${styles.textClass}`}>
+              <span className={`text-xs font-semibold ${styles.textClass}`}>
                 {bonus === 1 ? "0%" : formatBiomeBonus(bonus)}
               </span>
             </div>
@@ -146,7 +146,7 @@ export const UnoccupiedTileQuadrants = ({ biome }: { biome: BiomeType }) => {
   }, [biome, isPopupOpen, openPopup, setCombatSimulationBiome]);
 
   return (
-    <div className="h-full min-h-0 overflow-auto">
+    <div className="h-full min-h-0">
       <EntityDetailSection compact className="flex h-full flex-col overflow-hidden" tone="highlight">
         <BiomeSummaryCard biome={biome} onSimulateBattle={handleSimulateBattle} showSimulateAction />
       </EntityDetailSection>

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
@@ -34,7 +34,6 @@ import { Component, getComponentValue, Metadata, Schema } from "@dojoengine/recs
 import { memo, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { SelectedWorldmapEntity } from "@/ui/features/world/components/actions/selected-worldmap-entity";
-import { useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
 import { RealmUpgradeCompact } from "@/ui/modules/entity-details/realm/realm-details";
 import { ProductionModal } from "@/ui/features/settlement";
 import { TileManager } from "@bibliothecadao/eternum";
@@ -124,13 +123,13 @@ const PanelFrame = ({ title, children, headerAction, className, attached = false
     )}
     style={{ height: BOTTOM_PANEL_HEIGHT }}
   >
-    <header className="flex items-center justify-between gap-2 border-b border-gold/20 px-4 py-2">
+    <header className="flex items-center justify-between gap-2 border-b border-gold/20 px-3 py-1.5">
       <p className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.35em] text-gold/70">
         {title}
       </p>
       {headerAction ? <div className="shrink-0">{headerAction}</div> : null}
     </header>
-    <div className="flex-1 min-h-0 overflow-hidden px-3 py-2">{children}</div>
+    <div className="flex-1 min-h-0 overflow-hidden px-2.5 py-2">{children}</div>
   </section>
 );
 
@@ -166,7 +165,7 @@ const PanelTabs = ({
           onClick={() => onSelect(id)}
           aria-pressed={isActive}
           className={cn(
-            "flex h-10 w-10 items-center justify-center rounded-md border transition",
+            "flex h-11 w-11 items-center justify-center rounded-md border transition",
             isActive
               ? "border-gold/80 bg-black/80 text-gold shadow-[0_6px_18px_rgba(255,209,128,0.25)] ring-1 ring-gold/40"
               : "border-gold/30 bg-black/70 text-gold/70 hover:border-gold/60 hover:text-gold",
@@ -337,7 +336,6 @@ const LocalTilePanel = () => {
   const playerStructures = useUIStore((state) => state.playerStructures);
   const useSimpleCost = useUIStore((state) => state.useSimpleCost);
   const setTooltip = useUIStore((state) => state.setTooltip);
-  const structureUpgrade = useStructureUpgrade(structureEntityId ?? null);
   const toggleModal = useUIStore((state) => state.toggleModal);
   const currentDefaultTick = getBlockTimestamp().currentDefaultTick;
 
@@ -630,9 +628,9 @@ const LocalTilePanel = () => {
           </div>
         ) : hasBuilding ? (
           <div className="h-full min-h-0 overflow-hidden">
-            <div className="flex flex-col gap-3 text-xs text-gold">
+            <div className="grid h-full min-h-0 auto-rows-min grid-cols-2 gap-2 text-[11px] text-gold">
               {isPaused && (
-                <div className="flex items-center justify-between gap-2 py-2 px-3 bg-red/20 rounded">
+                <div className="col-span-2 flex items-center justify-between gap-2 rounded border border-red-400/40 bg-red/900/25 px-2 py-1.5">
                   <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-red-200">
                     ⚠️ Production Paused
                   </span>
@@ -643,113 +641,110 @@ const LocalTilePanel = () => {
                         variant="outline"
                         disabled={isActionLoading}
                         onClick={handleToggleProduction}
-                        className="text-xxs h-6 bg-green/20 hover:bg-green/40 border-green/50"
+                        className="h-7 border-green/50 bg-green/20 px-2 text-xxs hover:bg-green/40"
                       >
                         ▶ Resume
                       </Button>
-                      {!isCastleTile && (
-                        <Button
-                          size="xs"
-                          variant="danger"
-                          disabled={isActionLoading}
-                          onClick={handleDestroy}
-                          className="text-xxs h-6"
-                        >
-                          <Trash2 className="h-3 w-3" />
-                        </Button>
-                      )}
+                      <Button
+                        size="xs"
+                        variant="danger"
+                        disabled={isActionLoading}
+                        onClick={handleDestroy}
+                        className="h-7 px-2 text-xxs"
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
                     </div>
                   )}
                 </div>
               )}
 
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-1">
-                  <p className="text-xxs uppercase tracking-[0.2em] text-gold/60">
-                    {isCastleTile ? "Labor rate" : "Produces per sec"}
-                  </p>
-                  {producedResource && producedResourceName ? (
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-semibold text-green-300">+{producedPerTick}</span>
-                      <ResourceIcon withTooltip={false} resource={producedResourceName} size="sm" />
-                      <button
-                        type="button"
-                        className="text-xxs uppercase tracking-[0.2em] text-gold/60"
-                        onMouseEnter={() =>
-                          setTooltip({
-                            position: "right",
-                            content: (
-                              <div className="space-y-2">
-                                <p className="text-xxs uppercase tracking-[0.25em] text-gold/60">Consumed By</p>
-                                {consumedBy.length > 0 ? (
-                                  <div className="grid grid-cols-3 gap-2">
-                                    {consumedBy.map((resourceId) => {
-                                      const name =
-                                        findResourceById(Number(resourceId))?.trait ?? `Resource ${resourceId}`;
-                                      return (
-                                        <div
-                                          key={resourceId}
-                                          className="flex items-center gap-1 rounded border border-gold/20 bg-black/40 px-2 py-1"
-                                        >
-                                          <ResourceIcon withTooltip={false} resource={name} size="xs" />
-                                          <span className="text-xxs text-gold/80">{name}</span>
-                                        </div>
-                                      );
-                                    })}
-                                  </div>
-                                ) : (
-                                  <p className="text-xxs text-gold/60">Not consumed by other buildings.</p>
-                                )}
-                              </div>
-                            ),
-                          })
-                        }
-                        onMouseLeave={() => setTooltip(null)}
-                        aria-label="Show consumers"
-                      >
-                        <Info className="h-4 w-4 text-gold/70" />
-                      </button>
-                    </div>
-                  ) : (
-                    <p className="text-xxs text-gold/60">No production</p>
-                  )}
-                </div>
+              <div className="col-span-2 rounded border border-gold/15 bg-black/30 px-2 py-1.5">
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="space-y-1">
+                    <p className="text-xxs uppercase tracking-[0.2em] text-gold/60">Produces per sec</p>
+                    {producedResource && producedResourceName ? (
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-sm font-semibold text-green-300">+{producedPerTick}</span>
+                        <ResourceIcon withTooltip={false} resource={producedResourceName} size="sm" />
+                        <button
+                          type="button"
+                          className="text-xxs uppercase tracking-[0.2em] text-gold/60"
+                          onMouseEnter={() =>
+                            setTooltip({
+                              position: "right",
+                              content: (
+                                <div className="space-y-2">
+                                  <p className="text-xxs uppercase tracking-[0.25em] text-gold/60">Consumed By</p>
+                                  {consumedBy.length > 0 ? (
+                                    <div className="grid grid-cols-3 gap-2">
+                                      {consumedBy.map((resourceId) => {
+                                        const name = findResourceById(Number(resourceId))?.trait ?? `Resource ${resourceId}`;
+                                        return (
+                                          <div
+                                            key={resourceId}
+                                            className="flex items-center gap-1 rounded border border-gold/20 bg-black/40 px-2 py-1"
+                                          >
+                                            <ResourceIcon withTooltip={false} resource={name} size="xs" />
+                                            <span className="text-xxs text-gold/80">{name}</span>
+                                          </div>
+                                        );
+                                      })}
+                                    </div>
+                                  ) : (
+                                    <p className="text-xxs text-gold/60">Not consumed by other buildings.</p>
+                                  )}
+                                </div>
+                              ),
+                            })
+                          }
+                          onMouseLeave={() => setTooltip(null)}
+                          aria-label="Show consumers"
+                        >
+                          <Info className="h-4 w-4 text-gold/70" />
+                        </button>
+                      </div>
+                    ) : (
+                      <p className="text-xxs text-gold/60">No production</p>
+                    )}
+                  </div>
 
-                <div className="space-y-1">
-                  <p className="text-xxs uppercase tracking-[0.2em] text-gold/60">Population</p>
-                  <div className="flex items-center gap-2 text-sm">
-                    {populationCost !== 0 && (
-                      <span className="rounded bg-black/40 px-2 py-1 text-xxs font-semibold text-gold">
-                        Cost +{populationCost}
-                      </span>
-                    )}
-                    {populationCapacity !== 0 && (
-                      <span className="rounded bg-black/40 px-2 py-1 text-xxs font-semibold text-gold">
-                        Capacity +{populationCapacity}
-                      </span>
-                    )}
-                    {populationCost === 0 && populationCapacity === 0 && (
-                      <span className="text-xxs text-gold/60">No population impact</span>
-                    )}
+                  <div className="space-y-1">
+                    <p className="text-xxs uppercase tracking-[0.2em] text-gold/60">Population</p>
+                    <div className="flex flex-wrap items-center gap-1">
+                      {populationCost !== 0 && (
+                        <span className="rounded bg-black/40 px-1.5 py-1 text-xxs font-semibold text-gold">
+                          Cost +{populationCost}
+                        </span>
+                      )}
+                      {populationCapacity !== 0 && (
+                        <span className="rounded bg-black/40 px-1.5 py-1 text-xxs font-semibold text-gold">
+                          Capacity +{populationCapacity}
+                        </span>
+                      )}
+                      {populationCost === 0 && populationCapacity === 0 && (
+                        <span className="text-xxs text-gold/60">No population impact</span>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
 
-              <div className="space-y-1">
-                <p className="text-xxs uppercase tracking-[0.2em] text-gold/60">Consumes per sec</p>
+              <div className="rounded border border-gold/15 bg-black/30 px-2 py-1.5">
+                <p className="mb-1 text-xxs uppercase tracking-[0.2em] text-gold/60">Consumes per sec</p>
                 {ongoingCost.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
+                  <div className="flex flex-wrap gap-1.5">
                     {ongoingCost.map((entry, index) => {
                       const name = findResourceById(Number(entry.resource))?.trait ?? `Resource ${entry.resource}`;
                       return (
                         <div
                           key={`${entry.resource}-${index}`}
-                          className="flex items-center gap-2 rounded border border-gold/20 bg-black/40 px-2 py-1"
+                          className="flex items-center gap-1 rounded border border-gold/20 bg-black/40 px-1.5 py-1"
                         >
                           <span className="text-xxs font-semibold text-red-200">-{entry.amount}</span>
                           <button
                             type="button"
-                            className="flex h-6 w-6 items-center justify-center rounded"
+                            className="flex h-5 w-5 items-center justify-center rounded"
                             onMouseEnter={() =>
                               setTooltip({
                                 position: "top",
@@ -775,10 +770,10 @@ const LocalTilePanel = () => {
                 )}
               </div>
 
-              {buildCost.length > 0 && (
-                <div className="space-y-1">
-                  <p className="text-xxs uppercase tracking-[0.2em] text-gold/60">Build Cost</p>
-                  <div className="flex flex-wrap gap-2">
+              <div className="rounded border border-gold/15 bg-black/30 px-2 py-1.5">
+                <p className="mb-1 text-xxs uppercase tracking-[0.2em] text-gold/60">Build Cost</p>
+                {buildCost.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
                     {buildCost.map((entry, index) => {
                       const name = findResourceById(Number(entry.resource))?.trait ?? `Resource ${entry.resource}`;
                       const balanceInfo = getBalance(
@@ -794,7 +789,7 @@ const LocalTilePanel = () => {
                           type="button"
                           key={`build-cost-${entry.resource}-${index}`}
                           className={cn(
-                            "relative flex items-center gap-2 rounded px-2 py-1.5 text-[11px] shadow-inner",
+                            "relative flex items-center gap-1 rounded px-1.5 py-1 text-[10px] shadow-inner",
                             hasEnough
                               ? "bg-gold/5 border border-gold/10 text-gold/80"
                               : "bg-red-900/15 border border-red-500/30 text-red-100",
@@ -814,28 +809,30 @@ const LocalTilePanel = () => {
                           aria-label={`${name} build cost`}
                         >
                           <ResourceIcon withTooltip={false} resource={name} size="xs" />
-                          <span className={cn("text-[11px]", hasEnough ? "text-gold font-semibold" : "text-red-200")}>
+                          <span className={cn("text-[10px]", hasEnough ? "font-semibold text-gold" : "text-red-200")}>
                             {formatResourceAmount(balance)}
                           </span>
-                          <span className={cn("text-[11px]", hasEnough ? "text-gold/70" : "text-red-200")}>
+                          <span className={cn("text-[10px]", hasEnough ? "text-gold/70" : "text-red-200")}>
                             / {entry.amount}
                           </span>
                         </button>
                       );
                     })}
                   </div>
-                </div>
-              )}
+                ) : (
+                  <p className="text-xxs text-gold/60">No build cost data</p>
+                )}
+              </div>
 
               {isOwnedByPlayer && (
-                <div className="flex flex-wrap gap-2 pt-1">
+                <div className="col-span-2 flex flex-wrap gap-1.5 pt-0.5">
                   {canAddProduction && (
                     <Button
                       size="xs"
                       variant="gold"
                       disabled={isActionLoading}
                       onClick={() => toggleModal(<ProductionModal preSelectedResource={producedResource} />)}
-                      className="text-xxs h-7"
+                      className="h-8 px-2 text-xxs"
                     >
                       + Production
                     </Button>
@@ -846,63 +843,21 @@ const LocalTilePanel = () => {
                       variant="outline"
                       disabled={isActionLoading}
                       onClick={handleToggleProduction}
-                      className="text-xxs h-7"
+                      className="h-8 px-2 text-xxs"
                     >
                       {isPaused ? "▶ Resume" : "⏸ Pause"}
                     </Button>
                   )}
-                  {!isCastleTile && (
-                    <Button
-                      size="xs"
-                      variant="danger"
-                      disabled={isActionLoading}
-                      onClick={handleDestroy}
-                      className="text-xxs h-7 flex items-center gap-2"
-                    >
-                      <Trash2 className="h-3 w-3" />
-                      {showDestroyConfirm ? "Confirm" : "Delete"}
-                    </Button>
-                  )}
-                </div>
-              )}
-
-              {isCastleTile && structureUpgrade && (
-                <div className="space-y-2 rounded border border-gold/15 bg-black/40 p-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-xxs uppercase tracking-[0.25em] text-gold/60">
-                      Upgrade {structureUpgrade.nextLevelName ? `to ${structureUpgrade.nextLevelName}` : "(max)"}
-                    </p>
-                    <span className="text-xxs text-gold/70">{structureUpgrade.nextLevelName ?? "Max level"}</span>
-                  </div>
-                  {structureUpgrade.nextLevel ? (
-                    <div className="space-y-1">
-                      {structureUpgrade.requirements.map((req) => {
-                        const name = findResourceById(Number(req.resource))?.trait ?? `Resource ${req.resource}`;
-                        const pct = Math.min(100, Math.floor((req.current * 100) / (req.amount || 1)));
-                        return (
-                          <div key={req.resource} className="space-y-1">
-                            <div className="flex items-center justify-between gap-2 text-xxs text-gold">
-                              <span className="flex items-center gap-1">
-                                <ResourceIcon withTooltip={false} resource={name} size="xs" />
-                                {name}
-                              </span>
-                              <span className="text-gold/80">
-                                {formatResourceAmount(req.current)} / {req.amount.toLocaleString()}
-                              </span>
-                            </div>
-                            <div className="h-1.5 rounded bg-gold/10">
-                              <div className="h-full rounded bg-gold" style={{ width: `${pct}%` }} />
-                            </div>
-                          </div>
-                        );
-                      })}
-                      {!structureUpgrade.isOwner && (
-                        <p className="text-xxs text-gold/60">Only the owner can upgrade.</p>
-                      )}
-                    </div>
-                  ) : (
-                    <p className="text-xxs text-gold/60">Castle at maximum level.</p>
-                  )}
+                  <Button
+                    size="xs"
+                    variant="danger"
+                    disabled={isActionLoading}
+                    onClick={handleDestroy}
+                    className="flex h-8 items-center gap-1.5 px-2 text-xxs"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                    {showDestroyConfirm ? "Confirm" : "Delete"}
+                  </Button>
                 </div>
               )}
             </div>
@@ -1029,7 +984,7 @@ export const BottomRightPanel = memo(() => {
       aria-hidden={!shouldShow}
       style={{ bottom: BOTTOM_PANEL_MARGIN }}
     >
-      <div className="relative w-full md:w-[37%] lg:w-[27%] md:ml-auto min-h-[44px]">
+      <div className="relative w-full min-h-[44px] md:ml-auto md:w-[44%] lg:w-[36%] xl:w-[32%]">
         <PanelTabs
           tabs={availableTabs}
           activeTab={activeTab}

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/constants.ts
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/constants.ts
@@ -1,3 +1,3 @@
-export const BOTTOM_PANEL_HEIGHT = "35vh";
+export const BOTTOM_PANEL_HEIGHT = "clamp(320px, 48vh, 430px)";
 export const BOTTOM_PANEL_MARGIN = "0px";
 const BOTTOM_PANEL_RESERVED_SPACE = `calc(${BOTTOM_PANEL_HEIGHT} + 24px)`;

--- a/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
@@ -1,27 +1,11 @@
-import Bot from "lucide-react/dist/esm/icons/bot";
-import ChevronDown from "lucide-react/dist/esm/icons/chevron-down";
-import ChevronUp from "lucide-react/dist/esm/icons/chevron-up";
-import LayoutDashboard from "lucide-react/dist/esm/icons/layout-dashboard";
 import Loader from "lucide-react/dist/esm/icons/loader";
-import Settings from "lucide-react/dist/esm/icons/settings";
-import Square from "lucide-react/dist/esm/icons/square";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useMemo } from "react";
 
 import { ReactComponent as Lightning } from "@/assets/icons/common/lightning.svg";
 import { usePlayerAvatarByUsername } from "@/hooks/use-player-avatar";
-import {
-  DEFAULT_SCOPE_RADIUS,
-  DEFAULT_STRATEGY_ID,
-  useExplorationAutomationStore,
-} from "@/hooks/store/use-exploration-automation-store";
-import { useUIStore } from "@/hooks/store/use-ui-store";
-import { explorationAutomation } from "@/ui/features/world";
-import { NumberInput } from "@/ui/design-system/atoms/number-input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/design-system/atoms/select";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { TroopChip } from "@/ui/features/military/components/troop-chip";
-import { EXPLORATION_STRATEGIES } from "@/automation/exploration";
 import { configManager } from "@bibliothecadao/eternum";
 import { BiomeType, EntityType, ID, RelicRecipientType, TroopType } from "@bibliothecadao/types";
 import { ActiveRelicEffects } from "../active-relic-effects";
@@ -47,8 +31,6 @@ const ArmyBannerEntityDetailContent = memo(
     armyEntityId,
     className,
     compact = true,
-    showButtons: _showButtons = false,
-    variant: _variant,
   }: ArmyBannerEntityDetailContentProps) => {
     const {
       explorer,
@@ -77,6 +59,9 @@ const ArmyBannerEntityDetailContent = memo(
     if (!explorer || !derivedData) return null;
 
     const hasWarnings = Boolean(structureResources && explorerResources);
+    const visibleRelicEffects = compact ? relicEffects.slice(0, 2) : relicEffects;
+    const hiddenRelicEffects = Math.max(relicEffects.length - visibleRelicEffects.length, 0);
+    const inventoryLimit = compact ? 10 : undefined;
     const ownerDisplay = derivedData.addressName ?? `Army Owner`;
     const stationedDisplay = derivedData.structureOwnerName ?? "Field deployment";
     const ownerInitial = (ownerDisplay || "?").charAt(0).toUpperCase();
@@ -91,11 +76,11 @@ const ArmyBannerEntityDetailContent = memo(
       <EntityDetailSection
         compact={compact}
         tone={hasWarnings ? "highlight" : "default"}
-        className={cn("flex flex-col gap-3", className)}
+        className={cn("flex h-full min-h-0 flex-col gap-2 overflow-hidden", className)}
       >
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-3">
-            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full border border-gold/30 bg-black/40">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="h-9 w-9 shrink-0 overflow-hidden rounded-full border border-gold/30 bg-black/40">
               {ownerAvatarUrl ? (
                 <img className="h-full w-full object-cover" src={ownerAvatarUrl} alt={`${ownerDisplay} avatar`} />
               ) : (
@@ -146,7 +131,12 @@ const ArmyBannerEntityDetailContent = memo(
           <ArmyWarning army={explorer} explorerResources={explorerResources} structureResources={structureResources} />
         ) : null}
 
-        {relicEffects.length > 0 && <ActiveRelicEffects relicEffects={relicEffects} entityId={armyEntityId} compact />}
+        {visibleRelicEffects.length > 0 && (
+          <ActiveRelicEffects relicEffects={visibleRelicEffects} entityId={armyEntityId} compact />
+        )}
+        {hiddenRelicEffects > 0 && (
+          <p className="text-xxs text-gold/60 italic">+{hiddenRelicEffects} more relic effect(s) active</p>
+        )}
 
         <div className="flex flex-col gap-2">
           <span className="text-xxs uppercase tracking-[0.3em] text-gold/60">Relics</span>
@@ -159,6 +149,7 @@ const ArmyBannerEntityDetailContent = memo(
               entityType={EntityType.ARMY}
               allowRelicActivation={derivedData.isMine}
               variant="tight"
+              maxItems={inventoryLimit}
             />
           ) : (
             <p className="text-xxs text-gold/60 italic">No relics attached.</p>
@@ -191,294 +182,6 @@ export const ArmyBannerEntityDetail = memo(
 );
 
 ArmyBannerEntityDetail.displayName = "ArmyBannerEntityDetail";
-
-const ExplorationAutomationCompact = ({ explorerId, compact: _compact }: { explorerId: ID; compact: boolean }) => {
-  const entries = useExplorationAutomationStore((s) => s.entries);
-  const addEntry = useExplorationAutomationStore((s) => s.add);
-  const updateEntry = useExplorationAutomationStore((s) => s.update);
-  const toggleActive = useExplorationAutomationStore((s) => s.toggleActive);
-  const togglePopup = useUIStore((state) => state.togglePopup);
-
-  const handleOpenDashboard = () => {
-    togglePopup(explorationAutomation);
-  };
-
-  const entry = useMemo(
-    () => Object.values(entries).find((item) => item.explorerId === String(explorerId)),
-    [entries, explorerId],
-  );
-
-  const [showSettings, setShowSettings] = useState(false);
-  const [scopeRadius, setScopeRadius] = useState<number>(entry?.scopeRadius ?? DEFAULT_SCOPE_RADIUS);
-  const [strategyId, setStrategyId] = useState<string>(entry?.strategyId ?? DEFAULT_STRATEGY_ID);
-
-  useEffect(() => {
-    setScopeRadius(entry?.scopeRadius ?? DEFAULT_SCOPE_RADIUS);
-    setStrategyId(entry?.strategyId ?? DEFAULT_STRATEGY_ID);
-  }, [entry?.scopeRadius, entry?.strategyId]);
-
-  const hasChanges = Boolean(
-    entry &&
-    (entry.scopeRadius !== scopeRadius ||
-      entry.strategyId !== (strategyId as typeof entry.strategyId) ||
-      entry.blockedReason),
-  );
-
-  const handleQuickEnable = () => {
-    if (!entry) {
-      addEntry({
-        explorerId: String(explorerId),
-        scopeRadius: DEFAULT_SCOPE_RADIUS,
-        strategyId: DEFAULT_STRATEGY_ID,
-        active: true,
-      });
-    } else if (!entry.active) {
-      toggleActive(entry.id, true);
-    }
-  };
-
-  const handleSaveSettings = () => {
-    if (entry) {
-      updateEntry(entry.id, { scopeRadius, strategyId: strategyId as typeof entry.strategyId, blockedReason: null });
-      if (!entry.active) {
-        toggleActive(entry.id, true);
-      }
-    } else {
-      addEntry({
-        explorerId: String(explorerId),
-        scopeRadius,
-        strategyId: strategyId as typeof DEFAULT_STRATEGY_ID,
-        active: true,
-      });
-    }
-    setShowSettings(false);
-  };
-
-  const handleStop = () => {
-    if (!entry) return;
-    toggleActive(entry.id, false);
-  };
-
-  const isActive = entry?.active ?? false;
-  const isBlocked = Boolean(entry?.blockedReason);
-  const lastAction = entry?.lastAction;
-
-  // Time formatting
-  const formatRelativeTime = (timestamp?: number | null) => {
-    if (!timestamp) return "never";
-    const now = Date.now();
-    const diff = timestamp - now;
-    const absDiff = Math.abs(diff);
-
-    if (absDiff < 1000) return "now";
-
-    const seconds = Math.floor(absDiff / 1000);
-    if (seconds < 60) {
-      return diff > 0 ? `in ${seconds}s` : `${seconds}s ago`;
-    }
-
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) {
-      return diff > 0 ? `in ${minutes}m` : `${minutes}m ago`;
-    }
-
-    return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  };
-
-  // Status indicator styles
-  const getStatusColor = () => {
-    if (!entry) return "bg-gold/20 border-gold/30";
-    if (!isActive) return "bg-gold/10 border-gold/20";
-    if (isBlocked) return "bg-amber-500/20 border-amber-500/40";
-    return "bg-emerald-500/20 border-emerald-500/40";
-  };
-
-  const getStatusDot = () => {
-    if (!entry || !isActive) return null;
-    if (isBlocked) return "bg-amber-400";
-    return "bg-emerald-400 animate-pulse";
-  };
-
-  // Inactive state - show simple enable button
-  if (!entry || !isActive) {
-    return (
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={handleQuickEnable}
-            className={cn(
-              "flex flex-1 items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition-all",
-              "border-gold/30 bg-gold/5 text-gold/80 hover:bg-gold/15 hover:border-gold/50 hover:text-gold",
-            )}
-          >
-            <Bot className="h-3.5 w-3.5" />
-            <span>Enable Auto-Explore</span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowSettings(!showSettings)}
-            className={cn(
-              "flex items-center justify-center rounded-lg border p-2 transition-all",
-              "border-gold/20 bg-black/20 text-gold/50 hover:bg-gold/10 hover:text-gold/80",
-            )}
-            title="Settings"
-          >
-            <Settings className="h-3.5 w-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={handleOpenDashboard}
-            className={cn(
-              "flex items-center justify-center rounded-lg border p-2 transition-all",
-              "border-gold/20 bg-black/20 text-gold/50 hover:bg-gold/10 hover:text-gold/80",
-            )}
-            title="All Automations"
-          >
-            <LayoutDashboard className="h-3.5 w-3.5" />
-          </button>
-        </div>
-
-        {/* Expandable settings */}
-        {showSettings && (
-          <div className="flex flex-col gap-2 rounded-lg border border-gold/10 bg-black/40 p-2 animate-in slide-in-from-top-2 duration-200">
-            <SettingsPanel
-              scopeRadius={scopeRadius}
-              setScopeRadius={setScopeRadius}
-              strategyId={strategyId}
-              setStrategyId={setStrategyId}
-            />
-            <button
-              type="button"
-              onClick={handleSaveSettings}
-              className="w-full rounded border border-gold/30 bg-gold/10 px-3 py-1.5 text-xs font-medium text-gold/90 transition hover:bg-gold/20"
-            >
-              Save & Enable
-            </button>
-          </div>
-        )}
-      </div>
-    );
-  }
-
-  // Active state - show compact status with controls
-  return (
-    <div className="flex flex-col gap-1.5">
-      {/* Main status row */}
-      <div className={cn("flex items-center gap-2 rounded-lg border px-3 py-2 transition-all", getStatusColor())}>
-        <div className="flex items-center gap-2 flex-1 min-w-0">
-          <div className="relative">
-            <Bot className="h-4 w-4 text-gold/70" />
-            {getStatusDot() && (
-              <span className={cn("absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full", getStatusDot())} />
-            )}
-          </div>
-          <div className="flex flex-col min-w-0">
-            <span className="text-xs font-medium text-gold/90 truncate">
-              {isBlocked ? `Blocked: ${entry.blockedReason}` : "Auto-Exploring"}
-            </span>
-            {lastAction && !isBlocked && <span className="text-[10px] text-gold/50 truncate">Last: {lastAction}</span>}
-          </div>
-        </div>
-
-        <div className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={handleOpenDashboard}
-            className="flex items-center justify-center rounded p-1.5 text-gold/40 transition-all hover:bg-gold/10 hover:text-gold/70"
-            title="All Automations"
-          >
-            <LayoutDashboard className="h-3.5 w-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowSettings(!showSettings)}
-            className={cn(
-              "flex items-center justify-center rounded p-1.5 transition-all",
-              showSettings ? "bg-gold/20 text-gold" : "text-gold/40 hover:bg-gold/10 hover:text-gold/70",
-            )}
-            title="Settings"
-          >
-            {showSettings ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
-          </button>
-          <button
-            type="button"
-            onClick={handleStop}
-            className="flex items-center justify-center rounded p-1.5 text-red-400/70 transition-all hover:bg-red-500/10 hover:text-red-400"
-            title="Stop"
-          >
-            <Square className="h-3 w-3 fill-current" />
-          </button>
-        </div>
-      </div>
-
-      {/* Timing info row */}
-      <div className="flex items-center justify-between px-1 text-[10px] text-gold/40">
-        <span>Ran: {formatRelativeTime(entry.lastRunAt)}</span>
-        <span>Next: {formatRelativeTime(entry.nextRunAt)}</span>
-      </div>
-
-      {/* Expandable settings */}
-      {showSettings && (
-        <div className="flex flex-col gap-2 rounded-lg border border-gold/10 bg-black/40 p-2 animate-in slide-in-from-top-2 duration-200">
-          <SettingsPanel
-            scopeRadius={scopeRadius}
-            setScopeRadius={setScopeRadius}
-            strategyId={strategyId}
-            setStrategyId={setStrategyId}
-          />
-          <button
-            type="button"
-            onClick={handleSaveSettings}
-            disabled={!hasChanges}
-            className={cn(
-              "w-full rounded border px-3 py-1.5 text-xs font-medium transition",
-              hasChanges
-                ? "border-gold/30 bg-gold/10 text-gold/90 hover:bg-gold/20"
-                : "border-gold/10 bg-black/20 text-gold/30 cursor-not-allowed",
-            )}
-          >
-            {hasChanges ? "Save Changes" : "No Changes"}
-          </button>
-        </div>
-      )}
-    </div>
-  );
-};
-
-const SettingsPanel = ({
-  scopeRadius,
-  setScopeRadius,
-  strategyId,
-  setStrategyId,
-}: {
-  scopeRadius: number;
-  setScopeRadius: (v: number) => void;
-  strategyId: string;
-  setStrategyId: (v: string) => void;
-}) => (
-  <div className="flex flex-col gap-2">
-    <div className="flex items-center gap-2">
-      <span className="text-[10px] uppercase tracking-wider text-gold/40 w-16">Radius</span>
-      <NumberInput value={scopeRadius} onChange={setScopeRadius} min={1} className="h-7 text-xs flex-1" />
-    </div>
-    <div className="flex items-center gap-2">
-      <span className="text-[10px] uppercase tracking-wider text-gold/40 w-16">Strategy</span>
-      <Select value={strategyId} onValueChange={setStrategyId}>
-        <SelectTrigger className="h-7 text-xs flex-1">
-          <SelectValue placeholder="Select strategy" />
-        </SelectTrigger>
-        <SelectContent>
-          {EXPLORATION_STRATEGIES.map((strategy) => (
-            <SelectItem key={strategy.id} value={strategy.id}>
-              {strategy.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  </div>
-);
 
 const InlineStaminaBar = ({
   stamina,

--- a/client/apps/game/src/ui/features/world/components/entities/banner/structure-banner-entity-detail.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/banner/structure-banner-entity-detail.tsx
@@ -41,7 +41,6 @@ const StructureBannerEntityDetailContent = memo(
     structureEntityId,
     className,
     maxInventory = Infinity,
-    showButtons = false,
     compact = true,
     variant,
   }: StructureBannerEntityDetailContentProps) => {
@@ -111,7 +110,7 @@ const StructureBannerEntityDetailContent = memo(
         Number(rawCategory) as StructureType,
       ) &&
       typeof structure.entity_id !== "undefined";
-    const bodyTextClass = compact ? "text-xs" : "text-sm";
+    const inventoryLimit = compact && variant === "banner" ? Math.min(maxInventory, 10) : maxInventory;
     const labelTextClass = compact ? "text-xxs" : "text-xs";
     const headerTitleClass = compact ? "text-sm" : "text-base";
     const headerMetaClass = compact ? "text-xxs" : "text-xs";
@@ -120,10 +119,13 @@ const StructureBannerEntityDetailContent = memo(
     const showHyperstructureVP = isHyperstructure && hyperstructureRealmCount !== undefined;
 
     return (
-      <EntityDetailSection compact={compact} className={cn("flex h-full min-h-0 flex-col gap-2", className)}>
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-3 text-gold">
-            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full border border-gold/30 bg-black/40">
+      <EntityDetailSection
+        compact={compact}
+        className={cn("flex h-full min-h-0 flex-col gap-1.5 overflow-hidden", className)}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2 text-gold">
+            <div className="h-9 w-9 shrink-0 overflow-hidden rounded-full border border-gold/30 bg-black/40">
               {ownerAvatarUrl ? (
                 <img className="h-full w-full object-cover" src={ownerAvatarUrl} alt={`${ownerDisplayName} avatar`} />
               ) : (
@@ -159,9 +161,9 @@ const StructureBannerEntityDetailContent = memo(
           <ActiveRelicEffects relicEffects={relicEffects} entityId={structureEntityId} compact />
         )}
 
-        <Tabs variant="inventory" className="flex flex-1 flex-col gap-3">
-          <Tabs.Panels className="flex-1">
-            <Tabs.Panel className="flex flex-col gap-2">
+        <Tabs variant="inventory" className="flex min-h-0 flex-1 flex-col gap-2">
+          <Tabs.Panels className="flex-1 min-h-0">
+            <Tabs.Panel scrollable={false} className="flex h-full min-h-0 flex-col gap-1.5">
               {showHyperstructureVP && (
                 <HyperstructureVPDisplay
                   realmCount={hyperstructureRealmCount}
@@ -194,7 +196,7 @@ const StructureBannerEntityDetailContent = memo(
                       entityType={EntityType.STRUCTURE}
                       allowRelicActivation={isMine}
                       variant="tight"
-                      maxItems={maxInventory}
+                      maxItems={inventoryLimit}
                     />
                   ) : (
                     <p className="text-xxs text-gold/60 italic">No resources stored.</p>
@@ -204,7 +206,7 @@ const StructureBannerEntityDetailContent = memo(
             </Tabs.Panel>
 
             {showProductionTab && (
-              <Tabs.Panel className="flex flex-col gap-2 pt-4 pl-2">
+              <Tabs.Panel scrollable={false} className="flex h-full min-h-0 flex-col gap-1.5 pt-1">
                 {resources ? (
                   <StructureProductionPanel
                     structure={structure}
@@ -223,7 +225,7 @@ const StructureBannerEntityDetailContent = memo(
             )}
 
             {!showBalanceInline && (
-              <Tabs.Panel className="flex flex-col gap-2">
+              <Tabs.Panel scrollable={false} className="flex h-full min-h-0 flex-col gap-1.5">
                 {resources ? (
                   <CompactEntityInventory
                     resources={resources}
@@ -233,7 +235,7 @@ const StructureBannerEntityDetailContent = memo(
                     entityType={EntityType.STRUCTURE}
                     allowRelicActivation={isMine}
                     variant="tight"
-                    maxItems={maxInventory}
+                    maxItems={inventoryLimit}
                   />
                 ) : (
                   <p className="text-xxs text-gold/60 italic">No resources stored.</p>
@@ -243,16 +245,16 @@ const StructureBannerEntityDetailContent = memo(
           </Tabs.Panels>
 
           <Tabs.List className="mt-auto flex w-full items-center justify-between gap-2">
-            <Tabs.Tab className="!mx-0 flex flex-1 items-center justify-center rounded-lg border border-gold/30 bg-dark/40 px-3 py-2 text-center transition hover:bg-dark/60">
+            <Tabs.Tab className="!mx-0 flex min-h-11 flex-1 items-center justify-center rounded-lg border border-gold/30 bg-dark/40 px-3 text-center transition hover:bg-dark/60">
               <Shield className="h-4 w-4 text-gold" />
             </Tabs.Tab>
             {showProductionTab && (
-              <Tabs.Tab className="!mx-0 flex flex-1 items-center justify-center rounded-lg border border-gold/30 bg-dark/40 px-3 py-2 text-center transition hover:bg-dark/60">
+              <Tabs.Tab className="!mx-0 flex min-h-11 flex-1 items-center justify-center rounded-lg border border-gold/30 bg-dark/40 px-3 text-center transition hover:bg-dark/60">
                 <Factory className="h-4 w-4 text-gold" />
               </Tabs.Tab>
             )}
             {!showBalanceInline && (
-              <Tabs.Tab className="!mx-0 flex flex-1 items-center justify-center rounded-lg border border-gold/30 bg-dark/40 px-3 py-2 text-center transition hover:bg-dark/60">
+              <Tabs.Tab className="!mx-0 flex min-h-11 flex-1 items-center justify-center rounded-lg border border-gold/30 bg-dark/40 px-3 text-center transition hover:bg-dark/60">
                 <Coins className="h-4 w-4 text-gold" />
               </Tabs.Tab>
             )}


### PR DESCRIPTION
This updates the actual world bottom-right panel flow to fit laptop viewport heights without internal scrolling in the required tile-detail states (local structure, world structure, world army, and world biome). It rebalances panel height/width, compacts world entity detail layouts, and keeps tab controls touch-safe at 44px+. It also adds static before/after mockups at client/apps/game/public/mockups/bottom-right-panel-laptop/ and generated screenshot artifacts under .context/panel-screenshots/ for 1280x720, 1366x768, and 1536x864. Validation run: targeted eslint and tsc --noEmit passed; pnpm --dir client/apps/game test currently fails in this environment with upstream ERR_REQUIRE_ESM (html-encoding-sniffer/@exodus/bytes).