### PR TITLE
Fix army bonus ordering and military tab default

### DIFF
--- a/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
@@ -71,19 +71,17 @@ interface BiomeSummaryCardProps {
 export const BiomeSummaryCard = ({ biome, onSimulateBattle, showSimulateAction = false }: BiomeSummaryCardProps) => {
   const troopBonuses = useMemo(
     () =>
-      unoccupiedTileTroopTypes
-        .map((troopType) => {
-          const config = unoccupiedTileTroopConfig[troopType];
-          const bonus = configManager.getBiomeCombatBonus(troopType, biome);
-          const styles = getQuadrantBonusStyles(bonus);
-          return {
-            troopType,
-            config,
-            bonus,
-            styles,
-          };
-        })
-        .toSorted((a, b) => a.bonus - b.bonus),
+      unoccupiedTileTroopTypes.map((troopType) => {
+        const config = unoccupiedTileTroopConfig[troopType];
+        const bonus = configManager.getBiomeCombatBonus(troopType, biome);
+        const styles = getQuadrantBonusStyles(bonus);
+        return {
+          troopType,
+          config,
+          bonus,
+          styles,
+        };
+      }),
     [biome],
   );
 


### PR DESCRIPTION
This PR keeps the bottom-right army bonus list in a fixed troop order instead of reordering by bonus. It also resets the military construction army-type tab when switching realms so the default always selects the army type with the best biome bonus on that tile, with safe fallbacks when needed. Ran pnpm run format before creating this PR.