### PR TITLE
Run owned-structure backfill only once

### DIFF
--- a/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
+++ b/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
@@ -17,7 +17,6 @@ const PLAYER_STRUCTURE_MODELS: string[] = [
   "s1_eternum-Resource",
   "s1_eternum-ResourceArrival",
 ];
-const PLAYER_STRUCTURE_BACKFILL_INTERVAL_MS = 2500;
 
 export const usePlayerStructureSync = () => {
   const {
@@ -94,13 +93,9 @@ export const usePlayerStructureSync = () => {
     };
 
     void backfillOwnedStructures();
-    const intervalId = setInterval(() => {
-      void backfillOwnedStructures();
-    }, PLAYER_STRUCTURE_BACKFILL_INTERVAL_MS);
 
     return () => {
       cancelled = true;
-      clearInterval(intervalId);
     };
   }, [accountAddress, toriiClient, toriiComponents]);
 


### PR DESCRIPTION
Removes interval-based polling from `usePlayerStructureSync` so `backfillOwnedStructures` runs only on initial effect execution. Keeps cleanup logic and removes the unused backfill interval constant. This limits SQL backfill calls while preserving the initial ownership sync behavior.