### PR TITLE
Fix social leaderboard point refresh and pending claim handling

### DIFF
--- a/client/apps/game/src/ui/features/social/components/register-points-button.tsx
+++ b/client/apps/game/src/ui/features/social/components/register-points-button.tsx
@@ -1,21 +1,26 @@
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import { LEADERBOARD_UPDATE_INTERVAL } from "@/ui/constants";
 import Button from "@/ui/design-system/atoms/button";
+import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
 import { getRealmCountPerHyperstructure } from "@/ui/utils/utils";
 import { LeaderboardManager } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
 import { getComponentValue, Has } from "@dojoengine/recs";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSocialStore } from "./use-social-store";
 
 interface RegisterPointsButtonProps {
   className?: string;
 }
 
+const POINTS_SUMMARY_DEBUG = true;
+
 export const RegisterPointsButton = ({ className }: RegisterPointsButtonProps) => {
   const {
     account: { account },
+    network,
     setup: {
       components,
       systemCalls: { claim_share_points },
@@ -23,20 +28,17 @@ export const RegisterPointsButton = ({ className }: RegisterPointsButtonProps) =
   } = useDojo();
 
   const [isSharePointsLoading, setIsSharePointsLoading] = useState(false);
+  const [, setRefreshTick] = useState(0);
   const setTooltip = useUIStore((state) => state.setTooltip);
   const setPlayersByRank = useSocialStore((state) => state.setPlayersByRank);
 
   const hyperstructure_entities = useEntityQuery([Has(components.Hyperstructure)]);
+  const playerAddress = ContractAddress(account.address);
+  const leaderboardManager = LeaderboardManager.instance(components, getRealmCountPerHyperstructure());
 
-  const { registeredPoints, unregisteredShareholderPoints } = useMemo(() => {
-    const leaderboardManager = LeaderboardManager.instance(components, getRealmCountPerHyperstructure());
-    return {
-      registeredPoints: leaderboardManager.getPlayerRegisteredPoints(ContractAddress(account.address)),
-      unregisteredShareholderPoints: leaderboardManager.getPlayerHyperstructureUnregisteredShareholderPoints(
-        ContractAddress(account.address),
-      ),
-    };
-  }, [components, account.address]);
+  const registeredPoints = leaderboardManager.getPlayerRegisteredPoints(playerAddress);
+  const unregisteredShareholderPoints =
+    leaderboardManager.getPlayerHyperstructureUnregisteredShareholderPoints(playerAddress);
 
   const hyperstructuresEntityIds = useMemo(() => {
     return hyperstructure_entities
@@ -44,33 +46,96 @@ export const RegisterPointsButton = ({ className }: RegisterPointsButtonProps) =
       .filter((hyperstructure) => hyperstructure?.completed)
       .map((hyperstructure) => hyperstructure?.hyperstructure_id)
       .filter((id) => id !== undefined);
-  }, [hyperstructure_entities]);
+  }, [components.Hyperstructure, hyperstructure_entities]);
 
   const hasUnregisteredPoints = unregisteredShareholderPoints > 0;
   const totalPoints = registeredPoints + unregisteredShareholderPoints;
