### PR TITLE
Use UI store playerStructures in game hooks

### DIFF
--- a/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
+++ b/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
@@ -4,11 +4,12 @@ import { getStructuresDataFromTorii } from "@/dojo/queries";
 import { syncEntitiesDebounced } from "@/dojo/sync";
 import { sqlApi } from "@/services/api";
 import { padHexAddressTo66 } from "@/ui/utils/utils";
-import { useDojo, usePlayerStructures } from "@bibliothecadao/react";
+import { useDojo } from "@bibliothecadao/react";
 import { MemberClause } from "@dojoengine/sdk";
 import type { PatternMatching } from "@dojoengine/torii-client";
 import type { Clause } from "@dojoengine/torii-wasm/types";
 import { useAccountStore } from "../store/use-account-store";
+import { useUIStore } from "../store/use-ui-store";
 import { selectUnsyncedOwnedStructureTargets } from "./player-structure-sync-utils";
 
 // Models synced per-player via a scoped subscription (see usePlayerStructureSync)
@@ -27,7 +28,7 @@ export const usePlayerStructureSync = () => {
     setup,
   } = useDojo();
 
-  const playerStructures = usePlayerStructures();
+  const playerStructures = useUIStore((state) => state.playerStructures);
 
   const subscriptionRef = useRef<{ cancel: () => void } | null>(null);
   const syncedStructureIds = useRef<Set<number>>(new Set());

--- a/client/apps/game/src/ui/layouts/game-loading-overlay.tsx
+++ b/client/apps/game/src/ui/layouts/game-loading-overlay.tsx
@@ -1,7 +1,6 @@
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { LoadingStateKey } from "@/hooks/store/use-world-loading";
 import { Position } from "@bibliothecadao/eternum";
-import { usePlayerStructures } from "@bibliothecadao/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BootstrapTask } from "@/hooks/context/use-eager-bootstrap";
 import { BootstrapLoadingPanel } from "@/ui/layouts/bootstrap-loading/bootstrap-loading-panel";
@@ -38,7 +37,7 @@ export const GameLoadingOverlay = () => {
   const setShowBlankOverlay = useUIStore((state) => state.setShowBlankOverlay);
   const isSpectating = useUIStore((state) => state.isSpectating);
   const mapLoading = useUIStore((state) => state.loadingStates[LoadingStateKey.Map]);
-  const playerStructures = usePlayerStructures();
+  const playerStructures = useUIStore((state) => state.playerStructures);
   const hasDismissed = useRef(false);
   const hasSeenMapLoading = useRef(false);
   const startedAt = useRef(0);


### PR DESCRIPTION
This updates game-side consumers to read playerStructures from useUIStore instead of usePlayerStructures(). GameLoadingOverlay and usePlayerStructureSync now subscribe to the shared UI store value. The store-population path in PlayerStructuresStoreManager remains unchanged.