### PR TITLE
Fix mainnet realm settlement flow

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -28,16 +28,38 @@ import { getWorldKey } from "@/hooks/use-world-availability";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import Button from "@/ui/design-system/atoms/button";
 import { BootstrapLoadingPanel } from "@/ui/layouts/bootstrap-loading/bootstrap-loading-panel";
+import {
+  buildSettlementExecutionPlan,
+  deriveSettlementStatus,
+  type SettlementSnapshot,
+} from "./game-entry-settlement.utils";
 import type { Chain } from "@contracts";
 import type { Account } from "starknet";
 
 const DEBUG_MODAL = false;
 const BLITZ_REALM_SYSTEMS_SELECTOR = "0x3414be5ba2c90784f15eb572e9222b5c83a6865ec0e475a57d7dc18af9b3742";
+const SETTLEMENT_PROGRESS_POLL_MS = 1000;
+const SETTLEMENT_PROGRESS_TIMEOUT_MS = 30000;
 
 const debugLog = (_worldName: string | null, ..._args: unknown[]) => {
   if (DEBUG_MODAL) {
     console.log("[GameEntryModal]", ..._args);
   }
+};
+
+const extractTransactionHash = (value: unknown): string | null => {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { transaction_hash?: unknown; transactionHash?: unknown };
+
+  if (typeof candidate.transaction_hash === "string" && candidate.transaction_hash.length > 0) {
+    return candidate.transaction_hash;
+  }
+
+  if (typeof candidate.transactionHash === "string" && candidate.transactionHash.length > 0) {
+    return candidate.transactionHash;
+  }
+
+  return null;
 };
 
 // Types
@@ -658,6 +680,93 @@ export const GameEntryModal = ({
     worldName,
   ]);
 
