### PR TITLE
Improve transaction failure error messages across provider/client

### DIFF
--- a/client/apps/game/src/hooks/use-transaction-listener.ts
+++ b/client/apps/game/src/hooks/use-transaction-listener.ts
@@ -3,6 +3,7 @@ import { BatchedTransactionDetail, TransactionType } from "@bibliothecadao/provi
 import { useDojo } from "@bibliothecadao/react";
 import { useTransactionStore } from "@/hooks/store/use-transaction-store";
 import { getTxMessage } from "@/ui/components/transaction-center/types";
+import { extractReadableErrorMessage } from "@/utils/error-message";
 
 interface TransactionSubmittedPayload {
   transactionHash: string;
@@ -102,9 +103,7 @@ export const useTransactionListener = () => {
     };
 
     const handleTransactionFailed = (error: string | TransactionFailedPayload, meta?: TransactionFailedPayload) => {
-      // Parse the error payload (can be string or object)
-      const message =
-        typeof error === "string" ? error : typeof error?.message === "string" ? error.message : "Transaction failed";
+      const message = extractReadableErrorMessage(error, extractReadableErrorMessage(meta, "Transaction failed"));
 
       const type = typeof error === "object" && error?.type ? error.type : (meta?.type ?? null);
 
@@ -112,7 +111,7 @@ export const useTransactionListener = () => {
         typeof error === "object" && error?.transactionHash ? error.transactionHash : (meta?.transactionHash ?? null);
 
       const transactionCount =
-        typeof error === "object" && error?.transactionCount
+        typeof error === "object" && typeof error?.transactionCount === "number"
           ? error.transactionCount
           : (meta?.transactionCount ?? undefined);
 

--- a/client/apps/game/src/ui/shared/components/tx-emit.tsx
+++ b/client/apps/game/src/ui/shared/components/tx-emit.tsx
@@ -3,6 +3,7 @@ import { useDojo } from "@bibliothecadao/react";
 import { useEffect } from "react";
 import { toast } from "sonner";
 import { getTxMessage as getBaseMessage, getTxIcon } from "@/ui/components/transaction-center/types";
+import { extractReadableErrorMessage } from "@/utils/error-message";
 
 const getTxMessage = (type: TransactionType): string => {
   const icon = getTxIcon(type);
@@ -40,12 +41,11 @@ export function TransactionNotification() {
     };
 
     const handleTransactionFailed = (error: string | TransactionFailurePayload, meta?: TransactionFailurePayload) => {
-      const message =
-        typeof error === "string" ? error : typeof error?.message === "string" ? error.message : "Transaction failed.";
+      const message = extractReadableErrorMessage(error, extractReadableErrorMessage(meta, "Transaction failed."));
       const type =
         typeof error === "object" && error?.type ? error.type : typeof meta?.type !== "undefined" ? meta.type : null;
       const transactionCount =
-        typeof error === "object" && error?.transactionCount
+        typeof error === "object" && typeof error?.transactionCount === "number"
           ? error.transactionCount
           : typeof meta?.transactionCount === "number"
             ? meta.transactionCount

--- a/client/apps/game/src/utils/error-message.ts
+++ b/client/apps/game/src/utils/error-message.ts
@@ -1,0 +1,284 @@
+const NON_MEANINGFUL_ERROR_MESSAGES = new Set(["", "[object Object]", "undefined", "null"]);
+const GENERIC_ERROR_MESSAGES = new Set([
+  "transaction execution error",
+  "execution error",
+  "rpc error",
+  "unknown error",
+  "unknown revert reason",
+  "transaction failed",
+]);
+const GENERIC_ERROR_PREFIXES = ["transaction execution error:", "rpc error:", "rpc:"];
+const WRAPPED_ERROR_PREFIXES = [
+  "Transaction failed to submit:",
+  "Transaction failed while waiting for confirmation:",
+  "Transaction failed with reason:",
+];
+
+const normalizeErrorKey = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[.:]+$/g, "");
+
+const isProtocolErrorCode = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^0x[0-9a-f]+$/i.test(trimmed)) return true;
+  if (/^[A-Z0-9_]{3,}$/.test(trimmed)) return true;
+  if (/^[a-z0-9_-]+\/[a-z0-9_-]+$/i.test(trimmed)) return true;
+  return false;
+};
+
+const isWrappedGenericErrorMessage = (message: string): boolean => {
+  const normalizedMessage = normalizeErrorKey(message);
+  for (const wrappedPrefix of WRAPPED_ERROR_PREFIXES) {
+    const normalizedPrefix = wrappedPrefix.toLowerCase();
+    if (!normalizedMessage.startsWith(normalizedPrefix)) continue;
+    const rawSuffix = message.trim().slice(wrappedPrefix.length).trim();
+    const normalizedSuffix = normalizeErrorKey(rawSuffix);
+    return !rawSuffix || GENERIC_ERROR_MESSAGES.has(normalizedSuffix) || isProtocolErrorCode(rawSuffix);
+  }
+
+  return false;
+};
+
+const sanitizeReason = (value: string): string | null => {
+  const trimmed = value.trim().replace(/^['"]|['"]$/g, "");
+  if (!trimmed || NON_MEANINGFUL_ERROR_MESSAGES.has(trimmed)) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const asReasonCandidate = (value: string): string | null => {
+  const reason = sanitizeReason(value);
+  if (!reason) {
+    return null;
+  }
+
+  const normalized = normalizeErrorKey(reason);
+  if (GENERIC_ERROR_MESSAGES.has(normalized) || isWrappedGenericErrorMessage(reason) || isProtocolErrorCode(reason)) {
+    return null;
+  }
+
+  if (reason.includes("/")) return null;
+  if (/^[A-Z0-9_/-]+$/.test(reason)) return null;
+  if (/^0x[0-9a-f]+$/i.test(reason)) return null;
+  if (!/[a-zA-Z]/.test(reason)) return null;
+
+  return reason;
+};
+
+const decodeHexToAscii = (value: string): string | null => {
+  const normalized = value.startsWith("0x") ? value.slice(2) : value;
+  if (normalized.length < 4 || normalized.length % 2 !== 0) {
+    return null;
+  }
+
+  let decoded = "";
+  for (let i = 0; i < normalized.length; i += 2) {
+    const byte = Number.parseInt(normalized.slice(i, i + 2), 16);
+    if (Number.isNaN(byte)) {
+      return null;
+    }
+    decoded += String.fromCharCode(byte);
+  }
+
+  const cleaned = decoded.replace(/\0/g, "").trim();
+  if (!cleaned) {
+    return null;
+  }
+
+  const printableCount = [...cleaned].filter((char) => {
+    const code = char.charCodeAt(0);
+    return (code >= 32 && code <= 126) || code === 9 || code === 10 || code === 13;
+  }).length;
+
+  return printableCount / cleaned.length >= 0.85 ? cleaned : null;
+};
+
+const extractSpecificReasonFromMessage = (message: string): string | null => {
+  const explicitReasonPatterns = [
+    /,\s*\\"([^"\\]+)\\"\s*,\s*0x[0-9a-f]+ \('ENTRYPOINT_FAILED'\)/i,
+    /,\s*0x[0-9a-f]+ \('([^']+)'\)\s*,\s*0x[0-9a-f]+ \('ENTRYPOINT_FAILED'\)/i,
+    /Transaction failed with reason:\s*([^\n]+)/i,
+    /execution reverted(?: with reason)?[:\s]+["']?([^"\n']+)["']?/i,
+    /revert(?:ed)?(?: with reason)?[:\s]+["']?([^"\n']+)["']?/i,
+  ];
+  for (const pattern of explicitReasonPatterns) {
+    const match = message.match(pattern);
+    if (!match?.[1]) continue;
+    const reason = asReasonCandidate(match[1]);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  for (const match of message.matchAll(/"([^"]+)"/g)) {
+    const candidate = match[1]?.trim();
+    if (!candidate) continue;
+    const matchIndex = match.index ?? 0;
+    const charAfterQuote = message.slice(matchIndex + match[0].length).trimStart();
+    if (charAfterQuote.startsWith(":")) continue;
+    const reason = asReasonCandidate(candidate);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  for (const match of message.matchAll(/'([^']+)'/g)) {
+    const candidate = match[1]?.trim();
+    if (!candidate) continue;
+    const matchIndex = match.index ?? 0;
+    const charAfterQuote = message.slice(matchIndex + match[0].length).trimStart();
+    if (charAfterQuote.startsWith(":")) continue;
+    const reason = asReasonCandidate(candidate);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  for (const match of message.matchAll(/0x[0-9a-f]{8,}/gi)) {
+    const decoded = decodeHexToAscii(match[0]);
+    if (!decoded) continue;
+    const reason = asReasonCandidate(decoded);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  return null;
+};
+
+const isGenericErrorMessage = (message: string): boolean => {
+  const normalized = normalizeErrorKey(message);
+  if (
+    GENERIC_ERROR_MESSAGES.has(normalized) ||
+    GENERIC_ERROR_PREFIXES.some((prefix) => normalized.startsWith(prefix)) ||
+    isProtocolErrorCode(message)
+  ) {
+    return true;
+  }
+
+  return isWrappedGenericErrorMessage(message);
+};
+
+const asMeaningfulErrorMessage = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (NON_MEANINGFUL_ERROR_MESSAGES.has(trimmed)) {
+      return null;
+    }
+
+    for (const prefix of WRAPPED_ERROR_PREFIXES) {
+      if (!trimmed.startsWith(prefix)) continue;
+      const suffix = trimmed.slice(prefix.length).trim();
+      if (NON_MEANINGFUL_ERROR_MESSAGES.has(suffix)) {
+        return null;
+      }
+    }
+
+    const specificReason = extractSpecificReasonFromMessage(trimmed);
+    if (specificReason) {
+      return specificReason;
+    }
+
+    return trimmed;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  return null;
+};
+
+export const extractReadableErrorMessage = (error: unknown, fallback = "Unknown error"): string => {
+  const queue: unknown[] = [error];
+  const visited = new Set<object>();
+
+  const getSpecificMessage = (value: unknown): string | null => {
+    const candidate = asMeaningfulErrorMessage(value);
+    if (!candidate) {
+      return null;
+    }
+    if (isGenericErrorMessage(candidate)) {
+      return null;
+    }
+    return candidate;
+  };
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const directMessage = getSpecificMessage(current);
+    if (directMessage) {
+      return directMessage;
+    }
+
+    if (current instanceof Error) {
+      queue.push(current.message);
+      queue.push((current as Error & { cause?: unknown }).cause);
+      continue;
+    }
+
+    if (Array.isArray(current)) {
+      queue.push(...current);
+      continue;
+    }
+
+    if (current && typeof current === "object") {
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const record = current as Record<string, unknown>;
+
+      const directCandidates = [
+        record.shortMessage,
+        record.reason,
+        record.execution_error,
+        record.executionError,
+        record.revert_reason,
+        record.revertReason,
+        record.description,
+        record.message,
+      ];
+      for (const candidate of directCandidates) {
+        const directCandidateMessage = getSpecificMessage(candidate);
+        if (directCandidateMessage) {
+          return directCandidateMessage;
+        }
+      }
+
+      queue.push(
+        record.data,
+        record.error,
+        record.cause,
+        record.details,
+        record.execution_error,
+        record.executionError,
+        record.message,
+        record.reason,
+        record.revert_reason,
+        record.revertReason,
+        record.shortMessage,
+        record.description,
+      );
+    }
+  }
+
+  try {
+    if (error && typeof error === "object") {
+      const serialized = JSON.stringify(error);
+      if (serialized && serialized !== "{}" && serialized !== "[]") {
+        const serializedReason = extractSpecificReasonFromMessage(serialized);
+        if (serializedReason && !isGenericErrorMessage(serializedReason)) {
+          return serializedReason;
+        }
+      }
+    }
+  } catch {
+    // Ignore serialization failures and use fallback
+  }
+
+  return fallback;
+};

--- a/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
+++ b/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
@@ -209,4 +209,123 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
     });
     expect(provider.execute).toHaveBeenCalledTimes(2);
   });