+
+  const logPointsSummary = (...args: unknown[]) => {
+    if (!POINTS_SUMMARY_DEBUG) return;
+    console.log("[PointsSummary]", ...args);
+  };
+
+  useEffect(() => {
+    logPointsSummary("mounted", { playerAddress });
+    return () => {
+      logPointsSummary("unmounted", { playerAddress });
+    };
+  }, [playerAddress]);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setRefreshTick((previous) => previous + 1);
+      logPointsSummary("refresh tick", {
+        registeredPoints,
+        unregisteredShareholderPoints,
+        totalPoints,
+      });
+    }, LEADERBOARD_UPDATE_INTERVAL);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [registeredPoints, totalPoints, unregisteredShareholderPoints]);
+
+  useEffect(() => {
+    logPointsSummary("computed values", {
+      registeredPoints,
+      unregisteredShareholderPoints,
+      totalPoints,
+      hasUnregisteredPoints,
+      isSharePointsLoading,
+    });
+  }, [registeredPoints, unregisteredShareholderPoints, totalPoints, hasUnregisteredPoints, isSharePointsLoading]);
 
   const claimSharePoints = async () => {
     if (!hasUnregisteredPoints) return;
 
     setIsSharePointsLoading(true);
+    let txHash: string | null = null;
     try {
-      await claim_share_points({
+      const claimedPointsAtSubmit = leaderboardManager.getPlayerHyperstructureUnregisteredShareholderPoints(
+        playerAddress,
+        { ignorePendingClaimOverride: true },
+      );
+
+      const transactionResult = await claim_share_points({
         signer: account,
         hyperstructure_ids: hyperstructuresEntityIds,
       });
+      txHash = extractTransactionHash(transactionResult);
+      logPointsSummary("claim submitted", {
+        txHash,
+        claimedPointsAtSubmit,
+      });
 
-      // Hard refresh leaderboard after 3 seconds
-      console.log("Hard refreshing leaderboard data...");
-      const leaderboardManager = LeaderboardManager.instance(components, getRealmCountPerHyperstructure());
-
-      // Force complete re-initialization
-      leaderboardManager.initialize();
-
-      // Update UI store
+      if (claimedPointsAtSubmit > 0) {
+        leaderboardManager.setPendingSharePointsClaim(playerAddress, claimedPointsAtSubmit, txHash ?? undefined);
+      }
+      leaderboardManager.updatePoints();
       setPlayersByRank(leaderboardManager.playersByRank);
+      logPointsSummary("pending override applied");
 
-      console.log("Leaderboard hard refresh complete");
+      if (txHash) {
+        await waitForTransactionConfirmation({
+          txHash,
+          provider: network.provider as { waitForTransactionWithCheck?: (hash: string) => Promise<unknown> },
+          account: account as { waitForTransaction?: (hash: string) => Promise<unknown> },
+          label: "register points",
+        });
+      }
+
+      leaderboardManager.confirmPendingSharePointsClaim(playerAddress, txHash ?? undefined);
+      leaderboardManager.forceRefresh();
+      leaderboardManager.updatePoints();
+
+      setPlayersByRank(leaderboardManager.playersByRank);
+      logPointsSummary("claim confirmed and refreshed", { txHash });
     } catch (error) {
+      leaderboardManager.clearPendingSharePointsClaim(playerAddress, txHash ?? undefined);
+      leaderboardManager.updatePoints();
+      setPlayersByRank(leaderboardManager.playersByRank);
+      logPointsSummary("claim failed or confirmation failed", { txHash, error });
       console.error(error);
     } finally {
       setIsSharePointsLoading(false);

--- a/client/apps/game/src/ui/features/social/components/social.tsx
+++ b/client/apps/game/src/ui/features/social/components/social.tsx
@@ -79,6 +79,8 @@ export const Social = () => {
   );
 
   useEffect(() => {
+    if (!isOpen) return;
+
     // update first time - initialize with interval on first call
     const manager = LeaderboardManager.instance(
       components,
@@ -87,10 +89,12 @@ export const Social = () => {
     );
     manager.initialize();
     setPlayersByRank(manager.playersByRank);
-  }, [components, setPlayersByRank]);
+  }, [components, isOpen, setPlayersByRank]);
 
   // Add periodic updates every 1 minute to refresh unregistered shareholder points
   useEffect(() => {
+    if (!isOpen) return;
+
     const interval = setInterval(() => {
       const manager = LeaderboardManager.instance(components, getRealmCountPerHyperstructure());
       manager.updatePoints();
@@ -98,18 +102,22 @@ export const Social = () => {
     }, LEADERBOARD_UPDATE_INTERVAL);
 
     return () => clearInterval(interval);
-  }, [components, setPlayersByRank]);
+  }, [components, isOpen, setPlayersByRank]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     void refreshPlayerData();
     const intervalId = window.setInterval(() => {
       void refreshPlayerData();
     }, PLAYER_STRUCTURE_REFRESH_INTERVAL_MS);
 
     return () => window.clearInterval(intervalId);
-  }, [refreshPlayerData]);
+  }, [isOpen, refreshPlayerData]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     let cancelled = false;
 
     const loadStructureCounts = async () => {
@@ -142,13 +150,15 @@ export const Social = () => {
     return () => {
       cancelled = true;
     };
-  }, [lastPlayerDataRefreshTime]);
+  }, [isOpen, lastPlayerDataRefreshTime]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     setPlayerInfo(
       getPlayerInfo(players, ContractAddress(account.address), playersByRank, playerStructureCountsMap, components),
     );
