### PR TITLE
Enforce landing registration cap in UI

### DIFF
--- a/client/apps/game/src/hooks/use-world-availability.registration-capacity.test.ts
+++ b/client/apps/game/src/hooks/use-world-availability.registration-capacity.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("World availability registration capacity metadata", () => {
+  it("includes registration_count_max in blitz metadata query parsing", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/hooks/use-world-availability.ts"), "utf8");
+
+    expect(source).toContain('"blitz_registration_config.registration_count_max" AS registration_count_max');
+    expect(source).toContain("registrationCountMax");
+  });
+});

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -17,7 +17,7 @@ const HYPERSTRUCTURE_GLOBALS_TABLE = "s1_eternum-HyperstructureGlobals";
 const WORLD_MODE_QUERY = `SELECT "blitz_mode_on" AS blitz_mode_on FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
 
 // Note: registration_end_at uses start_main_at because registration ends when the main game starts.
-const WORLD_CONFIG_BLITZ_QUERY = `SELECT "season_config.start_settling_at" AS start_settling_at, "season_config.start_main_at" AS start_main_at, "season_config.end_at" AS end_at, "season_config.dev_mode_on" AS dev_mode_on, "blitz_registration_config.registration_count" AS registration_count, "blitz_registration_config.entry_token_address" AS entry_token_address, "blitz_registration_config.fee_token" AS fee_token, "blitz_registration_config.fee_amount" AS fee_amount, "blitz_registration_config.registration_start_at" AS registration_start_at, "season_config.start_main_at" AS registration_end_at, "mmr_config.enabled" AS mmr_enabled, "blitz_hypers_settlement_config.max_ring_count" AS max_ring_count, "blitz_settlement_config.two_player_mode" AS two_player_mode FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
+const WORLD_CONFIG_BLITZ_QUERY = `SELECT "season_config.start_settling_at" AS start_settling_at, "season_config.start_main_at" AS start_main_at, "season_config.end_at" AS end_at, "season_config.dev_mode_on" AS dev_mode_on, "blitz_registration_config.registration_count" AS registration_count, "blitz_registration_config.registration_count_max" AS registration_count_max, "blitz_registration_config.entry_token_address" AS entry_token_address, "blitz_registration_config.fee_token" AS fee_token, "blitz_registration_config.fee_amount" AS fee_amount, "blitz_registration_config.registration_start_at" AS registration_start_at, "season_config.start_main_at" AS registration_end_at, "mmr_config.enabled" AS mmr_enabled, "blitz_hypers_settlement_config.max_ring_count" AS max_ring_count, "blitz_settlement_config.two_player_mode" AS two_player_mode FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
 
 // Eternum worlds do not rely on blitz_registration_config. Fetch season timing + spacing config instead.
 const WORLD_CONFIG_ETERNUM_QUERY = `SELECT "season_config.start_settling_at" AS start_settling_at, "season_config.start_main_at" AS start_main_at, "season_config.end_at" AS end_at, "season_config.dev_mode_on" AS dev_mode_on, "mmr_config.enabled" AS mmr_enabled, "settlement_config.base_distance" AS settlement_base_distance, "settlement_config.spires_layer_distance" AS spires_layer_distance, "settlement_config.spires_max_count" AS spires_max_count, "settlement_config.spires_settled_count" AS spires_settled_count, "settlement_config.layer_max" AS settlement_layer_max, "settlement_config.layers_skipped" AS settlement_layers_skipped, "season_addresses_config.season_pass_address" AS season_pass_address, "map_center_offset" AS map_center_offset FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
