### PR TITLE
Hide dev-mode worlds from markets and score submit

### DIFF
--- a/client/apps/game/src/services/review/game-review-service.ts
+++ b/client/apps/game/src/services/review/game-review-service.ts
@@ -82,6 +82,7 @@ const REVIEW_MMR_CONFIG_QUERY = `
 
 const REVIEW_SEASON_TIMING_QUERY = `
   SELECT
+    "season_config.dev_mode_on" AS dev_mode_on,
     "season_config.end_at" AS season_end_at,
     "season_config.registration_grace_seconds" AS registration_grace_seconds,
     "blitz_registration_config.registration_count" AS registration_count
@@ -563,6 +564,7 @@ interface MmrConfigRow {
 }
 
 interface SeasonTimingRow {
+  dev_mode_on?: unknown;
   season_end_at?: unknown;
   registration_grace_seconds?: unknown;
   registration_count?: unknown;
@@ -613,10 +615,13 @@ interface ReviewFinalizationMeta {
   registrationCount: number;
   finalTrialId: bigint | null;
   rankingFinalized: boolean;
+  devModeOn: boolean;
   mmrCommitted: boolean;
   mmrEnabled: boolean;
   mmrMinPlayers: number;
   mmrTokenAddress: string | null;
+  seasonEndAt: number | null;
+  registrationGraceSeconds: number;
   scoreSubmissionOpensAt: number | null;
 }
 
@@ -759,24 +764,29 @@ const fetchReviewFinalizationMeta = async (toriiSqlBaseUrl: string): Promise<Rev
         : registeredPlayers.length;
   const finalTrialId = parseBigIntValue(rankFinalRows[0]?.trial_id);
   const rankingFinalized = finalTrialId != null && finalTrialId > 0n;
+  const devModeOn = parseBoolean(seasonTimingRows[0]?.dev_mode_on);
   const mmrCommitted = parseNumeric(mmrMetaRows[0]?.game_median) > 0;
 
   const mmrEnabled = parseNumeric(mmrConfigRows[0]?.mmr_enabled) !== 0;
   const mmrMinPlayers = Math.max(1, parseNumeric(mmrConfigRows[0]?.mmr_min_players) || 6);
   const mmrTokenAddress = parseAddress(mmrConfigRows[0]?.mmr_token_address);
-  const seasonEndAt = parseNumeric(seasonTimingRows[0]?.season_end_at);
+  const seasonEndAtRaw = parseNumeric(seasonTimingRows[0]?.season_end_at);
+  const seasonEndAt = seasonEndAtRaw > 0 ? seasonEndAtRaw : null;
   const registrationGraceSeconds = Math.max(0, parseNumeric(seasonTimingRows[0]?.registration_grace_seconds));
-  const scoreSubmissionOpensAt = seasonEndAt > 0 ? seasonEndAt + registrationGraceSeconds : null;
+  const scoreSubmissionOpensAt = seasonEndAt != null ? seasonEndAt + registrationGraceSeconds : null;
 
   return {
     registeredPlayers,
     registrationCount,
     finalTrialId,
     rankingFinalized,
+    devModeOn,
     mmrCommitted,
     mmrEnabled,
     mmrMinPlayers,
     mmrTokenAddress,
+    seasonEndAt,
+    registrationGraceSeconds,
     scoreSubmissionOpensAt,
   };
 };

--- a/client/apps/game/src/ui/features/landing/components/game-review-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-review-modal.tsx
@@ -1,4 +1,5 @@
 import { useAccountStore } from "@/hooks/store/use-account-store";
