### PR TITLE
Fix mainnet cosmetics marketplace routing

### DIFF
--- a/client/apps/game/src/ui/features/cosmetics/config/networks.runtime.test.ts
+++ b/client/apps/game/src/ui/features/cosmetics/config/networks.runtime.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 
+const envState = {
+  VITE_PUBLIC_CHAIN: "slot",
+  VITE_PUBLIC_MARKETPLACE_URL: "https://example.com/torii",
+};
+
 vi.mock("@contracts", () => ({
   getSeasonAddresses: (network: string) => ({
     "Collectibles: Realms: Cosmetic Items": `0x${network}-cosmetics`,
@@ -10,10 +15,7 @@ vi.mock("@contracts", () => ({
 }));
 
 vi.mock("../../../../../env", () => ({
-  env: {
-    VITE_PUBLIC_CHAIN: "slot",
-    VITE_PUBLIC_MARKETPLACE_URL: "https://example.com/torii",
-  },
+  env: envState,
 }));
 
 class MutableRpcController {
@@ -45,5 +47,18 @@ describe("resolveConnectedTxNetworkFromRuntime", () => {
     const { resolveConnectedTxNetworkFromRuntime } = await import("./networks");
     expect(resolveConnectedTxNetworkFromRuntime({ chainId: "SN_MAIN" })).toBe("mainnet");
     expect(resolveConnectedTxNetworkFromRuntime({ chainId: "SN_SEPOLIA" })).toBe("sepolia");
+  });
+});
+
+describe("marketplace URL resolution", () => {
+  it("does not reuse a sepolia generic URL for mainnet network config", async () => {
+    vi.resetModules();
+    envState.VITE_PUBLIC_CHAIN = "mainnet";
+    envState.VITE_PUBLIC_MARKETPLACE_URL = "https://api.cartridge.gg/x/eternum-marketplace-sepolia-1/torii";
+
+    const { COSMETICS_NETWORK_CONFIG } = await import("./networks");
+
+    expect(COSMETICS_NETWORK_CONFIG.mainnet.marketplaceUrl).toContain("mainnet");
+    expect(COSMETICS_NETWORK_CONFIG.sepolia.marketplaceUrl).toContain("sepolia");
   });
 });

--- a/client/apps/game/src/ui/features/cosmetics/config/networks.ts
+++ b/client/apps/game/src/ui/features/cosmetics/config/networks.ts
@@ -10,17 +10,50 @@ const DEFAULT_MARKETPLACE_URLS: Record<CosmeticsNetwork, string> = {
   sepolia: "https://api.cartridge.gg/x/eternum-marketplace-sepolia-1/torii",
 };
 
+const importMetaEnv = import.meta.env as Record<string, string | undefined>;
+
+const normalizeMarketplaceUrl = (url: string | undefined): string | undefined => {
+  const trimmed = url?.trim();
+  if (!trimmed) return undefined;
+  // Guard against common typo in env values.
+  if (trimmed.endsWith("/tori")) return `${trimmed}i`;
+  return trimmed.replace(/\/+$/, "");
+};
+
+const pointsToOtherNetwork = (url: string, network: CosmeticsNetwork): boolean => {
+  const lower = url.toLowerCase();
+  if (network === "mainnet") return lower.includes("sepolia");
+  return lower.includes("mainnet");
+};
+
+const resolveMarketplaceUrl = (network: CosmeticsNetwork): string => {
+  const envKey = network === "mainnet" ? "VITE_PUBLIC_MAINNET_MARKETPLACE_URL" : "VITE_PUBLIC_SEPOLIA_MARKETPLACE_URL";
+  const explicitOverride = normalizeMarketplaceUrl(importMetaEnv[envKey]);
+  if (explicitOverride) {
+    return explicitOverride;
+  }
+
+  const genericUrl = normalizeMarketplaceUrl(env.VITE_PUBLIC_MARKETPLACE_URL);
+  if (genericUrl && env.VITE_PUBLIC_CHAIN === network && !pointsToOtherNetwork(genericUrl, network)) {
+    return genericUrl;
+  }
+
+  return DEFAULT_MARKETPLACE_URLS[network];
+};
+
 const MARKETPLACE_URLS: Record<CosmeticsNetwork, string> = {
-  mainnet:
-    (import.meta.env.VITE_PUBLIC_MAINNET_MARKETPLACE_URL as string | undefined) ??
-    (env.VITE_PUBLIC_CHAIN === "mainnet" ? env.VITE_PUBLIC_MARKETPLACE_URL : DEFAULT_MARKETPLACE_URLS.mainnet),
-  sepolia:
-    (import.meta.env.VITE_PUBLIC_SEPOLIA_MARKETPLACE_URL as string | undefined) ??
-    (env.VITE_PUBLIC_CHAIN === "sepolia" ? env.VITE_PUBLIC_MARKETPLACE_URL : DEFAULT_MARKETPLACE_URLS.sepolia),
+  mainnet: resolveMarketplaceUrl("mainnet"),
+  sepolia: resolveMarketplaceUrl("sepolia"),
 };
 
 const MAINNET_ADDRESSES = getSeasonAddresses("mainnet");
 const SEPOLIA_ADDRESSES = getSeasonAddresses("sepolia");
+
+const resolveLootChestAddress = (addresses: ReturnType<typeof getSeasonAddresses>): string =>
+  addresses.lootChests || addresses["Collectibles: Realms: Loot Chest"];
+
+const resolveCosmeticsAddress = (addresses: ReturnType<typeof getSeasonAddresses>): string =>
+  addresses.cosmetics || addresses["Collectibles: Realms: Cosmetic Items"];
 
 export const COSMETICS_NETWORK_CONFIG: Record<
   CosmeticsNetwork,
@@ -37,8 +70,8 @@ export const COSMETICS_NETWORK_CONFIG: Record<
   mainnet: {
     label: "Mainnet",
     marketplaceUrl: MARKETPLACE_URLS.mainnet,
-    cosmeticsAddress: MAINNET_ADDRESSES["Collectibles: Realms: Cosmetic Items"],
-    lootChestsAddress: MAINNET_ADDRESSES["Collectibles: Realms: Loot Chest"],
+    cosmeticsAddress: resolveCosmeticsAddress(MAINNET_ADDRESSES),
+    lootChestsAddress: resolveLootChestAddress(MAINNET_ADDRESSES),
     cosmeticsClaimAddress: MAINNET_ADDRESSES.cosmeticsClaim,
     cosmeticsCollectionId: 4,
     lootChestCollectionId: 3,
@@ -46,8 +79,8 @@ export const COSMETICS_NETWORK_CONFIG: Record<
   sepolia: {
     label: "Sepolia",
     marketplaceUrl: MARKETPLACE_URLS.sepolia,
-    cosmeticsAddress: SEPOLIA_ADDRESSES["Collectibles: Realms: Cosmetic Items"],
-    lootChestsAddress: SEPOLIA_ADDRESSES["Collectibles: Realms: Loot Chest"],
+    cosmeticsAddress: resolveCosmeticsAddress(SEPOLIA_ADDRESSES),
+    lootChestsAddress: resolveLootChestAddress(SEPOLIA_ADDRESSES),
     cosmeticsClaimAddress: SEPOLIA_ADDRESSES.cosmeticsClaim,
     cosmeticsCollectionId: 6,
     lootChestCollectionId: 5,

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -690,9 +690,10 @@ export const GameEntryModal = ({
     const { getComponentValue, HasValue, runQuery } = await import("@dojoengine/recs");
 
     const entityId = getEntityIdFromKeys([BigInt(playerAddress)]);
-    const playerRegister = getComponentValue(components.BlitzRealmPlayerRegister, entityId) as
-      | { registered?: boolean; once_registered?: boolean }
-      | null;
+    const playerRegister = getComponentValue(components.BlitzRealmPlayerRegister, entityId) as {
+      registered?: boolean;
+      once_registered?: boolean;
+    } | null;
     const settleFinish = getComponentValue(components.BlitzRealmSettleFinish, entityId) as SettleFinishValue | null;
     const playerStructures = runQuery([HasValue(components.Structure, { owner: BigInt(playerAddress) })]);
 
@@ -717,7 +718,10 @@ export const GameEntryModal = ({
   );
 
   const waitForSettlementTarget = useCallback(
-    async (targetSettleCount: number, timeoutMs = SETTLEMENT_PROGRESS_TIMEOUT_MS): Promise<SettlementSnapshot | null> => {
+    async (
+      targetSettleCount: number,
+      timeoutMs = SETTLEMENT_PROGRESS_TIMEOUT_MS,
+    ): Promise<SettlementSnapshot | null> => {
       const startedAt = Date.now();
       let latestSnapshot: SettlementSnapshot | null = null;
 

--- a/client/apps/landing/src/components/ui/utils/addresses.ts
+++ b/client/apps/landing/src/components/ui/utils/addresses.ts
@@ -1,37 +1,41 @@
 import { Chain, getSeasonAddresses } from "@contracts";
 import { env } from "../../../../env";
 
+const getSeasonNetworkAddresses = () => getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain);
+
 export const getResourceAddresses = () => {
-  const addresses = getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain).resources;
+  const addresses = getSeasonNetworkAddresses().resources;
   return addresses as {
     [key: string]: [number, string];
   };
 };
 
 export const getSeasonPassAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain).seasonPass;
+  return getSeasonNetworkAddresses().seasonPass;
 };
 
 export const getLordsAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain).lords;
+  return getSeasonNetworkAddresses().lords;
 };
 
 export const getRealmsAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain).realms;
+  return getSeasonNetworkAddresses().realms;
 };
 
 export const getMarketplaceAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain).marketplace;
+  return getSeasonNetworkAddresses().marketplace;
 };
 
 export const getLootChestsAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain)["Collectibles: Realms: Loot Chest"];
+  const addresses = getSeasonNetworkAddresses();
+  return addresses.lootChests || addresses["Collectibles: Realms: Loot Chest"];
 };
 
 export const getCosmeticsAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain)["Collectibles: Realms: Cosmetic Items"];
