### PR TITLE
Add forge actions to Learn practice games

### DIFF
--- a/client/apps/game/src/ui/features/landing/views/play-view.live-dev-games.test.ts
+++ b/client/apps/game/src/ui/features/landing/views/play-view.live-dev-games.test.ts
@@ -15,6 +15,17 @@ describe("PlayView live games dev visibility", () => {
     expect(ongoingBlock).toContain("onForgeHyperstructures={onForgeHyperstructures}");
   });
 
+  it("wires forge callback in learn tab practice games", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/play-view.tsx"), "utf8");
+    const practiceStart = source.indexOf("{/* Row 2: Practice Games (full width) */}");
+    const footerCommentStart = source.indexOf("/**\n * Get icon and color for feature type");
+    const practiceBlock = source.slice(practiceStart, footerCommentStart);
+
+    expect(practiceStart).toBeGreaterThan(-1);
+    expect(footerCommentStart).toBeGreaterThan(practiceStart);
+    expect(practiceBlock).toContain("onForgeHyperstructures={onForgeHyperstructures}");
+  });
+
   it("does not hard-filter the live ongoing grid to production only", () => {
     const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/play-view.tsx"), "utf8");
     const liveStart = source.indexOf("{/* Live Games Column */}");

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -89,10 +89,12 @@ const WRITTEN_GUIDES = [
 const LearnContent = ({
   onSelectGame,
   onSpectate,
+  onForgeHyperstructures,
   onRegistrationComplete,
 }: {
   onSelectGame: (selection: WorldSelection) => void;
   onSpectate: (selection: WorldSelection) => void;
+  onForgeHyperstructures: (selection: WorldSelection, numHyperstructuresLeft: number) => Promise<void> | void;
   onRegistrationComplete: () => void;
 }) => (
   <div className="flex flex-col gap-4">
@@ -184,6 +186,7 @@ const LearnContent = ({
       <UnifiedGameGrid
         onSelectGame={onSelectGame}
         onSpectate={onSpectate}
+        onForgeHyperstructures={onForgeHyperstructures}
         onRegistrationComplete={onRegistrationComplete}
         devModeFilter={true}
         hideHeader
@@ -523,6 +526,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
           <LearnContent
             onSelectGame={handleSelectGame}
             onSpectate={handleSpectate}
+            onForgeHyperstructures={handleForgeHyperstructures}
             onRegistrationComplete={handleRegistrationComplete}
           />
         );


### PR DESCRIPTION
## Summary
- Wire onForgeHyperstructures through Learn tab Practice Games.
- Reuse existing handleForgeHyperstructures from PlayView.
- Add a regression test to assert Learn practice games pass the forge callback.

## Testing
- pnpm run format
- pnpm test -- src/ui/features/landing/views/play-view.live-dev-games.test.ts
