### PR TITLE
Update slot village pass address

### DIFF
--- a/config/environments/data/blitz.slot.json
+++ b/config/environments/data/blitz.slot.json
@@ -10,7 +10,7 @@
     "max_spawn_lords_amount": 35
   },
   "village": {
-    "village_pass_nft_address": "0x432531b2276e32aa5b82ae095e6694d68f49a2c82f2ee8b406f681ec3826c8b",
+    "village_pass_nft_address": "0x5379c1f2fc7853f00942a8c712f9439febb558eba6aafd75bd05d4cac03e209",
     "village_mint_initial_recipient": "0x03f7f4e5a23a712787f0c100f02934c4a88606b7f0c880c2fd43e817e6275d83"
   },
   "resources": {
@@ -1735,7 +1735,7 @@
       "realms": "0x99febb5c66ab7953f738c3756fe4840e1d3b92bcf922cbcb6c41e55fdef7c5",
       "lords": "0x3b1573ef7da572a464f0128b8ad230bb70e21c5960de2a689ad77ce62ccd951",
       "strk": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
-      "villagePass": "0x432531b2276e32aa5b82ae095e6694d68f49a2c82f2ee8b406f681ec3826c8b",
+      "villagePass": "0x5379c1f2fc7853f00942a8c712f9439febb558eba6aafd75bd05d4cac03e209",
       "lootChests": "",
       "marketplace": "",
       "cosmetics": "",

--- a/config/environments/data/eternum.slot.json
+++ b/config/environments/data/eternum.slot.json
@@ -10,7 +10,7 @@
     "max_spawn_lords_amount": 35
   },
   "village": {
-    "village_pass_nft_address": "0x432531b2276e32aa5b82ae095e6694d68f49a2c82f2ee8b406f681ec3826c8b",
+    "village_pass_nft_address": "0x5379c1f2fc7853f00942a8c712f9439febb558eba6aafd75bd05d4cac03e209",
     "village_mint_initial_recipient": "0x03f7f4e5a23a712787f0c100f02934c4a88606b7f0c880c2fd43e817e6275d83"
   },
   "resources": {
@@ -1735,7 +1735,7 @@
       "realms": "0x99febb5c66ab7953f738c3756fe4840e1d3b92bcf922cbcb6c41e55fdef7c5",
       "lords": "0x3b1573ef7da572a464f0128b8ad230bb70e21c5960de2a689ad77ce62ccd951",
       "strk": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
-      "villagePass": "0x432531b2276e32aa5b82ae095e6694d68f49a2c82f2ee8b406f681ec3826c8b",
+      "villagePass": "0x5379c1f2fc7853f00942a8c712f9439febb558eba6aafd75bd05d4cac03e209",
       "lootChests": "",
       "marketplace": "",
       "cosmetics": "",

--- a/contracts/common/addresses/slot.json
+++ b/contracts/common/addresses/slot.json
@@ -9,7 +9,7 @@
   "realms": "0x99febb5c66ab7953f738c3756fe4840e1d3b92bcf922cbcb6c41e55fdef7c5",
   "lords": "0x3b1573ef7da572a464f0128b8ad230bb70e21c5960de2a689ad77ce62ccd951",
   "strk": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
-  "villagePass": "0x432531b2276e32aa5b82ae095e6694d68f49a2c82f2ee8b406f681ec3826c8b",
+  "villagePass": "0x5379c1f2fc7853f00942a8c712f9439febb558eba6aafd75bd05d4cac03e209",
   "lootChests": "",
   "marketplace": "",
   "cosmetics": "",


### PR DESCRIPTION
## Summary
- update the slot village pass NFT address in the blitz environment config
- update the same slot village pass NFT address in the eternum environment config
- sync `contracts/common/addresses/slot.json` with the new address

## Testing
- not run