-  }, [players, account.address, playersByRank, playerStructureCountsMap, components, setPlayerInfo]);
+  }, [players, account.address, playersByRank, playerStructureCountsMap, components, isOpen, setPlayerInfo]);
 
   const viewGuildMembers = useCallback(
     (guildEntityId: ContractAddress) => {

--- a/client/apps/game/src/ui/features/social/player/players-panel.tsx
+++ b/client/apps/game/src/ui/features/social/player/players-panel.tsx
@@ -1,5 +1,4 @@
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { useUIStore } from "@/hooks/store/use-ui-store";
 import Button from "@/ui/design-system/atoms/button";
 import { RefreshButton } from "@/ui/design-system/atoms/refresh-button";
 import TextInput from "@/ui/design-system/atoms/text-input";
@@ -24,9 +23,9 @@ import { KeyboardEvent, useCallback, useEffect, useMemo, useState } from "react"
 const SOCIAL_LEADERBOARD_LIMIT = 1000;
 
 const normalizeAddress = (address: bigint | string): string => {
-  return toHexString(typeof address === "string" ? BigInt(address) : address)
-    .toLowerCase()
-    .padStart(66, "0");
+  const addressBigInt = typeof address === "string" ? BigInt(address) : address;
+  const canonicalHex = toHexString(addressBigInt).toLowerCase().replace(/^0x/, "");
+  return `0x${canonicalHex.padStart(64, "0")}`;
 };
 
 export const PlayersPanel = ({
@@ -58,7 +57,6 @@ export const PlayersPanel = ({
   const [inputValue, setInputValue] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
   const [showPointsBreakdown, setShowPointsBreakdown] = useState(false);
-  const seasonWinner = useUIStore((state) => state.gameWinner);
   const mode = useGameModeConfig();
 
   useEffect(() => {
@@ -131,13 +129,12 @@ export const PlayersPanel = ({
         };
       });
     return playersWithStructures;
-  }, [isLoading, players, components, account.address, mode]);
+  }, [GuildWhitelist, Structure, account.address, components, mode, players, userGuild]);
 
   const leaderboardEntryMap = useMemo(() => {
     const map = new Map<string, LandingLeaderboardEntry>();
 
     leaderboardEntries.forEach((entry) => {
-      console.log("setting for address", entry.address.toLowerCase(), "name", entry.displayName);
       map.set(normalizeAddress(entry.address), entry);
     });
 
@@ -147,7 +144,6 @@ export const PlayersPanel = ({
   const playersWithLeaderboardStats = useMemo(() => {
     return playersWithStructures.map((player) => {
       const normalizedAddress = normalizeAddress(player.address);
-      console.log("getting for address", normalizedAddress);
       const entry = leaderboardEntryMap.get(normalizedAddress) ?? null;
 
       return {

--- a/client/apps/game/src/ui/store-managers.tsx
+++ b/client/apps/game/src/ui/store-managers.tsx
@@ -5,6 +5,7 @@ import { usePlayerStore } from "@/hooks/store/use-player-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { sqlApi } from "@/services/api";
 import { RESOURCE_ARRIVAL_AUTO_CLAIM_RETRY_DELAY_SECONDS, RESOURCE_ARRIVAL_READY_BUFFER_SECONDS } from "@/ui/constants";
+import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
 import { getRealmCountPerHyperstructure } from "@/ui/utils/utils";
 import {
   formatArmies,
@@ -343,6 +344,7 @@ const AUTO_REGISTER_POINTS_DEBUG = true;
 const AutoRegisterPointsStoreManager = () => {
   const {
     account: { account },
+    network,
     setup: {
       components,
       systemCalls: { claim_share_points },
@@ -403,18 +405,45 @@ const AutoRegisterPointsStoreManager = () => {
 
       // Execute registration
       isProcessingRef.current = true;
+      let txHash: string | null = null;
       try {
-        await claim_share_points({
+        const playerAddress = ContractAddress(account.address);
+        const claimedPointsAtSubmit = leaderboardManager.getPlayerHyperstructureUnregisteredShareholderPoints(
+          playerAddress,
+          { ignorePendingClaimOverride: true },
+        );
+
+        const transactionResult = await claim_share_points({
           signer: account,
           hyperstructure_ids: hyperstructureIds,
         });
+        txHash = extractTransactionHash(transactionResult);
 
+        if (claimedPointsAtSubmit > 0) {
+          leaderboardManager.setPendingSharePointsClaim(playerAddress, claimedPointsAtSubmit, txHash ?? undefined);
+        }
+        leaderboardManager.updatePoints();
+        log("Points registration transaction submitted", txHash);
+
+        if (txHash) {
+          await waitForTransactionConfirmation({
+            txHash,
+            provider: network.provider as { waitForTransactionWithCheck?: (hash: string) => Promise<unknown> },
+            account: account as { waitForTransaction?: (hash: string) => Promise<unknown> },
+            label: "auto-register points",
+          });
+        }
+
+        leaderboardManager.confirmPendingSharePointsClaim(playerAddress, txHash ?? undefined);
         log("Points registered successfully");
 
         // Refresh leaderboard
-        leaderboardManager.initialize();
+        leaderboardManager.forceRefresh();
+        leaderboardManager.updatePoints();
         log("Leaderboard refreshed");
       } catch (error) {
+        leaderboardManager.clearPendingSharePointsClaim(ContractAddress(account.address), txHash ?? undefined);
+        leaderboardManager.updatePoints();
         console.error("[AutoRegisterPoints] Failed:", error);
       } finally {
         isProcessingRef.current = false;
@@ -429,7 +458,7 @@ const AutoRegisterPointsStoreManager = () => {
     const intervalId = setInterval(checkAndRegisterPoints, POLLING_INTERVALS.autoRegisterPointsMs);
 
     return () => clearInterval(intervalId);
-  }, [account, components, claim_share_points, hyperstructure_entities]);
+  }, [account, components, claim_share_points, hyperstructure_entities, network.provider]);
 
   return null;
 };

--- a/client/apps/game/src/ui/utils/transactions.ts
+++ b/client/apps/game/src/ui/utils/transactions.ts
@@ -1,0 +1,39 @@
+export const extractTransactionHash = (value: unknown): string | null => {
+  if (!value || typeof value !== "object") return null;
+
+  const maybeHash = (value as { transaction_hash?: unknown }).transaction_hash;
+  return typeof maybeHash === "string" && maybeHash.length > 0 ? maybeHash : null;
+};
+
+type WaitCapableProvider = {
+  waitForTransactionWithCheck?: (txHash: string) => Promise<unknown>;
+};
+
+type WaitCapableAccount = {
+  waitForTransaction?: (txHash: string) => Promise<unknown>;
+};
+
+export const waitForTransactionConfirmation = async ({
+  txHash,
+  provider,
+  account,
+  label,
+}: {
+  txHash: string;
+  provider?: WaitCapableProvider;
+  account?: WaitCapableAccount;
+  label?: string;
+}) => {
+  if (provider && typeof provider.waitForTransactionWithCheck === "function") {
+    await provider.waitForTransactionWithCheck(txHash);
+    return;
+  }
+
+  if (account && typeof account.waitForTransaction === "function") {
+    await account.waitForTransaction(txHash);
+    return;
+  }
+
+  const transactionLabel = label ?? "transaction";
+  throw new Error(`Unable to confirm ${transactionLabel}: no transaction wait method available`);
+};

--- a/packages/core/src/managers/leaderboard-manager.ts
+++ b/packages/core/src/managers/leaderboard-manager.ts
@@ -24,6 +24,14 @@ interface ContractAddressAndAmount {
   ];
 }
 
+interface PendingSharePointsClaim {
+  claimedPoints: number;
+  txHash?: string;
+  submittedAtMs: number;
+  confirmedAtMs?: number;
+  status: "submitted" | "confirmed";
+}
+
 export class LeaderboardManager {
   private static _instance: LeaderboardManager;
   public pointsPerPlayer: Map<ContractAddress, number> = new Map();
@@ -36,6 +44,8 @@ export class LeaderboardManager {
   private lastUnregisteredShareholderPointsUpdate: number = 0;
   private readonly unregisteredShareholderPointsUpdateInterval: number;
   private readonly realmCountPerHyperstructures: Map<ID, number> = new Map();
+  private pendingSharePointsClaims: Map<ContractAddress, PendingSharePointsClaim> = new Map();
+  private readonly pendingSharePointsClaimTtlMs: number = 2 * 60 * 1000;
 
   constructor(
     private readonly components: ClientComponents,
@@ -94,6 +104,37 @@ export class LeaderboardManager {
     this.playersByRank = this.getPlayersByRank();
   }
 
+  public setPendingSharePointsClaim(playerAddress: ContractAddress, claimedPoints: number, txHash?: string) {
+    if (claimedPoints <= 0) return;
+
+    this.pendingSharePointsClaims.set(playerAddress, {
+      claimedPoints,
+      txHash,
+      submittedAtMs: Date.now(),
+      status: "submitted",
+    });
+  }
+
+  public confirmPendingSharePointsClaim(playerAddress: ContractAddress, txHash?: string) {
+    const pendingClaim = this.pendingSharePointsClaims.get(playerAddress);
+    if (!pendingClaim) return;
+    if (txHash && pendingClaim.txHash && pendingClaim.txHash !== txHash) return;
+
+    pendingClaim.status = "confirmed";
+    pendingClaim.confirmedAtMs = Date.now();
+    if (txHash && !pendingClaim.txHash) {
+      pendingClaim.txHash = txHash;
+    }
+    this.pendingSharePointsClaims.set(playerAddress, pendingClaim);
+  }
+
+  public clearPendingSharePointsClaim(playerAddress: ContractAddress, txHash?: string) {
+    const pendingClaim = this.pendingSharePointsClaims.get(playerAddress);
+    if (!pendingClaim) return;
+    if (txHash && pendingClaim.txHash && pendingClaim.txHash !== txHash) return;
+    this.pendingSharePointsClaims.delete(playerAddress);
+  }
+
   /**
    * Start periodic updater for unregistered shareholder points
    */
@@ -126,6 +167,8 @@ export class LeaderboardManager {
    * Calculate and cache all unregistered shareholder points at once for efficiency
    */
   private updateUnregisteredShareholderPointsCache() {
+    this.pruneExpiredPendingSharePointsClaims();
+
     const configManager = ClientConfigManager.instance();
     const pointsPerSecondWithoutMultiplier = configManager.getHyperstructureConfig().pointsPerCycle;
     const seasonConfig = configManager.getSeasonConfig();
@@ -183,12 +226,44 @@ export class LeaderboardManager {
     this.lastUnregisteredShareholderPointsUpdate = Date.now();
   }
 
+  private pruneExpiredPendingSharePointsClaims() {
+    const now = Date.now();
+    for (const [playerAddress, pendingClaim] of this.pendingSharePointsClaims) {
+      if (now - pendingClaim.submittedAtMs > this.pendingSharePointsClaimTtlMs) {
+        this.pendingSharePointsClaims.delete(playerAddress);
+      }
+    }
+  }
+
+  private applyPendingSharePointsClaimOverride(playerAddress: ContractAddress, rawUnregisteredPoints: number): number {
+    this.pruneExpiredPendingSharePointsClaims();
+
+    const pendingClaim = this.pendingSharePointsClaims.get(playerAddress);
+    if (!pendingClaim) return rawUnregisteredPoints;
+
+    // Apply a pending claim offset to avoid double-counting immediately after submission,
+    // then clear the override once post-claim data has been observed.
+    if (pendingClaim.status === "confirmed" && rawUnregisteredPoints <= pendingClaim.claimedPoints) {
+      this.pendingSharePointsClaims.delete(playerAddress);
+      return rawUnregisteredPoints;
+    }
+
+    return Math.max(0, rawUnregisteredPoints - pendingClaim.claimedPoints);
+  }
+
   /**
    * Get cached unregistered shareholder points for a specific player
    */
-  public getPlayerHyperstructureUnregisteredShareholderPoints(playerAddress: ContractAddress): number {
+  public getPlayerHyperstructureUnregisteredShareholderPoints(
+    playerAddress: ContractAddress,
+    options?: { ignorePendingClaimOverride?: boolean },
+  ): number {
     this.updateUnregisteredShareholderPointsCacheIfNeeded();
-    return this.unregisteredShareholderPointsCache.get(playerAddress) || 0;
+    const rawUnregisteredPoints = this.unregisteredShareholderPointsCache.get(playerAddress) || 0;
+    if (options?.ignorePendingClaimOverride) {
+      return rawUnregisteredPoints;
+    }
+    return this.applyPendingSharePointsClaimOverride(playerAddress, rawUnregisteredPoints);
   }
 
   /**
@@ -318,14 +393,22 @@ export class LeaderboardManager {
       const registeredPoints = Number(playerRegisteredPoints.registered_points / pointsPrecision);
 
       // Add cached unregistered shareholder points to registered points
-      const unregisteredShareholderPoints = this.unregisteredShareholderPointsCache.get(playerAddress) || 0;
+      const rawUnregisteredShareholderPoints = this.unregisteredShareholderPointsCache.get(playerAddress) || 0;
+      const unregisteredShareholderPoints = this.applyPendingSharePointsClaimOverride(
+        playerAddress,
+        rawUnregisteredShareholderPoints,
+      );
       const totalPoints = registeredPoints + unregisteredShareholderPoints;
 
       pointsPerPlayer.set(playerAddress, totalPoints);
     }
 
     // Also add players who only have unregistered shareholder points but no registered points
-    for (const [playerAddress, unregisteredShareholderPoints] of this.unregisteredShareholderPointsCache) {
+    for (const [playerAddress, rawUnregisteredShareholderPoints] of this.unregisteredShareholderPointsCache) {
+      const unregisteredShareholderPoints = this.applyPendingSharePointsClaimOverride(
+        playerAddress,
+        rawUnregisteredShareholderPoints,
+      );
       if (!pointsPerPlayer.has(playerAddress) && unregisteredShareholderPoints > 0) {
         pointsPerPlayer.set(playerAddress, unregisteredShareholderPoints);
       }


### PR DESCRIPTION
This PR fixes point-summary double counting by adding pending-claim offsets in LeaderboardManager and applying them in both manual and auto share-point claim flows. It adds transaction helpers to extract tx hashes and wait for confirmation, then confirms or clears pending overrides based on transaction outcome. Social polling and data-refresh effects now run only while the leaderboard is open, and periodic points refresh uses the existing leaderboard interval. It also fixes player address normalization to canonical 0x-prefixed 64-hex format, removes noisy player panel logs, and adds targeted PointsSummary console logs to trace refresh/computation behavior.