### PR TITLE
fix: skip stamina requirement when claiming unguarded structures

### DIFF
--- a/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
+++ b/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
@@ -236,14 +236,14 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
 
   const hasDefenders = !!targetArmyData;
   const attackDisabled =
-    attackerOnCooldown || (hasDefenders && attackerStamina < combatConfig.stamina_attack_req) || !attackerArmyData;
+    (hasDefenders && (attackerOnCooldown || attackerStamina < combatConfig.stamina_attack_req)) || !attackerArmyData;
 
   const attackButtonLabel = (() => {
-    if (attackerOnCooldown) return "On cooldown";
-    if (hasDefenders && attackerStamina < combatConfig.stamina_attack_req)
-      return `Need ${combatConfig.stamina_attack_req} stamina`;
     if (!attackerArmyData) return "No troops selected";
-    return hasDefenders ? "Attack" : "Claim";
+    if (!hasDefenders) return "Claim";
+    if (attackerOnCooldown) return "On cooldown";
+    if (attackerStamina < combatConfig.stamina_attack_req) return `Need ${combatConfig.stamina_attack_req} stamina`;
+    return "Attack";
   })();
 
   const outcomeLabel = (() => {

--- a/client/apps/onchain-agent/data/soul.md
+++ b/client/apps/onchain-agent/data/soul.md
@@ -7,7 +7,8 @@ last_modified: tick-0
 
 ## Identity
 
-I am an autonomous agent playing Eternum, an onchain strategy game on StarkNet. I observe the world state each tick, reason about my position, and execute actions through the game's contract system.
+I am an autonomous agent playing Eternum, an onchain strategy game on StarkNet. I observe the world state each tick,
+reason about my position, and execute actions through the game's contract system.
 
 ## Personality Traits
 
@@ -19,9 +20,12 @@ I am an autonomous agent playing Eternum, an onchain strategy game on StarkNet. 
 
 ## Game Context
 
-Eternum is a hex-grid strategy game. Everything is an entity with a unique ID. I own structures (Realms, Villages, Mines) and armies (Explorers). I produce resources, build buildings, train troops, and fight other players. Points determine rank. The leaderboard is the scoreboard. See `tasks/game.md` for full rules and mechanics.
+Eternum is a hex-grid strategy game. Everything is an entity with a unique ID. I own structures (Realms, Villages,
+Mines) and armies (Explorers). I produce resources, build buildings, train troops, and fight other players. Points
+determine rank. The leaderboard is the scoreboard. See `tasks/game.md` for full rules and mechanics.
 
 ### Tools
+
 - `inspect_realm` / `inspect_explorer` / `inspect_market` — detailed entity queries
 - `execute_action` — submit onchain actions (build, move, attack, trade, etc.)
 - `list_actions` — catalog of all available action types and their parameters
@@ -29,16 +33,22 @@ Eternum is a hex-grid strategy game. Everything is an entity with a unique ID. I
 - `read` / `write` — read and update my data files (soul, tasks, heartbeat)
 
 ### Data Files
-All files below live in the data directory and persist across ticks. Use the `read` and `write` tools with these relative paths. These are your files — read them for reference, write to them to record what you learn.
 
-You may modify any `tasks/*` file. When writing to a file, always `read` it first and modify the existing content — never blindly overwrite. Preserve the YAML frontmatter block exactly as-is (the `---` delimited block at the top). Frontmatter must be plain YAML — no code comments, no markdown, no extra formatting.
+All files below live in the data directory and persist across ticks. Use the `read` and `write` tools with these
+relative paths. These are your files — read them for reference, write to them to record what you learn.
+
+You may modify any `tasks/*` file. When writing to a file, always `read` it first and modify the existing content —
+never blindly overwrite. Preserve the YAML frontmatter block exactly as-is (the `---` delimited block at the top).
+Frontmatter must be plain YAML — no code comments, no markdown, no extra formatting.
 
 **Auto-loaded each tick** (always in your context):
+
 - `soul.md` — this file; your identity and personality (do not modify unless absolutely necessary)
 - `tasks/priorities.md` — VP scoring system and current goals
 - `tasks/learnings.md` — your accumulated knowledge; write discoveries, opponent intel, and session events here
 
 **Reference handbooks** (use `read` to load when needed):
+
 - `tasks/game.md` — game rules and mechanics
 - `tasks/economy.md` — resource IDs, building types, costs, production chains
 - `tasks/exploration.md` — movement types, stamina costs, hex grid
@@ -46,10 +56,16 @@ You may modify any `tasks/*` file. When writing to a file, always `read` it firs
 - `HEARTBEAT.md` — cron jobs for automated periodic checks
 
 ### Reference Actions
+
 Use `list_actions` to see all available actions with their parameters. Key action groups:
-- **Economy**: `create_building`, `destroy_building`, `pause_production`, `resume_production`, `send_resources`, `pickup_resources`, `claim_arrivals`
-- **Movement**: `travel_explorer` (multi-hex, explored tiles), `explore` (single hex, new tiles), `move_explorer` (wrapper for both)
+
+- **Economy**: `create_building`, `destroy_building`, `pause_production`, `resume_production`, `send_resources`,
+  `pickup_resources`, `claim_arrivals`
+- **Movement**: `travel_explorer` (multi-hex, explored tiles), `explore` (single hex, new tiles), `move_explorer`
+  (wrapper for both)
 - **Combat**: `attack_explorer`, `attack_guard`, `guard_attack_explorer`, `raid`
-- **Troops**: `create_explorer`, `add_to_explorer`, `delete_explorer`, `add_guard`, `delete_guard`, `swap_explorer_to_guard`, `swap_guard_to_explorer`, `swap_explorer_to_explorer`
+- **Troops**: `create_explorer`, `add_to_explorer`, `delete_explorer`, `add_guard`, `delete_guard`,
+  `swap_explorer_to_guard`, `swap_guard_to_explorer`, `swap_explorer_to_explorer`
 - **Trade**: `create_order`, `accept_order`, `cancel_order`, `buy_resources`, `sell_resources`
-- **Other**: `upgrade_realm`, `contribute_hyperstructure`, `add_liquidity`, `remove_liquidity`, `create_guild`, `join_guild`
+- **Other**: `upgrade_realm`, `contribute_hyperstructure`, `add_liquidity`, `remove_liquidity`, `create_guild`,
+  `join_guild`

--- a/client/apps/onchain-agent/data/tasks/combat.md
+++ b/client/apps/onchain-agent/data/tasks/combat.md
@@ -8,11 +8,11 @@ autoload: false
 
 ## Troop Types
 
-| Category | T1 (Resource ID) | T2 (Resource ID) | T3 (Resource ID) |
-|----------|-------------------|-------------------|-------------------|
-| Knight | 26 | 27 | 28 |
-| Crossbowman | 29 | 30 | 31 |
-| Paladin | 32 | 33 | 34 |
+| Category    | T1 (Resource ID) | T2 (Resource ID) | T3 (Resource ID) |
+| ----------- | ---------------- | ---------------- | ---------------- |
+| Knight      | 26               | 27               | 28               |
+| Crossbowman | 29               | 30               | 31               |
+| Paladin     | 32               | 33               | 34               |
 
 - All T1 troops = 1 strength per unit
 - Production: 5 troops/tick per military building
@@ -22,19 +22,20 @@ autoload: false
 ## Army (Explorer) Management
 
 - **Create**: `create_explorer` — spawns army from structure's troop reserves
-  - Params: `forStructureId`, `category` (0=Knight, 1=Paladin, 2=Crossbow), `tier` (0=T1, 1=T2, 2=T3), `amount`, `spawnDirection`
+  - Params: `forStructureId`, `category` (0=Knight, 1=Paladin, 2=Crossbow), `tier` (0=T1, 1=T2, 2=T3), `amount`,
+    `spawnDirection`
 - **Reinforce**: `add_to_explorer` — add troops to existing army (must be adjacent to home structure)
 - **Disband**: `delete_explorer` — return troops to structure instantly
 - **Army limit**: Each structure has a max army count (check "Armies: X/Y" in inspect output)
 
 ## Combat Actions
 
-| Action | What It Does | Stamina Cost |
-|--------|-------------|-------------|
-| `attack_explorer` | Army vs army (field battle) | 50 attacker, 40 defender |
-| `attack_guard` | Army vs structure's guards (capture) | Varies |
-| `guard_attack_explorer` | Structure guards attack nearby army | Varies |
-| `raid` | Steal resources without destroying guards | Varies |
+| Action                  | What It Does                              | Stamina Cost             |
+| ----------------------- | ----------------------------------------- | ------------------------ |
+| `attack_explorer`       | Army vs army (field battle)               | 50 attacker, 40 defender |
+| `attack_guard`          | Army vs structure's guards (capture)      | Varies                   |
+| `guard_attack_explorer` | Structure guards attack nearby army       | Varies                   |
+| `raid`                  | Steal resources without destroying guards | Varies                   |
 
 - Combat resolution is instant (onchain)
 - Higher total strength wins

--- a/client/apps/onchain-agent/data/tasks/economy.md
+++ b/client/apps/onchain-agent/data/tasks/economy.md
@@ -10,21 +10,21 @@ autoload: false
 
 All resource types and their onchain IDs. Use these IDs with `send_resources`, `buy_resources`, `sell_resources`, etc.
 
-| ID | Resource | ID | Resource | ID | Resource |
-|----|----------|----|----------|----|----------|
-| 1 | Stone | 14 | Diamonds | 27 | Knight T2 |
-| 2 | Coal | 15 | Hartwood | 28 | Knight T3 |
-| 3 | Wood | 16 | Ignium | 29 | Crossbowman |
-| 4 | Copper | 17 | TwilightQuartz | 30 | Crossbowman T2 |
-| 5 | Ironwood | 18 | TrueIce | 31 | Crossbowman T3 |
-| 6 | Obsidian | 19 | Adamantine | 32 | Paladin |
-| 7 | Gold | 20 | Sapphire | 33 | Paladin T2 |
-| 8 | Silver | 21 | EtherealSilica | 34 | Paladin T3 |
-| 9 | Mithral | 22 | Dragonhide | 35 | Wheat |
-| 10 | AlchemicalSilver | 23 | Labor | 36 | Fish |
-| 11 | ColdIron | 24 | AncientFragment | 37 | Lords |
-| 12 | DeepCrystal | 25 | Donkey | 38 | Essence |
-| 13 | Ruby | 26 | Knight | | |
+| ID  | Resource         | ID  | Resource        | ID  | Resource       |
+| --- | ---------------- | --- | --------------- | --- | -------------- |
+| 1   | Stone            | 14  | Diamonds        | 27  | Knight T2      |
+| 2   | Coal             | 15  | Hartwood        | 28  | Knight T3      |
+| 3   | Wood             | 16  | Ignium          | 29  | Crossbowman    |
+| 4   | Copper           | 17  | TwilightQuartz  | 30  | Crossbowman T2 |
+| 5   | Ironwood         | 18  | TrueIce         | 31  | Crossbowman T3 |
+| 6   | Obsidian         | 19  | Adamantine      | 32  | Paladin        |
+| 7   | Gold             | 20  | Sapphire        | 33  | Paladin T2     |
+| 8   | Silver           | 21  | EtherealSilica  | 34  | Paladin T3     |
+| 9   | Mithral          | 22  | Dragonhide      | 35  | Wheat          |
+| 10  | AlchemicalSilver | 23  | Labor           | 36  | Fish           |
+| 11  | ColdIron         | 24  | AncientFragment | 37  | Lords          |
+| 12  | DeepCrystal      | 25  | Donkey          | 38  | Essence        |
+| 13  | Ruby             | 26  | Knight          |     |                |
 
 Note: Building type IDs (used with `create_building`) are different from resource IDs. See Building sections below.
 
@@ -41,49 +41,50 @@ Basic (Wood, Coal, Copper)
 
 ### Basic Resource Buildings
 
-| Building | Type ID | Labor-Only Cost | Resource Cost |
-|----------|---------|----------------|---------------|
-| Wood Mill | 5 | 30 Labor | 30 Labor |
-| Coal Mine | 4 | 90 Labor | 30 Labor, 30 Wood |
-| Copper Smelter | 6 | 300 Labor | 60 Labor, 60 Wood, 30 Coal |
+| Building       | Type ID | Labor-Only Cost | Resource Cost              |
+| -------------- | ------- | --------------- | -------------------------- |
+| Wood Mill      | 5       | 30 Labor        | 30 Labor                   |
+| Coal Mine      | 4       | 90 Labor        | 30 Labor, 30 Wood          |
+| Copper Smelter | 6       | 300 Labor       | 60 Labor, 60 Wood, 30 Coal |
 
 ### Mid-Tier Resource Buildings
 
-| Building | Type ID | Labor-Only Cost | Resource Cost |
-|----------|---------|----------------|---------------|
-| Ironwood Mill | 7 | 720 Labor | 120 Labor, 120 Wood, 60 Coal, 30 Copper |
-| Cold Iron Foundry | 13 | 720 Labor | 120 Labor, 120 Wood, 60 Coal, 30 Copper |
-| Gold Mine | 9 | 720 Labor | 120 Labor, 120 Wood, 60 Coal, 30 Copper |
+| Building          | Type ID | Labor-Only Cost | Resource Cost                           |
+| ----------------- | ------- | --------------- | --------------------------------------- |
+| Ironwood Mill     | 7       | 720 Labor       | 120 Labor, 120 Wood, 60 Coal, 30 Copper |
+| Cold Iron Foundry | 13      | 720 Labor       | 120 Labor, 120 Wood, 60 Coal, 30 Copper |
+| Gold Mine         | 9       | 720 Labor       | 120 Labor, 120 Wood, 60 Coal, 30 Copper |
 
 ### Rare Resource Buildings (Resource Mode Only)
 
-| Building | Type ID | Resource Cost |
-|----------|---------|---------------|
-| Adamantine Mine | 21 | 240 Labor, 180 Wood, 120 Copper, 60 Ironwood, 600 Essence |
-| Mithral Forge | 11 | 240 Labor, 180 Wood, 120 Copper, 60 Cold Iron, 600 Essence |
-| Dragonhide Tannery | 24 | 240 Labor, 180 Wood, 120 Copper, 60 Gold, 600 Essence |
+| Building           | Type ID | Resource Cost                                              |
+| ------------------ | ------- | ---------------------------------------------------------- |
+| Adamantine Mine    | 21      | 240 Labor, 180 Wood, 120 Copper, 60 Ironwood, 600 Essence  |
+| Mithral Forge      | 11      | 240 Labor, 180 Wood, 120 Copper, 60 Cold Iron, 600 Essence |
+| Dragonhide Tannery | 24      | 240 Labor, 180 Wood, 120 Copper, 60 Gold, 600 Essence      |
 
 ## Other Building IDs
 
-| ID | Building | Notes |
-|----|----------|-------|
-| 1 | WorkersHut | +6 population capacity |
-| 25 | Labor | Free to build, free upkeep |
-| 37 | Wheat/Farm | Foundation of all production |
-| 27 | Donkey | Transport |
+| ID  | Building   | Notes                        |
+| --- | ---------- | ---------------------------- |
+| 1   | WorkersHut | +6 population capacity       |
+| 25  | Labor      | Free to build, free upkeep   |
+| 37  | Wheat/Farm | Foundation of all production |
+| 27  | Donkey     | Transport                    |
 
 ## Structure Levels & Building Slots
 
-| Level | Name | Building Slots |
-|-------|------|---------------|
-| L0 | Settlement | 6 |
-| L1 | Village | 18 |
-| L2 | Kingdom | 36 |
-| L3 | Empire | 60 (max) |
+| Level | Name       | Building Slots |
+| ----- | ---------- | -------------- |
+| L0    | Settlement | 6              |
+| L1    | Village    | 18             |
+| L2    | Kingdom    | 36             |
+| L3    | Empire     | 60 (max)       |
 
 ## Building Placement
 
 Building placement uses direction arrays from the structure center:
+
 - Ring 1: 6 slots
 - Ring 2: 12 slots
 - Ring 3: 18 slots

--- a/client/apps/onchain-agent/data/tasks/exploration.md
+++ b/client/apps/onchain-agent/data/tasks/exploration.md
@@ -8,7 +8,8 @@ autoload: false
 
 ## Exploration & Victory Points
 
-Each newly explored tile awards Victory Points (VP). Exploration is a direct VP source — see `tasks/priorities.md` for the full scoring breakdown.
+Each newly explored tile awards Victory Points (VP). Exploration is a direct VP source — see `tasks/priorities.md` for
+the full scoring breakdown.
 
 ## Hex Grid
 
@@ -18,6 +19,7 @@ Each newly explored tile awards Victory Points (VP). Exploration is a direct VP 
 ## Movement Types
 
 ### `travel_explorer` — Fast Movement (Explored Tiles Only)
+
 - **Multi-hex**: Can move 5+ hexes in one action — e.g. `directions: [4,4,4,4,4]`
 - **Stamina**: ~10 per hex
 - **Requirement**: All tiles in path must be explored AND unoccupied
@@ -26,11 +28,13 @@ Each newly explored tile awards Victory Points (VP). Exploration is a direct VP 
   - `"one of the tiles in path is occupied"` — another army is blocking, reroute
 
 ### `move_explorer` — Combined Wrapper
+
 - With `explore: false`: same as `travel_explorer` (multi-hex through explored tiles)
 - With `explore: true`: same as `explore` (single hex, reveals new tile)
 - Prefer using `travel_explorer` or `explore` directly
 
 ### `explore` — Dedicated Scouting
+
 - Pure exploration action
 - **Stamina**: 30 per hex
 - **Minimum**: 10 troops required in the army
@@ -40,14 +44,17 @@ Each newly explored tile awards Victory Points (VP). Exploration is a direct VP 
 ## Multi-Hex Travel
 
 Moving 5+ hexes in a single action is possible:
+
 - All tiles in the path must already be explored
 - All tiles must be unoccupied (no other armies blocking)
 - Stamina cost scales linearly (~10/hex for travel)
-- Exploring tiles first (1 hex at a time, 30 stamina each) reveals them permanently, enabling fast multi-hex travel through those tiles afterward
+- Exploring tiles first (1 hex at a time, 30 stamina each) reveals them permanently, enabling fast multi-hex travel
+  through those tiles afterward
 
 ## Nearby Entities
 
 The `observe_game` tick prompt and `inspect_explorer` tool show neighbor tiles around each army:
+
 - Direction, explored status, occupied status, biome, occupant info
 - Use this to decide which direction to explore or travel
 

--- a/client/apps/onchain-agent/data/tasks/priorities.md
+++ b/client/apps/onchain-agent/data/tasks/priorities.md
@@ -13,26 +13,29 @@ last_evaluated: tick-0
 
 Leaderboard rank is determined by total accumulated VP. VP is awarded for:
 
-| Source | Type | Notes |
-|--------|------|-------|
-| Exploring tiles | One-time per tile | Every new hex discovered awards VP |
-| Claiming World Structures (Essence Rifts, Camps) | One-time | Only awarded on first capture from bandit forces |
-| Opening Relic Crates | One-time | Found during exploration |
-| Claiming Hyperstructures | One-time | Only awarded on first capture from bandit forces |
-| Holding Hyperstructures | **Ongoing** | **Accumulates VP per cycle for as long as you hold it** |
+| Source                                           | Type              | Notes                                                   |
+| ------------------------------------------------ | ----------------- | ------------------------------------------------------- |
+| Exploring tiles                                  | One-time per tile | Every new hex discovered awards VP                      |
+| Claiming World Structures (Essence Rifts, Camps) | One-time          | Only awarded on first capture from bandit forces        |
+| Opening Relic Crates                             | One-time          | Found during exploration                                |
+| Claiming Hyperstructures                         | One-time          | Only awarded on first capture from bandit forces        |
+| Holding Hyperstructures                          | **Ongoing**       | **Accumulates VP per cycle for as long as you hold it** |
 
 **Key facts:**
-- VP from claiming structures/hyperstructures is only awarded the **first time** they are captured from bandits — recapturing from other players does not award claim VP
-- Hyperstructures in Blitz are **pre-built** and positioned on the map at game start — no construction needed, just defeat the bandit guards to claim
+
+- VP from claiming structures/hyperstructures is only awarded the **first time** they are captured from bandits —
+  recapturing from other players does not award claim VP
+- Hyperstructures in Blitz are **pre-built** and positioned on the map at game start — no construction needed, just
+  defeat the bandit guards to claim
 - Holding hyperstructures is the only **ongoing** VP source — all others are one-time awards
 
 ## World Structures
 
-| Type | What It Provides |
-|------|-----------------|
-| Essence Rift (Fragment Mine) | Produces Essence (1/tick) — required for T2/T3 troops |
-| Camp | Capturable structure |
-| Hyperstructure | **Ongoing VP accumulation** while held — the primary scoring engine |
+| Type                         | What It Provides                                                    |
+| ---------------------------- | ------------------------------------------------------------------- |
+| Essence Rift (Fragment Mine) | Produces Essence (1/tick) — required for T2/T3 troops               |
+| Camp                         | Capturable structure                                                |
+| Hyperstructure               | **Ongoing VP accumulation** while held — the primary scoring engine |
 
 ## Active Goals
 

--- a/client/apps/onchain-agent/src/adapter/action-registry.ts
+++ b/client/apps/onchain-agent/src/adapter/action-registry.ts
@@ -514,7 +514,10 @@ register(
   [
     n("toExplorerId", "Explorer entity ID to reinforce"),
     n("amount", "Number of troops to add"),
-    n("homeDirection", `Direction FROM the explorer TO its home structure (${DIR}). Check explorer's neighbor tiles to find which direction the structure is in.`),
+    n(
+      "homeDirection",
+      `Direction FROM the explorer TO its home structure (${DIR}). Check explorer's neighbor tiles to find which direction the structure is in.`,
+    ),
   ],
   (client, signer, p) =>
     wrapTx(() =>
@@ -1064,7 +1067,10 @@ register(
   [
     n("hyperstructureEntityId", "Hyperstructure entity ID"),
     n("contributorEntityId", "Your structure entity ID contributing"),
-    na("contributions", "Flat array of [resourceType, amount, resourceType, amount, ...] pairs. Use resource IDs from the resource list."),
+    na(
+      "contributions",
+      "Flat array of [resourceType, amount, resourceType, amount, ...] pairs. Use resource IDs from the resource list.",
+    ),
   ],
   (client, signer, p) =>
     wrapTx(() =>

--- a/client/apps/onchain-agent/src/adapter/world-state.ts
+++ b/client/apps/onchain-agent/src/adapter/world-state.ts
@@ -41,7 +41,6 @@ export interface EternumEntity {
   // Battle history — parsed from already-fetched raw SQL fields
   lastAttack?: { attackerId: number; timestamp: number; pos?: { x: number; y: number } };
   lastDefense?: { defenderId: number; timestamp: number; pos?: { x: number; y: number } };
-
 }
 
 /**
@@ -612,7 +611,9 @@ function buildOperatingArea(
     }
   }
 
-  const lines: string[] = [`### Operating Area (radius ${OPERATING_AREA_RADIUS} around all entities, ${areaTiles.size} tiles)`];
+  const lines: string[] = [
+    `### Operating Area (radius ${OPERATING_AREA_RADIUS} around all entities, ${areaTiles.size} tiles)`,
+  ];
   if (unexplored.length > 0) {
     lines.push(`  Unexplored (${unexplored.length}): ${unexplored.join(", ")}`);
   }
@@ -649,12 +650,25 @@ function parseLastDefense(raw: any): EternumEntity["lastDefense"] {
 /** Actions available on structures — displayed once per section, not per entity. */
 function getStructureActions(): string[] {
   return [
-    "create_building", "destroy_building", "pause_production", "resume_production",
-    "create_explorer", "delete_explorer", "upgrade_realm",
-    "add_guard", "delete_guard", "swap_explorer_to_guard", "swap_guard_to_explorer",
-    "send_resources", "pickup_resources", "claim_arrivals",
-    "create_order", "accept_order", "cancel_order",
-    "buy_resources", "sell_resources",
+    "create_building",
+    "destroy_building",
+    "pause_production",
+    "resume_production",
+    "create_explorer",
+    "delete_explorer",
+    "upgrade_realm",
+    "add_guard",
+    "delete_guard",
+    "swap_explorer_to_guard",
+    "swap_guard_to_explorer",
+    "send_resources",
+    "pickup_resources",
+    "claim_arrivals",
+    "create_order",
+    "accept_order",
+    "cancel_order",
+    "buy_resources",
+    "sell_resources",
     "contribute_hyperstructure",
   ];
 }
@@ -662,10 +676,18 @@ function getStructureActions(): string[] {
 /** Actions available on armies — displayed once per section, not per entity. */
 function getArmyActions(): string[] {
   return [
-    "travel_explorer", "explore", "move_explorer",
-    "attack_explorer", "attack_guard", "guard_attack_explorer", "raid",
-    "add_to_explorer", "delete_explorer",
-    "swap_explorer_to_explorer", "swap_explorer_to_guard", "swap_guard_to_explorer",
+    "travel_explorer",
+    "explore",
+    "move_explorer",
+    "attack_explorer",
+    "attack_guard",
+    "guard_attack_explorer",
+    "raid",
+    "add_to_explorer",
+    "delete_explorer",
+    "swap_explorer_to_explorer",
+    "swap_explorer_to_guard",
+    "swap_guard_to_explorer",
     "pickup_resources",
   ];
 }
@@ -1146,7 +1168,12 @@ export function formatEternumTickPrompt(state: EternumWorldState): string {
           );
         }
         // Free building paths — only show when there are actually free slots
-        if (e.freeSlots && e.freeSlots.length > 0 && e.buildingSlots && e.buildingSlots.total - e.buildingSlots.used > 0) {
+        if (
+          e.freeSlots &&
+          e.freeSlots.length > 0 &&
+          e.buildingSlots &&
+          e.buildingSlots.total - e.buildingSlots.used > 0
+        ) {
           lines.push(`    Free paths: ${e.freeSlots.join(",")}`);
         }
         // Population — only show when near capacity or full

--- a/client/apps/onchain-agent/src/session/controller-session.ts
+++ b/client/apps/onchain-agent/src/session/controller-session.ts
@@ -381,8 +381,10 @@ export class ControllerSession {
     const backend = (this.provider as any)._backend;
     if (backend) {
       backend.openLink = (url: string) => {
+        console.log(`\n  🔗 APPROVE SESSION: ${url}\n`);
+        // Also try opening browser (will fail silently on headless)
         const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-        execFile(openCmd, [url]);
+        execFile(openCmd, [url], () => {});
       };
     }
   }


### PR DESCRIPTION
## Problem

The client requires stamina to attack even when a structure has no defending troops. The contract (`attack_explorer_vs_guard`) does an early return with `battle_claim` when `guard_slot.is_none()` — no stamina check. But the client blocks the attack button if `attackerStamina < stamina_attack_req`, regardless of defenders.

This means players see "No defending troops. You can claim without resistance" but still can't click attack without sufficient stamina.

## Fix

- Only enforce the stamina requirement when there are actual defenders (`hasDefenders`)
- Changed button label from "Attack" to "Claim" when no defenders are present for clearer UX