### PR TITLE
feat: Add Bloberts NFT collection to marketplace

### DIFF
--- a/client/apps/landing/src/config.ts
+++ b/client/apps/landing/src/config.ts
@@ -26,6 +26,7 @@ const COLLECTION_IDS = {
     "golden-tokens": 5,
     beasts: 7,
     adventurers: 8,
+    bloberts: null, // TODO: Register in marketplace contract to get collection ID
   },
   sepolia: {
     realms: 4,
@@ -34,6 +35,7 @@ const COLLECTION_IDS = {
     "golden-tokens": null,
     beasts: null,
     adventurers: null,
+    bloberts: null,
   },
 } as const;
 
@@ -84,6 +86,13 @@ export const marketplaceCollections = {
     defaultTraitFilters: {
       "Minted By": ["0xa67ef20b61a9846e1c82b411175e6ab167ea9f8632bd6c2091823c3629ec42"],
     },
+  },
+  bloberts: {
+    address: currentNetwork === "mainnet" ? "0x00539f522b29ae9251dbf7443c7a950cf260372e69efab3710a11bf17a9599f1" : "",
+    id: COLLECTION_IDS[currentNetwork].bloberts,
+    name: "Bloberts",
+    image: "/collections/bloberts.png",
+    defaultTraitFilters: {},
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Adds the **Bloberts** NFT collection to the empire.realms.world/trade marketplace.

**Contract address:** `0x00539f522b29ae9251dbf7443c7a950cf260372e69efab3710a11bf17a9599f1`

**Source code:** [BibliothecaDAO/codename-bobby-realms](https://github.com/BibliothecaDAO/codename-bobby-realms)

## Changes

- Added `bloberts` entry to `marketplaceCollections` in `client/apps/landing/src/config.ts`
- Added collection ID slots (currently `null` — needs marketplace contract registration)

## TODO before merge

- [ ] Register Bloberts in the marketplace contract to get a collection ID
- [ ] Add `bloberts.png` to the `/collections/` static assets