### PR TITLE
Show guard stamina bars and attack stamina timing

### DIFF
--- a/client/apps/game/src/ui/features/military/components/guard-stamina-bar.tsx
+++ b/client/apps/game/src/ui/features/military/components/guard-stamina-bar.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+
+interface GuardStaminaBarProps {
+  current?: number | bigint | null;
+  max?: number | null;
+  className?: string;
+}
+
+const getStaminaFillClass = (current: number, percentage: number) => {
+  if (current < 40) return "bg-progress-bar-danger";
+  if (percentage > 66) return "bg-progress-bar-good";
+  if (percentage > 33) return "bg-progress-bar-medium";
+  return "bg-progress-bar-danger";
+};
+
+export const GuardStaminaBar = ({ current, max, className }: GuardStaminaBarProps) => {
+  const maxValue = Number(max ?? 0);
+  if (!Number.isFinite(maxValue) || maxValue <= 0) return null;
+
+  const rawCurrent = typeof current === "bigint" ? Number(current) : Number(current ?? 0);
+  const currentValue = Number.isFinite(rawCurrent) ? rawCurrent : 0;
+  const clampedCurrent = Math.min(Math.max(currentValue, 0), maxValue);
+  const percentage = (clampedCurrent / maxValue) * 100;
+  const roundedCurrent = Math.round(clampedCurrent);
+  const roundedMax = Math.round(maxValue);
+
+  return (
+    <div
+      className={cn("h-1 w-full overflow-hidden rounded-full border border-gold/20 bg-dark-brown/70", className)}
+      title={`Stamina ${roundedCurrent}/${roundedMax}`}
+      aria-label={`Stamina ${roundedCurrent}/${roundedMax}`}
+    >
+      <div
+        className={cn("h-full transition-all duration-300", getStaminaFillClass(clampedCurrent, percentage))}
+        style={{ width: `${Math.min(100, Math.max(0, percentage))}%` }}
+      />
+    </div>
+  );
+};

