### PR TITLE
fix(factory): use connected account as blitz fee recipient default

### DIFF
--- a/client/apps/game/src/ui/features/admin/pages/factory.tsx
+++ b/client/apps/game/src/ui/features/admin/pages/factory.tsx
@@ -391,6 +391,17 @@ export const FactoryPage = ({ embedded = false }: FactoryPageProps = {}) => {
     if (!Number.isFinite(secs) || secs <= 0) return 30;
     return Math.max(0, Math.round((secs % 3600) / 60));
   }, [eternumConfig]);
+  const configuredBlitzFeeRecipient = (eternumConfig as any)?.blitz?.registration?.fee_recipient || "";
+  const defaultBlitzFeeRecipient = account?.address || configuredBlitzFeeRecipient;
+  const getBlitzFeeRecipientForWorld = useCallback(
+    (name: string) => {
+      if (Object.prototype.hasOwnProperty.call(blitzFeeRecipientOverrides, name)) {
+        return blitzFeeRecipientOverrides[name] ?? "";
+      }
+      return defaultBlitzFeeRecipient;
+    },
+    [blitzFeeRecipientOverrides, defaultBlitzFeeRecipient],
+  );
 
   // Check indexer and deployment status for all stored worlds
   const checkAllWorldStatuses = useCallback(async () => {
@@ -1785,12 +1796,9 @@ export const FactoryPage = ({ embedded = false }: FactoryPageProps = {}) => {
                                             <input
                                               type="text"
                                               placeholder={
-                                                (eternumConfig as any)?.blitz?.registration?.fee_recipient || "0x..."
+                                                defaultBlitzFeeRecipient || "0x..."
                                               }
-                                              value={
-                                                blitzFeeRecipientOverrides[name] ??
-                                                ((eternumConfig as any)?.blitz?.registration?.fee_recipient || "")
-                                              }
+                                              value={getBlitzFeeRecipientForWorld(name)}
                                               onChange={(e) =>
                                                 setBlitzFeeRecipientOverrides((p) => ({ ...p, [name]: e.target.value }))
                                               }
@@ -2225,7 +2233,7 @@ export const FactoryPage = ({ embedded = false }: FactoryPageProps = {}) => {
                                                     blitzFeeAmount: blitzFeeAmountOverrides[name],
                                                     blitzFeePrecision: blitzFeePrecisionOverrides[name],
                                                     blitzFeeToken: blitzFeeTokenOverrides[name],
-                                                    blitzFeeRecipient: blitzFeeRecipientOverrides[name],
+                                                    blitzFeeRecipient: getBlitzFeeRecipientForWorld(name),
                                                     registrationCountMax: registrationCountMaxOverrides[name],
                                                     registrationDelaySeconds: registrationDelaySecondsOverrides[name],
                                                     registrationPeriodSeconds: registrationPeriodSecondsOverrides[name],


### PR DESCRIPTION
## Summary
- update `FactoryPage` blitz fee recipient behavior so default value is now dynamic:
  - use configured `blitz.registration.fee_recipient` when no wallet is connected
  - use connected account address when a user is logged in
- apply the same resolved value when building world config overrides, so the submitted config matches what the form shows

## Changes
- add `getBlitzFeeRecipientForWorld(name)` helper in `client/apps/game/src/ui/features/admin/pages/factory.tsx`
- use helper for the Blitz Fee Recipient input `value` and `placeholder`
- use helper when passing `blitzFeeRecipient` into `buildWorldConfigForFactory`

## Validation
- attempted lint check:
  - `pnpm --dir client/apps/game exec eslint src/ui/features/admin/pages/factory.tsx`
  - failed in this environment due missing package `@eslint/js` (tooling dependency), so no local lint pass was produced
