### PR TITLE
Improve landing prediction market UX and performance

### DIFF
--- a/client/apps/game/src/pm/hooks/controllers/use-controllers.tsx
+++ b/client/apps/game/src/pm/hooks/controllers/use-controllers.tsx
@@ -1,6 +1,8 @@
 import { Controller } from "@dojoengine/torii-client";
-import { createContext, useCallback, useContext, useEffect, useState } from "react";
-import { BigNumberish } from "starknet";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { BigNumberish } from "starknet";
+
+import { normalizeAvatarAddress, normalizeAvatarUsername } from "@/hooks/use-player-avatar";
 import { useDojoSdk } from "../dojo/use-dojo-sdk";
 
 type ControllersProviderProps = {
@@ -9,8 +11,11 @@ type ControllersProviderProps = {
 
 type ControllersProviderState = {
   controllers?: Controller[];
-  refreshControllers: any;
-  findController: (address: string) => Controller | undefined;
+  isLoading: boolean;
+  refreshControllers: () => Promise<void>;
+  findController: (address: BigNumberish) => Controller | undefined;
+  findControllerByUsername: (username: string) => Controller | undefined;
+  findControllerAddressByUsername: (username: string) => string | undefined;
 };
 
 const ControllersProviderContext = createContext<ControllersProviderState | undefined>(undefined);
@@ -18,43 +23,101 @@ const ControllersProviderContext = createContext<ControllersProviderState | unde
 export function ControllersProvider({ children, ...props }: ControllersProviderProps) {
   const { sdk } = useDojoSdk();
   const [controllers, setControllers] = useState<Controller[]>();
+  const [isLoading, setIsLoading] = useState(false);
 
-  const refreshControllers = async () => {
-    // fetch all
-    const res = await sdk?.getControllers([], [], {
-      cursor: undefined,
-      direction: "Backward",
-      limit: 50_000,
-      order_by: [],
+  const indexedControllers = useMemo(() => {
+    const byAddress = new Map<string, Controller>();
+    const byUsername = new Map<string, Controller>();
+    const addressByUsername = new Map<string, string>();
+
+    controllers?.forEach((controller) => {
+      const normalizedAddress = normalizeAvatarAddress(controller.address);
+      if (normalizedAddress) {
+        byAddress.set(normalizedAddress, controller);
+      }
+
+      const normalizedUsername = normalizeAvatarUsername(controller.username);
+      if (normalizedUsername && normalizedAddress) {
+        byUsername.set(normalizedUsername, controller);
+        addressByUsername.set(normalizedUsername, normalizedAddress);
+      }
     });
 
-    setControllers(res.items as Controller[]);
-  };
+    return { byAddress, byUsername, addressByUsername };
+  }, [controllers]);
+
+  const refreshControllers = useCallback(async () => {
+    if (!sdk) return;
+
+    setIsLoading(true);
+    try {
+      const res = await sdk.getControllers([], [], {
+        cursor: undefined,
+        direction: "Backward",
+        limit: 50_000,
+        order_by: [],
+      });
+
+      setControllers(res.items as Controller[]);
+    } catch (error) {
+      console.error("[controllers] Failed to load controllers", error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sdk]);
 
   const findController = useCallback(
     (address: BigNumberish) => {
-      try {
-        return controllers?.find((i) => BigInt(i.address) === BigInt(address));
-      } catch (e: any) {
-        return undefined;
-      }
+      const normalizedAddress = normalizeAvatarAddress(address as string | bigint | number | null | undefined);
+      if (!normalizedAddress) return undefined;
+      return indexedControllers.byAddress.get(normalizedAddress);
     },
-    [controllers],
+    [indexedControllers.byAddress],
+  );
+
+  const findControllerByUsername = useCallback(
+    (username: string) => {
+      const normalizedUsername = normalizeAvatarUsername(username);
+      if (!normalizedUsername) return undefined;
+      return indexedControllers.byUsername.get(normalizedUsername);
+    },
+    [indexedControllers.byUsername],
+  );
+
+  const findControllerAddressByUsername = useCallback(
+    (username: string) => {
+      const normalizedUsername = normalizeAvatarUsername(username);
+      if (!normalizedUsername) return undefined;
+      return indexedControllers.addressByUsername.get(normalizedUsername);
+    },
+    [indexedControllers.addressByUsername],
   );
 
   useEffect(() => {
-    refreshControllers();
-  }, []);
+    void refreshControllers();
+  }, [refreshControllers]);
+
+  const value = useMemo(
+    () => ({
+      controllers,
+      isLoading,
+      refreshControllers,
+      findController,
+      findControllerByUsername,
+      findControllerAddressByUsername,
+    }),
+    [
+      controllers,
+      findController,
+      findControllerAddressByUsername,
+      findControllerByUsername,
+      isLoading,
+      refreshControllers,
+    ],
+  );
 
   return (
-    <ControllersProviderContext.Provider
-      {...props}
-      value={{
-        controllers,
-        refreshControllers,
-        findController,
-      }}
-    >
+    <ControllersProviderContext.Provider {...props} value={value}>
       {children}
     </ControllersProviderContext.Provider>
   );

--- a/client/apps/game/src/pm/hooks/dojo/use-dojo-sdk.tsx
+++ b/client/apps/game/src/pm/hooks/dojo/use-dojo-sdk.tsx
@@ -1,6 +1,6 @@
 import type { SDK } from "@dojoengine/sdk";
 import { DojoSdkProvider, useDojoSDK } from "@dojoengine/sdk/react";
-import { type PropsWithChildren, useEffect, useState } from "react";
+import { type PropsWithChildren, type ReactNode, useEffect, useState } from "react";
 import type { StarknetDomain } from "starknet";
 import type { PredictionMarketChain } from "../../manifest-loader";
 import { setupWorld, type SchemaType } from "../../bindings";
@@ -20,8 +20,10 @@ export const useDojoSdk = () => {
 function DojoSdkProviderInner({
   children,
   domain = appDomain,
+  fallback = null,
 }: PropsWithChildren<{
   domain?: StarknetDomain;
+  fallback?: ReactNode;
 }>) {
   const { dojoConfig } = useDojoConfig();
   const [sdk, setSdk] = useState<SDK<SchemaType>>();
@@ -55,7 +57,7 @@ function DojoSdkProviderInner({
     };
   }, [dojoConfig, domain]);
 
-  if (!sdk) return null;
+  if (!sdk) return <>{fallback}</>;
 
   return (
     <DojoSdkProvider sdk={sdk} dojoConfig={dojoConfig} clientFn={setupWorld}>
@@ -70,15 +72,19 @@ export const DojoSdkProviderInitialized = ({
   toriiUrl = "",
   worldAddress = "",
   chain,
+  fallback = null,
 }: PropsWithChildren<{
   domain?: StarknetDomain;
   toriiUrl?: string;
   worldAddress?: string;
   chain?: PredictionMarketChain;
+  fallback?: ReactNode;
 }>) => {
   return (
     <DojoConfigProvider toriiUrl={toriiUrl} worldAddress={worldAddress} chain={chain}>
-      <DojoSdkProviderInner domain={domain}>{children}</DojoSdkProviderInner>
+      <DojoSdkProviderInner domain={domain} fallback={fallback}>
+        {children}
+      </DojoSdkProviderInner>
     </DojoConfigProvider>
   );
 };

--- a/client/apps/game/src/pm/hooks/markets/use-market-history.tsx
+++ b/client/apps/game/src/pm/hooks/markets/use-market-history.tsx
@@ -49,7 +49,7 @@ const compactLabel = (value: string) => {
 
 export const useMarketHistory = (market: MarketClass, refreshKey = 0) => {
   const { sdk } = useDojoSdk();
-  const { findController, controllers } = useControllers();
+  const { findController } = useControllers();
 
   const outcomesText = useMemo(() => market.getMarketTextOutcomes(), [market]);
   const collateralToken = market.collateralToken as RegisteredToken;
@@ -133,7 +133,7 @@ export const useMarketHistory = (market: MarketClass, refreshKey = 0) => {
         ];
       }),
     );
-  }, [market.outcome_slot_count, outcomesText, findController, controllers]);
+  }, [market.outcome_slot_count, outcomesText, findController]);
 
   // Pre-compute entity IDs for each outcome slot
   const numeratorsEntityIds = useMemo(

--- a/client/apps/game/src/ui/features/landing/views/market-details-modal.chain-data-source.test.ts
+++ b/client/apps/game/src/ui/features/landing/views/market-details-modal.chain-data-source.test.ts
@@ -11,7 +11,8 @@ describe("MarketDetailsModal chain-aware data sources", () => {
     );
 
     expect(source).toContain("chain: MarketDataChain");
-    expect(source).toContain("<MarketsProviders chain={chain}>");
+    expect(source).toContain("<MarketsProviders chain={chain} loadingFallback={");
+    expect(source).toContain("MarketDetailsModalLoadingFallback");
     expect(source).toContain("getPmSqlApiForUrl(GLOBAL_TORII_BY_CHAIN[chain])");
     expect(source).toContain("fetchMarketBuyUniqueAccountsCountByMarket");
     expect(source).toContain("<MarketPositions market={market} chain={chain} address={address} />");

--- a/client/apps/game/src/ui/features/landing/views/market-details-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/views/market-details-modal.tsx
@@ -633,6 +633,7 @@ const MarketDetailsModalContent = ({
                   maxVisible={4}
                   collapsible
                   showPlayerMeta
+                  variant="list"
                 />
               </section>
 
@@ -663,12 +664,33 @@ const MarketDetailsModalContent = ({
   );
 };
 
+const MarketDetailsModalLoadingFallback = ({ onClose }: { onClose: () => void }) => (
+  <div className="relative mx-auto flex h-[100dvh] w-full max-w-6xl flex-col overflow-hidden rounded-none border border-gold/15 bg-black/95 shadow-2xl md:h-[90vh] md:max-h-[90vh] md:rounded-2xl">
+    <div className="flex items-center justify-end border-b border-gold/15 px-4 py-4 md:px-6 md:py-5">
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-lg p-2 text-gold/60 transition-colors hover:bg-gold/10 hover:text-gold"
+        aria-label="Close"
+      >
+        <X className="h-5 w-5" />
+      </button>
+    </div>
+    <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-8">
+      <div className="flex items-center gap-3 rounded-xl border border-gold/25 bg-black/40 px-4 py-3 text-sm text-gold/85">
+        <Loader2 className="h-4 w-4 animate-spin text-gold" />
+        <span>Loading market data...</span>
+      </div>
+    </div>
+  </div>
+);
+
 /**
  * Modal wrapper that provides the necessary context providers
  */
 export const MarketDetailsModal = ({ market, chain, initialOutcomeIndex, onClose }: MarketDetailsModalProps) => {
   return (
-    <MarketsProviders chain={chain}>
+    <MarketsProviders chain={chain} loadingFallback={<MarketDetailsModalLoadingFallback onClose={onClose} />}>
       <MarketDetailsModalContent
         initialMarket={market}
         chain={chain}

--- a/client/apps/game/src/ui/features/landing/views/markets-view.modal-chain-prop.test.ts
+++ b/client/apps/game/src/ui/features/landing/views/markets-view.modal-chain-prop.test.ts
@@ -15,6 +15,14 @@ describe("MarketsView modal chain wiring", () => {
 
     expect(source).toContain("const hasLiveMarkets = counts.live > 0;");
     expect(source).toContain("isLiveOption && hasLiveMarkets");
-    expect(source).toContain("shadow-[0_0_18px_rgba(16,185,129,0.35)]");
+    expect(source).toContain("shadow-[0_0_20px_rgba(125,255,186,0.25)]");
+  });
+
+  it("shows skeleton cards while markets are loading", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/markets-view.tsx"), "utf8");
+
+    expect(source).toContain("const isInitialLoad = (isLoading || isFetching) && markets.length === 0;");
+    expect(source).toContain("Loading live markets...");
+    expect(source).toContain("MarketTerminalSkeletonCard");
   });
 });

--- a/client/apps/game/src/ui/features/landing/views/markets-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/markets-view.tsx
@@ -173,10 +173,10 @@ const STATUS_OPTIONS: Array<{
   key: MarketStatusKey;
   label: string;
 }> = [
-  { key: "all", label: "All" },
   { key: "live", label: "Live" },
   { key: "awaiting", label: "Awaiting" },
   { key: "resolved", label: "Resolved" },
+  { key: "all", label: "All" },
 ];
 
 const CHAIN_OPTIONS: Array<{ key: MarketChainFilter; label: string }> = [
@@ -199,6 +199,7 @@ const getChainFromParam = (value: string | null): MarketChainFilter => {
 };
 
 const PAGE_SIZE = 9;
+const INITIAL_MARKETS_SKELETON_COUNT = 6;
 
 const formatOddsPercentage = (raw: string | number) => {
   const value = Number(raw);
@@ -276,16 +277,7 @@ const MarketTerminalCard = ({
     return { outcomes: ordered, winningOutcomeOrdersSet: winningSet };
   }, [item.market]);
   const controllers = useOptionalControllers();
-  const controllerAddressByUsername = useMemo(() => {
-    const map = new Map<string, string>();
-    controllers?.controllers?.forEach((controller) => {
-      const normalizedUsername = normalizeAvatarUsername(controller.username);
-      const normalizedAddress = normalizeAvatarAddress(controller.address);
-      if (!normalizedUsername || !normalizedAddress) return;
-      map.set(normalizedUsername, normalizedAddress);
-    });
-    return map;
-  }, [controllers?.controllers]);
+  const findControllerAddressByUsername = controllers?.findControllerAddressByUsername;
 
   const visibleOutcomes = outcomes.slice(0, 3);
   const hiddenCount = Math.max(0, outcomes.length - visibleOutcomes.length);
@@ -337,7 +329,7 @@ const MarketTerminalCard = ({
           [
             ...outcomeAddresses,
             ...outcomeUsernames
-              .map((username) => controllerAddressByUsername.get(username) ?? null)
+              .map((username) => findControllerAddressByUsername?.(username) ?? null)
               .filter((address): address is string => Boolean(address)),
             ...avatarProfilesByAddress
               .map((profile) => normalizeAvatarAddress(profile.playerAddress))
@@ -351,7 +343,7 @@ const MarketTerminalCard = ({
     [
       outcomeAddresses,
       outcomeUsernames,
-      controllerAddressByUsername,
+      findControllerAddressByUsername,
       avatarProfilesByAddress,
       avatarProfilesByUsername,
     ],
@@ -409,7 +401,9 @@ const MarketTerminalCard = ({
               : null;
             const avatarProfileByResolvedUsername = normalizedName ? avatarProfileByUsername.get(normalizedName) : null;
             const avatarProfile = avatarProfileByResolvedAddress ?? avatarProfileByResolvedUsername;
-            const controllerAddress = normalizedName ? (controllerAddressByUsername.get(normalizedName) ?? null) : null;
+            const controllerAddress = normalizedName
+              ? (findControllerAddressByUsername?.(normalizedName) ?? null)
+              : null;
             const playerAddress =
               normalizedAddress ?? normalizeAvatarAddress(avatarProfile?.playerAddress) ?? controllerAddress;
             const avatarSeed = playerAddress ?? normalizedName ?? rawName;
@@ -505,6 +499,40 @@ const MarketTerminalCard = ({
   );
 };
 
+const MarketTerminalSkeletonCard = () => (
+  <article className="relative flex h-full flex-col overflow-hidden rounded-xl border border-gold/15 bg-black/40 p-4">
+    <div className="flex items-start gap-3">
+      <div className="h-12 w-12 animate-pulse rounded-lg border border-gold/20 bg-gold/10" />
+      <div className="flex-1 space-y-2">
+        <div className="h-3 w-20 animate-pulse rounded bg-gold/10" />
+        <div className="h-4 w-3/4 animate-pulse rounded bg-gold/10" />
+      </div>
+      <div className="h-6 w-16 animate-pulse rounded-full border border-gold/20 bg-gold/10" />
+    </div>
+
+    <div className="mt-4 flex-1 rounded-lg border border-gold/15 bg-black/45 p-3">
+      <div className="space-y-2.5">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between gap-2 rounded-md border border-gold/15 bg-black/20 p-2"
+          >
+            <div className="h-3 w-1/2 animate-pulse rounded bg-gold/10" />
+            <div className="h-4 w-10 animate-pulse rounded bg-gold/10" />
+          </div>
+        ))}
+      </div>
+    </div>
+
+    <div className="mt-3 grid grid-cols-2 gap-2">
+      <div className="h-14 animate-pulse rounded-lg border border-gold/25 bg-gold/10" />
+      <div className="h-14 animate-pulse rounded-lg border border-gold/20 bg-black/40" />
+    </div>
+
+    <div className="mt-3 h-9 animate-pulse rounded-lg border border-gold/30 bg-gold/10" />
+  </article>
+);
+
 /**
  * Unified prediction markets view with in-page status filters.
  */
@@ -589,6 +617,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const startIndex = totalCount > 0 ? offset + 1 : 0;
   const endIndex = Math.min(offset + markets.length, totalCount);
+  const isInitialLoad = (isLoading || isFetching) && markets.length === 0;
 
   const sourceWarnings = useMemo(() => {
     const selected = selectedChain === "all" ? (["slot", "mainnet"] as MarketDataChain[]) : [selectedChain];
@@ -708,7 +737,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
       >
         <span>{totalCount > 0 ? `Showing ${startIndex}-${endIndex} of ${totalCount}` : "No markets found"}</span>
         <div className="flex items-center gap-3">
-          <span>Sort: Creation Date (Newest)</span>
+          <span>Sort: Live First • Newest</span>
           {isFetching ? <span className="text-gold/45">Refreshing…</span> : null}
           <RefreshButton aria-label="Refresh markets" isLoading={isFetching || isLoading} onClick={refresh} />
         </div>
@@ -732,7 +761,18 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
           "max-h-[calc(100vh-260px)] flex-1 overflow-y-auto border-gold/15 bg-black/25 p-4 md:p-5",
         )}
       >
-        {markets.length === 0 && !isFetching ? (
+        {isInitialLoad ? (
+          <div className="space-y-4">
+            <div className="rounded-xl border border-gold/20 bg-black/35 px-3 py-2 text-xs uppercase tracking-[0.12em] text-gold/65">
+              Loading live markets...
+            </div>
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: INITIAL_MARKETS_SKELETON_COUNT }).map((_, index) => (
+                <MarketTerminalSkeletonCard key={`market-skeleton-${index}`} />
+              ))}
+            </div>
+          </div>
+        ) : markets.length === 0 && !isFetching ? (
           <div className="rounded-2xl border border-gold/20 bg-black/35 p-6 text-center">
             <p className="font-cinzel text-lg text-gold">{emptyState.title}</p>
             {emptyState.description ? <p className="mt-2 text-sm text-gold/70">{emptyState.description}</p> : null}

--- a/client/apps/game/src/ui/features/market/landing-markets/market-odds.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/market-odds.tsx
@@ -154,6 +154,8 @@ const getOutcomes = (market: MarketClass): MarketOutcome[] => {
   return outcomes as MarketOutcome[];
 };
 
+type MarketOddsVariant = "default" | "list";
+
 const parseNumericOdds = (outcome: MarketOutcome) => {
   const oddsValue = getOddsValue(outcome);
   if (oddsValue == null) return null;
@@ -170,6 +172,7 @@ export const MarketOdds = ({
   maxVisible,
   collapsible = false,
   showPlayerMeta = false,
+  variant = "default",
 }: {
   market: MarketClass;
   selectable?: boolean;
@@ -178,20 +181,13 @@ export const MarketOdds = ({
   maxVisible?: number;
   collapsible?: boolean;
   showPlayerMeta?: boolean;
+  variant?: MarketOddsVariant;
 }) => {
   const outcomes = useMemo(() => getOutcomes(market), [market]);
   const [isExpanded, setIsExpanded] = useState(false);
   const controllers = useOptionalControllers();
-  const controllerAddressByUsername = useMemo(() => {
-    const map = new Map<string, string>();
-    controllers?.controllers?.forEach((controller) => {
-      const normalizedUsername = normalizeAvatarUsername(controller.username);
-      const normalizedAddress = normalizeAvatarAddress(controller.address);
-      if (!normalizedUsername || !normalizedAddress) return;
-      map.set(normalizedUsername, normalizedAddress);
-    });
-    return map;
-  }, [controllers?.controllers]);
+  const findControllerAddressByUsername = controllers?.findControllerAddressByUsername;
+  const isListVariant = variant === "list";
 
   const { sortedOutcomes, winningOutcomeOrdersSet } = useMemo(() => {
     const resolvedPayouts = market.isResolved() ? (market.conditionResolution?.payout_numerators ?? []) : [];
@@ -286,7 +282,7 @@ export const MarketOdds = ({
           [
             ...outcomeAddresses,
             ...outcomeUsernames
-              .map((username) => controllerAddressByUsername.get(username) ?? null)
+              .map((username) => findControllerAddressByUsername?.(username) ?? null)
               .filter((address): address is string => Boolean(address)),
             ...avatarProfilesByAddress
               .map((profile) => normalizeAvatarAddress(profile.playerAddress))
@@ -300,7 +296,7 @@ export const MarketOdds = ({
     [
       outcomeAddresses,
       outcomeUsernames,
-      controllerAddressByUsername,
+      findControllerAddressByUsername,
       avatarProfilesByAddress,
       avatarProfilesByUsername,
     ],
@@ -313,6 +309,12 @@ export const MarketOdds = ({
 
   return (
     <div className="flex flex-col gap-2">
+      {isListVariant ? (
+        <div className="mb-1 flex items-center justify-between">
+          <p className="text-[10px] uppercase tracking-[0.12em] text-gold/50">Top Outcomes</p>
+          <p className="text-[10px] uppercase tracking-[0.12em] text-gold/40">Percent</p>
+        </div>
+      ) : null}
       {visibleOutcomes.map(({ outcome, order, resolutionIndex }) => {
         const oddsRaw = getOddsValue(outcome);
         const odds = formatOdds(oddsRaw);
@@ -333,7 +335,7 @@ export const MarketOdds = ({
         const avatarProfileByResolvedAddress = normalizedAddress ? avatarProfileByAddress.get(normalizedAddress) : null;
         const avatarProfileByResolvedUsername = normalizedName ? avatarProfileByUsername.get(normalizedName) : null;
         const avatarProfile = avatarProfileByResolvedAddress ?? avatarProfileByResolvedUsername;
-        const controllerAddress = normalizedName ? (controllerAddressByUsername.get(normalizedName) ?? null) : null;
+        const controllerAddress = normalizedName ? (findControllerAddressByUsername?.(normalizedName) ?? null) : null;
         const playerAddress =
           normalizedAddress ?? normalizeAvatarAddress(avatarProfile?.playerAddress) ?? controllerAddress;
         const avatarSeed = playerAddress ?? normalizedName ?? rawName;
@@ -344,12 +346,21 @@ export const MarketOdds = ({
           <button
             key={`${outcome.index}-${resolutionIndex}-${order}`}
             className={cx(
-              "group relative flex min-h-[56px] justify-between overflow-hidden rounded-sm border px-3 py-2.5 text-left text-xs transition-all duration-200",
+              "group relative flex justify-between overflow-hidden border text-left text-xs font-sans normal-case transition-all duration-200",
+              isListVariant ? "rounded-md px-2 py-1.5" : "min-h-[56px] rounded-sm px-3 py-2.5",
               showPlayerMeta ? "items-start" : "items-center",
               isWinner ? "border-progress-bar-good/55 bg-progress-bar-good/10" : "border-gold/20 bg-brown/40",
               "text-lightest",
-              isSelectable ? "cursor-pointer hover:border-gold/50 hover:bg-gold/10" : "cursor-default",
-              isSelected ? "border-gold/70 bg-gold/15 ring-1 ring-gold/40" : null,
+              isSelectable
+                ? isListVariant
+                  ? "cursor-pointer hover:border-gold/45 hover:bg-gold/10"
+                  : "cursor-pointer hover:border-gold/50 hover:bg-gold/10"
+                : "cursor-default",
+              isSelected
+                ? isListVariant
+                  ? "border-gold/70 bg-gold/15"
+                  : "border-gold/70 bg-gold/15 ring-1 ring-gold/40"
+                : null,
             )}
             type="button"
             onClick={
@@ -372,8 +383,8 @@ export const MarketOdds = ({
                 />
               ) : null}
               <div className="min-w-0 flex-1">
-                <span className="block min-w-0 truncate font-medium">
-                  <MaybeController address={outcome.name} />
+                <span className="block min-w-0 truncate text-xs font-medium tracking-normal text-lightest">
+                  <MaybeController address={outcome.name} showAddress={!isListVariant} />
                 </span>
                 {showPlayerMeta ? (
                   <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
@@ -394,19 +405,24 @@ export const MarketOdds = ({
 
             {/* Pool amount & Odds */}
             <div className={cx("relative flex flex-shrink-0 items-center gap-2 pl-2", showPlayerMeta && "pt-0.5")}>
-              {/* Pool amount pill */}
-              <div className="flex items-center gap-1 rounded-full bg-brown/60 px-2 py-0.5 backdrop-blur-sm">
-                <span className="text-[10px] font-medium tabular-nums text-gold/80">{poolAmount}</span>
-                <TokenIcon token={market.collateralToken} size={11} />
-              </div>
+              {!isListVariant ? (
+                <div className="flex items-center gap-1 rounded-full bg-brown/60 px-2 py-0.5 backdrop-blur-sm">
+                  <span className="text-[10px] font-medium tabular-nums text-gold/80">{poolAmount}</span>
+                  <TokenIcon token={market.collateralToken} size={11} />
+                </div>
+              ) : null}
 
               {/* Odds badge */}
               <div
                 className={cx(
-                  "min-w-[48px] rounded px-2 py-1 text-center text-sm font-bold tabular-nums",
+                  isListVariant
+                    ? "rounded border px-2 py-0.5 text-xs font-semibold tabular-nums"
+                    : "min-w-[48px] rounded px-2 py-1 text-center text-sm font-bold tabular-nums",
                   isWinner
                     ? "border border-progress-bar-good/45 bg-progress-bar-good/15 text-progress-bar-good"
-                    : "bg-gold/10 text-gold group-hover:bg-gold/20",
+                    : isListVariant
+                      ? "border-gold/30 bg-gold/10 text-gold"
+                      : "bg-gold/10 text-gold group-hover:bg-gold/20",
                 )}
               >
                 {odds ?? "--"}

--- a/client/apps/game/src/ui/features/market/landing-markets/maybe-controller.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/maybe-controller.tsx
@@ -15,17 +15,30 @@ export function MaybeController({
 }) {
   const controllers = useOptionalControllers();
 
-  const label = useMemo(() => {
-    const controller = controllers?.findController(address);
-    if (controller) {
-      return showAddress ? `${controller.username} (${shortAddress(address)})` : controller.username;
-    }
+  const fallbackLabel = useMemo(() => {
     try {
       return shortAddress(address);
     } catch {
       return address;
     }
-  }, [address, controllers, showAddress]);
+  }, [address]);
+
+  const label = useMemo(() => {
+    const controllerByAddress = controllers?.findController(address);
+    if (controllerByAddress) {
+      return showAddress ? `${controllerByAddress.username} (${shortAddress(address)})` : controllerByAddress.username;
+    }
+
+    const controllerByUsername = controllers?.findControllerByUsername(address);
+    if (controllerByUsername) {
+      const resolvedAddress = controllers?.findControllerAddressByUsername(address) ?? controllerByUsername.address;
+      return showAddress
+        ? `${controllerByUsername.username} (${shortAddress(resolvedAddress)})`
+        : controllerByUsername.username;
+    }
+
+    return fallbackLabel;
+  }, [address, controllers, fallbackLabel, showAddress]);
 
   return (
     <div className={className} {...props}>

--- a/client/apps/game/src/ui/features/market/landing-markets/use-multi-chain-markets.live-priority.test.ts
+++ b/client/apps/game/src/ui/features/market/landing-markets/use-multi-chain-markets.live-priority.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("useMultiChainMarkets live-first ordering", () => {
+  it("prioritizes live markets when mixed statuses are shown", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/market/landing-markets/use-multi-chain-markets.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain("const getMarketStatusPriority = (market: MarketClass) => {");
+    expect(source).toContain("if (!market.isResolved() && !market.isEnded()) return 0; // Live / open trading.");
+    expect(source).toContain('if (status === "all")');
+    expect(source).toContain(
+      "const statusDifference = getMarketStatusPriority(a.market) - getMarketStatusPriority(b.market);",
+    );
+  });
+});

--- a/client/apps/game/src/ui/features/market/landing-markets/use-multi-chain-markets.ts
+++ b/client/apps/game/src/ui/features/market/landing-markets/use-multi-chain-markets.ts
@@ -285,8 +285,20 @@ const fetchChainMarkets = async ({
     .filter((item): item is EnrichedMarket => Boolean(item));
 };
 
-const mergeAndSortByNewest = (markets: EnrichedMarket[]) =>
+const getMarketStatusPriority = (market: MarketClass) => {
+  if (!market.isResolved() && !market.isEnded()) return 0; // Live / open trading.
+  if (!market.isResolved() && !market.isResolvable()) return 1; // Trading ended, awaiting resolve window.
+  if (!market.isResolved() && market.isResolvable()) return 2; // Awaiting resolution.
+  return 3; // Resolved.
+};
+
+const mergeAndSortMarkets = (markets: EnrichedMarket[], status: MarketStatusKey) =>
   markets.toSorted((a, b) => {
+    if (status === "all") {
+      const statusDifference = getMarketStatusPriority(a.market) - getMarketStatusPriority(b.market);
+      if (statusDifference !== 0) return statusDifference;
+    }
+
     const createdAtDifference = Number(b.market.created_at ?? 0) - Number(a.market.created_at ?? 0);
     if (createdAtDifference !== 0) return createdAtDifference;
     if (a.volumeRaw !== b.volumeRaw) return a.volumeRaw > b.volumeRaw ? -1 : 1;
@@ -418,7 +430,7 @@ export function useMultiChainMarkets({
       });
 
       return {
-        markets: mergeAndSortByNewest(merged),
+        markets: mergeAndSortMarkets(merged, status),
         sourceStatus,
       };
     },

--- a/client/apps/game/src/ui/features/market/markets-providers.tsx
+++ b/client/apps/game/src/ui/features/market/markets-providers.tsx
@@ -41,7 +41,15 @@ const MARKET_FILTERS_ALL: MarketFiltersParams = {
   oracle: "All",
 };
 
-export const MarketsProviders = ({ children, chain }: { children: ReactNode; chain?: PredictionMarketChain }) => {
+export const MarketsProviders = ({
+  children,
+  chain,
+  loadingFallback,
+}: {
+  children: ReactNode;
+  chain?: PredictionMarketChain;
+  loadingFallback?: ReactNode;
+}) => {
   const resolvedChain = chain ?? getPredictionMarketChain();
   const config = getPredictionMarketConfigForChain(resolvedChain);
   return (
@@ -50,6 +58,7 @@ export const MarketsProviders = ({ children, chain }: { children: ReactNode; cha
         chain={resolvedChain}
         toriiUrl={GLOBAL_TORII_BY_CHAIN[resolvedChain] ?? config.toriiUrl}
         worldAddress={config.worldAddress}
+        fallback={loadingFallback}
       >
         <UserProvider>
           <ControllersProvider>{children}</ControllersProvider>


### PR DESCRIPTION
This PR prioritizes LIVE markets in mixed views and adds explicit skeleton/loading feedback in the landing markets panel. It optimizes controller resolution by indexing controller lookups and reusing those lookups across list/detail odds and market-history labels. It adds provider fallback loading UI so market-details modal never appears empty, and introduces a list-style odds variant in the details modal to better match the market-list typography and spacing. Tests are updated and a new live-priority sorting test is included.