### PR TITLE
Use map-data realm names for worldmap labels

### DIFF
--- a/packages/core/src/systems/data-enhancer.ts
+++ b/packages/core/src/systems/data-enhancer.ts
@@ -1,6 +1,6 @@
-import { ID, TroopTier, TroopType } from "@bibliothecadao/types";
+import { ID, StructureType, TroopTier, TroopType } from "@bibliothecadao/types";
 import { StaminaManager } from "../managers";
-import { ActiveProduction, ArmyMapData, GuardArmy, MapDataStore } from "../stores/map-data-store";
+import { ActiveProduction, ArmyMapData, GuardArmy, MapDataStore, StructureMapData } from "../stores/map-data-store";
 
 export interface EnhancedArmyData {
   troopCount: number;
@@ -25,6 +25,7 @@ export interface EnhancedStructureData {
   owner: { address: bigint | undefined; ownerName: string; guildName: string };
   guardArmies: GuardArmy[];
   activeProductions: ActiveProduction[];
+  structureName?: string;
   battleData?: {
     battleCooldownEnd: number;
     latestAttackerId: number | null;
@@ -180,8 +181,22 @@ export class DataEnhancer {
       },
       guardArmies: structureMapData?.guardArmies || [],
       activeProductions: structureMapData?.activeProductions || [],
+      structureName: this.getStructureDisplayName(structureMapData),
       battleData: structureMapData?.battleData || undefined,
     };
+  }
+
+  private getStructureDisplayName(structureMapData: StructureMapData | undefined): string | undefined {
+    if (!structureMapData) {
+      return undefined;
+    }
+
+    if (structureMapData.structureType !== StructureType.Realm) {
+      return undefined;
+    }
+
+    const trimmedName = structureMapData.structureTypeName.trim();
+    return trimmedName.length > 0 ? trimmedName : undefined;
   }
 
   /**

--- a/packages/core/src/systems/world-update-listener.test.ts
+++ b/packages/core/src/systems/world-update-listener.test.ts
@@ -158,4 +158,52 @@ describe("WorldUpdateListener army tile bootstrap", () => {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback.mock.calls[0][0].structureName).toBe("Essence Rift 921");
   });
+
+  it("uses enhanced structure name when Structure component is unavailable", async () => {
+    isComponentUpdateMock.mockReturnValue(true);
+    tileOptToTileMock.mockReturnValue({
+      occupier_type: 1,
+      occupier_id: 921,
+      col: 10,
+      row: 15,
+    });
+    getStructureInfoFromTileOccupierMock.mockReturnValue({
+      type: 4,
+      stage: 0,
+      level: 1,
+      hasWonder: false,
+    });
+    enhanceStructureDataMock.mockResolvedValue({
+      owner: { address: 123n, ownerName: "", guildName: "" },
+      guardArmies: [],
+      activeProductions: [],
+      battleData: undefined,
+      structureName: "Realm of Testing",
+    });
+
+    const listener = new WorldUpdateListener(
+      {
+        network: { world: {} },
+        components: {
+          TileOpt: {},
+          Hyperstructure: {},
+          Structure: {},
+          AddressName: {},
+        },
+      } as any,
+      {} as any,
+    );
+
+    const callback = vi.fn();
+    listener.Structure.onTileUpdate(callback);
+
+    const handleUpdate = defineComponentSystemMock.mock.calls[0][2];
+    await handleUpdate({
+      value: [{}, undefined],
+      entity: "0x123",
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0].structureName).toBe("Realm of Testing");
+  });
 });

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -484,9 +484,10 @@ export class WorldUpdateListener {
 
                 const isBlitz = getIsBlitz();
                 const fallbackTypeName = getStructureTypeName(structureInfo.type, isBlitz) || "Structure";
+                const enhancedStructureName = enhancedData.structureName?.trim();
                 const structureName = structureComponent
                   ? getStructureName(structureComponent, isBlitz).name
-                  : `${fallbackTypeName} ${rawOccupierId}`;
+                  : enhancedStructureName || `${fallbackTypeName} ${rawOccupierId}`;
 
                 const battleData = enhancedData.battleData
                   ? {


### PR DESCRIPTION
This PR fixes worldmap realm labels when the live Structure component is missing by introducing a secondary name fallback from enhanced map data. DataEnhancer now exposes an optional structure display name and limits that fallback to Realm structures so camps/rifts keep their existing behavior. WorldUpdateListener now resolves structure names in order: live Structure name, enhanced realm name, then existing type+entity id fallback. A regression test was added to prove the enhanced-name fallback path, while the existing type-based fallback test remains in place. Validation run: pnpm run format, targeted vitest for world-update-listener, and tsc --noEmit in packages/core.