### PR TITLE
Fix blitz leaderboard chest and MMR stability

### DIFF
--- a/client/apps/game/src/ui/features/prize/components/blitz-mmr-table.tsx
+++ b/client/apps/game/src/ui/features/prize/components/blitz-mmr-table.tsx
@@ -5,26 +5,33 @@ import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
 import { getComponentValue, Has } from "@dojoengine/recs";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { hash } from "starknet";
 import { dojoConfig } from "../../../../../dojo-config";
 import { env } from "../../../../../env";
 
 type PlayerMMR = { address: bigint; mmr: bigint };
+type MmrSnapshot = { key: string; rows: PlayerMMR[] };
+type RpcCallResponse = {
+  id: number;
+  result?: Array<string | number>;
+  error?: unknown;
+};
 
 // Batch size for JSON-RPC calls
 const BATCH_SIZE = 20;
 
 // Selector for get_player_mmr function
 const GET_PLAYER_MMR_SELECTOR = hash.getSelectorFromName("get_player_mmr");
+let cachedMmrSnapshot: MmrSnapshot | null = null;
 
 export const BlitzMMRTable = () => {
   const {
     setup: { components },
   } = useDojo();
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [playerMMRs, setPlayerMMRs] = useState<PlayerMMR[]>([]);
+  const [isLoading, setIsLoading] = useState(cachedMmrSnapshot == null);
+  const [playerMMRs, setPlayerMMRs] = useState<PlayerMMR[]>(() => cachedMmrSnapshot?.rows ?? []);
   const [error, setError] = useState<string | null>(null);
 
   // Get RPC URL from config
@@ -74,61 +81,72 @@ export const BlitzMMRTable = () => {
       return points !== undefined && points > 0n;
     });
   }, [registeredPlayerAddresses, playerPointsByPlayer]);
+  const registeredPlayersSignature = useMemo(
+    () =>
+      registeredPlayers
+        .map((address) => toHexString(address).toLowerCase())
+        .toSorted((a, b) => a.localeCompare(b))
+        .join(","),
+    [registeredPlayers],
+  );
 
   /**
    * Fetch MMRs for a batch of players using JSON-RPC batch request
    */
-  const fetchMMRBatch = async (players: bigint[], tokenAddress: string): Promise<PlayerMMR[]> => {
-    const batchRequest = players.map((playerAddress, idx) => ({
-      jsonrpc: "2.0",
-      id: idx,
-      method: "starknet_call",
-      params: [
-        {
-          contract_address: tokenAddress,
-          entry_point_selector: GET_PLAYER_MMR_SELECTOR,
-          calldata: [toHexString(playerAddress)],
-        },
-        "pre_confirmed",
-      ],
-    }));
+  const fetchMMRBatch = useCallback(
+    async (players: bigint[], tokenAddress: string): Promise<PlayerMMR[]> => {
+      const batchRequest = players.map((playerAddress, idx) => ({
+        jsonrpc: "2.0",
+        id: idx,
+        method: "starknet_call",
+        params: [
+          {
+            contract_address: tokenAddress,
+            entry_point_selector: GET_PLAYER_MMR_SELECTOR,
+            calldata: [toHexString(playerAddress)],
+          },
+          "pre_confirmed",
+        ],
+      }));
 
-    const response = await fetch(rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(batchRequest),
-    });
+      const response = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(batchRequest),
+      });
 
