### PR TITLE
fix: guard blitz ranking trial ids to u32

### DIFF
--- a/client/apps/game/src/services/review/game-review-service.ts
+++ b/client/apps/game/src/services/review/game-review-service.ts
@@ -7,6 +7,7 @@ import {
 import { GLOBAL_TORII_BY_CHAIN, MMR_TOKEN_BY_CHAIN } from "@/config/global-chain";
 import { commitAndClaimMMR } from "@/ui/features/prize/utils/mmr-utils";
 import { getMMRTierFromRaw, toMmrIntegerFromRaw } from "@/ui/utils/mmr-tiers";
+import { randomU32TrialId } from "@/utils/trial-id";
 import { SqlApi, buildApiUrl, fetchWithErrorHandling } from "@bibliothecadao/torii";
 import { RESOURCE_PRECISION } from "@bibliothecadao/types";
 import type { Chain } from "@contracts";
@@ -482,9 +483,6 @@ const fetchLatestMmrForPlayers = async ({
     return new Map();
   }
 };
-
-const randomTrialId = () =>
-  BigInt(`0x${(globalThis.crypto?.randomUUID?.().replace(/-/g, "") || Date.now().toString(16)).slice(0, 31)}`);
 
 const chunk = <T>(items: T[], chunkSize: number): T[][] => {
   const out: T[][] = [];
@@ -1070,7 +1068,7 @@ export const finalizeGameRankingAndMMR = async ({
         const playerRankCall: Call = {
           contractAddress: prizeDistributionAddress,
           entrypoint: "blitz_prize_player_rank",
-          calldata: [randomTrialId(), index === 0 ? totalPlayers : 0, batch.length, ...batch],
+          calldata: [randomU32TrialId(), index === 0 ? totalPlayers : 0, batch.length, ...batch],
         };
         await signer.execute([playerRankCall]);
       }

--- a/client/apps/game/src/ui/features/market/landing-markets/details/market-resolution.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/details/market-resolution.tsx
@@ -12,6 +12,7 @@ import { toast } from "sonner";
 import { Call, uint256 } from "starknet";
 
 import { buildWorldProfile, getFactorySqlBaseUrl, patchManifestWithFactory } from "@/runtime/world";
+import { randomU32TrialId } from "@/utils/trial-id";
 import { Chain, getGameManifest } from "@contracts";
 import { env } from "../../../../../../env";
 import { decodePaddedFeltAscii } from "../market-utils";
@@ -24,9 +25,6 @@ const chunk = <T,>(arr: T[], size: number) => {
   for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
   return out;
 };
-
-const randomTrialId = () =>
-  BigInt("0x" + (globalThis.crypto?.randomUUID?.().replace(/-/g, "") || Date.now().toString(16)));
 
 const toAddressHex = (value: any): string | null => {
   try {
@@ -340,7 +338,7 @@ export const MarketResolution = ({ market }: { market: MarketClass }) => {
         const rankCall: Call = {
           contractAddress: prizeContract.address,
           entrypoint: "blitz_prize_player_rank",
-          calldata: [randomTrialId(), i === 0 ? total : 0, batch.length, ...batch],
+          calldata: [randomU32TrialId(), i === 0 ? total : 0, batch.length, ...batch],
         };
         await account.execute([rankCall]);
       }

--- a/client/apps/game/src/ui/features/prize/prize-panel.tsx
+++ b/client/apps/game/src/ui/features/prize/prize-panel.tsx
@@ -2,6 +2,7 @@ import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { NumberInput } from "@/ui/design-system/atoms";
 import Button from "@/ui/design-system/atoms/button";
+import { normalizeU32TrialId, randomU32TrialId } from "@/utils/trial-id";
 import { displayAddress, getRealmCountPerHyperstructure } from "@/ui/utils/utils";
 import { LeaderboardManager, toHexString } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
@@ -46,7 +47,7 @@ export const PrizePanel = () => {
   const {
     setup: {
       components,
-      systemCalls: { blitz_prize_player_rank, blitz_prize_claim_no_game, uuid, commit_and_claim_game_mmr },
+      systemCalls: { blitz_prize_player_rank, blitz_prize_claim_no_game, commit_and_claim_game_mmr },
     },
   } = useDojo();
 
@@ -368,7 +369,7 @@ export const PrizePanel = () => {
       const addresses = registeredPlayers.map((p) => p.address.toString());
 
       // Determine trial id and committed count
-      const trialId: bigint = myTrial ? (myTrial.trial_id as bigint) : ((await uuid()) as unknown as bigint);
+      const trialId: bigint = myTrial ? normalizeU32TrialId(myTrial.trial_id as bigint) : randomU32TrialId();
       const committed: number = myTrial ? Number(myTrial.total_player_count_committed) : addresses.length;
       const revealed: number = myTrial ? Number(myTrial.total_player_count_revealed) : 0;
 

--- a/client/apps/game/src/utils/trial-id.ts
+++ b/client/apps/game/src/utils/trial-id.ts
@@ -1,0 +1,36 @@
+const U32_MAX_TRIAL_ID = 4294967295n;
+
+export const normalizeU32TrialId = (trialId: bigint | number | string): bigint => {
+  let parsedTrialId: bigint;
+  try {
+    parsedTrialId = BigInt(trialId);
+  } catch {
+    throw new Error(
+      `Invalid trial_id value "${String(trialId)}". trial_id must be a non-negative integer <= ${U32_MAX_TRIAL_ID.toString()}.`,
+    );
+  }
+
+  if (parsedTrialId < 0n) {
+    throw new Error(
+      `Invalid trial_id value "${parsedTrialId.toString()}". trial_id must be a non-negative integer <= ${U32_MAX_TRIAL_ID.toString()}.`,
+    );
+  }
+
+  if (parsedTrialId > U32_MAX_TRIAL_ID) {
+    throw new Error(
+      `Invalid trial_id value "${parsedTrialId.toString()}". trial_id exceeds u32::MAX (${U32_MAX_TRIAL_ID.toString()}).`,
+    );
+  }
+
+  return parsedTrialId;
+};
+
+export const randomU32TrialId = (): bigint => {
+  if (globalThis.crypto?.getRandomValues) {
+    const values = new Uint32Array(1);
+    globalThis.crypto.getRandomValues(values);
+    return normalizeU32TrialId(BigInt(values[0] ?? 0));
+  }
+
+  return normalizeU32TrialId(BigInt(Math.floor(Math.random() * 0x1_0000_0000)));
+};

--- a/packages/provider/src/index.test.ts
+++ b/packages/provider/src/index.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeU32TrialId } from "./index";
+
+describe("normalizeU32TrialId", () => {
+  it("accepts valid trial ids in u32 range", () => {
+    expect(normalizeU32TrialId(0)).toBe("0");
+    expect(normalizeU32TrialId(4294967295n)).toBe("4294967295");
+  });
+
+  it("rejects negative trial ids", () => {
+    expect(() => normalizeU32TrialId(-1)).toThrow(/non-negative integer/);
+  });
+
+  it("rejects trial ids greater than u32::MAX", () => {
+    expect(() => normalizeU32TrialId(4294967296n)).toThrow(/u32::MAX/);
+  });
+});


### PR DESCRIPTION
## Summary
- add provider-side `trial_id` normalization/validation for `blitz_prize_player_rank` to enforce `trial_id <= u32::MAX`
- add provider tests for valid, negative, and overflow `trial_id` values
- add shared client `trial-id` utilities and update direct ranking submission flows to use bounded `u32` trial ids
- update prize panel ranking flow to use bounded trial ids instead of `uuid()`

## Validation
- `pnpm --dir packages/provider test -- --run`
- `pnpm --dir packages/provider build`
- `pnpm --dir client/apps/game exec tsc --noEmit`
- `pnpm --dir client/apps/game exec eslint src/ui/features/prize/prize-panel.tsx src/services/review/game-review-service.ts src/utils/trial-id.ts`