+
+  it("emits readable submission failures for object-shaped errors", async () => {
+    const provider = makeProvider();
+    provider.execute = vi.fn().mockRejectedValue({
+      message: { code: 40, details: "fallback object message" },
+      data: { message: "Execution reverted: insufficient balance" },
+    });
+
+    const signer = {
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBeDefined();
+
+    const failedEmit = provider.emit.mock.calls.find((emitCall: unknown[]) => emitCall[0] === "transactionFailed");
+    expect(failedEmit?.[1]).toBe("Transaction failed to submit: insufficient balance");
+  });
+
+  it("prefers nested revert reason over generic short rpc messages", async () => {
+    const provider = makeProvider();
+    provider.execute = vi.fn().mockRejectedValue({
+      shortMessage: "Transaction execution error",
+      details:
+        'Transaction execution error: {"transaction_index":0,"execution_error":"Nested error: (0x617267656e742f6d756c746963616c6c2d6661696c6564 (\'argent/multicall-failed\'), 0x3, \\"one of the tiles in path is occupied\\", 0x454e545259504f494e545f4641494c4544 (\'ENTRYPOINT_FAILED\'))"}',
+    });
+
+    const signer = {
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBeDefined();
+
+    const failedEmit = provider.emit.mock.calls.find((emitCall: unknown[]) => emitCall[0] === "transactionFailed");
+    expect(failedEmit?.[1]).toBe("Transaction failed to submit: one of the tiles in path is occupied");
+  });
+
+  it("extracts hex-annotated starknet nested reasons before generic rpc text", async () => {
+    const provider = makeProvider();
+    provider.execute = vi.fn().mockRejectedValue({
+      shortMessage: "Transaction execution error",
+      details:
+        `Transaction execution error: {"transaction_index":0,"execution_error":"Nested error: ` +
+        `(0x617267656e742f6d756c746963616c6c2d6661696c6564 ('argent/multicall-failed'), ` +
+        `0x0 (''), 0x506f70756c6174696f6e2065786365656473206361706163697479 ('Population exceeds capacity'), ` +
+        `0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED'))"}`,
+    });
+
+    const signer = {
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBeDefined();
+
+    const failedEmit = provider.emit.mock.calls.find((emitCall: unknown[]) => emitCall[0] === "transactionFailed");
+    expect(failedEmit?.[1]).toBe("Transaction failed to submit: Population exceeds capacity");
+  });
+
+  it("does not surface protocol error codes when no readable reason is available", async () => {
+    const provider = makeProvider();
+    provider.execute = vi.fn().mockRejectedValue(new Error("Transaction failed with reason: ENTRYPOINT_FAILED"));
+
+    const signer = {
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBeDefined();
+
+    const failedEmit = provider.emit.mock.calls.find((emitCall: unknown[]) => emitCall[0] === "transactionFailed");
+    expect(failedEmit?.[1]).toBe("Transaction failed to submit: Unknown error");
+  });
+
+  it("falls back for wrapped generic string errors without serializing quotes", async () => {
+    const provider = makeProvider();
+    provider.execute = vi.fn().mockRejectedValue("Transaction failed to submit: Unknown error");
+
+    const signer = {
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBeDefined();
+
+    const failedEmit = provider.emit.mock.calls.find((emitCall: unknown[]) => emitCall[0] === "transactionFailed");
+    expect(failedEmit?.[1]).toBe("Transaction failed to submit: Unknown error");
+  });
 });

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -33,6 +33,290 @@ export type { VrfSource } from "./vrf";
 const MIN_V3_L2_GAS_MAX_AMOUNT = 1_500_000_000n;
 const V3_L2_GAS_OVERHEAD_PERCENT = 50n;
 const HUNDRED_PERCENT = 100n;
+const NON_MEANINGFUL_ERROR_MESSAGES = new Set(["", "[object Object]", "undefined", "null"]);
+const GENERIC_ERROR_MESSAGES = new Set([
+  "transaction execution error",
+  "execution error",
+  "rpc error",
+  "unknown error",
+  "unknown revert reason",
+  "transaction failed",
+]);
+const GENERIC_ERROR_PREFIXES = ["transaction execution error:", "rpc error:", "rpc:"];
+const WRAPPED_ERROR_PREFIXES = [
+  "Transaction failed to submit:",
+  "Transaction failed while waiting for confirmation:",
+  "Transaction failed with reason:",
+];
+
+const normalizeErrorKey = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[.:]+$/g, "");
+
+const isProtocolErrorCode = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^0x[0-9a-f]+$/i.test(trimmed)) return true;
+  if (/^[A-Z0-9_]{3,}$/.test(trimmed)) return true;
+  if (/^[a-z0-9_-]+\/[a-z0-9_-]+$/i.test(trimmed)) return true;
+  return false;
+};
+
+const isWrappedGenericErrorMessage = (message: string): boolean => {
+  const normalizedMessage = normalizeErrorKey(message);
+  for (const wrappedPrefix of WRAPPED_ERROR_PREFIXES) {
+    const normalizedPrefix = wrappedPrefix.toLowerCase();
+    if (!normalizedMessage.startsWith(normalizedPrefix)) continue;
+    const rawSuffix = message.trim().slice(wrappedPrefix.length).trim();
+    const normalizedSuffix = normalizeErrorKey(rawSuffix);
+    return !rawSuffix || GENERIC_ERROR_MESSAGES.has(normalizedSuffix) || isProtocolErrorCode(rawSuffix);
+  }
+
+  return false;
+};
+
+const sanitizeReason = (value: string): string | null => {
+  const trimmed = value.trim().replace(/^['"]|['"]$/g, "");
+  if (!trimmed || NON_MEANINGFUL_ERROR_MESSAGES.has(trimmed)) {
+    return null;
+  }
+
+  return trimmed;
+};
+
+const asReasonCandidate = (value: string): string | null => {
+  const reason = sanitizeReason(value);
+  if (!reason) {
+    return null;
+  }
+
+  const normalized = normalizeErrorKey(reason);
+  if (GENERIC_ERROR_MESSAGES.has(normalized) || isWrappedGenericErrorMessage(reason) || isProtocolErrorCode(reason)) {
+    return null;
+  }
+
+  if (reason.includes("/")) return null;
+  if (/^[A-Z0-9_/-]+$/.test(reason)) return null;
+  if (/^0x[0-9a-f]+$/i.test(reason)) return null;
+  if (!/[a-zA-Z]/.test(reason)) return null;
+
+  return reason;
+};
+
+const decodeHexToAscii = (value: string): string | null => {
+  const normalized = value.startsWith("0x") ? value.slice(2) : value;
+  if (normalized.length < 4 || normalized.length % 2 !== 0) {
+    return null;
+  }
+
+  let decoded = "";
+  for (let i = 0; i < normalized.length; i += 2) {
+    const byte = Number.parseInt(normalized.slice(i, i + 2), 16);
+    if (Number.isNaN(byte)) {
+      return null;
+    }
+    decoded += String.fromCharCode(byte);
+  }
+
+  const cleaned = decoded.replace(/\0/g, "").trim();
+  if (!cleaned) {
+    return null;
+  }
+
+  const printableCount = [...cleaned].filter((char) => {
+    const code = char.charCodeAt(0);
+    return (code >= 32 && code <= 126) || code === 9 || code === 10 || code === 13;
+  }).length;
+
+  return printableCount / cleaned.length >= 0.85 ? cleaned : null;
+};
+
+const extractSpecificReasonFromMessage = (message: string): string | null => {
+  const explicitReasonPatterns = [
+    /,\s*\\"([^"\\]+)\\"\s*,\s*0x[0-9a-f]+ \('ENTRYPOINT_FAILED'\)/i,
+    /,\s*0x[0-9a-f]+ \('([^']+)'\)\s*,\s*0x[0-9a-f]+ \('ENTRYPOINT_FAILED'\)/i,
+    /Transaction failed with reason:\s*([^\n]+)/i,
+    /execution reverted(?: with reason)?[:\s]+["']?([^"\n']+)["']?/i,
+    /revert(?:ed)?(?: with reason)?[:\s]+["']?([^"\n']+)["']?/i,
+  ];
+  for (const pattern of explicitReasonPatterns) {
+    const match = message.match(pattern);
+    if (!match?.[1]) continue;
+    const reason = asReasonCandidate(match[1]);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  for (const match of message.matchAll(/"([^"]+)"/g)) {
+    const candidate = match[1]?.trim();
+    if (!candidate) continue;
+    const matchIndex = match.index ?? 0;
+    const charAfterQuote = message.slice(matchIndex + match[0].length).trimStart();
+    if (charAfterQuote.startsWith(":")) continue;
+    const reason = asReasonCandidate(candidate);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  for (const match of message.matchAll(/'([^']+)'/g)) {
+    const candidate = match[1]?.trim();
+    if (!candidate) continue;
+    const matchIndex = match.index ?? 0;
+    const charAfterQuote = message.slice(matchIndex + match[0].length).trimStart();
+    if (charAfterQuote.startsWith(":")) continue;
+    const reason = asReasonCandidate(candidate);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  for (const match of message.matchAll(/0x[0-9a-f]{8,}/gi)) {
+    const decoded = decodeHexToAscii(match[0]);
+    if (!decoded) continue;
+    const reason = asReasonCandidate(decoded);
+    if (reason) {
+      return reason;
+    }
+  }
+
+  return null;
+};
+
+const isGenericErrorMessage = (message: string): boolean => {
+  const normalized = normalizeErrorKey(message);
+  if (
+    GENERIC_ERROR_MESSAGES.has(normalized) ||
+    GENERIC_ERROR_PREFIXES.some((prefix) => normalized.startsWith(prefix)) ||
+    isProtocolErrorCode(message)
+  ) {
+    return true;
+  }
+
+  return isWrappedGenericErrorMessage(message);
+};
+
+const asMeaningfulErrorMessage = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (NON_MEANINGFUL_ERROR_MESSAGES.has(trimmed)) {
+      return null;
+    }
+
+    for (const prefix of WRAPPED_ERROR_PREFIXES) {
+      if (!trimmed.startsWith(prefix)) continue;
+      const suffix = trimmed.slice(prefix.length).trim();
+      if (NON_MEANINGFUL_ERROR_MESSAGES.has(suffix)) {
+        return null;
+      }
+    }
+
+    const specificReason = extractSpecificReasonFromMessage(trimmed);
+    if (specificReason) {
+      return specificReason;
+    }
+
+    return trimmed;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  return null;
+};
+
+const extractErrorMessage = (error: unknown, fallback = "Unknown error"): string => {
+  const queue: unknown[] = [error];
+  const visited = new Set<object>();
+
+  const getSpecificMessage = (value: unknown): string | null => {
+    const candidate = asMeaningfulErrorMessage(value);
+    if (!candidate) {
+      return null;
+    }
+    if (isGenericErrorMessage(candidate)) {
+      return null;
+    }
+    return candidate;
+  };
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const directMessage = getSpecificMessage(current);
+    if (directMessage) {
+      return directMessage;
+    }
+
+    if (current instanceof Error) {
+      queue.push(current.message);
+      queue.push((current as Error & { cause?: unknown }).cause);
+      continue;
+    }
+
+    if (Array.isArray(current)) {
+      queue.push(...current);
+      continue;
+    }
+
+    if (current && typeof current === "object") {
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const record = current as Record<string, unknown>;
+
+      const directCandidates = [
+        record.shortMessage,
+        record.reason,
+        record.execution_error,
+        record.executionError,
+        record.revert_reason,
+        record.revertReason,
+        record.description,
+        record.message,
+      ];
+      for (const candidate of directCandidates) {
+        const directCandidateMessage = getSpecificMessage(candidate);
+        if (directCandidateMessage) {
+          return directCandidateMessage;
+        }
+      }
+
+      queue.push(
+        record.data,
+        record.error,
+        record.cause,
+        record.details,
+        record.execution_error,
+        record.executionError,
+        record.message,
+        record.reason,
+        record.revert_reason,
+        record.revertReason,
+        record.shortMessage,
+        record.description,
+      );
+    }
+  }
+
+  try {
+    if (error && typeof error === "object") {
+      const serialized = JSON.stringify(error);
+      if (serialized && serialized !== "{}" && serialized !== "[]") {
+        const serializedReason = extractSpecificReasonFromMessage(serialized);
+        if (serializedReason && !isGenericErrorMessage(serializedReason)) {
+          return serializedReason;
+        }
+      }
+    }
+  } catch {
+    // Ignore serialization errors and use fallback
+  }
+
+  return fallback;
+};
 
 const withL2GasHeadroom = (resourceBounds?: ResourceBoundsBN): ResourceBoundsBN | undefined => {
   if (!resourceBounds?.l2_gas || typeof resourceBounds.l2_gas.max_amount !== "bigint") {
@@ -543,7 +827,7 @@ export class EternumProvider extends EnhancedDojoProvider {
   }
 
   private failTransactionSpan(span: Span, transactionHash: string | undefined, error: unknown): void {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = extractErrorMessage(error);
 
     span.recordException(error as Error);
     span.setAttributes({
@@ -689,7 +973,7 @@ export class EternumProvider extends EnhancedDojoProvider {
     } catch (error) {
       releaseVrfExecutionLock?.();
       releaseVrfExecutionLock = undefined;
-      const message = error instanceof Error ? error.message : String(error);
+      const message = extractErrorMessage(error);
       this.emit("transactionFailed", `Transaction failed to submit: ${message}`, transactionMeta);
       this.failTransactionSpan(span, undefined, error);
       throw error;
@@ -1058,7 +1342,7 @@ export class EternumProvider extends EnhancedDojoProvider {
         retryInterval: 500,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = extractErrorMessage(error);
       this.emit("transactionFailed", `Transaction failed while waiting for confirmation: ${message}`, {
         ...transactionMeta,
         transactionHash,
@@ -1075,12 +1359,18 @@ export class EternumProvider extends EnhancedDojoProvider {
 
     // Check if the transaction was reverted and throw an error if it was
     if (receipt.isReverted()) {
-      const revertReason =
-        typeof receiptAny?.revert_reason === "string"
-          ? receiptAny.revert_reason
-          : typeof receiptAny?.revertReason === "string"
-            ? receiptAny.revertReason
-            : "Unknown revert reason";
+      const revertReason = extractErrorMessage(
+        {
+          execution_error: receiptAny?.execution_error,
+          executionError: receiptAny?.executionError,
+          revert_reason: receiptAny?.revert_reason,
+          revertReason: receiptAny?.revertReason,
+          reason: receiptAny?.reason,
+          message: receiptAny?.message,
+          details: receiptAny?.details,
+        },
+        "Unknown revert reason",
+      );
       const message = `Transaction failed with reason: ${revertReason}`;
       this.emit("transactionFailed", message, {
         ...transactionMeta,


### PR DESCRIPTION
This PR improves transaction failure messaging across provider and game client by extracting human-readable reasons from nested, object-shaped, and hex-encoded Starknet errors while filtering generic protocol codes. It applies the extractor to submission failures, confirmation failures, reverted receipts, and failed span attributes in `packages/provider/src/index.ts`, and adds focused coverage in `packages/provider/src/execute-and-check-transaction.l2-gas.test.ts`. It also adds `client/apps/game/src/utils/error-message.ts` and wires it into `client/apps/game/src/hooks/use-transaction-listener.ts` and `client/apps/game/src/ui/shared/components/tx-emit.tsx` so UI failure messages stay readable for structured payloads. Verified with `pnpm --dir packages/provider test -- --run execute-and-check-transaction.l2-gas.test.ts`.