+import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
 import {
   claimGameReviewRewards,
   finalizeGameRankingAndMMR,
@@ -58,6 +59,7 @@ const MAP_FINGERPRINT_GOLD_LEVELS = [0.4, 0.65, 0.8, 1] as const;
 const MAP_FINGERPRINT_DEFAULT_GOLD_LEVEL = MAP_FINGERPRINT_GOLD_LEVELS[0];
 const CLAIM_RECONCILIATION_POLL_MS = 5_000;
 const CLAIM_RECONCILIATION_MAX_ATTEMPTS = 12;
+const BLOCK_TIMESTAMP_REFRESH_MS = 10_000;
 
 const formatValue = (value: number): string => numberFormatter.format(Math.max(0, Math.round(value)));
 
@@ -178,9 +180,35 @@ const getSecondsUntilScoreSubmissionOpen = (
   return remaining > 0 ? remaining : 0;
 };
 
+const getSecondsUntilSeasonEnd = (finalization: GameReviewData["finalization"], nowTs: number): number | null => {
+  const seasonEndAt = finalization.seasonEndAt;
+  if (seasonEndAt == null) return null;
+
+  const remaining = seasonEndAt - nowTs;
+  return remaining > 0 ? remaining : 0;
+};
+
 const isScoreSubmissionWindowOpen = (finalization: GameReviewData["finalization"], nowTs: number): boolean => {
   const secondsUntilOpen = getSecondsUntilScoreSubmissionOpen(finalization, nowTs);
   return secondsUntilOpen === 0;
+};
+
+const getScoreSubmissionLockedDescription = (finalization: GameReviewData["finalization"], nowTs: number): string => {
+  const secondsUntilSeasonEnd = getSecondsUntilSeasonEnd(finalization, nowTs);
+  const secondsUntilOpen = getSecondsUntilScoreSubmissionOpen(finalization, nowTs);
+
+  if (secondsUntilSeasonEnd != null && secondsUntilSeasonEnd > 0) {
+    if (secondsUntilOpen != null && secondsUntilOpen > 0) {
+      return `Season ends in ${formatCountdown(secondsUntilSeasonEnd)}. Submission unlocks in ${formatCountdown(secondsUntilOpen)}.`;
+    }
+    return "Season is still running. Submission unlocks once the season and registration grace period end.";
+  }
+
+  if (secondsUntilOpen != null && secondsUntilOpen > 0) {
+    return `Point registration closes in ${formatCountdown(secondsUntilOpen)}.`;
+  }
+
+  return "Submission opens once the game and registration grace period end.";
 };
 
 const GameFinishedStep = ({ data }: { data: GameReviewData }) => {
@@ -231,11 +259,16 @@ const SubmitScoreStep = ({
   onRequireSignIn: () => void;
 }) => {
   const scoreSubmitted = data.finalization.rankingFinalized;
+  const isDevModeGame = data.finalization.devModeOn;
   const secondsUntilOpen = getSecondsUntilScoreSubmissionOpen(data.finalization, nowTs);
+  const secondsUntilSeasonEnd = getSecondsUntilSeasonEnd(data.finalization, nowTs);
   const submissionWindowOpen = isScoreSubmissionWindowOpen(data.finalization, nowTs);
+  const seasonStillRunning = !scoreSubmitted && secondsUntilSeasonEnd != null && secondsUntilSeasonEnd > 0;
   const canRetryMMR = canRetryMmrUpdate(data);
   const canSubmitScore = !scoreSubmitted && submissionWindowOpen;
-  const canRunPrimaryAction = canSubmitScore || canRetryMMR;
+  const canRunPrimaryAction = !isDevModeGame && (canSubmitScore || canRetryMMR);
+  const seasonEndTime =
+    data.finalization.seasonEndAt != null ? new Date((data.finalization.seasonEndAt + 1) * 1000) : null;
   const submissionUnlockTime =
     data.finalization.scoreSubmissionOpensAt != null
       ? new Date((data.finalization.scoreSubmissionOpensAt + 1) * 1000)
@@ -267,11 +300,26 @@ const SubmitScoreStep = ({
           Connect a wallet to submit score.
         </div>
       )}
+      {!scoreSubmitted && isDevModeGame && (
+        <div className="rounded-xl border border-orange/30 bg-orange/10 p-3 text-sm text-orange">
+          Score submission is disabled for dev mode games.
+        </div>
+      )}
 
       {!scoreSubmitted && !submissionWindowOpen && secondsUntilOpen != null && secondsUntilOpen > 0 && (
         <div className="rounded-xl border border-gold/35 bg-gold/10 p-3 text-sm text-gold">
-          <div className="font-medium">Point registration is still open.</div>
+          <div className="font-medium">
+            {seasonStillRunning ? "Season is still running." : "Point registration is still open."}
+          </div>
+          {seasonStillRunning && secondsUntilSeasonEnd != null && secondsUntilSeasonEnd > 0 && (
+            <div className="mt-1">Season ends in {formatCountdown(secondsUntilSeasonEnd)}.</div>
+          )}
           <div className="mt-1">Score submission unlocks in {formatCountdown(secondsUntilOpen)}.</div>
+          {seasonStillRunning && seasonEndTime && (
+            <div className="mt-1 text-xs text-gold/75">
+              Season ends at {seasonEndTime.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}.
+            </div>
+          )}
           {submissionUnlockTime && (
             <div className="mt-1 text-xs text-gold/75">
               Opens at {submissionUnlockTime.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}.
@@ -313,11 +361,13 @@ const SubmitScoreStep = ({
               ? "Retry MMR update"
               : scoreSubmitted
                 ? "Score already submitted"
-                : !submissionWindowOpen && secondsUntilOpen != null
-                  ? `Opens in ${formatCountdown(secondsUntilOpen)}`
-                  : !submissionWindowOpen
-                    ? "Waiting for window"
-                    : "Submit score now"}
+                : isDevModeGame
+                  ? "Disabled in dev mode"
+                  : !submissionWindowOpen && secondsUntilOpen != null
+                    ? `Opens in ${formatCountdown(secondsUntilOpen)}`
+                    : !submissionWindowOpen
+                      ? "Waiting for window"
+                      : "Submit score now"}
         </Button>
       </div>
 
@@ -480,6 +530,8 @@ export const GameReviewModal = ({
   const worldChain = world?.chain;
 
   const account = useAccountStore((state) => state.account);
+  const currentBlockTimestamp = useBlockTimestampStore((state) => state.currentBlockTimestamp);
+  const refreshBlockTimestamp = useBlockTimestampStore((state) => state.tick);
   const reviewPlayerAddress = account?.address && account.address !== "0x0" ? account.address : "anonymous";
   const claimOptimisticKey = buildClaimRewardsOptimisticKey({
     worldName,
@@ -621,6 +673,7 @@ export const GameReviewModal = ({
   const canProceedToNextStep = useMemo(() => {
     if (!reviewData) return true;
     if (currentStep === "submit-score") {
+      if (reviewData.finalization.devModeOn) return true;
       return reviewData.finalization.rankingFinalized;
     }
     if (currentStep === "claim-rewards") {
@@ -632,7 +685,11 @@ export const GameReviewModal = ({
 
   const nextStepBlockedReason = useMemo(() => {
     if (!reviewData) return null;
-    if (currentStep === "submit-score" && !reviewData.finalization.rankingFinalized) {
+    if (
+      currentStep === "submit-score" &&
+      !reviewData.finalization.devModeOn &&
+      !reviewData.finalization.rankingFinalized
+    ) {
       return "Submit score before continuing.";
     }
     if (
@@ -714,8 +771,27 @@ export const GameReviewModal = ({
 
   useEffect(() => {
     if (!isOpen) return;
+    refreshBlockTimestamp();
+    const interval = setInterval(() => {
+      refreshBlockTimestamp();
+    }, BLOCK_TIMESTAMP_REFRESH_MS);
+    return () => clearInterval(interval);
+  }, [isOpen, refreshBlockTimestamp]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (currentBlockTimestamp > 0) {
+      setNowTs(currentBlockTimestamp);
+      return;
+    }
     setNowTs(Math.floor(Date.now() / 1000));
-    const interval = setInterval(() => setNowTs(Math.floor(Date.now() / 1000)), 1000);
+  }, [currentBlockTimestamp, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const interval = setInterval(() => {
+      setNowTs((previous) => previous + 1);
+    }, 1000);
     return () => clearInterval(interval);
   }, [isOpen]);
 
@@ -755,14 +831,13 @@ export const GameReviewModal = ({
     onError: (caughtError) => {
       console.error("Failed to submit score/MMR", caughtError);
       const errorMessage = getErrorMessage(caughtError, "Unknown error while submitting score/MMR.");
-      const isGracePeriodError = errorMessage.toLowerCase().includes("registration grace period is not over");
+      const normalizedErrorMessage = errorMessage.toLowerCase();
+      const isSubmissionWindowError =
+        normalizedErrorMessage.includes("registration grace period is not over") ||
+        normalizedErrorMessage.includes("season is not over");
 
-      if (isGracePeriodError && reviewData) {
-        const secondsUntilOpen = getSecondsUntilScoreSubmissionOpen(reviewData.finalization, nowTs);
-        const description =
-          secondsUntilOpen != null && secondsUntilOpen > 0
-            ? `Point registration closes in ${formatCountdown(secondsUntilOpen)}.`
-            : "Submission opens once the game and registration grace period end.";
+      if (isSubmissionWindowError && reviewData) {
+        const description = getScoreSubmissionLockedDescription(reviewData.finalization, nowTs);
         setSubmitTxError(`Score submission is not open yet. ${description}`);
         toast.error("Score submission is not open yet.", {
           description,
@@ -828,6 +903,11 @@ export const GameReviewModal = ({
     }
 
     if (reviewData) {
+      if (reviewData.finalization.devModeOn) {
+        toast.error("Score submission is disabled for dev mode games.");
+        return;
+      }
+
       const retryAvailable = canRetryMmrUpdate(reviewData);
       if (reviewData.finalization.rankingFinalized) {
         if (!retryAvailable) {
@@ -839,11 +919,9 @@ export const GameReviewModal = ({
       } else {
         const secondsUntilOpen = getSecondsUntilScoreSubmissionOpen(reviewData.finalization, nowTs);
         if (secondsUntilOpen == null || secondsUntilOpen > 0) {
+          const description = getScoreSubmissionLockedDescription(reviewData.finalization, nowTs);
           toast.error("Score submission is not open yet.", {
-            description:
-              secondsUntilOpen != null
-                ? `Point registration closes in ${formatCountdown(secondsUntilOpen)}.`
-                : "Submission opens once the game and registration grace period end.",
+            description,
           });
           return;
         }

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -291,6 +291,7 @@ const GameCard = ({
   const isMainnetGame = game.chain === "mainnet";
   const marketSnapshot = marketState?.data ?? null;
   const hasPrizeAddress = Boolean(game.config?.prizeDistributionAddress);
+  const showPredictionMarket = hasPrizeAddress && !devModeOn;
   const marketChain = marketSnapshot?.chain;
   const marketCanTrade = marketChain ? canInteractOnChain(marketChain) : true;
   const { claimableDisplay: marketClaimableDisplay, hasAnythingToClaim: hasMarketWinningsToClaim } = useMarketRedeem(
@@ -479,7 +480,7 @@ const GameCard = ({
           />
         </div>
 
-        {marketSnapshot ? (
+        {showPredictionMarket && marketSnapshot ? (
           <div className="rounded-lg border border-emerald-400/35 bg-gradient-to-br from-emerald-500/10 via-black/40 to-black/20 p-2.5">
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
@@ -546,7 +547,7 @@ const GameCard = ({
               </p>
             ) : null}
           </div>
-        ) : hasPrizeAddress ? (
+        ) : showPredictionMarket ? (
           <div className="rounded-lg border border-white/15 bg-white/[0.04] px-2 py-1.5 text-[10px] text-white/55">
             {marketState?.isLoading
               ? "Loading prediction market..."
@@ -1024,15 +1025,16 @@ export const UnifiedGameGrid = ({
     queries: resolvedGames.map((game) => {
       const preferredChain = toMarketChain(game.chain);
       const paddedPrizeAddress = normalizeHexAddress(game.config?.prizeDistributionAddress);
+      const showPredictionMarket = Boolean(paddedPrizeAddress) && !(game.config?.devModeOn ?? false);
 
       return {
         queryKey: ["landing", "game-market", game.worldKey, preferredChain, paddedPrizeAddress ?? "none"],
-        enabled: Boolean(paddedPrizeAddress),
+        enabled: showPredictionMarket,
         staleTime: 30 * 1000,
         gcTime: 5 * 60 * 1000,
         retry: 1,
         queryFn: async (): Promise<GameMarketSnapshot | null> => {
-          if (!paddedPrizeAddress) return null;
+          if (!showPredictionMarket || !paddedPrizeAddress) return null;
           const chainsToCheck: MarketDataChain[] =
             preferredChain === "mainnet" ? ["mainnet", "slot"] : ["slot", "mainnet"];
 

--- a/client/apps/game/src/ui/features/landing/views/markets-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/markets-view.tsx
@@ -6,7 +6,9 @@ import {
   useAvatarProfiles,
   useAvatarProfilesByUsernames,
 } from "@/hooks/use-player-avatar";
+import { useFactoryWorlds } from "@/hooks/use-factory-worlds";
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import { useWorldsAvailability } from "@/hooks/use-world-availability";
 import type { MarketClass } from "@/pm/class";
 import { useOptionalControllers } from "@/pm/hooks/controllers/use-controllers";
 import { getPredictionMarketChain } from "@/pm/prediction-market-config";
@@ -554,6 +556,22 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
   const [pagesByFilter, setPagesByFilter] = useState<Record<string, number>>({});
   const currentPage = pagesByFilter[filterKey] ?? 1;
   const offset = (currentPage - 1) * PAGE_SIZE;
+  const { worlds: factoryWorlds } = useFactoryWorlds(["mainnet", "slot"]);
+  const { results: worldAvailabilityByKey } = useWorldsAvailability(factoryWorlds, factoryWorlds.length > 0);
+  const blockedDevModeOracleAddresses = useMemo(() => {
+    const blockedAddresses = new Set<string>();
+
+    worldAvailabilityByKey.forEach((availability) => {
+      if (!availability.meta?.devModeOn) return;
+
+      const prizeDistributionAddress = normalizeHexAddress(availability.meta.prizeDistributionAddress ?? "");
+      if (prizeDistributionAddress) {
+        blockedAddresses.add(prizeDistributionAddress);
+      }
+    });
+
+    return Array.from(blockedAddresses);
+  }, [worldAvailabilityByKey]);
 
   const { counts, isLoading: isCountsLoading, isFetching: isCountsFetching } = useMultiChainMarketCounts(selectedChain);
   const hasLiveMarkets = counts.live > 0;
@@ -563,6 +581,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
     chainFilter: selectedChain,
     limit: PAGE_SIZE,
     offset,
+    blockedOracleAddresses: blockedDevModeOracleAddresses,
   });
 
   const handleCardClick = useCallback(

--- a/client/apps/game/src/ui/features/market/in-game-market.tsx
+++ b/client/apps/game/src/ui/features/market/in-game-market.tsx
@@ -44,6 +44,20 @@ const InGameMarketContent = () => {
     const seasonConfig = configManager.getSeasonConfig();
     return seasonConfig?.endAt ?? null;
   }, []);
+  const isDevModeGame = useMemo(() => {
+    const devModeConfig = configManager.getDevModeConfig();
+    return Boolean(devModeConfig?.dev_mode_on);
+  }, []);
+
+  if (isDevModeGame) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <Panel tone="wood" padding="md" radius="lg" border="subtle" className="w-full max-w-sm text-center">
+          <p className="text-sm text-gold/80">Prediction markets are disabled for dev mode games.</p>
+        </Panel>
+      </div>
+    );
+  }
 
   // Render loading state
   if (isLoading) {

--- a/client/apps/game/src/ui/features/market/landing-markets/use-multi-chain-markets.ts
+++ b/client/apps/game/src/ui/features/market/landing-markets/use-multi-chain-markets.ts
@@ -64,6 +64,25 @@ const toErrorMessage = (error: unknown): string => {
   return "Unknown data source error";
 };
 
+const normalizeHexAddress = (value: unknown): string | null => {
+  if (value == null) return null;
+
+  try {
+    const normalized = `0x${BigInt(String(value)).toString(16)}`.toLowerCase();
+    return normalized;
+  } catch {
+    return null;
+  }
+};
+
+const getMarketPrizeAddress = (market: MarketClass): string | null => {
+  if (!Array.isArray(market.oracle_params) || market.oracle_params.length < 2) {
+    return null;
+  }
+
+  return normalizeHexAddress(market.oracle_params[1]);
+};
+
 const getSelectedChains = (chainFilter: MarketChainFilter): MarketDataChain[] =>
   chainFilter === "all" ? CHAIN_ORDER : [chainFilter];
 
@@ -389,22 +408,37 @@ export function useMultiChainMarkets({
   chainFilter,
   limit,
   offset,
+  blockedOracleAddresses = [],
 }: {
   status: MarketStatusKey;
   chainFilter: MarketChainFilter;
   limit: number;
   offset: number;
+  blockedOracleAddresses?: string[];
 }) {
   const { getRegisteredToken } = useConfig();
   const queryClient = useQueryClient();
   const selectedChains = useMemo(() => getSelectedChains(chainFilter), [chainFilter]);
+  const blockedOracleAddressesKey = useMemo(
+    () =>
+      blockedOracleAddresses
+        .map((address) => address.toLowerCase())
+        .toSorted()
+        .join(","),
+    [blockedOracleAddresses],
+  );
 
   const query = useQuery({
-    queryKey: ["pm", "multi-chain", "markets", status, chainFilter],
+    queryKey: ["pm", "multi-chain", "markets", status, chainFilter, blockedOracleAddressesKey],
     queryFn: async () => {
       const now = Math.ceil(Date.now() / 1000);
       const sourceStatus = createEmptySourceStatus(selectedChains);
       const statusFilter = STATUS_TO_FILTER[status];
+      const blockedOracleSet = new Set(
+        blockedOracleAddresses
+          .map((address) => normalizeHexAddress(address))
+          .filter((address): address is string => !!address),
+      );
 
       const results = await Promise.allSettled(
         selectedChains.map((chain) =>
@@ -429,8 +463,25 @@ export function useMultiChainMarkets({
         sourceStatus[chain] = { ok: false, error: toErrorMessage(result.reason) };
       });
 
+      const filteredMarkets =
+        blockedOracleSet.size === 0
+          ? merged
+          : merged.filter((entry) => {
+              const oracle = normalizeHexAddress(entry.market.oracle);
+              if (oracle && blockedOracleSet.has(oracle)) {
+                return false;
+              }
+
+              const marketPrizeAddress = getMarketPrizeAddress(entry.market);
+              if (marketPrizeAddress && blockedOracleSet.has(marketPrizeAddress)) {
+                return false;
+              }
+
+              return true;
+            });
+
       return {
-        markets: mergeAndSortMarkets(merged, status),
+        markets: mergeAndSortMarkets(filteredMarkets, status),
         sourceStatus,
       };
     },


### PR DESCRIPTION
This PR prevents dev-mode games from exposing prediction markets and score submission paths in the game UI. It disables score submission in the review flow for dev-mode worlds and improves locked-window messaging using season/grace timing metadata. It hides prediction-market UI for dev-mode games in cards and in-game market, and filters the /markets list by blocked prize addresses (including market oracle params mapping) so worlds like fruity-fruity-sandbox are excluded. Validation run: pnpm run format, pnpm -C client/apps/game exec eslint on touched files, and pnpm -C client/apps/game exec tsc --noEmit.