### PR TITLE
docs: fix introduction.mdx game duration to 90 minutes

### DIFF
--- a/client/apps/game-docs/docs/pages/overview/introduction.mdx
+++ b/client/apps/game-docs/docs/pages/overview/introduction.mdx
@@ -62,7 +62,7 @@ resource trading, exploration, and minigames. Whether aspiring to dominate the c
 peaceful corner of the world, Eternum offers rewarding experiences suited to every play style.
 
 **[Blitz](/blitz/key-concepts)** - Blitz provides an exciting contrast through rapid, high-intensity, free-for-all
-competition lasting exactly two hours. This mode distills strategic gameplay into streamlined mechanics, accelerated
+competition lasting exactly 90 minutes. This mode distills strategic gameplay into streamlined mechanics, accelerated
 resource production, and immediate military engagements, rewarding quick thinking and decisive action. Blitz is
 structured around a competitive bracket system—Recruit, Gladiator, Warrior, and Elite—allowing Lords to engage at their
 preferred intensity level, from casual challenges to elite competitions with significant stakes and rewards. Whether


### PR DESCRIPTION
Updates the remaining "two hours" reference in `overview/introduction.mdx` to 90 minutes, matching the config change.