@@ -121,6 +121,7 @@ export interface WorldConfigMeta {
   mapCenterOffset: number | null;
   seasonPassAddress: string | null;
   registrationCount: number | null;
+  registrationCountMax: number | null;
   // Blitz registration config
   entryTokenAddress: string | null;
   feeTokenAddress: string | null;
@@ -250,6 +251,7 @@ const fetchWorldConfigMeta = async (
     mapCenterOffset: null,
     seasonPassAddress: null,
     registrationCount: null,
+    registrationCountMax: null,
     entryTokenAddress: null,
     feeTokenAddress: null,
     feeAmount: 0n,
@@ -298,6 +300,8 @@ const fetchWorldConfigMeta = async (
 
       if (meta.mode === "blitz") {
         if (row.registration_count != null) meta.registrationCount = parseMaybeHexToNumber(row.registration_count);
+        if (row.registration_count_max != null)
+          meta.registrationCountMax = parseMaybeHexToNumber(row.registration_count_max);
         if (row.entry_token_address != null) meta.entryTokenAddress = parseMaybeHexToAddress(row.entry_token_address);
         if (row.fee_token != null) meta.feeTokenAddress = parseMaybeHexToAddress(row.fee_token);
         if (row.fee_amount != null) meta.feeAmount = parseMaybeHexToBigInt(row.fee_amount) ?? 0n;

--- a/client/apps/game/src/hooks/use-world-registration.ts
+++ b/client/apps/game/src/hooks/use-world-registration.ts
@@ -106,6 +106,8 @@ interface UseWorldRegistrationReturn {
   feeAmount: bigint;
   /** Whether registration is currently possible */
   canRegister: boolean;
+  /** Whether registration capacity has been reached */
+  isRegistrationFull: boolean;
   /** Whether fee balance is being checked */
   isCheckingFeeBalance: boolean;
   /** Whether wallet has enough fee token balance for registration */
@@ -179,6 +181,9 @@ export const useWorldRegistration = ({
   const requiresEntryToken = Boolean(config?.entryTokenAddress && config.feeAmount > 0n);
   const feeAmount = config?.feeAmount ?? 0n;
   const devModeOn = config?.devModeOn ?? false;
+  const registrationCount = config?.registrationCount ?? 0;
+  const registrationCountMax = config?.registrationCountMax ?? null;
+  const isRegistrationFull = registrationCountMax !== null && registrationCount >= registrationCountMax;
   const requiresFeeBalanceForRegistration = chain === "mainnet";
   const needsFeeBalanceCheck = requiresFeeBalanceForRegistration && Boolean(config?.feeTokenAddress && feeAmount > 0n);
 
@@ -205,6 +210,7 @@ export const useWorldRegistration = ({
     !!usernameFelt &&
     !isCheckingFeeBalance &&
     hasSufficientFeeBalance &&
+    !isRegistrationFull &&
     registrationStage === "idle";
 
   const isRegistering = registrationStage !== "idle" && registrationStage !== "done" && registrationStage !== "error";
@@ -518,6 +524,7 @@ export const useWorldRegistration = ({
     requiresEntryToken,
     feeAmount,
     canRegister,
+    isRegistrationFull,
     isCheckingFeeBalance,
     hasSufficientFeeBalance,
   };

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.registration-capacity.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.registration-capacity.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("Game card registration capacity", () => {
+  it("renders a full-capacity state when registration is full", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/landing/components/game-selector/game-card-grid.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("isRegistrationFull");
+    expect(source).toContain("Registration full");
+  });
+
+  it("shows current and max players when max capacity is known", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/landing/components/game-selector/game-card-grid.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain("const registrationCountMax = game.config?.registrationCountMax ?? null;");
+    expect(source).toContain("`${registrationCount}/${registrationCountMax} players`");
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -223,6 +223,7 @@ const buildGameResolutionSignature = (game: GameData): string => {
     registrationValue,
     config?.devModeOn ? "1" : "0",
     config?.mmrEnabled ? "1" : "0",
+    config?.registrationCountMax ?? "",
     config?.numHyperstructuresLeft ?? "",
     config?.winnerJackpotAmount?.toString() ?? "",
   ].join(":");
@@ -325,6 +326,7 @@ const GameCard = ({
     isRegistering,
     error,
     canRegister,
+    isRegistrationFull,
     isCheckingFeeBalance,
     hasSufficientFeeBalance,
   } = useWorldRegistration({
@@ -419,6 +421,12 @@ const GameCard = ({
 
   const showRegistered = game.isRegistered || registrationStage === "done";
   const canClaimRewards = isEnded && showRegistered && Boolean(claimSummary?.canClaimNow) && Boolean(onClaimRewards);
+  const registrationCount = game.registrationCount ?? 0;
+  const registrationCountMax = game.config?.registrationCountMax ?? null;
+  const registrationLabel =
+    registrationCountMax !== null
+      ? `${registrationCount}/${registrationCountMax} players`
+      : `${registrationCount} players`;
 
   return (
     <div
@@ -459,7 +467,7 @@ const GameCard = ({
         <div className="flex items-center justify-between text-xs text-white/60">
           <div className="flex items-center gap-1">
             <Users className="w-3 h-3" />
-            <span>{game.registrationCount ?? 0} players</span>
+            <span>{registrationLabel}</span>
           </div>
           {showRegistered && (
             <div className="flex items-center gap-1 text-emerald-400">
@@ -609,6 +617,10 @@ const GameCard = ({
                   <UserPlus className="w-3 h-3" />
                   Register
                 </button>
+              ) : isRegistrationFull ? (
+                <div className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-xs font-medium bg-white/5 text-white/40 border border-white/10">
+                  Registration full
+                </div>
               ) : isCheckingFeeBalance ? (
                 <div className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-xs font-medium bg-white/5 text-white/40 border border-white/10">
                   <Loader2 className="w-3 h-3 animate-spin" />

--- a/client/apps/game/src/ui/features/landing/components/season-placement-map.tsx
+++ b/client/apps/game/src/ui/features/landing/components/season-placement-map.tsx
@@ -234,7 +234,10 @@ export const SeasonPlacementMap = ({
     startCamera: SeasonPlacementMapCamera;
     hasMoved: boolean;
   } | null>(null);
-  const mapViewBox = useMemo(() => seasonMapCameraToViewBox(mapCamera ?? defaultMapCamera), [defaultMapCamera, mapCamera]);
+  const mapViewBox = useMemo(
+    () => seasonMapCameraToViewBox(mapCamera ?? defaultMapCamera),
+    [defaultMapCamera, mapCamera],
+  );
 
   const handleSlotSelect = useCallback(
     (slot: SeasonPlacementMapSlot) => {

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -583,7 +583,6 @@ const PlayTabContent = ({
               </div>
             </div>
           </div>
-
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Add registration_count_max to landing world metadata and surface it through WorldConfigMeta.
- Enforce capacity client-side in useWorldRegistration and show a disabled Registration full state in game cards.
- Display player counts as current/max when max capacity is available.
- Add regression tests for metadata parsing and game-card capacity UI, and include formatter-only whitespace/layout cleanup from pnpm run format in landing files.