### PR TITLE
Fix clean CLI loading for grant workflow

### DIFF
--- a/config/deployer/clean/cli/create.ts
+++ b/config/deployer/clean/cli/create.ts
@@ -7,10 +7,9 @@ import {
   DEFAULT_MAX_ACTIONS,
   DEFAULT_NAMESPACE,
   DEFAULT_VERSION,
-  launchGame,
-  type ExecutionMode,
-  type LaunchGameRequest,
-} from "..";
+} from "../constants";
+import { launchGame } from "../launch/runner";
+import type { ExecutionMode, LaunchGameRequest } from "../types";
 
 function usage(): void {
   console.log(

--- a/config/deployer/clean/cli/grant-village-pass-minter-role.ts
+++ b/config/deployer/clean/cli/grant-village-pass-minter-role.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { parseArgs, resolveOptionalArg } from "./args";
-import { grantVillagePassRoleToRealmInternalSystems } from "..";
+import { grantVillagePassRoleToRealmInternalSystems } from "../eternum/village-pass-role";
 
 function usage(): void {
   console.log(


### PR DESCRIPTION
This is a small follow-up after #4407 merged.

The grant village pass workflow was failing before it ever reached the contract call. The clean CLI entrypoints were importing through the clean root barrel, which dragged in the Eternum bank module even for the village pass command. That widened the module-loading path for a workflow that never needs bank creation.

This change narrows each CLI entrypoint to the code it actually runs:
- the village pass CLI imports the village pass role module directly
- the create CLI imports its runner, constants, and types directly

The goal is to make the grant workflow load cleanly without adding extra package build steps to a command that does not use those modules.

Verification:
- bun config/deployer/clean/cli/grant-village-pass-minter-role.ts --help
- bun config/deployer/clean/cli/create.ts --help
- bun test config/deployer/clean/tests
- git diff --check

pnpm run knip still reports the existing unrelated client/apps/game unused exports and exported types.