+  const readSettlementSnapshot = useCallback(async (): Promise<SettlementSnapshot | null> => {
+    if (!setupResult || !account?.address) return null;
+
+    const { components } = setupResult;
+    const playerAddress = account.address;
+
+    const { getEntityIdFromKeys } = await import("@bibliothecadao/eternum");
+    const { getComponentValue, HasValue, runQuery } = await import("@dojoengine/recs");
+
+    const entityId = getEntityIdFromKeys([BigInt(playerAddress)]);
+    const playerRegister = getComponentValue(components.BlitzRealmPlayerRegister, entityId) as
+      | { registered?: boolean; once_registered?: boolean }
+      | null;
+    const settleFinish = getComponentValue(components.BlitzRealmSettleFinish, entityId) as SettleFinishValue | null;
+    const playerStructures = runQuery([HasValue(components.Structure, { owner: BigInt(playerAddress) })]);
+
+    return {
+      registered: playerRegister?.registered === true,
+      onceRegistered: playerRegister?.once_registered === true,
+      hasSettledStructure: playerStructures.size > 0,
+      coordsCount: settleFinish?.coords?.length ?? 0,
+      settledCount: settleFinish?.structure_ids?.length ?? 0,
+    };
+  }, [setupResult, account]);
+
+  const syncSettlementStateFromSnapshot = useCallback(
+    (snapshot: SettlementSnapshot) => {
+      const status = deriveSettlementStatus(snapshot);
+      setAssignedRealmCount(status.assignedCount);
+      setSettledRealmCount(status.settledCount);
+      setNeedsSettlement(status.needsSettlement);
+      return status;
+    },
+    [setAssignedRealmCount, setSettledRealmCount, setNeedsSettlement],
+  );
+
+  const waitForSettlementTarget = useCallback(
+    async (targetSettleCount: number, timeoutMs = SETTLEMENT_PROGRESS_TIMEOUT_MS): Promise<SettlementSnapshot | null> => {
+      const startedAt = Date.now();
+      let latestSnapshot: SettlementSnapshot | null = null;
+
+      while (Date.now() - startedAt < timeoutMs) {
+        const snapshot = await readSettlementSnapshot();
+        if (snapshot) {
+          latestSnapshot = snapshot;
+          const status = syncSettlementStateFromSnapshot(snapshot);
+          if (status.settledCount >= targetSettleCount || status.remainingToSettle === 0) {
+            return snapshot;
+          }
+        }
+        await new Promise((resolve) => setTimeout(resolve, SETTLEMENT_PROGRESS_POLL_MS));
+      }
+
+      return latestSnapshot;
+    },
+    [readSettlementSnapshot, syncSettlementStateFromSnapshot],
+  );
+
+  const waitForSubmittedTransaction = useCallback(
+    async (result: unknown, label: string) => {
+      const txHash = extractTransactionHash(result);
+      if (!txHash) {
+        throw new Error(`Missing transaction hash for ${label}`);
+      }
+
+      const provider = setupResult?.network?.provider as
+        | {
+            waitForTransactionWithCheck?: (txHash: string) => Promise<unknown>;
+          }
+        | undefined;
+
+      if (provider && typeof provider.waitForTransactionWithCheck === "function") {
+        await provider.waitForTransactionWithCheck(txHash);
+        return;
+      }
+
+      const accountWithWait = account as unknown as { waitForTransaction?: (txHash: string) => Promise<unknown> };
+      if (typeof accountWithWait.waitForTransaction === "function") {
+        await accountWithWait.waitForTransaction(txHash);
+        return;
+      }
+
+      throw new Error(`Unable to confirm ${label}: no transaction wait method available`);
+    },
+    [setupResult, account],
+  );
+
   // Check settlement status after bootstrap completes
   useEffect(() => {
     debugLog(
@@ -685,57 +794,32 @@ export const GameEntryModal = ({
     const checkSettlementStatus = async () => {
       debugLog(worldName, "Running settlement status check...");
       try {
-        const { components } = setupResult;
-        const playerAddress = account?.address;
-        debugLog(worldName, "Player address:", playerAddress);
-
-        if (!playerAddress) {
+        if (!account?.address) {
           debugLog(worldName, "No player address, skipping settlement check");
           setNeedsSettlement(false);
           setSettlementCheckComplete(true);
           return;
         }
 
-        // Import Dojo utilities
-        const { getEntityIdFromKeys } = await import("@bibliothecadao/eternum");
-        const { getComponentValue, HasValue, runQuery } = await import("@dojoengine/recs");
-
-        const entityId = getEntityIdFromKeys([BigInt(playerAddress)]);
-        debugLog(worldName, "Entity ID:", entityId);
-
-        // Check if player is registered
-        const playerRegister = getComponentValue(components.BlitzRealmPlayerRegister, entityId);
-        debugLog(worldName, "playerRegister:", playerRegister);
-        const isRegistered = playerRegister?.registered === true;
-
-        // Check if player has any structures (meaning they've settled)
-        const playerStructures = runQuery([HasValue(components.Structure, { owner: BigInt(playerAddress) })]);
-        debugLog(worldName, "playerStructures count:", playerStructures.size);
-        const hasSettled = playerStructures.size > 0;
-
-        // Check settlement finish status
-        const settleFinish = getComponentValue(components.BlitzRealmSettleFinish, entityId) as SettleFinishValue | null;
-        debugLog(worldName, "settleFinish:", settleFinish);
-        const coordsCount = settleFinish?.coords?.length ?? 0;
-        const settledCount = settleFinish?.structure_ids?.length ?? 0;
-
-        setAssignedRealmCount(coordsCount + settledCount);
-        setSettledRealmCount(settledCount);
-
-        // Player needs settlement if registered but not fully settled
-        const canPlay = hasSettled && coordsCount + settledCount > 0 && settledCount === coordsCount + settledCount;
-        const needsSettlementResult = isRegistered && !canPlay;
+        const snapshot = await readSettlementSnapshot();
+        if (!snapshot) {
+          setNeedsSettlement(false);
+          setSettlementCheckComplete(true);
+          return;
+        }
+        const status = syncSettlementStateFromSnapshot(snapshot);
 
         debugLog(worldName, "Settlement check result:", {
-          isRegistered,
-          hasSettled,
-          coordsCount,
-          settledCount,
-          canPlay,
-          needsSettlement: needsSettlementResult,
+          registered: snapshot.registered,
+          onceRegistered: snapshot.onceRegistered,
+          hasSettledStructure: snapshot.hasSettledStructure,
+          coordsCount: snapshot.coordsCount,
+          settledCount: snapshot.settledCount,
+          assignedCount: status.assignedCount,
+          canPlay: status.canPlay,
+          needsSettlement: status.needsSettlement,
         });
 
-        setNeedsSettlement(needsSettlementResult);
         setSettlementCheckComplete(true);
       } catch (error) {
         debugLog(worldName, "Failed to check settlement status:", error);
@@ -747,7 +831,16 @@ export const GameEntryModal = ({
 
     // Run the check
     checkSettlementStatus();
-  }, [bootstrapStatus, setupResult, account, isSpectateMode, isForgeMode, worldName]);
+  }, [
+    bootstrapStatus,
+    setupResult,
+    account,
+    isSpectateMode,
+    isForgeMode,
+    worldName,
+    readSettlementSnapshot,
+    syncSettlementStateFromSnapshot,
+  ]);
 
   // Check hyperstructure initialization status after bootstrap completes
   useEffect(() => {
@@ -963,7 +1056,6 @@ export const GameEntryModal = ({
     if (!setupResult || !account) return;
 
     setIsSettling(true);
-    setSettleStage("assigning");
 
     try {
       const { systemCalls } = setupResult;
@@ -976,44 +1068,54 @@ export const GameEntryModal = ({
 
       debugLog(worldName, "Settlement config:", { isMainnet, singleRealmMode, blitzConfig });
 
-      // Settlement configuration
-      const SETTLEMENT_CONFIG = {
-        MAINNET: {
-          MULTI_REALM: { INITIAL_SETTLE_COUNT: 1, EXTRA_CALLS: 2 },
-          SINGLE_REALM: { INITIAL_SETTLE_COUNT: 1, EXTRA_CALLS: 0 },
-        },
-        NON_MAINNET: {
-          MULTI_REALM: { INITIAL_SETTLE_COUNT: 3 },
-          SINGLE_REALM: { INITIAL_SETTLE_COUNT: 1 },
-        },
-      };
+      const initialSnapshot = await readSettlementSnapshot();
+      if (!initialSnapshot) {
+        throw new Error("Unable to read settlement status for current player.");
+      }
+      const initialStatus = syncSettlementStateFromSnapshot(initialSnapshot);
+      let targetProgress = initialStatus.settledCount;
 
-      if (isMainnet) {
-        const config = singleRealmMode ? SETTLEMENT_CONFIG.MAINNET.SINGLE_REALM : SETTLEMENT_CONFIG.MAINNET.MULTI_REALM;
+      const plan = buildSettlementExecutionPlan({
+        isMainnet,
+        singleRealmMode,
+        snapshot: initialSnapshot,
+      });
+      debugLog(worldName, "Settlement execution plan:", plan);
 
-        debugLog(worldName, "Starting settlement (mainnet):", config);
-        await systemCalls.blitz_realm_assign_and_settle_realms({
+      if (plan.missingAssignmentRegistration) {
+        throw new Error("Cannot assign realm positions because the player is no longer in registered state.");
+      }
+
+      if (plan.shouldAssignAndSettle && plan.initialSettleCount > 0) {
+        setSettleStage("assigning");
+        debugLog(worldName, "Submitting assign + settle call:", { settlement_count: plan.initialSettleCount });
+        const assignResult = await systemCalls.blitz_realm_assign_and_settle_realms({
           signer: account,
-          settlement_count: config.INITIAL_SETTLE_COUNT,
+          settlement_count: plan.initialSettleCount,
         });
+        await waitForSubmittedTransaction(assignResult, "assign_and_settle_realms");
+        targetProgress = Math.min(plan.targetSettleCount, targetProgress + plan.initialSettleCount);
+        await waitForSettlementTarget(targetProgress);
+      }
 
-        if (config.EXTRA_CALLS > 0) {
-          setSettleStage("settling");
-          for (let i = 0; i < config.EXTRA_CALLS; i++) {
-            debugLog(worldName, `Extra settle call ${i + 1}/${config.EXTRA_CALLS}`);
-            await systemCalls.blitz_realm_settle_realms({ signer: account, settlement_count: 1 });
-          }
+      if (plan.extraSettleCalls > 0) {
+        setSettleStage("settling");
+        for (let i = 0; i < plan.extraSettleCalls; i++) {
+          debugLog(worldName, `Extra settle call ${i + 1}/${plan.extraSettleCalls}`);
+          const settleResult = await systemCalls.blitz_realm_settle_realms({ signer: account, settlement_count: 1 });
+          await waitForSubmittedTransaction(settleResult, `settle_realms ${i + 1}/${plan.extraSettleCalls}`);
+          targetProgress = Math.min(plan.targetSettleCount, targetProgress + 1);
+          await waitForSettlementTarget(targetProgress);
         }
-      } else {
-        const config = singleRealmMode
-          ? SETTLEMENT_CONFIG.NON_MAINNET.SINGLE_REALM
-          : SETTLEMENT_CONFIG.NON_MAINNET.MULTI_REALM;
+      }
 
-        debugLog(worldName, "Starting settlement (non-mainnet):", config);
-        await systemCalls.blitz_realm_assign_and_settle_realms({
-          signer: account,
-          settlement_count: config.INITIAL_SETTLE_COUNT,
-        });
+      const finalSnapshot = await waitForSettlementTarget(plan.targetSettleCount);
+      if (!finalSnapshot) {
+        throw new Error("Timed out waiting for settlement progress.");
+      }
+      const finalStatus = syncSettlementStateFromSnapshot(finalSnapshot);
+      if (finalStatus.settledCount < plan.targetSettleCount) {
+        throw new Error(`Settlement incomplete: ${finalStatus.settledCount}/${plan.targetSettleCount} realms settled.`);
       }
 
       debugLog(worldName, "Settlement complete!");
@@ -1030,7 +1132,16 @@ export const GameEntryModal = ({
     } finally {
       setIsSettling(false);
     }
-  }, [setupResult, account, handleEnterGame, worldName]);
+  }, [
+    setupResult,
+    account,
+    handleEnterGame,
+    worldName,
+    readSettlementSnapshot,
+    syncSettlementStateFromSnapshot,
+    waitForSettlementTarget,
+    waitForSubmittedTransaction,
+  ]);
 
   // Forge hyperstructures handler - creates new hyperstructures during registration period
   const handleForgeHyperstructures = useCallback(async () => {

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSettlementExecutionPlan,
+  deriveSettlementStatus,
+  getExpectedSettlementCount,
+  type SettlementSnapshot,
+} from "./game-entry-settlement.utils";
+
+const snapshot = (partial: Partial<SettlementSnapshot> = {}): SettlementSnapshot => ({
+  registered: false,
+  onceRegistered: false,
+  hasSettledStructure: false,
+  coordsCount: 0,
+  settledCount: 0,
+  ...partial,
+});
+
+describe("deriveSettlementStatus", () => {
+  it("does not require settlement for unregistered players", () => {
+    const result = deriveSettlementStatus(snapshot());
+    expect(result.needsSettlement).toBe(false);
+    expect(result.canPlay).toBe(false);
+  });
+
+  it("requires settlement for registered players who have not settled yet", () => {
+    const result = deriveSettlementStatus(snapshot({ registered: true }));
+    expect(result.needsSettlement).toBe(true);
+    expect(result.assignedCount).toBe(0);
+  });
+
+  it("keeps settlement required for partial states even when registered is false", () => {
+    const result = deriveSettlementStatus(
+      snapshot({
+        registered: false,
+        onceRegistered: true,
+        hasSettledStructure: true,
+        coordsCount: 2,
+        settledCount: 1,
+      }),
+    );
+
+    expect(result.assignedCount).toBe(3);
+    expect(result.remainingToSettle).toBe(2);
+    expect(result.canPlay).toBe(false);
+    expect(result.needsSettlement).toBe(true);
+  });
+
+  it("marks complete states as playable", () => {
+    const result = deriveSettlementStatus(
+      snapshot({
+        registered: false,
+        onceRegistered: true,
+        hasSettledStructure: true,
+        coordsCount: 0,
+        settledCount: 3,
+      }),
+    );
+
+    expect(result.assignedCount).toBe(3);
+    expect(result.remainingToSettle).toBe(0);
+    expect(result.canPlay).toBe(true);
+    expect(result.needsSettlement).toBe(false);
+  });
+});
+
+describe("buildSettlementExecutionPlan", () => {
+  it("plans 1 + 2 calls for fresh mainnet multi-realm settlement", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: true,
+      singleRealmMode: false,
+      snapshot: snapshot({ registered: true }),
+    });
+
+    expect(plan.targetSettleCount).toBe(3);
+    expect(plan.shouldAssignAndSettle).toBe(true);
+    expect(plan.initialSettleCount).toBe(1);
+    expect(plan.extraSettleCalls).toBe(2);
+    expect(plan.missingAssignmentRegistration).toBe(false);
+  });
+
+  it("continues settling from partial mainnet progress without re-assigning", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: true,
+      singleRealmMode: false,
+      snapshot: snapshot({
+        registered: false,
+        onceRegistered: true,
+        coordsCount: 2,
+        settledCount: 1,
+      }),
+    });
+
+    expect(plan.targetSettleCount).toBe(3);
+    expect(plan.shouldAssignAndSettle).toBe(false);
+    expect(plan.initialSettleCount).toBe(0);
+    expect(plan.extraSettleCalls).toBe(2);
+    expect(plan.missingAssignmentRegistration).toBe(false);
+  });
+
+  it("plans single-call non-mainnet multi-realm settlement", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: false,
+      singleRealmMode: false,
+      snapshot: snapshot({ registered: true }),
+    });
+
+    expect(plan.targetSettleCount).toBe(3);
+    expect(plan.shouldAssignAndSettle).toBe(true);
+    expect(plan.initialSettleCount).toBe(3);
+    expect(plan.extraSettleCalls).toBe(0);
+  });
+
+  it("uses target count of one in single realm mode", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: true,
+      singleRealmMode: true,
+      snapshot: snapshot({ registered: true }),
+    });
+
+    expect(getExpectedSettlementCount(true)).toBe(1);
+    expect(plan.targetSettleCount).toBe(1);
+    expect(plan.initialSettleCount).toBe(1);
+    expect(plan.extraSettleCalls).toBe(0);
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
@@ -1,0 +1,89 @@
+export type SettlementSnapshot = {
+  registered: boolean;
+  onceRegistered: boolean;
+  hasSettledStructure: boolean;
+  coordsCount: number;
+  settledCount: number;
+};
+
+export type SettlementStatus = {
+  assignedCount: number;
+  settledCount: number;
+  remainingToSettle: number;
+  canPlay: boolean;
+  needsSettlement: boolean;
+};
+
+export const getExpectedSettlementCount = (singleRealmMode: boolean): number => (singleRealmMode ? 1 : 3);
+
+export const deriveSettlementStatus = (snapshot: SettlementSnapshot): SettlementStatus => {
+  const coordsCount = Math.max(0, snapshot.coordsCount);
+  const settledCount = Math.max(0, snapshot.settledCount);
+  const assignedCount = coordsCount + settledCount;
+  const remainingToSettle = Math.max(0, assignedCount - settledCount);
+  const canPlay = snapshot.hasSettledStructure && assignedCount > 0 && remainingToSettle === 0;
+  const isRegisteredForSettlement = snapshot.registered || snapshot.onceRegistered;
+  const needsSettlement = isRegisteredForSettlement && !canPlay;
+
+  return {
+    assignedCount,
+    settledCount,
+    remainingToSettle,
+    canPlay,
+    needsSettlement,
+  };
+};
+
+export type SettlementExecutionPlan = {
+  targetSettleCount: number;
+  shouldAssignAndSettle: boolean;
+  initialSettleCount: number;
+  extraSettleCalls: number;
+  missingAssignmentRegistration: boolean;
+};
+
+export const buildSettlementExecutionPlan = ({
+  isMainnet,
+  singleRealmMode,
+  snapshot,
+}: {
+  isMainnet: boolean;
+  singleRealmMode: boolean;
+  snapshot: SettlementSnapshot;
+}): SettlementExecutionPlan => {
+  const targetSettleCount = getExpectedSettlementCount(singleRealmMode);
+  const settledCount = Math.max(0, snapshot.settledCount);
+  const coordsCount = Math.max(0, snapshot.coordsCount);
+
+  if (settledCount >= targetSettleCount) {
+    return {
+      targetSettleCount,
+      shouldAssignAndSettle: false,
+      initialSettleCount: 0,
+      extraSettleCalls: 0,
+      missingAssignmentRegistration: false,
+    };
+  }
+
+  if (coordsCount > 0) {
+    const remainingToTarget = Math.max(0, targetSettleCount - settledCount);
+    return {
+      targetSettleCount,
+      shouldAssignAndSettle: false,
+      initialSettleCount: 0,
+      extraSettleCalls: Math.min(coordsCount, remainingToTarget),
+      missingAssignmentRegistration: false,
+    };
+  }
+
+  const initialSettleCount = isMainnet ? 1 : Math.max(0, targetSettleCount - settledCount);
+  const extraSettleCalls = Math.max(0, targetSettleCount - (settledCount + initialSettleCount));
+
+  return {
+    targetSettleCount,
+    shouldAssignAndSettle: true,
+    initialSettleCount,
+    extraSettleCalls,
+    missingAssignmentRegistration: !snapshot.registered,
+  };
+};

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -9,6 +9,13 @@ interface LatestFeature {
 
 export const latestFeatures: LatestFeature[] = [
   {
+    date: "2026-03-06",
+    title: "Reliable Mainnet Realm Settlement",
+    description:
+      "Fixed cases where mainnet settlement could stop after the first realm. Settlement now resumes correctly from partial progress and waits for confirmed transactions so all expected realms are created.",
+    type: "fix",
+  },
+  {
     date: "2026-02-18",
     title: "Smoother Worldmap Chunking",
     description:


### PR DESCRIPTION
## Summary
Mainnet realm settlement now resumes from partial progress instead of stalling after the first realm.
The entry modal reads a reusable settlement snapshot, derives settlement state consistently, and waits for transaction confirmation plus on-chain progress before continuing.
This PR also adds unit coverage for the settlement planning/status helpers and records the fix in latest features.

## Verification
Could not run the touched Vitest and ESLint checks in this workspace because client/apps/game/node_modules is not installed, so vitest and eslint were unavailable.