+  const addresses = getSeasonNetworkAddresses();
+  return addresses.cosmetics || addresses["Collectibles: Realms: Cosmetic Items"];
 };
 
 export const getCosmeticsClaimAddress = () => {
-  return getSeasonAddresses(env.VITE_PUBLIC_CHAIN as Chain).cosmeticsClaim;
+  return getSeasonNetworkAddresses().cosmeticsClaim;
 };

--- a/contracts/utils/utils.ts
+++ b/contracts/utils/utils.ts
@@ -16,6 +16,10 @@ import slottestGameManifest from "../../contracts/game/manifest_slottest.json";
 export interface SeasonAddresses {
   "Collectibles: Realms: Loot Chest": string;
   "Collectibles: Realms: Cosmetic Items": string;
+  /** New loot chest contract key used on some chains (mainnet). */
+  lootChests?: string;
+  /** New cosmetics contract key used on some chains (mainnet). */
+  cosmetics?: string;
   "Collectibles: Timelock Maker": string;
   "Collectibles: Realms: Elite Invite": string;
   /** Class hash of the collectibles ERC721 contract */


### PR DESCRIPTION
This fixes cosmetics/chest data routing so the mainnet tab no longer falls back to a Sepolia marketplace Torii URL when generic env values are mismatched.
It also updates season address resolution to prefer the newer lootChests and cosmetics keys with legacy collectible-key fallback, so mainnet collectibles resolve correctly.
A runtime regression test was added for the mainnet + sepolia generic URL case, and existing network runtime tests were kept passing.
pnpm run format was run per preference, which also introduced a formatter-only reflow in client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx.
