### PR TITLE
Force controller session refresh on game selection

### DIFF
--- a/client/apps/game/src/hooks/context/policies.test.ts
+++ b/client/apps/game/src/hooks/context/policies.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("policies dynamic world tokens", () => {
+  it("derives active-world token addresses inside buildPolicies instead of module scope", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/hooks/context/policies.ts"), "utf8");
+    const buildPoliciesStart = source.indexOf("export const buildPolicies");
+
+    expect(buildPoliciesStart).toBeGreaterThan(-1);
+
+    const moduleScope = source.slice(0, buildPoliciesStart);
+    const buildPoliciesBlock = source.slice(buildPoliciesStart, buildPoliciesStart + 1500);
+
+    expect(moduleScope).not.toContain("const activeWorld = getActiveWorld()");
+    expect(moduleScope).not.toContain("const entryTokenAddress");
+    expect(moduleScope).not.toContain("const feeTokenAddress");
+
+    expect(buildPoliciesBlock).toContain("const activeWorld = getActiveWorld()");
+    expect(buildPoliciesBlock).toContain("const entryTokenAddress");
+    expect(buildPoliciesBlock).toContain("const feeTokenAddress");
+  });
+});

--- a/client/apps/game/src/hooks/context/policies.ts
+++ b/client/apps/game/src/hooks/context/policies.ts
@@ -2,44 +2,45 @@ import { getActiveWorld } from "@/runtime/world";
 import { getSeasonPassAddress, getVillagePassAddress } from "@/utils/addresses";
 import { toSessionPolicies } from "@cartridge/controller";
 import { getContractByName } from "@dojoengine/core";
-import { dojoConfig } from "../../../dojo-config";
 import { env } from "../../../env";
 import { messages } from "./signing-policy";
 
-// Get entry token address from active world profile, fallback to env var
-const activeWorld = getActiveWorld();
-const entryTokenAddress = activeWorld?.entryTokenAddress || env.VITE_PUBLIC_ENTRY_TOKEN_ADDRESS;
-const feeTokenAddress = activeWorld?.feeTokenAddress || env.VITE_PUBLIC_FEE_TOKEN_ADDRESS;
+type ManifestLike = Record<string, unknown>;
 