--- a/client/apps/game/src/ui/features/military/components/transfer-troops/transfer-slot-selection.tsx
+++ b/client/apps/game/src/ui/features/military/components/transfer-troops/transfer-slot-selection.tsx
@@ -5,6 +5,7 @@ import { DISPLAYED_SLOT_NUMBER_MAP, GUARD_SLOT_NAMES, resources, TroopTier, Troo
 import clsx from "clsx";
 import AlertTriangle from "lucide-react/dist/esm/icons/alert-triangle";
 import Timer from "lucide-react/dist/esm/icons/timer";
+import { GuardStaminaBar } from "../guard-stamina-bar";
 import { TransferDirection } from "../help-container";
 
 interface SlotTroopInfo {
@@ -13,6 +14,8 @@ interface SlotTroopInfo {
     tier: TroopTier;
     category: TroopType;
     count: number;
+    staminaCurrent?: number;
+    staminaMax?: number;
   };
   cooldownEnd?: number;
 }
@@ -58,7 +61,13 @@ export const TransferSlotSelection = ({
   lastGuardSlot,
   currentBlockTimestamp,
 }: TransferSlotSelectionProps) => {
-  const renderTroopPill = (troop?: { tier: TroopTier; category: TroopType; count: number }) => {
+  const renderTroopPill = (troop?: {
+    tier: TroopTier;
+    category: TroopType;
+    count: number;
+    staminaCurrent?: number;
+    staminaMax?: number;
+  }) => {
     if (!troop) {
       return (
         <div className="flex items-center gap-2">
@@ -91,6 +100,7 @@ export const TransferSlotSelection = ({
         <div className="flex-1 min-w-0">
           <div className="text-sm font-bold text-gold">{countLabel}</div>
           <div className="text-xxs uppercase tracking-wide text-gold/70">{typeLabel}</div>
+          <GuardStaminaBar current={troop.staminaCurrent} max={troop.staminaMax} className="mt-1" />
         </div>
       </div>
     );

--- a/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/defense-slot-selection.tsx
+++ b/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/defense-slot-selection.tsx
@@ -1,12 +1,11 @@
-import Button from "@/ui/design-system/atoms/button";
 import { ResourceIcon } from "@/ui/design-system/molecules";
 import { getTroopResourceId } from "@bibliothecadao/eternum";
 import { DISPLAYED_SLOT_NUMBER_MAP, GUARD_SLOT_NAMES, resources, TroopTier } from "@bibliothecadao/types";
 import clsx from "clsx";
 import AlertTriangle from "lucide-react/dist/esm/icons/alert-triangle";
-import Shield from "lucide-react/dist/esm/icons/shield";
 import { useMemo } from "react";
 
+import { GuardStaminaBar } from "../guard-stamina-bar";
 import type { GuardSummary, SelectedTroopCombo } from "./types";
 
 interface DefenseSlotSelectionProps {
@@ -63,9 +62,9 @@ export const DefenseSlotSelection = ({
           const guardCategory = guardInfo?.troops?.category;
           const guardTier = guardInfo?.troops?.tier;
           const guardCount = guardInfo?.troops?.count;
+          const guardStaminaCurrent = guardInfo?.troops?.staminaCurrent;
+          const guardStaminaMax = guardInfo?.troops?.staminaMax;
           const guardCountLabel = guardCount !== undefined ? guardCount.toLocaleString() : null;
-          const guardLabel = [guardTier, guardCategory].filter(Boolean).join(" ");
-          const guardLabelText = guardLabel || "Unknown";
           const troopResourceTrait = guardCategory
             ? (resources.find(
                 (resource) => resource.id === getTroopResourceId(guardCategory, guardTier ?? TroopTier.T1),
@@ -107,8 +106,11 @@ export const DefenseSlotSelection = ({
                   {slotName}
                 </div>
                 {hasGuard ? (
-                  <div className={clsx("text-xs font-bold", isSelected ? "text-gold" : "text-gold/90")}>
-                    {guardCountLabel}
+                  <div className="flex flex-col gap-0.5">
+                    <div className={clsx("text-xs font-bold", isSelected ? "text-gold" : "text-gold/90")}>
+                      {guardCountLabel}
+                    </div>
+                    <GuardStaminaBar current={guardStaminaCurrent} max={guardStaminaMax} />
                   </div>
                 ) : (
                   <div className={clsx("text-xxs", isSelected ? "text-gold" : "text-gold/60")}>Empty</div>

--- a/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/types.ts
+++ b/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/types.ts
@@ -23,5 +23,7 @@ export interface GuardSummary {
     category?: TroopType;
     tier?: TroopTier;
     count?: number;
+    staminaCurrent?: number;
+    staminaMax?: number;
   } | null;
 }

--- a/client/apps/game/src/ui/features/military/utils/guard-stamina.ts
+++ b/client/apps/game/src/ui/features/military/utils/guard-stamina.ts
@@ -1,0 +1,63 @@
+import { StaminaManager } from "@bibliothecadao/eternum";
+import { Troops, TroopTier, TroopType } from "@bibliothecadao/types";
+
+interface GuardTroopsLike {
+  category?: unknown;
+  tier?: unknown;
+  stamina?: {
+    amount?: unknown;
+    updated_tick?: unknown;
+  } | null;
+  boosts?: {
+    incr_stamina_regen_percent_num?: unknown;
+    incr_stamina_regen_tick_count?: unknown;
+  } | null;
+}
+
+const toGuardTroopsLike = (troops: unknown): GuardTroopsLike => {
+  if (typeof troops !== "object" || troops === null) {
+    return {};
+  }
+  return troops as GuardTroopsLike;
+};
+
+const hasStaminaBoostData = (troops: GuardTroopsLike): boolean => {
+  if (!troops?.stamina || !troops?.boosts) return false;
+
+  return (
+    troops.boosts.incr_stamina_regen_percent_num !== undefined &&
+    troops.boosts.incr_stamina_regen_tick_count !== undefined
+  );
+};
+
+export const getGuardStaminaSnapshot = (
+  troops: unknown,
+  currentArmiesTick: number,
+): { current: number; max: number } | null => {
+  const data = toGuardTroopsLike(troops);
+  const category = data.category as TroopType | undefined | null;
+  const tier = data.tier as TroopTier | undefined | null;
+
+  if (category === undefined || category === null || tier === undefined || tier === null) {
+    return null;
+  }
+
+  let max = 0;
+  try {
+    max = StaminaManager.getMaxStamina(category, tier);
+  } catch {
+    return null;
+  }
+
+  const baseAmount = data.stamina?.amount;
+  const baseCurrent = Number(baseAmount ?? 0n);
+
+  if (hasStaminaBoostData(data)) {
+    return {
+      current: Number(StaminaManager.getStamina(data as unknown as Troops, currentArmiesTick).amount),
+      max,
+    };
+  }
+
+  return { current: baseCurrent, max };
+};


### PR DESCRIPTION
Adds a reusable `GuardStaminaBar` and a safe stamina snapshot helper that avoids crashes when guard boost data is missing.

Displays compact, bar-only stamina indicators across mounted guard-slot UIs (compact defense display, transfer slot selection, defense slot selection modal, and combat guard selection).

Low stamina bars now render in red when current stamina is below 40 to make weak guards immediately visible.

In quick attack preview, when stamina is insufficient, the UI now shows current vs required stamina plus an estimated ready timer based on armies tick cadence and refill rate.

Ran `pnpm run format` before creating this PR.
