### PR TITLE
Fix missing unit meshes after async model load

### DIFF
--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -260,6 +260,8 @@ export class ArmyModel {
 
       this.updateInstance(entityId, instance.matrixIndex, position, scale, rotation, color);
     });
+
+    this.syncModelDrawCount(modelData);
   }
 
   private reapplyInstancesForModel(modelType: ModelType, modelData: ModelData): void {
@@ -281,6 +283,22 @@ export class ArmyModel {
 
       this.updateInstance(entityId, instance.matrixIndex, position, scale, rotation, color);
     });
+
+    this.syncModelDrawCount(modelData);
+  }
+
+  /**
+   * Keep draw counts in sync after async model load replays instance state.
+   * Without this, meshes can stay hidden until the next explicit visibility sync.
+   */
+  private syncModelDrawCount(modelData: ModelData): void {
+    const drawCount = this.getModelDrawCount(modelData);
+    modelData.instancedMeshes.forEach((mesh) => {
+      mesh.count = drawCount;
+    });
+    if (modelData.contactShadowMesh) {
+      modelData.contactShadowMesh.count = drawCount;
+    }
   }
 
   private createModelData(gltf: any): ModelData {

--- a/client/apps/game/src/three/managers/army-model.visibility.test.ts
+++ b/client/apps/game/src/three/managers/army-model.visibility.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AnimationClip,
+  AnimationMixer,
+  BoxGeometry,
+  Group,
+  InstancedMesh,
+  Mesh,
+  MeshBasicMaterial,
+  Scene,
+  Vector3,
+} from "three";
+import { ModelType } from "@/three/types/army";
+import { ArmyModel } from "./army-model";
+
+describe("ArmyModel visibility after async model load", () => {
+  it("restores draw count when a model finishes loading after visible slots were already resolved", () => {
+    const subject = new ArmyModel(new Scene());
+
+    const entityId = 42;
+    const slot = subject.allocateInstanceSlot(entityId);
+    (subject as any).entityModelMap.set(entityId, ModelType.Knight1);
+
+    subject.updateInstance(entityId, slot, new Vector3(1, 0, 1), new Vector3(1, 1, 1));
+    subject.setVisibleSlots([slot]);
+
+    const geometry = new BoxGeometry(1, 1, 1);
+    const material = new MeshBasicMaterial();
+    const mesh = new InstancedMesh(geometry, material, 1);
+    mesh.count = 0;
+
+    const modelData = {
+      group: new Group(),
+      instancedMeshes: [mesh],
+      baseMeshes: [new Mesh(geometry, material)],
+      mixer: new AnimationMixer(new Group()),
+      animations: {
+        idle: new AnimationClip("idle", 1, []),
+        moving: new AnimationClip("moving", 1, []),
+      },
+      animationActions: new Map(),
+      activeInstances: new Set<number>(),
+      lastAnimationUpdate: 0,
+      animationUpdateInterval: 50,
+      contactShadowMesh: null,
+      contactShadowScale: 1,
+    };
+
+    (subject as any).models.set(ModelType.Knight1, modelData);
+    (subject as any).reapplyInstancesForModel(ModelType.Knight1, modelData);
+
+    expect(modelData.activeInstances.has(slot)).toBe(true);
+    expect(mesh.count).toBe(1);
+  });
+});


### PR DESCRIPTION
This PR fixes a rendering race where army models could stay invisible if the model finished loading after visibility slots were already resolved. It now syncs per-model draw counts immediately after replaying instances in both base-model and cosmetic reapply paths. It also adds a regression test that reproduces the async load ordering and asserts the mesh draw count is restored. This addresses the spectator-path symptom where labels were visible while unit meshes were not.