-const entryTokenPolicies =
-  entryTokenAddress && entryTokenAddress !== "0x0"
+export const buildPolicies = (manifest: ManifestLike) => {
+  // Resolve world-specific tokens at call-time so policies follow the selected game without reload.
+  const activeWorld = getActiveWorld();
+  const entryTokenAddress = activeWorld?.entryTokenAddress || env.VITE_PUBLIC_ENTRY_TOKEN_ADDRESS;
+  const feeTokenAddress = activeWorld?.feeTokenAddress || env.VITE_PUBLIC_FEE_TOKEN_ADDRESS;
+
+  const entryTokenPolicies =
+    entryTokenAddress && entryTokenAddress !== "0x0"
+      ? {
+          [entryTokenAddress]: {
+            methods: [
+              {
+                name: "token_lock",
+                entrypoint: "token_lock",
+              },
+            ],
+          },
+        }
+      : {};
+
+  const feeTokenPolicies = feeTokenAddress
     ? {
-        [entryTokenAddress]: {
+        [feeTokenAddress]: {
           methods: [
             {
-              name: "token_lock",
-              entrypoint: "token_lock",
+              name: "approve",
+              entrypoint: "approve",
             },
           ],
         },
       }
     : {};
 
-const feeTokenPolicies = feeTokenAddress
-  ? {
-      [feeTokenAddress]: {
-        methods: [
-          {
-            name: "approve",
-            entrypoint: "approve",
-          },
-        ],
-      },
-    }
-  : {};
-
-export const buildPolicies = (manifest: any) =>
-  toSessionPolicies({
+  return toSessionPolicies({
     contracts: {
       ...entryTokenPolicies,
       ...feeTokenPolicies,
@@ -399,7 +400,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "realm_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "realm_systems").address]: {
         methods: [
           {
             name: "create",
@@ -415,7 +416,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "resource_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "resource_systems").address]: {
         methods: [
           {
             name: "deposit",
@@ -435,7 +436,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "resource_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "resource_systems").address]: {
         methods: [
           {
             name: "approve",
@@ -483,7 +484,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "relic_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "relic_systems").address]: {
         methods: [
           {
             name: "open_chest",
@@ -503,7 +504,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "season_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "season_systems").address]: {
         methods: [
           {
             name: "register_to_leaderboard",
@@ -523,7 +524,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "structure_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "structure_systems").address]: {
         methods: [
           {
             name: "level_up",
@@ -539,7 +540,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "swap_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "swap_systems").address]: {
         methods: [
           {
             name: "buy",
@@ -559,7 +560,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "trade_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "trade_systems").address]: {
         methods: [
           {
             name: "create_order",
@@ -583,7 +584,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "troop_battle_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "troop_battle_systems").address]: {
         methods: [
           {
             name: "attack_explorer_vs_explorer",
@@ -607,7 +608,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "troop_management_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "troop_management_systems").address]: {
         methods: [
           {
             name: "guard_add",
@@ -651,7 +652,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "troop_movement_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "troop_movement_systems").address]: {
         methods: [
           {
             name: "explorer_move",
@@ -672,7 +673,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "troop_movement_util_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "troop_movement_util_systems").address]: {
         methods: [
           {
             name: "dojo_name",
@@ -684,7 +685,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "troop_raid_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "troop_raid_systems").address]: {
         methods: [
           {
             name: "raid_explorer_vs_guard",
@@ -700,7 +701,7 @@ export const buildPolicies = (manifest: any) =>
           },
         ],
       },
-      [getContractByName(dojoConfig.manifest, "s1_eternum", "village_systems").address]: {
+      [getContractByName(manifest, "s1_eternum", "village_systems").address]: {
         methods: [
           {
             name: "upgrade",
@@ -748,3 +749,4 @@ export const buildPolicies = (manifest: any) =>
     },
     messages,
   });
+};

--- a/client/apps/game/src/runtime/world/store.ts
+++ b/client/apps/game/src/runtime/world/store.ts
@@ -4,6 +4,7 @@ import { WorldProfile, WorldProfilesMap } from "./types";
 const ACTIVE_KEY = "ACTIVE_WORLD_NAME";
 const CHAIN_KEY = "ACTIVE_WORLD_CHAIN";
 const PROFILES_KEY = "WORLD_PROFILES";
+export const WORLD_SELECTION_CHANGED_EVENT = "eternum:world-selection-changed";
 
 const safeParse = <T>(raw: string | null, fallback: T): T => {
   if (!raw) return fallback;
@@ -43,6 +44,11 @@ const writeStorageValue = (key: string, value: string | null) => {
   }
 };
 
+const emitWorldSelectionChanged = () => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(WORLD_SELECTION_CHANGED_EVENT));
+};
+
 export const getSelectedChain = (): Chain | null => {
   const stored = readStorageValue(CHAIN_KEY);
   return isValidChain(stored) ? stored : null;
@@ -50,10 +56,7 @@ export const getSelectedChain = (): Chain | null => {
 
 export const setSelectedChain = (chain: Chain) => {
   writeStorageValue(CHAIN_KEY, chain);
-};
-
-const clearSelectedChain = () => {
-  writeStorageValue(CHAIN_KEY, null);
+  emitWorldSelectionChanged();
 };
 
 export const resolveChain = (fallback: Chain): Chain => getSelectedChain() ?? fallback;
@@ -77,16 +80,6 @@ export const saveWorldProfile = (profile: WorldProfile) => {
   saveWorldProfiles(profiles);
 };
 
-const deleteWorldProfile = (name: string) => {
-  const profiles = getWorldProfiles();
-  if (profiles[name]) {
-    delete profiles[name];
-    saveWorldProfiles(profiles);
-  }
-  const active = getActiveWorldName();
-  if (active === name) clearActiveWorld();
-};
-
 const getWorldProfile = (name: string): WorldProfile | null => {
   const profiles = getWorldProfiles();
   return profiles[name] ?? null;
@@ -94,9 +87,10 @@ const getWorldProfile = (name: string): WorldProfile | null => {
 
 export const getActiveWorldName = (): string | null => localStorage.getItem(ACTIVE_KEY);
 
-export const setActiveWorldName = (name: string) => localStorage.setItem(ACTIVE_KEY, name);
-
-const clearActiveWorld = () => localStorage.removeItem(ACTIVE_KEY);
+export const setActiveWorldName = (name: string) => {
+  localStorage.setItem(ACTIVE_KEY, name);
+  emitWorldSelectionChanged();
+};
 
 export const getActiveWorld = (): WorldProfile | null => {
   const name = getActiveWorldName();


### PR DESCRIPTION
This PR fixes controller auth/session behavior when selecting games from landing without requiring a page refresh. It rebuilds Starknet Controller connector config when world selection changes and emits a world-selection event from runtime world storage so provider state refreshes immediately. It also moves token policy resolution into buildPolicies so active-world token addresses are resolved at call time instead of being cached at module load, and uses the passed manifest consistently for contract lookup. A guard test was added to ensure active-world token policy derivation remains inside buildPolicies.