### PR TITLE
docs(game): add critical git rules for parallel agents

### DIFF
--- a/client/apps/game/AGENTS.md
+++ b/client/apps/game/AGENTS.md
@@ -41,3 +41,50 @@ export const latestFeatures = [
 - Write the description from the user's perspective, focusing on the benefit
 - Use present tense ("Added", "Improved", "Fixed")
 - New entries go at the top of the array (most recent first)
+
+## CRITICAL Git Rules for Parallel Agents CRITICAL
+
+Multiple agents may work on different files in the same worktree simultaneously. You MUST follow these rules:
+
+### Committing
+
+ONLY commit files YOU changed in THIS session
+ALWAYS include fixes #<number> or closes #<number> in the commit message when there is a related issue or PR
+NEVER use git add -A or git add . - these sweep up changes from other agents
+ALWAYS use git add <specific-file-paths> listing only files you modified
+Before committing, run git status and verify you are only staging YOUR files
+Track which files you created/modified/deleted during the session
+
+### Forbidden Git Operations
+
+These commands can destroy other agents' work:
+
+git reset --hard - destroys uncommitted changes
+git checkout . - destroys uncommitted changes
+git clean -fd - deletes untracked files
+git stash - stashes ALL changes including other agents' work
+git add -A / git add . - stages other agents' uncommitted work
+git commit --no-verify - bypasses required checks and is never allowed
+
+### Safe Workflow
+
+```bash
+# 1. Check status first
+git status
+
+# 2. Add ONLY your specific files
+git add packages/ai/src/providers/transform-messages.ts
+git add packages/ai/CHANGELOG.md
+
+# 3. Commit
+git commit -m "fix(ai): description"
+
+# 4. Push (pull --rebase if needed, but NEVER reset/checkout)
+git pull --rebase && git push
+```
+
+### If Rebase Conflicts Occur
+
+Resolve conflicts in YOUR files only
+If conflict is in a file you didn't modify, abort and ask the user
+NEVER force push


### PR DESCRIPTION
Adds a critical section to the game client AGENTS.md with required git rules for parallel agent workflows.\n\nThe update documents safe commit/staging practices, forbidden destructive operations, a safe push workflow, and conflict-handling guidance.