### PR TITLE
Split season registration path and align S2 docs

### DIFF
--- a/client/apps/game/src/hooks/use-world-registration.ts
+++ b/client/apps/game/src/hooks/use-world-registration.ts
@@ -16,8 +16,18 @@ import { env } from "../../env";
 import { useUsername } from "./use-username";
 import type { WorldConfigMeta } from "./use-world-availability";
 
-// Known contract selector for blitz_realm_systems
+// Known contract selectors
 const BLITZ_REALM_SYSTEMS_SELECTOR = "0x3414be5ba2c90784f15eb572e9222b5c83a6865ec0e475a57d7dc18af9b3742";
+const REALM_SYSTEMS_SELECTOR = "0x3b4cc14cbb49692c85e1b132ac8536fe7d0d1361cd2fb5ba8df29f726ca02d2";
+
+export interface SeasonRegistrationParams {
+  realmId?: number;
+  ownerAddress?: string;
+  frontendAddress?: string;
+  side?: number;
+  layer?: number;
+  point?: number;
+}
 
 /**
  * Fetch ERC20 token balance using RPC call
@@ -83,7 +93,7 @@ interface UseWorldRegistrationProps {
 
 interface UseWorldRegistrationReturn {
   /** Execute registration */
-  register: () => Promise<void>;
+  register: (params?: SeasonRegistrationParams) => Promise<void>;
   /** Current registration stage */
   registrationStage: RegistrationStage;
   /** Whether registration is in progress */