-    if (!response.ok) {
-      throw new Error(`RPC request failed: ${response.status}`);
-    }
-
-    const results = await response.json();
-    const resultsArray = Array.isArray(results) ? results : [results];
-
-    const playerMMRs: PlayerMMR[] = [];
-    for (let idx = 0; idx < players.length; idx++) {
-      const playerAddress = players[idx];
-      const result = resultsArray.find((r: any) => r.id === idx);
-
-      if (result?.error) {
-        throw new Error(`Failed to fetch MMR for ${toHexString(playerAddress)}: ${JSON.stringify(result.error)}`);
+      if (!response.ok) {
+        throw new Error(`RPC request failed: ${response.status}`);
       }
 
-      if (!result?.result) {
-        throw new Error(`No result for player ${toHexString(playerAddress)}`);
+      const results = (await response.json()) as RpcCallResponse | RpcCallResponse[];
+      const resultsArray: RpcCallResponse[] = Array.isArray(results) ? results : [results];
+
+      const playerMMRs: PlayerMMR[] = [];
+      for (let idx = 0; idx < players.length; idx++) {
+        const playerAddress = players[idx];
+        const result = resultsArray.find((r) => r.id === idx);
+
+        if (result?.error) {
+          throw new Error(`Failed to fetch MMR for ${toHexString(playerAddress)}: ${JSON.stringify(result.error)}`);
+        }
+
+        if (!result?.result) {
+          throw new Error(`No result for player ${toHexString(playerAddress)}`);
+        }
+
+        // u256 is returned as two felts [low, high]
+        const resultArray = result.result;
+        const low = BigInt(resultArray[0] ?? 0);
+        const high = BigInt(resultArray[1] ?? 0);
+        const mmr = low + (high << 128n);
+        playerMMRs.push({ address: playerAddress, mmr });
       }
 
-      // u256 is returned as two felts [low, high]
-      const resultArray = result.result;
-      const low = BigInt(resultArray[0] || "0");
-      const high = BigInt(resultArray[1] || "0");
-      const mmr = low + (high << 128n);
-      playerMMRs.push({ address: playerAddress, mmr });
-    }
-
-    return playerMMRs;
-  };
+      return playerMMRs;
+    },
+    [rpcUrl],
+  );
 
   // Fetch all player MMRs on mount or when dependencies change
   useEffect(() => {
@@ -137,8 +155,16 @@ export const BlitzMMRTable = () => {
       return;
     }
 
+    const fetchKey = `${rpcUrl}|${mmrTokenAddress}|${registeredPlayersSignature}`;
+    if (cachedMmrSnapshot?.key === fetchKey) {
+      setPlayerMMRs(cachedMmrSnapshot.rows);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
     const fetchAllMMRs = async () => {
-      setIsLoading(true);
+      setIsLoading(cachedMmrSnapshot == null);
       setError(null);
 
       try {
@@ -156,23 +182,24 @@ export const BlitzMMRTable = () => {
         }
 
         // Sort by MMR descending (highest first)
-        allPlayerMMRs.sort((a, b) => {
+        const sortedPlayerMMRs = allPlayerMMRs.toSorted((a, b) => {
           if (a.mmr > b.mmr) return -1;
           if (a.mmr < b.mmr) return 1;
           return 0;
         });
 
-        setPlayerMMRs(allPlayerMMRs);
-      } catch (e: any) {
+        cachedMmrSnapshot = { key: fetchKey, rows: sortedPlayerMMRs };
+        setPlayerMMRs(sortedPlayerMMRs);
+      } catch (e: unknown) {
         console.error("Failed to fetch player MMRs:", e);
-        setError(e?.message || String(e));
+        setError(e instanceof Error ? e.message : String(e));
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchAllMMRs();
-  }, [mmrTokenAddress, registeredPlayers, rpcUrl]);
+  }, [fetchMMRBatch, mmrTokenAddress, registeredPlayers, registeredPlayersSignature, rpcUrl]);
 
   // Format MMR for display (convert from token units with 18 decimals)
   const formatMMR = (mmr: bigint): string => {
@@ -204,7 +231,7 @@ export const BlitzMMRTable = () => {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="max-h-[700px] overflow-y-auto">
+      <div>
         <table className="w-full text-xs">
           <thead className="sticky top-0 bg-dark/90">
             <tr className="text-gold/70 border-b border-gold/10">

--- a/client/apps/game/src/ui/features/prize/components/winners-table.tsx
+++ b/client/apps/game/src/ui/features/prize/components/winners-table.tsx
@@ -1,11 +1,55 @@
+import { getActiveWorld } from "@/runtime/world";
 import { displayAddress } from "@/ui/utils/utils";
+import { buildApiUrl, fetchWithErrorHandling } from "@bibliothecadao/torii";
 import { getAddressName, toHexString } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
 import { getComponentValue, Has } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { env } from "../../../../../env";
+
+const POINTS_PRECISION = 1_000_000n;
+const GAME_REWARD_CHEST_POINTS_THRESHOLD = 500n * POINTS_PRECISION;
+const GAME_CHEST_REWARD_QUERY = `
+  SELECT
+    allocated_chests
+  FROM "s1_eternum-GameChestReward"
+  LIMIT 1;
+`;
+const SEASON_PRIZE_QUERY = `
+  SELECT
+    total_registered_points
+  FROM "s1_eternum-SeasonPrize"
+  LIMIT 1;
+`;
+
+type GameChestRewardRow = {
+  allocated_chests?: unknown;
+};
+type SeasonPrizeRow = {
+  total_registered_points?: unknown;
+};
+type ChestRewardSnapshot = {
+  allocatedRewardChests: bigint;
+  totalRegisteredPoints: bigint;
+};
+
+let cachedChestRewardSnapshot: ChestRewardSnapshot | null = null;
+
+const toBigIntValue = (value: unknown): bigint | undefined => {
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return BigInt(Math.trunc(value));
+  if (typeof value === "string" && value.trim().length > 0) {
+    try {
+      return BigInt(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
 
 type Row = {
   player: bigint;
@@ -13,6 +57,7 @@ type Row = {
   paid: boolean;
   prizeShare?: bigint;
   points?: bigint;
+  earnedChests?: bigint;
 };
 
 export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
@@ -25,7 +70,7 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
   const finalEntities = useEntityQuery([Has(components.PlayersRankFinal)]);
   const final = useMemo(
     () => (finalEntities[0] ? getComponentValue(components.PlayersRankFinal, finalEntities[0]) : undefined),
-    [finalEntities],
+    [finalEntities, components.PlayersRankFinal],
   );
   const finalTrialId = final?.trial_id as bigint | undefined;
 
@@ -44,19 +89,82 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
     return points;
   }, [playerRegisteredPointsEntities, components.PlayerRegisteredPoints]);
 
+  const [chestRewardSnapshot, setChestRewardSnapshot] = useState<ChestRewardSnapshot | null>(
+    () => cachedChestRewardSnapshot,
+  );
+  const allocatedRewardChests = chestRewardSnapshot?.allocatedRewardChests ?? 0n;
+  const totalRegisteredPoints = chestRewardSnapshot?.totalRegisteredPoints ?? 0n;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadAllocatedRewardChests = async () => {
+      try {
+        const activeWorld = getActiveWorld();
+        const toriiBaseUrl = activeWorld?.toriiBaseUrl ?? env.VITE_PUBLIC_TORII;
+        const sqlBaseUrl = toriiBaseUrl.endsWith("/sql") ? toriiBaseUrl : `${toriiBaseUrl}/sql`;
+
+        const [chestRows, seasonRows] = await Promise.all([
+          fetchWithErrorHandling<GameChestRewardRow>(
+            buildApiUrl(sqlBaseUrl, GAME_CHEST_REWARD_QUERY),
+            "Failed to fetch game chest reward state",
+          ),
+          fetchWithErrorHandling<SeasonPrizeRow>(
+            buildApiUrl(sqlBaseUrl, SEASON_PRIZE_QUERY),
+            "Failed to fetch season prize state",
+          ),
+        ]);
+
+        if (cancelled) return;
+
+        const nextAllocatedRewardChests = toBigIntValue(chestRows[0]?.allocated_chests);
+        const nextTotalRegisteredPoints = toBigIntValue(seasonRows[0]?.total_registered_points);
+        if (nextAllocatedRewardChests == null || nextTotalRegisteredPoints == null) {
+          return;
+        }
+
+        const nextSnapshot: ChestRewardSnapshot = {
+          allocatedRewardChests: nextAllocatedRewardChests,
+          totalRegisteredPoints: nextTotalRegisteredPoints,
+        };
+        cachedChestRewardSnapshot = nextSnapshot;
+        setChestRewardSnapshot(nextSnapshot);
+      } catch (error) {
+        if (!cancelled) {
+          console.warn("Failed to load game chest reward allocation", error);
+        }
+      }
+    };
+
+    void loadAllocatedRewardChests();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   // Fetch ERC20 decimals for the blitz fee token, fallback to raw units
   const decimals = 18;
   const formatTokenAmount = (amount?: bigint) => {
     if (typeof amount !== "bigint") return "-";
     if (decimals == null) return amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    const d = decimals;
-    const s = amount.toString();
-    const pad = d - s.length;
-    const whole = pad >= 0 ? "0" : s.slice(0, s.length - d);
-    const fracRaw = pad >= 0 ? "0".repeat(pad) + s : s.slice(s.length - d);
-    const wholeFmt = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    const frac = fracRaw.replace(/0+$/, "");
-    return frac.length > 0 ? `${wholeFmt}.${frac}` : wholeFmt;
+    const d = Math.max(0, decimals);
+    if (d === 0) return amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+    if (d <= 2) {
+      const scaled = amount * 10n ** BigInt(2 - d);
+      const whole = scaled / 100n;
+      const fractional = (scaled % 100n).toString().padStart(2, "0");
+      const wholeFmt = whole.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      return fractional === "00" ? wholeFmt : `${wholeFmt}.${fractional}`;
+    }
+
+    const divisor = 10n ** BigInt(d - 2);
+    const roundedToTwoDecimals = (amount + divisor / 2n) / divisor;
+    const whole = roundedToTwoDecimals / 100n;
+    const fractional = (roundedToTwoDecimals % 100n).toString().padStart(2, "0");
+    const wholeFmt = whole.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return fractional === "00" ? wholeFmt : `${wholeFmt}.${fractional}`;
   };
   const pointsPrecision = 1_000_000n;
   const formatPoints = (value?: bigint) => {
@@ -68,6 +176,10 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
     const frac = remainder.toString().padStart(6, "0").replace(/0+$/, "");
     return `${wholeFmt}.${frac}`;
   };
+  const formatInteger = (value?: bigint) => {
+    if (typeof value !== "bigint") return "-";
+    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  };
   const rows = useMemo(() => {
     const useTrialId = typeof trialId === "bigint" ? trialId : finalTrialId;
     if (!useTrialId) return [] as Row[];
@@ -76,24 +188,35 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
       .filter((r) => r && (r.trial_id as bigint) === useTrialId)
       .map((r) => {
         const player = r!.player as unknown as bigint;
+        const points = playerPointsByPlayer.get(player);
+        const safePoints = typeof points === "bigint" ? points : 0n;
+        const guaranteedChestCount = safePoints >= GAME_REWARD_CHEST_POINTS_THRESHOLD ? 1n : 0n;
+        const proportionalChestCount =
+          allocatedRewardChests > 0n && totalRegisteredPoints > 0n
+            ? (allocatedRewardChests * safePoints) / totalRegisteredPoints
+            : 0n;
+
         return {
           player,
           rank: Number(r!.rank),
           paid: Boolean(r!.paid),
-          points: playerPointsByPlayer.get(player),
+          points,
+          earnedChests: guaranteedChestCount + proportionalChestCount,
         };
       });
 
     // Attach prize per rank
     const withPrize = list.map((r) => {
       const prizeId = getEntityIdFromKeys([useTrialId as unknown as bigint, BigInt(r.rank)]);
-      const prize = getComponentValue(components.RankPrize, prizeId as any);
+      const prize = getComponentValue(components.RankPrize, prizeId as never);
       let share: bigint | undefined = undefined;
       if (prize && prize.total_players_same_rank_count > 0) {
         try {
           const total: bigint = prize.total_prize_amount as bigint;
           share = total / BigInt(prize.total_players_same_rank_count);
-        } catch {}
+        } catch {
+          share = undefined;
+        }
       }
       return { ...r, prizeShare: share };
     });
@@ -106,8 +229,9 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
     components.RankPrize,
     finalTrialId,
     trialId,
-    decimals,
     playerPointsByPlayer,
+    allocatedRewardChests,
+    totalRegisteredPoints,
   ]);
 
   // Helper to get player display name
@@ -123,11 +247,12 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
   return (
     <div className="w-full overflow-x-auto">
       <table className="min-w-full text-sm">
-        <thead className="text-left text-gray-400">
+        <thead className="text-left text-gold/70">
           <tr>
             <th className="py-2 pr-4">Rank</th>
             <th className="py-2 pr-4">Player</th>
             <th className="py-2 pr-4">Points</th>
+            <th className="py-2 pr-4">Chests Earned</th>
             <th className="py-2 pr-4">Prize Share</th>
             <th className="py-2 pr-4">Status</th>
           </tr>
@@ -138,6 +263,7 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
               <td className="py-2 pr-4">{r.rank}</td>
               <td className="py-2 pr-4">{getPlayerDisplayName(r.player)}</td>
               <td className="py-2 pr-4">{formatPoints(r.points)}</td>
+              <td className="py-2 pr-4">{formatInteger(r.earnedChests)}</td>
               <td className="py-2 pr-4">
                 {typeof r.prizeShare === "bigint" ? (
                   <span className="inline-flex items-center gap-1">

--- a/client/apps/game/src/ui/features/social/components/social.tsx
+++ b/client/apps/game/src/ui/features/social/components/social.tsx
@@ -229,9 +229,9 @@ export const Social = () => {
           </div>
         ),
         component: (
-          <div className="h-full p-4">
-            <div className="panel-wood bg-dark/80 rounded-2xl border border-gold/20 p-5 shadow-[0_25px_45px_-25px_rgba(0,0,0,0.65)] h-full">
-              <div className="flex flex-col gap-3 h-full">
+          <div className="p-4">
+            <div className="panel-wood bg-dark/80 rounded-2xl border border-gold/20 p-5 shadow-[0_25px_45px_-25px_rgba(0,0,0,0.65)]">
+              <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-2 text-gold">
                   <span className="grid h-8 w-8 place-items-center rounded-full bg-gold/15">
                     <TrendingUp size={16} />
@@ -241,7 +241,7 @@ export const Social = () => {
                     <div className="text-xs text-gold/70">Player skill ratings</div>
                   </div>
                 </div>
-                <div className="rounded-xl border border-gold/15 panel-wood bg-dark/70 p-4 flex-1 overflow-auto">
+                <div className="rounded-xl border border-gold/15 panel-wood bg-dark/70 p-4">
                   <BlitzMMRTable />
                 </div>
                 <div className="text-xs text-gold/70 mt-2">
@@ -307,6 +307,7 @@ export const Social = () => {
   return (
     <ExpandableOSWindow
       width="1100px"
+      height="760px"
       widthExpanded="400px"
       onClick={() => togglePopup(leaderboard)}
       show={isOpen}


### PR DESCRIPTION
This updates the in-game leaderboard Blitz Prize and MMR tabs to prevent visible refresh glitches and remount-like resets. It adds a Chests Earned column with deterministic chest calculation inputs, and formats prize share values to two decimal places. It also aligns MMR scrolling behavior with Blitz Prize by keeping only the outer scroll container. Finally, it fixes leaderboard window height so tab switches no longer change container size.