### PR TITLE
fix: skip stamina/cooldown check when claiming unguarded structures

### DIFF
--- a/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
+++ b/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
@@ -234,12 +234,15 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
   const attackerCooldownRemaining = Math.max(0, attackerCooldownEnd - currentTime);
   const attackerOnCooldown = attackerCooldownRemaining > 0;
 
-  const attackDisabled = attackerOnCooldown || attackerStamina < combatConfig.stamina_attack_req || !attackerArmyData;
+  const hasDefenders = !!targetArmyData;
+  const attackDisabled =
+    (hasDefenders && (attackerOnCooldown || attackerStamina < combatConfig.stamina_attack_req)) || !attackerArmyData;
 
   const attackButtonLabel = (() => {
+    if (!attackerArmyData) return "No troops selected";
+    if (!hasDefenders) return "Claim";
     if (attackerOnCooldown) return "On cooldown";
     if (attackerStamina < combatConfig.stamina_attack_req) return `Need ${combatConfig.stamina_attack_req} stamina`;
-    if (!attackerArmyData) return "No troops selected";
     return "Attack";
   })();
 


### PR DESCRIPTION
Fixes the quick attack preview to allow claiming unguarded structures without stamina or cooldown requirements.

- Skip stamina requirement and cooldown for unguarded structure claims
- Show "Claim" button label instead of "Attack" when no defenders
- Prioritize "No troops selected" check first

Clean version of #4241 (removed unrelated onchain-agent changes).