@@ -268,6 +278,16 @@ export const useWorldRegistration = ({
   }, []);
 
   /**
+   * Get the realm_systems contract address (season mode settle path)
+   */
+  const getRealmSystemsAddress = useCallback(async (contracts: Record<string, string>): Promise<string> => {
+    const normalizedSelector = normalizeSelector(REALM_SYSTEMS_SELECTOR);
+    const address = contracts[normalizedSelector];
+    if (!address) throw new Error("realm_systems contract not found for this world");
+    return address;
+  }, []);
+
+  /**
    * Build calls to obtain entry token (approve fee + mint)
    */
   const buildObtainTokenCalls = useCallback(
@@ -366,103 +386,129 @@ export const useWorldRegistration = ({
   /**
    * Execute full registration flow
    */
-  const register = useCallback(async () => {
-    if (!canRegister || !account) return;
+  const register = useCallback(
+    async (params?: SeasonRegistrationParams) => {
+      if (!canRegister || !account) return;
 
-    setError(null);
-    setRegistrationStage("preparing");
+      setError(null);
+      setRegistrationStage("preparing");
 
-    try {
-      // Resolve contracts
-      const contracts = await resolveContracts();
-      const blitzSystemsAddress = await getBlitzRealmSystemsAddress(contracts);
+      try {
+        // Resolve contracts
+        const contracts = await resolveContracts();
 
-      // Cast account to starknet Account for execute
-      const starknetAccount = account as unknown as Account;
+        // Cast account to starknet Account for execute
+        const starknetAccount = account as unknown as Account;
 
-      if (requiresEntryToken && config?.entryTokenAddress && config?.feeTokenAddress) {
-        // Create RPC provider for balance checks and entry token queries
-        const rpcUrl = getRpcUrlForChain(chain);
-        const rpcProvider = new RpcProvider({ nodeUrl: rpcUrl });
+        // Season mode path (Eternum): realm_systems.create(owner, realm_id, frontend, {side, layer, point})
+        // Placement + realm ID are accepted as params for future UI wiring. Defaults are placeholders.
+        if (config?.mode === "eternum") {
+          const realmSystemsAddress = await getRealmSystemsAddress(contracts);
+          const owner = params?.ownerAddress ?? address!;
+          const frontend = params?.frontendAddress ?? address!;
+          const realmId = params?.realmId ?? 0;
+          const side = params?.side ?? 0;
+          const layer = params?.layer ?? 1;
+          const point = params?.point ?? 0;
 
-        // Check if we already have an entry token
-        let tokenId = await fetchAvailableEntryTokenId(rpcProvider, config.entryTokenAddress, address!);
+          setRegistrationStage("registering");
+          await starknetAccount.execute({
+            contractAddress: realmSystemsAddress,
+            entrypoint: "create",
+            calldata: CallData.compile([owner, realmId, frontend, side, layer, point]),
+          });
+          setRegistrationStage("done");
+          return;
+        }
 
-        if (!tokenId) {
-          // Auto top-up on non-mainnet if fee balance is insufficient
-          const isNonMainnet = chain !== "mainnet";
-          if (isNonMainnet && feeAmount > 0n) {
-            // Check current fee token balance
-            const currentBalance = await fetchTokenBalance(rpcProvider, config.feeTokenAddress, address!);
+        const blitzSystemsAddress = await getBlitzRealmSystemsAddress(contracts);
 
-            if (currentBalance < feeAmount) {
-              // Transfer shortfall from master account
-              const masterAccount = createMasterAccount(rpcProvider);
-              if (masterAccount) {
-                const shortfall = feeAmount - currentBalance;
-                const amount = uint256.bnToUint256(shortfall);
-                try {
-                  await masterAccount.execute({
-                    contractAddress: config.feeTokenAddress,
-                    entrypoint: "transfer",
-                    calldata: CallData.compile([address!, amount.low, amount.high]),
-                  });
-                  // Wait a bit for the transfer to be indexed
-                  await new Promise((resolve) => setTimeout(resolve, 2000));
-                } catch (topUpError) {
-                  console.error("Auto top-up failed:", topUpError);
-                  // Continue anyway - the user might have gotten tokens elsewhere
+        if (requiresEntryToken && config?.entryTokenAddress && config?.feeTokenAddress) {
+          // Create RPC provider for balance checks and entry token queries
+          const rpcUrl = getRpcUrlForChain(chain);
+          const rpcProvider = new RpcProvider({ nodeUrl: rpcUrl });
+
+          // Check if we already have an entry token
+          let tokenId = await fetchAvailableEntryTokenId(rpcProvider, config.entryTokenAddress, address!);
+
+          if (!tokenId) {
+            // Auto top-up on non-mainnet if fee balance is insufficient
+            const isNonMainnet = chain !== "mainnet";
+            if (isNonMainnet && feeAmount > 0n) {
+              // Check current fee token balance
+              const currentBalance = await fetchTokenBalance(rpcProvider, config.feeTokenAddress, address!);
+
+              if (currentBalance < feeAmount) {
+                // Transfer shortfall from master account
+                const masterAccount = createMasterAccount(rpcProvider);
+                if (masterAccount) {
+                  const shortfall = feeAmount - currentBalance;
+                  const amount = uint256.bnToUint256(shortfall);
+                  try {
+                    await masterAccount.execute({
+                      contractAddress: config.feeTokenAddress,
+                      entrypoint: "transfer",
+                      calldata: CallData.compile([address!, amount.low, amount.high]),
+                    });
+                    // Wait a bit for the transfer to be indexed
+                    await new Promise((resolve) => setTimeout(resolve, 2000));
+                  } catch (topUpError) {
+                    console.error("Auto top-up failed:", topUpError);
+                    // Continue anyway - the user might have gotten tokens elsewhere
+                  }
                 }
               }
             }
+
+            // Step 1: Obtain entry token
+            setRegistrationStage("obtaining-token");
+            const obtainCalls = buildObtainTokenCalls(blitzSystemsAddress);
+            await starknetAccount.execute(obtainCalls);
+
+            // Step 2: Wait for token
+            setRegistrationStage("waiting-for-token");
+            tokenId = await waitForEntryToken(rpcProvider);
+            console.log({ tokenId });
+            if (!tokenId) {
+              throw new Error("Failed to obtain entry token. Please try again.");
+            }
           }
 
-          // Step 1: Obtain entry token
-          setRegistrationStage("obtaining-token");
-          const obtainCalls = buildObtainTokenCalls(blitzSystemsAddress);
-          await starknetAccount.execute(obtainCalls);
-
-          // Step 2: Wait for token
-          setRegistrationStage("waiting-for-token");
-          tokenId = await waitForEntryToken(rpcProvider);
-          console.log({ tokenId });
-          if (!tokenId) {
-            throw new Error("Failed to obtain entry token. Please try again.");
-          }
+          // Step 3: Register with token
+          setRegistrationStage("registering");
+          const registerCalls = buildRegisterCalls(blitzSystemsAddress, tokenId);
+          await starknetAccount.execute(registerCalls);
+        } else {
+          // No entry token required - direct registration
+          setRegistrationStage("registering");
+          const registerCalls = buildRegisterCalls(blitzSystemsAddress, 0n);
+          await starknetAccount.execute(registerCalls);
         }
 
-        // Step 3: Register with token
-        setRegistrationStage("registering");
-        const registerCalls = buildRegisterCalls(blitzSystemsAddress, tokenId);
-        await starknetAccount.execute(registerCalls);
-      } else {
-        // No entry token required - direct registration
-        setRegistrationStage("registering");
-        const registerCalls = buildRegisterCalls(blitzSystemsAddress, 0n);
-        await starknetAccount.execute(registerCalls);
+        setRegistrationStage("done");
+      } catch (err) {
+        console.error("Registration failed:", err);
+        setError(err instanceof Error ? err.message : "Registration failed");
+        setRegistrationStage("error");
       }
-
-      setRegistrationStage("done");
-    } catch (err) {
-      console.error("Registration failed:", err);
-      setError(err instanceof Error ? err.message : "Registration failed");
-      setRegistrationStage("error");
-    }
-  }, [
-    canRegister,
-    account,
-    address,
-    config,
-    worldName,
-    chain,
-    feeAmount,
-    requiresEntryToken,
-    resolveContracts,
-    getBlitzRealmSystemsAddress,
-    buildObtainTokenCalls,
-    buildRegisterCalls,
-    waitForEntryToken,
-  ]);
+    },
+    [
+      canRegister,
+      account,
+      address,
+      config,
+      worldName,
+      chain,
+      feeAmount,
+      requiresEntryToken,
+      resolveContracts,
+      getBlitzRealmSystemsAddress,
+      getRealmSystemsAddress,
+      buildObtainTokenCalls,
+      buildRegisterCalls,
+      waitForEntryToken,
+    ],
+  );
 
   return {
     register,

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -57,11 +57,7 @@ import { PlayerIndicatorManager } from "./player-indicator-manager";
 import { PointsLabelRenderer } from "./points-label-renderer";
 import { resolveMovementPath } from "./army-move-path";
 import { shouldUseWorkerPathForArmy } from "./army-movement-path-strategy";
-import {
-  addVisibleArmyOrderEntry,
-  removeVisibleArmyOrderEntry,
-  replaceVisibleArmyOrder,
-} from "./army-visible-order";
+import { addVisibleArmyOrderEntry, removeVisibleArmyOrderEntry, replaceVisibleArmyOrder } from "./army-visible-order";
 import { getIndicatorYOffset } from "../constants/indicator-constants";
 import { MAX_INSTANCES } from "../constants/army-constants";
 import { resolveArmyVisibilityBoundsDecision } from "./army-visibility";
@@ -1740,7 +1736,9 @@ export class ArmyManager {
       incrementWorldmapRenderCounter("workerFindPathBypasses");
     }
 
-    const workerPath = shouldUseWorkerPath ? await gameWorkerManager.findPath(armyData.hexCoords, hexCoords, maxHex) : null;
+    const workerPath = shouldUseWorkerPath
+      ? await gameWorkerManager.findPath(armyData.hexCoords, hexCoords, maxHex)
+      : null;
     const path = resolveMovementPath(armyData.hexCoords, hexCoords, workerPath);
 
     // Convert path to world positions

--- a/client/apps/game/src/three/managers/chest-manager.ts
+++ b/client/apps/game/src/three/managers/chest-manager.ts
@@ -413,9 +413,7 @@ export class ChestManager {
       });
       this.pointsRenderer.setMany(nextPointConfigs);
 
-      const stalePointIds = this.pointsRenderer
-        .getEntityIds()
-        .filter((entityId) => !visibleChestIds.has(entityId));
+      const stalePointIds = this.pointsRenderer.getEntityIds().filter((entityId) => !visibleChestIds.has(entityId));
       this.pointsRenderer.removeMany(stalePointIds);
     }
   }

--- a/client/apps/game/src/three/managers/hover-label-manager.leave-path.test.ts
+++ b/client/apps/game/src/three/managers/hover-label-manager.leave-path.test.ts
@@ -13,9 +13,10 @@ describe("HoverLabelManager leave path", () => {
     const source = readHoverLabelManagerSource();
     const onHexLeaveStart = source.indexOf("onHexLeave()");
     const updateCameraViewStart = source.indexOf("updateCameraView(", onHexLeaveStart);
-    const methodSource = onHexLeaveStart >= 0 && updateCameraViewStart > onHexLeaveStart
-      ? source.slice(onHexLeaveStart, updateCameraViewStart)
-      : "";
+    const methodSource =
+      onHexLeaveStart >= 0 && updateCameraViewStart > onHexLeaveStart
+        ? source.slice(onHexLeaveStart, updateCameraViewStart)
+        : "";
 
     expect(methodSource).toMatch(/this\.controllers\[type\]\?\.hide\(activeId\)/);
     expect(methodSource).not.toMatch(/hideAll\?\.\(\)/);

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -2,10 +2,7 @@ import { useAccountStore } from "@/hooks/store/use-account-store";
 import { getGameModeConfig } from "@/config/game-modes";
 import type { GameModeConfig } from "@/config/game-modes";
 import InstancedModel, { LAND_NAME } from "@/three/managers/instanced-model";
-import {
-  recordWorldmapRenderDuration,
-  setWorldmapRenderGauge,
-} from "@/three/perf/worldmap-render-diagnostics";
+import { recordWorldmapRenderDuration, setWorldmapRenderGauge } from "@/three/perf/worldmap-render-diagnostics";
 import { CameraView, HexagonScene } from "@/three/scenes/hexagon-scene";
 import { gltfLoader, isAddressEqualToAccount } from "@/three/utils/utils";
 import { FELT_CENTER } from "@/ui/config";
@@ -937,17 +934,16 @@ export class StructureManager {
 
     const isCurrentlyVisible = this.isInCurrentChunk(normalizedCoord);
     const visibleUpdateInput = {
-      previous:
-        existingStructure && {
-          hexCoords: existingStructure.hexCoords,
-          structureType: existingStructure.structureType,
-          stage: existingStructure.stage,
-          level: existingStructure.level,
-          isMine: existingStructure.isMine,
-          isAlly: existingStructure.isAlly,
-          cosmeticId: existingStructure.cosmeticId,
-          attachmentSignature: existingAttachmentSignature,
-        },
+      previous: existingStructure && {
+        hexCoords: existingStructure.hexCoords,
+        structureType: existingStructure.structureType,
+        stage: existingStructure.stage,
+        level: existingStructure.level,
+        isMine: existingStructure.isMine,
+        isAlly: existingStructure.isAlly,
+        cosmeticId: existingStructure.cosmeticId,
+        attachmentSignature: existingAttachmentSignature,
+      },
       next: {
         hexCoords: normalizedCoord,
         structureType: key,
@@ -968,10 +964,7 @@ export class StructureManager {
       return;
     }
 
-    if (
-      visibleUpdateMode === "rebuild" ||
-      shouldRebuildVisibleStructuresForStructureUpdate(visibleUpdateInput)
-    ) {
+    if (visibleUpdateMode === "rebuild" || shouldRebuildVisibleStructuresForStructureUpdate(visibleUpdateInput)) {
       this.updateVisibleStructures();
     }
   }
@@ -1314,272 +1307,272 @@ export class StructureManager {
         Object.values(this.pointsRenderers).forEach((renderer) => renderer.beginBatch());
       }
 
-    for (const [structureType, structures] of structuresByType) {
-      const models = this.structureModels.get(structureType);
+      for (const [structureType, structures] of structuresByType) {
+        const models = this.structureModels.get(structureType);
 
-      if (!models || models.length === 0) {
-        continue;
-      }
-
-      if (!this.entityIdMaps.has(structureType)) {
-        this.entityIdMaps.set(structureType, new Map());
-      }
-
-      structures.forEach((structure) => {
-        visibleStructureIds.add(structure.entityId);
-        // Use scratch vector to avoid allocation
-        const { col, row } = structure.hexCoords;
-        getWorldPositionForHexCoordsInto(col, row, this.scratchPosition);
-        this.scratchPosition.y += 0.05;
-
-        const existingLabel = this.entityIdLabels.get(structure.entityId);
-        if (existingLabel) {
-          this.updateStructureLabelData(structure, existingLabel);
-          // Use scratch vector for label position
-          getWorldPositionForHexCoordsInto(col, row, this.scratchLabelPosition);
-          this.scratchLabelPosition.y += 2;
-          existingLabel.position.copy(this.scratchLabelPosition);
+        if (!models || models.length === 0) {
+          continue;
         }
 
-        this.dummy.position.copy(this.scratchPosition);
+        if (!this.entityIdMaps.has(structureType)) {
+          this.entityIdMaps.set(structureType, new Map());
+        }
 
-        if (structureType === StructureType.Bank) {
-          this.dummy.rotation.y = (4 * Math.PI) / 6;
-        } else {
+        structures.forEach((structure) => {
+          visibleStructureIds.add(structure.entityId);
+          // Use scratch vector to avoid allocation
+          const { col, row } = structure.hexCoords;
+          getWorldPositionForHexCoordsInto(col, row, this.scratchPosition);
+          this.scratchPosition.y += 0.05;
+
+          const existingLabel = this.entityIdLabels.get(structure.entityId);
+          if (existingLabel) {
+            this.updateStructureLabelData(structure, existingLabel);
+            // Use scratch vector for label position
+            getWorldPositionForHexCoordsInto(col, row, this.scratchLabelPosition);
+            this.scratchLabelPosition.y += 2;
+            existingLabel.position.copy(this.scratchLabelPosition);
+          }
+
+          this.dummy.position.copy(this.scratchPosition);
+
+          if (structureType === StructureType.Bank) {
+            this.dummy.rotation.y = (4 * Math.PI) / 6;
+          } else {
+            const rotationSeed = hashCoordinates(col, row);
+            const rotationIndex = Math.floor(rotationSeed * 6);
+            const randomRotation = (rotationIndex * Math.PI) / 3;
+            this.dummy.rotation.y = randomRotation;
+          }
+          this.dummy.updateMatrix();
+
+          // Add point icon for this structure (always visible)
+          if (this.pointsRenderers) {
+            // Use scratch vector for icon position
+            this.scratchIconPosition.copy(this.scratchPosition);
+            this.scratchIconPosition.y += 2; // Match CSS2D label height
+
+            const renderer = this.getRendererForStructure(structure);
+            if (renderer) {
+              renderer.setPoint({
+                entityId: structure.entityId,
+                position: this.scratchIconPosition,
+              });
+            }
+          }
+
+          const entityNumericId = Number(structure.entityId);
+          const templates = this.resolveStructureAttachmentsForRender(structure);
+          if (templates.length > 0) {
+            attachmentRetain.add(entityNumericId);
+            const signature = this.getAttachmentSignature(templates);
+            const isActive = this.activeStructureAttachmentEntities.has(entityNumericId);
+            if (!isActive || this.structureAttachmentSignatures.get(entityNumericId) !== signature) {
+              this.attachmentManager.spawnAttachments(entityNumericId, templates);
+              this.structureAttachmentSignatures.set(entityNumericId, signature);
+              this.activeStructureAttachmentEntities.add(entityNumericId);
+            }
+
+            this.tempCosmeticPosition.copy(this.scratchPosition);
+            this.tempCosmeticRotation.copy(this.dummy.rotation);
+
+            const baseTransform = {
+              position: this.tempCosmeticPosition,
+              rotation: this.tempCosmeticRotation,
+              scale: this.dummy.scale,
+            };
+
+            const mountTransforms = resolveStructureMountTransforms(
+              structure.structureType,
+              baseTransform,
+              this.structureAttachmentTransformScratch,
+            );
+
+            this.attachmentManager.updateAttachmentTransforms(entityNumericId, baseTransform, mountTransforms);
+          } else if (this.activeStructureAttachmentEntities.has(entityNumericId)) {
+            this.attachmentManager.removeAttachments(entityNumericId);
+            this.activeStructureAttachmentEntities.delete(entityNumericId);
+            this.structureAttachmentSignatures.delete(entityNumericId);
+          }
+
+          let modelType = models[structure.stage];
+          if (structureType === StructureType.Realm) {
+            modelType = models[structure.level];
+
+            // Use tracked count instead of getCount/setCount to avoid repeated needsUpdate calls
+            const currentCount = modelInstanceCounts.get(modelType) ?? 0;
+            modelType.setMatrixAt(currentCount, this.dummy.matrix);
+            modelInstanceCounts.set(modelType, currentCount + 1);
+            this.entityIdMaps.get(structureType)!.set(currentCount, structure.entityId);
+
+            if (structure.hasWonder) {
+              const wonderModel = models[WONDER_MODEL_INDEX];
+              const wonderCount = modelInstanceCounts.get(wonderModel) ?? 0;
+              wonderModel.setMatrixAt(wonderCount, this.dummy.matrix);
+              modelInstanceCounts.set(wonderModel, wonderCount + 1);
+              this.wonderEntityIdMaps.set(wonderCount, structure.entityId);
+            }
+          } else {
+            // Use tracked count instead of getCount/setCount to avoid repeated needsUpdate calls
+            const currentCount = modelInstanceCounts.get(modelType) ?? 0;
+            modelType.setMatrixAt(currentCount, this.dummy.matrix);
+            modelInstanceCounts.set(modelType, currentCount + 1);
+            this.entityIdMaps.get(structureType)!.set(currentCount, structure.entityId);
+          }
+        });
+
+        // Note: setCount will be called once per model after all structures are processed
+      }
+
+      // Render structures with cosmetic skins
+      for (const [cosmeticId, structures] of structuresByCosmeticId) {
+        const models = this.cosmeticStructureModels.get(cosmeticId);
+
+        if (!models || models.length === 0) {
+          continue;
+        }
+
+        if (!this.cosmeticEntityIdMaps.has(cosmeticId)) {
+          this.cosmeticEntityIdMaps.set(cosmeticId, new Map());
+        }
+
+        structures.forEach((structure) => {
+          visibleStructureIds.add(structure.entityId);
+          // Use scratch vector to avoid allocation
+          const { col, row } = structure.hexCoords;
+          getWorldPositionForHexCoordsInto(col, row, this.scratchPosition);
+          this.scratchPosition.y += 0.05;
+
+          const existingLabel = this.entityIdLabels.get(structure.entityId);
+          if (existingLabel) {
+            this.updateStructureLabelData(structure, existingLabel);
+            // Use scratch vector for label position
+            getWorldPositionForHexCoordsInto(col, row, this.scratchLabelPosition);
+            this.scratchLabelPosition.y += 2;
+            existingLabel.position.copy(this.scratchLabelPosition);
+          }
+
+          this.dummy.position.copy(this.scratchPosition);
+
           const rotationSeed = hashCoordinates(col, row);
           const rotationIndex = Math.floor(rotationSeed * 6);
           const randomRotation = (rotationIndex * Math.PI) / 3;
           this.dummy.rotation.y = randomRotation;
-        }
-        this.dummy.updateMatrix();
+          this.dummy.updateMatrix();
 
-        // Add point icon for this structure (always visible)
-        if (this.pointsRenderers) {
-          // Use scratch vector for icon position
-          this.scratchIconPosition.copy(this.scratchPosition);
-          this.scratchIconPosition.y += 2; // Match CSS2D label height
+          // Add point icon for this structure
+          if (this.pointsRenderers) {
+            // Use scratch vector for icon position
+            this.scratchIconPosition.copy(this.scratchPosition);
+            this.scratchIconPosition.y += 2;
 
-          const renderer = this.getRendererForStructure(structure);
-          if (renderer) {
-            renderer.setPoint({
-              entityId: structure.entityId,
-              position: this.scratchIconPosition,
-            });
-          }
-        }
-
-        const entityNumericId = Number(structure.entityId);
-        const templates = this.resolveStructureAttachmentsForRender(structure);
-        if (templates.length > 0) {
-          attachmentRetain.add(entityNumericId);
-          const signature = this.getAttachmentSignature(templates);
-          const isActive = this.activeStructureAttachmentEntities.has(entityNumericId);
-          if (!isActive || this.structureAttachmentSignatures.get(entityNumericId) !== signature) {
-            this.attachmentManager.spawnAttachments(entityNumericId, templates);
-            this.structureAttachmentSignatures.set(entityNumericId, signature);
-            this.activeStructureAttachmentEntities.add(entityNumericId);
-          }
-
-          this.tempCosmeticPosition.copy(this.scratchPosition);
-          this.tempCosmeticRotation.copy(this.dummy.rotation);
-
-          const baseTransform = {
-            position: this.tempCosmeticPosition,
-            rotation: this.tempCosmeticRotation,
-            scale: this.dummy.scale,
-          };
-
-          const mountTransforms = resolveStructureMountTransforms(
-            structure.structureType,
-            baseTransform,
-            this.structureAttachmentTransformScratch,
-          );
-
-          this.attachmentManager.updateAttachmentTransforms(entityNumericId, baseTransform, mountTransforms);
-        } else if (this.activeStructureAttachmentEntities.has(entityNumericId)) {
-          this.attachmentManager.removeAttachments(entityNumericId);
-          this.activeStructureAttachmentEntities.delete(entityNumericId);
-          this.structureAttachmentSignatures.delete(entityNumericId);
-        }
-
-        let modelType = models[structure.stage];
-        if (structureType === StructureType.Realm) {
-          modelType = models[structure.level];
-
-          // Use tracked count instead of getCount/setCount to avoid repeated needsUpdate calls
-          const currentCount = modelInstanceCounts.get(modelType) ?? 0;
-          modelType.setMatrixAt(currentCount, this.dummy.matrix);
-          modelInstanceCounts.set(modelType, currentCount + 1);
-          this.entityIdMaps.get(structureType)!.set(currentCount, structure.entityId);
-
-          if (structure.hasWonder) {
-            const wonderModel = models[WONDER_MODEL_INDEX];
-            const wonderCount = modelInstanceCounts.get(wonderModel) ?? 0;
-            wonderModel.setMatrixAt(wonderCount, this.dummy.matrix);
-            modelInstanceCounts.set(wonderModel, wonderCount + 1);
-            this.wonderEntityIdMaps.set(wonderCount, structure.entityId);
-          }
-        } else {
-          // Use tracked count instead of getCount/setCount to avoid repeated needsUpdate calls
-          const currentCount = modelInstanceCounts.get(modelType) ?? 0;
-          modelType.setMatrixAt(currentCount, this.dummy.matrix);
-          modelInstanceCounts.set(modelType, currentCount + 1);
-          this.entityIdMaps.get(structureType)!.set(currentCount, structure.entityId);
-        }
-      });
-
-      // Note: setCount will be called once per model after all structures are processed
-    }
-
-    // Render structures with cosmetic skins
-    for (const [cosmeticId, structures] of structuresByCosmeticId) {
-      const models = this.cosmeticStructureModels.get(cosmeticId);
-
-      if (!models || models.length === 0) {
-        continue;
-      }
-
-      if (!this.cosmeticEntityIdMaps.has(cosmeticId)) {
-        this.cosmeticEntityIdMaps.set(cosmeticId, new Map());
-      }
-
-      structures.forEach((structure) => {
-        visibleStructureIds.add(structure.entityId);
-        // Use scratch vector to avoid allocation
-        const { col, row } = structure.hexCoords;
-        getWorldPositionForHexCoordsInto(col, row, this.scratchPosition);
-        this.scratchPosition.y += 0.05;
-
-        const existingLabel = this.entityIdLabels.get(structure.entityId);
-        if (existingLabel) {
-          this.updateStructureLabelData(structure, existingLabel);
-          // Use scratch vector for label position
-          getWorldPositionForHexCoordsInto(col, row, this.scratchLabelPosition);
-          this.scratchLabelPosition.y += 2;
-          existingLabel.position.copy(this.scratchLabelPosition);
-        }
-
-        this.dummy.position.copy(this.scratchPosition);
-
-        const rotationSeed = hashCoordinates(col, row);
-        const rotationIndex = Math.floor(rotationSeed * 6);
-        const randomRotation = (rotationIndex * Math.PI) / 3;
-        this.dummy.rotation.y = randomRotation;
-        this.dummy.updateMatrix();
-
-        // Add point icon for this structure
-        if (this.pointsRenderers) {
-          // Use scratch vector for icon position
-          this.scratchIconPosition.copy(this.scratchPosition);
-          this.scratchIconPosition.y += 2;
-
-          const renderer = this.getRendererForStructure(structure);
-          if (renderer) {
-            renderer.setPoint({
-              entityId: structure.entityId,
-              position: this.scratchIconPosition,
-            });
-          }
-        }
-
-        // Handle attachments
-        const entityNumericId = Number(structure.entityId);
-        const templates = this.resolveStructureAttachmentsForRender(structure);
-        if (templates.length > 0) {
-          attachmentRetain.add(entityNumericId);
-          const signature = this.getAttachmentSignature(templates);
-          const isActive = this.activeStructureAttachmentEntities.has(entityNumericId);
-          if (!isActive || this.structureAttachmentSignatures.get(entityNumericId) !== signature) {
-            this.attachmentManager.spawnAttachments(entityNumericId, templates);
-            this.structureAttachmentSignatures.set(entityNumericId, signature);
-            this.activeStructureAttachmentEntities.add(entityNumericId);
-          }
-
-          this.tempCosmeticPosition.copy(this.scratchPosition);
-          this.tempCosmeticRotation.copy(this.dummy.rotation);
-
-          const baseTransform = {
-            position: this.tempCosmeticPosition,
-            rotation: this.tempCosmeticRotation,
-            scale: this.dummy.scale,
-          };
-
-          const mountTransforms = resolveStructureMountTransforms(
-            structure.structureType,
-            baseTransform,
-            this.structureAttachmentTransformScratch,
-          );
-
-          this.attachmentManager.updateAttachmentTransforms(entityNumericId, baseTransform, mountTransforms);
-        } else if (this.activeStructureAttachmentEntities.has(entityNumericId)) {
-          this.attachmentManager.removeAttachments(entityNumericId);
-          this.activeStructureAttachmentEntities.delete(entityNumericId);
-          this.structureAttachmentSignatures.delete(entityNumericId);
-        }
-
-        // Cosmetic skins typically have a single model (index 0)
-        const model = models[0];
-        if (model) {
-          // Use tracked count instead of getCount/setCount to avoid repeated needsUpdate calls
-          const currentCount = modelInstanceCounts.get(model) ?? 0;
-          model.setMatrixAt(currentCount, this.dummy.matrix);
-          modelInstanceCounts.set(model, currentCount + 1);
-          this.cosmeticEntityIdMaps.get(cosmeticId)!.set(currentCount, structure.entityId);
-        }
-      });
-
-      // Note: setCount will be called once per model after all structures are processed
-    }
-
-    // Batch update: call setCount once per model that was used (triggers needsUpdate + computeBoundingSphere once)
-    for (const [model, count] of modelInstanceCounts) {
-      model.setCount(count);
-    }
-
-    // End batch mode for all point renderers (triggers single computeBoundingSphere per renderer)
-    if (this.pointsRenderers) {
-      Object.values(this.pointsRenderers).forEach((renderer) => renderer.endBatch());
-    }
-
-    if (this.activeStructureAttachmentEntities.size > 0) {
-      const toRemove: number[] = [];
-      this.activeStructureAttachmentEntities.forEach((entityId) => {
-        if (!attachmentRetain.has(entityId)) {
-          toRemove.push(entityId);
-        }
-      });
-
-      toRemove.forEach((entityId) => {
-        this.attachmentManager.removeAttachments(entityId);
-        this.activeStructureAttachmentEntities.delete(entityId);
-        this.structureAttachmentSignatures.delete(entityId);
-      });
-    }
-
-    const labelsToRemove: ID[] = [];
-    for (const entityId of this.entityIdLabels.keys()) {
-      if (!visibleStructureIds.has(entityId)) {
-        labelsToRemove.push(entityId);
-      }
-    }
-
-    labelsToRemove.forEach((entityId) => {
-      this.removeEntityIdLabel(entityId);
-    });
-
-    // Remove points for structures no longer visible (diff-based: O(previously_visible) instead of O(all_structures))
-    if (this.pointsRenderers) {
-      for (const entityId of this.previousVisibleIds) {
-        if (!visibleStructureIds.has(entityId)) {
-          // Structure was visible last frame but not anymore - remove its point
-          const structure = this.structures.getStructureByEntityId(entityId);
-          if (structure) {
             const renderer = this.getRendererForStructure(structure);
-            renderer?.removePoint(entityId);
+            if (renderer) {
+              renderer.setPoint({
+                entityId: structure.entityId,
+                position: this.scratchIconPosition,
+              });
+            }
+          }
+
+          // Handle attachments
+          const entityNumericId = Number(structure.entityId);
+          const templates = this.resolveStructureAttachmentsForRender(structure);
+          if (templates.length > 0) {
+            attachmentRetain.add(entityNumericId);
+            const signature = this.getAttachmentSignature(templates);
+            const isActive = this.activeStructureAttachmentEntities.has(entityNumericId);
+            if (!isActive || this.structureAttachmentSignatures.get(entityNumericId) !== signature) {
+              this.attachmentManager.spawnAttachments(entityNumericId, templates);
+              this.structureAttachmentSignatures.set(entityNumericId, signature);
+              this.activeStructureAttachmentEntities.add(entityNumericId);
+            }
+
+            this.tempCosmeticPosition.copy(this.scratchPosition);
+            this.tempCosmeticRotation.copy(this.dummy.rotation);
+
+            const baseTransform = {
+              position: this.tempCosmeticPosition,
+              rotation: this.tempCosmeticRotation,
+              scale: this.dummy.scale,
+            };
+
+            const mountTransforms = resolveStructureMountTransforms(
+              structure.structureType,
+              baseTransform,
+              this.structureAttachmentTransformScratch,
+            );
+
+            this.attachmentManager.updateAttachmentTransforms(entityNumericId, baseTransform, mountTransforms);
+          } else if (this.activeStructureAttachmentEntities.has(entityNumericId)) {
+            this.attachmentManager.removeAttachments(entityNumericId);
+            this.activeStructureAttachmentEntities.delete(entityNumericId);
+            this.structureAttachmentSignatures.delete(entityNumericId);
+          }
+
+          // Cosmetic skins typically have a single model (index 0)
+          const model = models[0];
+          if (model) {
+            // Use tracked count instead of getCount/setCount to avoid repeated needsUpdate calls
+            const currentCount = modelInstanceCounts.get(model) ?? 0;
+            model.setMatrixAt(currentCount, this.dummy.matrix);
+            modelInstanceCounts.set(model, currentCount + 1);
+            this.cosmeticEntityIdMaps.get(cosmeticId)!.set(currentCount, structure.entityId);
+          }
+        });
+
+        // Note: setCount will be called once per model after all structures are processed
+      }
+
+      // Batch update: call setCount once per model that was used (triggers needsUpdate + computeBoundingSphere once)
+      for (const [model, count] of modelInstanceCounts) {
+        model.setCount(count);
+      }
+
+      // End batch mode for all point renderers (triggers single computeBoundingSphere per renderer)
+      if (this.pointsRenderers) {
+        Object.values(this.pointsRenderers).forEach((renderer) => renderer.endBatch());
+      }
+
+      if (this.activeStructureAttachmentEntities.size > 0) {
+        const toRemove: number[] = [];
+        this.activeStructureAttachmentEntities.forEach((entityId) => {
+          if (!attachmentRetain.has(entityId)) {
+            toRemove.push(entityId);
+          }
+        });
+
+        toRemove.forEach((entityId) => {
+          this.attachmentManager.removeAttachments(entityId);
+          this.activeStructureAttachmentEntities.delete(entityId);
+          this.structureAttachmentSignatures.delete(entityId);
+        });
+      }
+
+      const labelsToRemove: ID[] = [];
+      for (const entityId of this.entityIdLabels.keys()) {
+        if (!visibleStructureIds.has(entityId)) {
+          labelsToRemove.push(entityId);
+        }
+      }
+
+      labelsToRemove.forEach((entityId) => {
+        this.removeEntityIdLabel(entityId);
+      });
+
+      // Remove points for structures no longer visible (diff-based: O(previously_visible) instead of O(all_structures))
+      if (this.pointsRenderers) {
+        for (const entityId of this.previousVisibleIds) {
+          if (!visibleStructureIds.has(entityId)) {
+            // Structure was visible last frame but not anymore - remove its point
+            const structure = this.structures.getStructureByEntityId(entityId);
+            if (structure) {
+              const renderer = this.getRendererForStructure(structure);
+              renderer?.removePoint(entityId);
+            }
           }
         }
       }
-    }
 
       // Update tracking for next frame's diff
       this.previousVisibleIds = visibleStructureIds;

--- a/client/apps/game/src/three/managers/structure-update-policy.ts
+++ b/client/apps/game/src/three/managers/structure-update-policy.ts
@@ -99,7 +99,8 @@ export function resolveVisibleStructureUpdateMode(input: {
 
   const ownershipBucketChanged = shouldRefreshVisibleStructures(input.previous, input.next);
   const positionChanged =
-    input.previous.hexCoords.col !== input.next.hexCoords.col || input.previous.hexCoords.row !== input.next.hexCoords.row;
+    input.previous.hexCoords.col !== input.next.hexCoords.col ||
+    input.previous.hexCoords.row !== input.next.hexCoords.row;
   if (!ownershipBucketChanged && !positionChanged) {
     return "none";
   }

--- a/client/apps/game/src/three/scenes/fast-travel-runtime-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/fast-travel-runtime-lifecycle.ts
@@ -15,14 +15,7 @@ interface FastTravelPathRenderer {
   setSelectedPath(entityId: number | null): void;
 }
 
-interface ResetFastTravelRuntimeStateInput<
-  THydratedChunk,
-  TRenderState,
-  TEntityAnchor,
-  TArmy,
-  TSpire,
-  TTimeout,
-> {
+interface ResetFastTravelRuntimeStateInput<THydratedChunk, TRenderState, TEntityAnchor, TArmy, TSpire, TTimeout> {
   currentHydratedChunk: THydratedChunk | null;
   currentRenderState: TRenderState | null;
   currentEntityAnchors: TEntityAnchor[];

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -3356,8 +3356,7 @@ export default class WorldmapScene extends WarpTravel {
     const interactiveStartRow = chunkCenterRow - Math.floor(normalizedHeight / 2);
     const interactiveStartCol = chunkCenterCol - Math.floor(normalizedWidth / 2);
 
-    const nextInteractiveHexWindowKey =
-      `${interactiveStartRow}:${interactiveStartCol}:${normalizedWidth}:${normalizedHeight}`;
+    const nextInteractiveHexWindowKey = `${interactiveStartRow}:${interactiveStartCol}:${normalizedWidth}:${normalizedHeight}`;
 
     if (this.interactiveHexWindowKey !== nextInteractiveHexWindowKey) {
       // Keep interaction state bounded to the active rendered window.
@@ -4122,7 +4121,8 @@ export default class WorldmapScene extends WarpTravel {
 
       const cachedMetadata = cachedMatrices.get("__meta__");
       const expectedExploredTerrainInstances =
-        cachedMetadata?.expectedExploredTerrainInstances ?? this.getExpectedExploredTerrainInstances(startRow, startCol);
+        cachedMetadata?.expectedExploredTerrainInstances ??
+        this.getExpectedExploredTerrainInstances(startRow, startCol);
       if (
         this.shouldRejectTerrainCacheSnapshot(totalCachedTerrainInstances) ||
         this.shouldRejectExploredTerrainCacheSnapshot(cachedExploredTerrainInstances, expectedExploredTerrainInstances)
@@ -4568,132 +4568,136 @@ export default class WorldmapScene extends WarpTravel {
     const preChunkStats = memoryMonitor?.getCurrentStats(`chunk-switch-pre-${chunkKey}`);
 
     try {
-
       // Keep selection continuity during shortcut tabbing to avoid visible label/selection flashes.
       if (reason !== "shortcut") {
         this.clearEntitySelection();
       }
 
-    const oldChunk = this.currentChunk;
-    const reversalRefreshDecision = resolveChunkReversalRefreshDecision({
-      previousSwitchPosition: this.lastChunkSwitchPosition
-        ? {
-            x: this.lastChunkSwitchPosition.x,
-            z: this.lastChunkSwitchPosition.z,
-          }
-        : null,
-      nextSwitchPosition: switchPosition
-        ? {
-            x: switchPosition.x,
-            z: switchPosition.z,
-          }
-        : null,
-      previousMovementVector: this.lastChunkSwitchMovement,
-      minMovementDistance: 0.001,
-    });
-    const shouldAggressiveReversalRefresh = reversalRefreshDecision.shouldForceRefresh;
-    const effectiveForce = force || shouldAggressiveReversalRefresh;
-    const previousPinnedChunks = Array.from(this.pinnedChunkKeys);
-    const oldChunkCoordinates = oldChunk !== "null" ? oldChunk.split(",").map(Number) : null;
-    const hasFiniteOldChunkCoordinates =
-      oldChunkCoordinates !== null &&
-      Number.isFinite(oldChunkCoordinates[0]) &&
-      Number.isFinite(oldChunkCoordinates[1]);
-    prepareWarpTravelChunkBounds({
-      targetChunkKey: chunkKey,
-      startRow,
-      startCol,
-      hasFiniteOldChunkCoordinates,
-      oldChunkCoordinates:
-        hasFiniteOldChunkCoordinates && oldChunkCoordinates !== null
-          ? [oldChunkCoordinates[0], oldChunkCoordinates[1]]
+      const oldChunk = this.currentChunk;
+      const reversalRefreshDecision = resolveChunkReversalRefreshDecision({
+        previousSwitchPosition: this.lastChunkSwitchPosition
+          ? {
+              x: this.lastChunkSwitchPosition.x,
+              z: this.lastChunkSwitchPosition.z,
+            }
           : null,
-      computeChunkBounds: (targetStartRow, targetStartCol) => this.computeChunkBounds(targetStartRow, targetStartCol),
-      registerChunk: (targetChunkKey, bounds) => this.visibilityManager?.registerChunk(targetChunkKey, bounds),
-      combineChunkBounds: (previousBounds, nextBounds) => this.combineChunkBounds(previousBounds, nextBounds),
-      applySceneChunkBounds: (bounds) => this.applySceneChunkBounds(bounds),
-    });
-
-    // Load surrounding pinned chunks for better UX.
-    const surroundingChunks = this.getSurroundingChunkKeys(startRow, startCol);
-    if (shouldAggressiveReversalRefresh) {
-      this.aggressivelyInvalidateChunkTerrainCaches(chunkKey, {
-        includeSurroundingChunks: surroundingChunks,
-        invalidateFetchAreas: true,
+        nextSwitchPosition: switchPosition
+          ? {
+              x: switchPosition.x,
+              z: switchPosition.z,
+            }
+          : null,
+        previousMovementVector: this.lastChunkSwitchMovement,
+        minMovementDistance: 0.001,
       });
-    } else if (effectiveForce) {
-      this.removeCachedMatricesForChunk(startRow, startCol);
-    }
+      const shouldAggressiveReversalRefresh = reversalRefreshDecision.shouldForceRefresh;
+      const effectiveForce = force || shouldAggressiveReversalRefresh;
+      const previousPinnedChunks = Array.from(this.pinnedChunkKeys);
+      const oldChunkCoordinates = oldChunk !== "null" ? oldChunk.split(",").map(Number) : null;
+      const hasFiniteOldChunkCoordinates =
+        oldChunkCoordinates !== null &&
+        Number.isFinite(oldChunkCoordinates[0]) &&
+        Number.isFinite(oldChunkCoordinates[1]);
+      prepareWarpTravelChunkBounds({
+        targetChunkKey: chunkKey,
+        startRow,
+        startCol,
+        hasFiniteOldChunkCoordinates,
+        oldChunkCoordinates:
+          hasFiniteOldChunkCoordinates && oldChunkCoordinates !== null
+            ? [oldChunkCoordinates[0], oldChunkCoordinates[1]]
+            : null,
+        computeChunkBounds: (targetStartRow, targetStartCol) => this.computeChunkBounds(targetStartRow, targetStartCol),
+        registerChunk: (targetChunkKey, bounds) => this.visibilityManager?.registerChunk(targetChunkKey, bounds),
+        combineChunkBounds: (previousBounds, nextBounds) => this.combineChunkBounds(previousBounds, nextBounds),
+        applySceneChunkBounds: (bounds) => this.applySceneChunkBounds(bounds),
+      });
 
-    const { tileFetchSucceeded } = await hydrateWarpTravelChunk({
-      chunkKey,
-      startRow,
-      startCol,
-      surroundingChunks,
-      transitionToken,
-      renderSize: this.renderChunkSize,
-      computeTileEntities: (targetChunkKey) => this.computeTileEntities(targetChunkKey),
-      updatePinnedChunks: (chunkKeys) => this.updatePinnedChunks(chunkKeys),
-      updateBoundsSubscription: (targetChunkKey, nextTransitionToken) =>
-        this.updateToriiBoundsSubscription(targetChunkKey, nextTransitionToken),
-      updateHexagonGrid: (targetStartRow, targetStartCol, height, width) =>
-        this.updateHexagonGrid(targetStartRow, targetStartCol, height, width),
-      onChunkHydrated: (hydratedChunkKey) => {
-        this.hydratedChunkRefreshes.delete(hydratedChunkKey);
-      },
-    });
-
-    const finalizeResult = await finalizeWarpTravelChunkSwitch({
-      fetchSucceeded: tileFetchSucceeded,
-      isCurrentTransition: transitionToken === this.chunkTransitionToken,
-      targetChunk: chunkKey,
-      previousChunk: oldChunk,
-      currentChunk: this.currentChunk,
-      previousPinnedChunks,
-      hasFiniteOldChunkCoordinates,
-      oldChunkCoordinates:
-        hasFiniteOldChunkCoordinates && oldChunkCoordinates !== null
-          ? [oldChunkCoordinates[0], oldChunkCoordinates[1]]
-          : null,
-      startRow,
-      startCol,
-      force: effectiveForce,
-      transitionToken,
-      setCurrentChunk: (targetChunkKey) => this.commitCurrentChunkAuthority(targetChunkKey),
-      updatePinnedChunks: (chunkKeys) => this.updatePinnedChunks(chunkKeys),
-      unregisterChunk: (targetChunkKey) => this.unregisterVisibilityChunk(targetChunkKey),
-      restorePreviousChunkVisuals: (oldStartRow, oldStartCol, previousChunk, previousTransitionToken) =>
-        this.restorePreviousChunkVisualsAfterRollback(oldStartRow, oldStartCol, previousChunk, previousTransitionToken),
-      clearSceneChunkBounds: () => this.clearSceneChunkBounds(),
-      forceVisibilityUpdate: () => this.forceVisibilityManagerUpdate(),
-      updateCurrentChunkBounds: (targetStartRow, targetStartCol) =>
-        this.updateCurrentChunkBounds(targetStartRow, targetStartCol),
-      updateManagersForChunk: (targetChunkKey, managerOptions) =>
-        this.updateManagersForChunk(targetChunkKey, managerOptions),
-      unregisterPreviousChunkOnNextFrame: (targetChunkKey) => this.queueChunkVisibilityUnregister(targetChunkKey),
-    });
-
-    if (finalizeResult.status === "rolled_back") {
-      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_rolled_back");
-      return;
-    }
-
-    if (finalizeResult.status === "stale_dropped") {
-      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_prepare_stale_dropped");
-      return;
-    }
-
-    recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_committed");
-
-    // Track memory usage after chunk switch
-    if (memoryMonitor) {
-      const postChunkStats = memoryMonitor.getCurrentStats(`chunk-switch-post-${chunkKey}`);
-      if (preChunkStats && postChunkStats) {
-        const memoryDelta = postChunkStats.heapUsedMB - preChunkStats.heapUsedMB;
-        // Memory monitoring hooks - intentionally silent unless threshold exceeded
-        void memoryDelta;
+      // Load surrounding pinned chunks for better UX.
+      const surroundingChunks = this.getSurroundingChunkKeys(startRow, startCol);
+      if (shouldAggressiveReversalRefresh) {
+        this.aggressivelyInvalidateChunkTerrainCaches(chunkKey, {
+          includeSurroundingChunks: surroundingChunks,
+          invalidateFetchAreas: true,
+        });
+      } else if (effectiveForce) {
+        this.removeCachedMatricesForChunk(startRow, startCol);
       }
-    }
+
+      const { tileFetchSucceeded } = await hydrateWarpTravelChunk({
+        chunkKey,
+        startRow,
+        startCol,
+        surroundingChunks,
+        transitionToken,
+        renderSize: this.renderChunkSize,
+        computeTileEntities: (targetChunkKey) => this.computeTileEntities(targetChunkKey),
+        updatePinnedChunks: (chunkKeys) => this.updatePinnedChunks(chunkKeys),
+        updateBoundsSubscription: (targetChunkKey, nextTransitionToken) =>
+          this.updateToriiBoundsSubscription(targetChunkKey, nextTransitionToken),
+        updateHexagonGrid: (targetStartRow, targetStartCol, height, width) =>
+          this.updateHexagonGrid(targetStartRow, targetStartCol, height, width),
+        onChunkHydrated: (hydratedChunkKey) => {
+          this.hydratedChunkRefreshes.delete(hydratedChunkKey);
+        },
+      });
+
+      const finalizeResult = await finalizeWarpTravelChunkSwitch({
+        fetchSucceeded: tileFetchSucceeded,
+        isCurrentTransition: transitionToken === this.chunkTransitionToken,
+        targetChunk: chunkKey,
+        previousChunk: oldChunk,
+        currentChunk: this.currentChunk,
+        previousPinnedChunks,
+        hasFiniteOldChunkCoordinates,
+        oldChunkCoordinates:
+          hasFiniteOldChunkCoordinates && oldChunkCoordinates !== null
+            ? [oldChunkCoordinates[0], oldChunkCoordinates[1]]
+            : null,
+        startRow,
+        startCol,
+        force: effectiveForce,
+        transitionToken,
+        setCurrentChunk: (targetChunkKey) => this.commitCurrentChunkAuthority(targetChunkKey),
+        updatePinnedChunks: (chunkKeys) => this.updatePinnedChunks(chunkKeys),
+        unregisterChunk: (targetChunkKey) => this.unregisterVisibilityChunk(targetChunkKey),
+        restorePreviousChunkVisuals: (oldStartRow, oldStartCol, previousChunk, previousTransitionToken) =>
+          this.restorePreviousChunkVisualsAfterRollback(
+            oldStartRow,
+            oldStartCol,
+            previousChunk,
+            previousTransitionToken,
+          ),
+        clearSceneChunkBounds: () => this.clearSceneChunkBounds(),
+        forceVisibilityUpdate: () => this.forceVisibilityManagerUpdate(),
+        updateCurrentChunkBounds: (targetStartRow, targetStartCol) =>
+          this.updateCurrentChunkBounds(targetStartRow, targetStartCol),
+        updateManagersForChunk: (targetChunkKey, managerOptions) =>
+          this.updateManagersForChunk(targetChunkKey, managerOptions),
+        unregisterPreviousChunkOnNextFrame: (targetChunkKey) => this.queueChunkVisibilityUnregister(targetChunkKey),
+      });
+
+      if (finalizeResult.status === "rolled_back") {
+        recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_rolled_back");
+        return;
+      }
+
+      if (finalizeResult.status === "stale_dropped") {
+        recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_prepare_stale_dropped");
+        return;
+      }
+
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_committed");
+
+      // Track memory usage after chunk switch
+      if (memoryMonitor) {
+        const postChunkStats = memoryMonitor.getCurrentStats(`chunk-switch-post-${chunkKey}`);
+        if (preChunkStats && postChunkStats) {
+          const memoryDelta = postChunkStats.heapUsedMB - preChunkStats.heapUsedMB;
+          // Memory monitoring hooks - intentionally silent unless threshold exceeded
+          void memoryDelta;
+        }
+      }
 
       if (switchPosition) {
         this.lastChunkSwitchPosition = switchPosition;

--- a/docs/prd/eternum-s2/eternum-s2-detailed-task-dispatch-2026-03-11.md
+++ b/docs/prd/eternum-s2/eternum-s2-detailed-task-dispatch-2026-03-11.md
@@ -1,32 +1,43 @@
 # Eternum S2 Detailed Task Dispatch
 
-Date: 2026-03-11 Scope: Frontend and config only (contracts assumed complete)
+Date: 2026-03-11 Scope: Frontend and config only (contracts are source of truth)
 
 ## Raschel (Frontend Systems + Lobby + Non-Map S2 Features)
 
-1. Refactor game mode system to support explicit `s2` mode in `client/apps/game/src/config/game-modes/index.ts`.
-2. Replace current Blitz boolean-only mode detection with a mode discriminator from world config/metadata.
-3. Add S2 labels/rules/assets config object in parallel to Blitz config.
-4. Update world availability logic in `client/apps/game/src/hooks/use-world-availability.ts` to be mode-aware instead of
-   Blitz-only SQL fields.
+1. Refactor game mode system to keep canonical `eternum`/`blitz` ids and layer S2 presentation config under `eternum` in
+   `client/apps/game/src/config/game-modes/index.ts`.
+2. Keep mode detection contract-aligned: resolve mode from world config `blitz_mode_on` only.
+3. Add S2 labels/rules/assets config object under `eternum` while preserving Blitz behavior.
+4. Update world availability logic in `client/apps/game/src/hooks/use-world-availability.ts` to query `blitz_mode_on`
+   first, then run mode-specific world-config query.
 5. Remove hard `s1_eternum-*` assumptions where possible in lobby queries.
-6. Split registration flow in `client/apps/game/src/hooks/use-world-registration.ts`: Blitz path vs S2 path.
-7. Split entry flow in `client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx`: Blitz systems vs S2
-   systems.
-8. Ensure S2 entry path never calls `blitz_*` contracts/selectors.
+6. Split registration flow in `client/apps/game/src/hooks/use-world-registration.ts`: Blitz (`obtain_entry_token` +
+   `register`) vs season (`realm_systems.create`).
+7. Split entry flow in `client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx`: Blitz systems vs
+   season systems.
+8. Ensure season entry path never calls `blitz_*` selectors and adds preflight UX for spire settlement, season pass, and
+   season timing prerequisites.
 9. Add S2 preset to factory admin in `client/apps/game/src/ui/features/admin/pages/factory.tsx`.
 10. Extend world-config builder in `client/apps/game/src/ui/features/admin/services/world-config-builder.ts` for S2
     defaults (duration, spacing, registration knobs, etc).
-11. Update deployer config writer in `config/deployer/config.ts` and provider call surface if S2 mode payload differs
-    from Blitz bool.
-12. Extend structure type UI for S2 structures (Spire, Camp, Essence Rift, Holy Site, Bitcoin Mine) in
-    minimap/panels/tooltips.
+11. Keep deployer/provider mode config payload on `blitz_mode_on` bool; do not introduce alternate mode payload.
+12. Extend structure/entity UI for season-relevant entities (Spire occupier interaction, Mine/Essence Rift label
+    mapping, Holy Site, Bitcoin Mine), while keeping Camp discovery Blitz-only.
 13. Build Faith UX surfaces: faith leaderboard, devotion actions, wonder detail view, FP wallet visibility.
 14. Build village and army UX surfaces: militia timer, raid immunity timer, army strength and deployment cap indicators.
-15. Build agent UX updates: agent type badges, local messaging UI, essence messaging cost preview.
+15. Build agent UX updates: troop type/tier badges and metadata; defer local messaging and essence messaging cost
+    preview until contracts exist.
 16. Build exploration reward UX: subtle tile indicator for unclaimed rewards plus collect/bypass action state.
 17. Validate that realm resource construction remains metadata-driven and no UI regression on that rule.
 18. Own integration QA for all non-map S2 features plus Blitz regression sanity.
+19. Build season pass inventory UI for connected wallet using configured `season_pass_address`.
+20. Decode and display season pass metadata (realm identity and allowed resources) for each pass before settlement.
+21. Implement per-pass settlement picker (`side/layer/point`) with contract-aligned bounds/preflight validation and
+    transaction error handling.
+22. Build village pass inventory flow and settlement action via
+    `village_systems.create(village_pass_token_id, realm_id, direction)`.
+23. Implement casino-style village resource reveal animation that resolves from post-tx on-chain village resource state.
+24. Treat village pass "buy" as external acquisition; gate in-game flow on ownership/availability only.
 
 ## Loaf (Map Layer Owner)
 
@@ -41,32 +52,43 @@ Date: 2026-03-11 Scope: Frontend and config only (contracts assumed complete)
 7. Ensure scene rendering in `client/apps/game/src/three/scenes/worldmap.tsx` correctly handles base layer vs Ethereal
    layer.
 8. Implement spire interaction transitions (base -> ethereal -> base) with proper camera and selection continuity.
-9. Implement cross-layer occupancy conflict UX hook when destination tile is occupied.
+9. Implement cross-layer occupancy conflict UX with pre-check and revert handling for `toggle_alternate` destination
+   occupancy failures.
 10. Add layer state cues in map HUD and minimap and ensure selection and action paths are consistent per layer.
-11. Validate pathing and movement costs shown correctly per layer rule set.
+11. Validate pathing/movement and cross-layer battle affordances against contract layer rules.
 12. Run a performance pass focused on chunk loading and layer switching.
 13. Write and adjust tests for layer parsing, URL sync, and map query branching.
 14. Own map-layer integration QA in both desktop and mobile viewports.
+15. Add map overlays/previews for realm settlement slot selection (`side/layer/point`) and resulting target coordinate.
+16. Add map overlays/previews for village direction-slot selection relative to connected realms.
 
 ## Ermakow (Visual Artist)
 
 1. Define S2 visual direction pack: Ethereal Plains mood, color language, lighting references, marker hierarchy.
 2. Deliver Spire visual kit: icon, label, map marker variants, interaction state assets.
-3. Deliver Camp visual kit (distinct from Village), including map and panel iconography.
-4. Deliver Essence Rift visual kit aligned to S2 style.
+3. Deliver Camp visual kit (distinct from Village) for Blitz-only discovery contexts.
+4. Deliver Mine/Essence Rift visual kit with mode-aware naming treatment.
 5. Deliver Holy Site visual kit with readability at minimap scale.
 6. Deliver Bitcoin Mine visual kit, including satoshi visual motif.
 7. Produce Ethereal-layer-specific minimap treatment and map symbol system.
 8. Produce layer transition FX frames and guides for frontend implementation.
 9. Produce Faith UI art assets: leaderboard accents, devotion and wonder motifs, badge system.
-10. Produce agent class markers (Basic, Advanced, Ethereal) with clear readability tiers.
+10. Produce agent type/tier markers aligned to troop type+tier readability needs.
 11. Create subtle exploration reward indicator assets with low-noise presentation.
 12. Provide final export pack with naming conventions and usage notes for frontend integration.
 13. Run visual QA pass on desktop and mobile and deliver revision set.
 14. Sign off consistency pass so Blitz visuals remain unchanged and S2 visuals are clearly distinct.
+15. Deliver season pass card/metadata presentation assets (inventory and selection states).
+16. Deliver village resource reveal sequence assets for the casino-style post-settlement reveal.
 
 ## Notes
 
 - Confirmed S2 rule included in planning: each realm can construct only resources from its NFT metadata (S0/S1
   behavior).
-- Contracts are assumed complete; tasks above are for client integration, UX, visuals, and config/admin tooling.
+- Contracts are source of truth; tasks above are for client integration, UX, visuals, and config/admin tooling.
+- Contract alignment anchors for this plan: mode comes from `blitz_mode_on`; season entry uses `realm_systems.create`;
+  Spire is a tile occupier interaction point (not structure category); Camp is Blitz-only discovery; Mine naming/reward
+  differs by mode.
+- Additional alignment anchors: settlement uses `side/layer/point`; village settlement consumes village pass ownership;
+  village resource is randomized on creation and revealed from post-tx state; village pass purchase is external to game
+  systems.

--- a/docs/prd/eternum-s2/eternum-s2-frontend-config-prd-2026-03-11.md
+++ b/docs/prd/eternum-s2/eternum-s2-frontend-config-prd-2026-03-11.md
@@ -1,7 +1,7 @@
 # Eternum S2 Frontend + Config PRD
 
-Date: 2026-03-11 Status: Draft Branch: `aymericdelab/season-notes` Scope: Frontend and config only (contracts for S2
-assumed complete)
+Date: 2026-03-11 Status: Contract-aligned draft Branch: `aymericdelab/s2-prd-review` Scope: Frontend and config only
+(contracts are source of truth)
 
 ## 1. Objective
 
@@ -26,8 +26,8 @@ This PRD covers:
 
 ### 3.1 Game mode and config state
 
-- Game mode registry only supports `standard` and `blitz`: `client/apps/game/src/config/game-modes/index.ts`.
-- Mode resolution is currently tied to one bool (`blitz_mode_on`) instead of an explicit mode id.
+- Game mode registry currently supports `eternum` and `blitz`: `client/apps/game/src/config/game-modes/index.ts`.
+- Mode resolution is intentionally tied to contract world config bool (`blitz_mode_on`).
 - Shared config defaults are Blitz-like and short duration (`SEASON_DURATION_SECONDS` currently 1.5h):
   `config/environments/_shared_.ts`.
 - Admin factory presets are Blitz-centric (`sandbox`, `blitz-slot`):
@@ -69,31 +69,41 @@ This PRD covers:
   `client/apps/game/src/ui/features/world/components/bottom-right-panel/hex-minimap.tsx` and
   `packages/core/src/utils/structure.ts`.
 
+### 3.6 Season pass, settlement picker, and village flow state
+
+- Season realm settlement consumes a season pass token and reads pass metadata from `season_pass_address`.
+- Season realm placement is selected via `side/layer/point` inputs (contract computes coordinate), not raw `x,y`.
+- Village settlement consumes a village pass token and requires choosing a connected realm + available direction slot.
+- Village resource is assigned randomly on `village_systems.create` and can only be revealed from post-tx state.
+- There is no in-game "buy village pass" function in game systems; acquisition is external to this contract set.
+
 ## 4. Product Requirements (Frontend + Config)
 
-### R1. Add explicit `Eternum S2` mode in client architecture
+### R1. Align mode architecture to current contract truth
 
-- Add `s2` mode config alongside `blitz`.
-- Remove boolean-only mode resolution and resolve mode via explicit world mode metadata/config.
+- Keep canonical mode ids as `eternum` and `blitz`.
+- Resolve mode from `blitz_mode_on` (`true => blitz`, `false => eternum`).
+- Layer S2-specific labels/rules/assets under `eternum` mode config.
 - Keep Blitz behavior unchanged.
 
 Acceptance criteria:
 
-- Client can detect and render correct mode for Blitz and S2 worlds.
+- Client detects and renders mode using world-config `blitz_mode_on`.
 - No Blitz regressions in labels/assets/rules.
 
 ### R2. Make lobby, registration, and entry flow mode-aware
 
-- Replace Blitz-only availability query with mode/capability-based world metadata.
+- Replace Blitz-only availability assumptions with contract-aware mode query based on `blitz_mode_on`.
 - Split registration pipeline by mode.
-- Keep Blitz token/registration flow intact.
-- Implement S2 entry path using S2 systems only.
+- Keep Blitz token/registration flow intact (`obtain_entry_token` + `register`).
+- Implement season (`eternum`) entry via `realm_systems.create`.
+- Add season preflight UX for contract prerequisites (spires settled, season pass approval/consumption, season timing).
 
 Acceptance criteria:
 
 - Player can join Blitz world through existing flow.
 - Player can join S2 world without Blitz-only blockers.
-- No Blitz system calls are executed for S2 join flow.
+- No Blitz system calls are executed for season (`eternum`) join flow.
 
 ### R3. Implement S2 multi-layer map support
 
@@ -101,7 +111,8 @@ Acceptance criteria:
 - Add URL/state/navigation support for active layer.
 - Update map fetch/query/stream paths to include layer discriminator.
 - Add layer-switch interaction around Spires and transition UX.
-- Support cross-layer occupancy conflict prompt from spire travel results.
+- Handle cross-layer occupancy conflicts with pre-check and revert UX (`destination tile is occupied`).
+- Apply cross-layer battle eligibility rule in UI affordances (same `x,y` across layers + adjacent to spire).
 
 Acceptance criteria:
 
@@ -111,19 +122,22 @@ Acceptance criteria:
 
 ### R4. Add S2 structure/UI support
 
-- Extend structure types, labels, markers, and detail panels for S2 structures.
-- Minimum required S2 structures for frontend: Spire, Camp, Essence Rift, Holy Site, Bitcoin Mine.
+- Extend discovery/entity mapping, labels, markers, and detail panels for contract-exposed entities.
+- Minimum required surfaces for season support: Spire (tile occupier interaction), Mine (mode-specific label), Holy
+  Site, Bitcoin Mine.
+- Camp remains Blitz-only in discovery UX.
 
 Acceptance criteria:
 
-- All S2 structures render with correct icon/name/interaction entry points.
+- Contract-exposed entities render with correct icon/name/interaction entry points for each mode.
 - Unknown structure fallback is not shown for expected S2 entities.
 
 ### R5. Add S2 systems UX surfaces
 
 - Faith system surfaces: faith leaderboard, devotion controls, wonder detail panels.
 - Village and deployment updates: militia timer state, raid immunity state, army strength/deployment cap UI.
-- Agent updates: type badges/metadata, local-message UX with essence cost preview.
+- Agent updates: type/tier badges and metadata from discovered troop data.
+- De-scope local-message UX with essence cost preview until messaging contracts exist.
 - Optional exploration reward UX: subtle tile indicator and collect/bypass behavior in explore flow.
 
 Acceptance criteria:
@@ -135,12 +149,29 @@ Acceptance criteria:
 
 - Add S2 preset in factory/admin world-config builder.
 - Add S2 duration and spacing defaults.
-- Ensure deployer supports S2 mode config payload shape expected by contracts.
+- Keep deployer/provider mode config on `set_game_mode_config(blitz_mode_on: bool)`.
 
 Acceptance criteria:
 
 - Admin can deploy/configure a world as Blitz or S2 from factory UI.
 - Config calldata generated by admin matches contract interfaces.
+
+### R7. Implement season pass inventory, settlement picker, and village reveal loop
+
+- Show owned season pass inventory and decode pass metadata (realm identity + resources) for the connected player.
+- Build per-pass settle flow that submits `realm_systems.create(owner, realm_id, frontend, {side,layer,point})`.
+- Add placement picker UX for `side/layer/point` with contract-aligned bounds checks and tx-error mapping.
+- Show village pass inventory and allow village settlement via
+  `village_systems.create(village_pass_token_id, realm_id, direction)`.
+- Treat village-pass "buy" as external inventory acquisition; in-game flow starts once pass ownership is present.
+- Add casino-style village resource reveal animation driven by post-transaction on-chain result.
+
+Acceptance criteria:
+
+- User can see eligible season passes and their decoded realm resource metadata before settling.
+- User can settle each selected season pass with explicit placement choice and clear validation feedback.
+- User can settle a village next to a chosen realm only on available directions.
+- Village reveal animation always resolves to the actual on-chain assigned resource.
 
 ## 5. Implementation Plan and Ownership
 
@@ -150,9 +181,10 @@ Owner: Raschel
 
 Deliverables:
 
-- Game mode registry refactor and `s2` mode addition.
+- Game mode registry refactor for contract-aligned `eternum`/`blitz` mode resolution with S2 presentation config.
 - Mode-aware availability query model.
 - Mode-aware registration and entry orchestration.
+- Season pass inventory and per-pass settlement picker UX.
 - Factory/admin `s2-season` preset.
 
 Primary files:
@@ -169,7 +201,8 @@ Primary files:
 Definition of done:
 
 - User can select and enter both modes with correct flow.
-- S2 no longer depends on Blitz selectors/system names.
+- Season (`eternum`) flow no longer depends on `blitz_*` selectors/system names.
+- Season pass ownership and metadata are visible before settlement decisions.
 
 ## Phase 2: New Map Layer and Spire Travel
 
@@ -203,10 +236,11 @@ Owner: Raschel
 
 Deliverables:
 
-- Structure type extension and UI support for S2 structures.
+- Structure/entity mapping and UI support for season-relevant discoveries and occupiers.
 - Faith UX and leaderboard surfaces.
 - Village/deployment strength/timer UI.
-- Agent and exploration-reward UI updates.
+- Agent metadata and exploration-reward UI updates (messaging UX deferred).
+- Village pass settlement flow and post-settlement resource reveal UX.
 
 Primary files:
 
@@ -247,8 +281,9 @@ Raschel:
 1. Mode architecture and mode resolution refactor.
 2. Lobby, registration, and entry flows for S2.
 3. Admin/deployer S2 preset and config plumbing.
-4. S2 structure and systems UI implementation.
+4. Contract-aligned season structure/entity and systems UI implementation.
 5. Integration QA pass across non-map features.
+6. Season pass inventory + placement picker + village pass settlement/reveal flow.
 
 Loaf:
 
@@ -257,14 +292,16 @@ Loaf:
 3. Spire traversal UX and occupancy-conflict interaction.
 4. Minimap and navigation updates for dual-layer play.
 5. Performance sanity pass for map-layer switching.
+6. Settlement/village placement map overlays and validity cues for slot selection.
 
 Ermakow:
 
 1. Ethereal layer art direction and style guide.
-2. Spire, Camp, Essence Rift, Holy Site, Bitcoin Mine visual assets.
+2. Spire, Mine (Essence Rift label treatment), Holy Site, Bitcoin Mine, and Blitz-only Camp visual assets.
 3. Minimap marker/icon system for new structures.
 4. UI overlays for faith, layer state, and S2 interaction moments.
 5. Final readability pass across desktop and mobile breakpoints.
+6. Season pass card visuals and village reveal animation assets.
 
 ## 7. QA and Validation
 
@@ -273,7 +310,9 @@ Functional checks:
 - Blitz and S2 worlds both load, register, and enter correctly.
 - S2 layer switch via spires works with consistent camera and selection state.
 - Structure names/icons/interactions match expected S2 behavior.
+- Camp discovery UI remains Blitz-only; Mine naming and rewards are mode-aware.
 - Faith/deployment/agent/explore UI reflects contract state accurately.
+- Season pass metadata, placement selection, and village reveal UX match on-chain outcomes.
 
 Regression checks:
 
@@ -288,11 +327,14 @@ Test scope:
 
 ## 8. Risks and Open Decisions
 
-- Final mode-discriminator source in world config must be confirmed against deployed S2 contracts.
-- Namespace assumptions (`s1_eternum-*`) must be removed or abstracted for S2 worlds.
-- Exact system names/selectors for S2 replacements of Blitz-only calls need to be locked before implementation starts.
-- If contracts expose additional layer-specific rules (donkey restrictions, ethereal-only entities), frontend guards
-  must mirror them explicitly.
+- `blitz_mode_on` is the canonical mode discriminator until contracts add another source.
+- Namespace assumptions (`s1_eternum-*`) should be abstracted where possible for multi-world compatibility.
+- Season entry prerequisites (spire settlement + season pass handling) must be surfaced before send-tx to avoid opaque
+  failures.
+- Spire is a tile occupier, not a structure category; UI mapping mistakes here will break layer-travel affordances.
+- Local messaging/essence-send UX remains out of scope until message contracts are implemented.
+- Village pass acquisition ("buy") is external to game systems and must be integrated from marketplace/inventory
+  sources.
 
 ## 9. Release Readiness Criteria
 

--- a/docs/prd/eternum-s2/eternum-s2-worldmap-mass-exploration-rendering-prd-2026-03-13.md
+++ b/docs/prd/eternum-s2/eternum-s2-worldmap-mass-exploration-rendering-prd-2026-03-13.md
@@ -1,6 +1,7 @@
 # Eternum S2 Worldmap Mass-Exploration Rendering PRD
 
-Date: 2026-03-13 Status: Implemented Scope: `client/apps/game/src/three` render path and adjacent movement/pathfinding hot paths
+Date: 2026-03-13 Status: Implemented Scope: `client/apps/game/src/three` render path and adjacent movement/pathfinding
+hot paths
 
 ## Implementation Tracking
 
@@ -142,23 +143,19 @@ Primary hot spots:
 
 ### 5.1 Full refresh path
 
-`GameRenderer controls change / world event -> WorldmapScene.requestChunkRefresh or updateVisibleChunks(true) ->
-updateVisibleChunks -> performChunkSwitch or refreshCurrentChunk -> updateManagersForChunk -> ArmyManager.updateChunk +
-StructureManager.updateChunk + ChestManager.updateChunk`
+`GameRenderer controls change / world event -> WorldmapScene.requestChunkRefresh or updateVisibleChunks(true) -> updateVisibleChunks -> performChunkSwitch or refreshCurrentChunk -> updateManagersForChunk -> ArmyManager.updateChunk + StructureManager.updateChunk + ChestManager.updateChunk`
 
 This is the main path that must be backpressured and made incremental.
 
 ### 5.2 Remote exploration path
 
-`WorldUpdateListener.ExplorerTroopsTile -> WorldmapScene.updateArmyHexes + ArmyManager.onTileUpdate -> moveArmy ->
-worker findPath -> ArmyModel.startMovement + PathRenderer.createPath`
+`WorldUpdateListener.ExplorerTroopsTile -> WorldmapScene.updateArmyHexes + ArmyManager.onTileUpdate -> moveArmy -> worker findPath -> ArmyModel.startMovement + PathRenderer.createPath`
 
 This is the path that makes high player concurrency expensive even when the local user is only observing.
 
 ### 5.3 Tile update path
 
-`WorldUpdateListener.Tile -> WorldmapScene.updateExploredHex -> cache invalidation -> visible-tile incremental add or
-full refresh fallback`
+`WorldUpdateListener.Tile -> WorldmapScene.updateExploredHex -> cache invalidation -> visible-tile incremental add or full refresh fallback`
 
 This is the path that can convert exploration churn into terrain cache churn and forced manager fanout.
 


### PR DESCRIPTION
This PR splits world registration dispatch by mode in use-world-registration: Blitz keeps obtain_entry_token/register, while Eternum now calls realm_systems.create with optional settlement params and placeholder defaults. It also updates the Eternum S2 frontend PRD and detailed task dispatch to match contract truth, including season pass inventory/placement flow and village pass reveal constraints. Per your preference, I ran pnpm run format and committed resulting formatting-only changes in several worldmap/manager files plus one PRD line-wrap cleanup. Validation: pnpm -C client/apps/game exec tsc --noEmit --pretty false passed.