### PR TITLE
Add Eternum village settle flow and split entry actions

### DIFF
--- a/client/apps/game/src/hooks/use-village-pass-inventory.ts
+++ b/client/apps/game/src/hooks/use-village-pass-inventory.ts
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { RpcProvider } from "starknet";
+import type { Chain } from "@contracts";
+import { getRpcUrlForChain } from "@/ui/features/admin/constants";
+
+export interface VillagePassInventoryItem {
+  tokenId: bigint;
+}
+
+interface UseVillagePassInventoryProps {
+  chain: Chain;
+  ownerAddress?: string | null;
+  villagePassAddress?: string | null;
+  rpcUrl?: string | null;
+  enabled?: boolean;
+  refetchIntervalMs?: number;
+}
+
+interface UseVillagePassInventoryReturn {
+  villagePassBalance: bigint;
+  villagePasses: VillagePassInventoryItem[];
+  isLoading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+const parseUint256 = (result: string[] | undefined): bigint => {
+  if (!result || result.length < 2) return 0n;
+  const low = BigInt(result[0] ?? 0);
+  const high = BigInt(result[1] ?? 0);
+  return low + (high << 128n);
+};
+
+export const useVillagePassInventory = ({
+  chain,
+  ownerAddress,
+  villagePassAddress,
+  rpcUrl,
+  enabled = true,
+  refetchIntervalMs = 15_000,
+}: UseVillagePassInventoryProps): UseVillagePassInventoryReturn => {
+  const [villagePassBalance, setVillagePassBalance] = useState(0n);
+  const [villagePasses, setVillagePasses] = useState<VillagePassInventoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  const resolvedRpcUrl = useMemo(() => {
+    const customRpcUrl = rpcUrl?.trim();
+    if (customRpcUrl) return customRpcUrl;
+    return getRpcUrlForChain(chain);
+  }, [chain, rpcUrl]);
+
+  const provider = useMemo(() => new RpcProvider({ nodeUrl: resolvedRpcUrl }), [resolvedRpcUrl]);
+
+  const refetch = useCallback(() => {
+    setRefreshTick((prev) => prev + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || refetchIntervalMs <= 0) return;
+    const timer = window.setInterval(() => {
+      setRefreshTick((prev) => prev + 1);
+    }, refetchIntervalMs);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [enabled, refetchIntervalMs]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!enabled || !ownerAddress || !villagePassAddress) {
+      setVillagePassBalance(0n);
+      setVillagePasses([]);
+      setIsLoading(false);
+      setError(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const load = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const balanceResult = await provider.callContract({
+          contractAddress: villagePassAddress,
+          entrypoint: "balance_of",
+          calldata: [ownerAddress],
+        });
+        const balance = parseUint256(balanceResult as string[]);
+        if (!cancelled) {
+          setVillagePassBalance(balance);
+        }
+
+        if (balance === 0n) {
+          if (!cancelled) {
+            setVillagePasses([]);
+          }
+          return;
+        }
+
+        const items: VillagePassInventoryItem[] = [];
+
+        for (let index = 0n; index < balance; index += 1n) {
+          const tokenResult = await provider.callContract({
+            contractAddress: villagePassAddress,
+            entrypoint: "token_of_owner_by_index",
+            calldata: [ownerAddress, index.toString(), "0"],
+          });
+          const tokenId = parseUint256(tokenResult as string[]);
+          items.push({ tokenId });
+        }
+
+        if (!cancelled) {
+          const sorted = items.toSorted((a, b) => {
+            if (a.tokenId === b.tokenId) return 0;
+            return a.tokenId < b.tokenId ? -1 : 1;
+          });
+          setVillagePasses(sorted);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setVillagePasses([]);
+          const message = loadError instanceof Error ? loadError.message : "Failed to load village passes.";
+          const normalizedMessage = message.toLowerCase();
+          if (normalizedMessage.includes("token_of_owner_by_index") || normalizedMessage.includes("entry point")) {
+            setError("Village pass detected, but this contract does not expose token enumeration.");
+          } else {
+            setError(message);
+          }
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, ownerAddress, provider, refreshTick, villagePassAddress]);
+
+  return {
+    villagePassBalance,
+    villagePasses,
+    isLoading,
+    error,
+    refetch,
+  };
+};

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -135,6 +135,8 @@ export interface WorldConfigMeta {
   devModeOn: boolean;
   // Player registration status (null if not checked or no player)
   isPlayerRegistered: boolean | null;
+  // Eternum-only: whether the connected player already has at least one settled realm.
+  hasPlayerSettledRealm: boolean | null;
   // Number of hyperstructures left to create (for forging)
   numHyperstructuresLeft: number | null;
   // Reward distribution contract for this world
@@ -193,6 +195,23 @@ const fetchPlayerRegistration = async (toriiBaseUrl: string, playerAddress: stri
     return false;
   } catch {
     // Silently fail - registration check is best-effort
+  }
+  return null;
+};
+
+const fetchPlayerHasSettledRealm = async (toriiBaseUrl: string, playerAddress: string): Promise<boolean | null> => {
+  try {
+    const query = `SELECT COUNT(*) AS realm_count FROM "s1_eternum-Structure" WHERE owner = "${playerAddress}" AND category = 1 LIMIT 1;`;
+    const url = `${toriiBaseUrl}/sql?query=${encodeURIComponent(query)}`;
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const data = (await response.json()) as Record<string, unknown>[];
+    const [row] = data;
+    const realmCount = parseMaybeHexToNumber(row?.realm_count);
+    if (realmCount == null) return null;
+    return realmCount > 0;
+  } catch {
+    // Silently fail - settled realm check is best-effort
   }
   return null;
 };
@@ -262,6 +281,7 @@ const fetchWorldConfigMeta = async (
     mmrEnabled: false,
     devModeOn: false,
     isPlayerRegistered: null,
+    hasPlayerSettledRealm: null,
     numHyperstructuresLeft: null,
     prizeDistributionAddress: null,
     winnerJackpotAmount: 0n,
@@ -373,6 +393,13 @@ const fetchWorldConfigMeta = async (
       sideFetches.push(
         fetchPlayerRegistration(toriiBaseUrl, playerAddress).then((isRegistered) => {
           meta.isPlayerRegistered = isRegistered;
+        }),
+      );
+    }
+    if (playerAddress && meta.mode === "eternum") {
+      sideFetches.push(
+        fetchPlayerHasSettledRealm(toriiBaseUrl, playerAddress).then((hasSettledRealm) => {
+          meta.hasPlayerSettledRealm = hasSettledRealm;
         }),
       );
     }

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -40,6 +40,8 @@ import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { getWorldKey, useWorldsAvailability } from "@/hooks/use-world-availability";
 import { useSeasonPassInventory, type SeasonPassInventoryItem } from "@/hooks/use-season-pass-inventory";
+import { useVillagePassInventory, type VillagePassInventoryItem } from "@/hooks/use-village-pass-inventory";
+import { getRpcUrlForChain } from "@/ui/features/admin/constants";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import Button from "@/ui/design-system/atoms/button";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
@@ -50,9 +52,10 @@ import {
   type SettlementSnapshot,
 } from "./game-entry-settlement.utils";
 import { SeasonPlacementMap, type SeasonPlacementMapSlot } from "./season-placement-map";
-import { Coord, Direction, ResourcesIds } from "@bibliothecadao/types";
+import { Coord, Direction, DirectionName, ResourcesIds, StructureType } from "@bibliothecadao/types";
+import type { PlayerStructure, RealmVillageSlot } from "@bibliothecadao/torii";
 import { getSeasonAddresses, type Chain } from "@contracts";
-import { CallData, type Account, uint256 } from "starknet";
+import { CallData, type Account, RpcProvider, uint256 } from "starknet";
 
 const DEBUG_MODAL = false;
 const BLITZ_REALM_SYSTEMS_SELECTOR = "0x3414be5ba2c90784f15eb572e9222b5c83a6865ec0e475a57d7dc18af9b3742";
@@ -61,6 +64,8 @@ const SPIRE_SYSTEMS_SELECTOR = "0x3c0936482acd769add8a662a6f1390e50b010607b29958
 const SETTLEMENT_PROGRESS_POLL_MS = 1000;
 const SETTLEMENT_PROGRESS_TIMEOUT_MS = 30000;
 const CONTRACT_MAP_CENTER = 2147483646;
+const NEXT_FREE_REALM_ID_SCAN_LIMIT = 512;
+const REALM_OWNER_LOOKUP_ENTRYPOINTS = ["owner_of", "ownerOf"] as const;
 
 const START_DIRECTIONS: ReadonlyArray<readonly [Direction, Direction]> = [
   [Direction.EAST, Direction.SOUTH_WEST],
@@ -95,6 +100,124 @@ const extractTransactionHash = (value: unknown): string | null => {
 const resolveResourceLabel = (resourceId: number): string | null => {
   const label = ResourcesIds[resourceId as ResourcesIds];
   return typeof label === "string" ? label : null;
+};
+
+const ALL_VILLAGE_DIRECTIONS: readonly Direction[] = [
+  Direction.EAST,
+  Direction.NORTH_EAST,
+  Direction.NORTH_WEST,
+  Direction.WEST,
+  Direction.SOUTH_WEST,
+  Direction.SOUTH_EAST,
+];
+
+const VILLAGE_DIRECTION_LAYOUT: ReadonlyArray<readonly [Direction, number, number]> = [
+  [Direction.NORTH_WEST, 1, 1],
+  [Direction.NORTH_EAST, 1, 3],
+  [Direction.WEST, 2, 1],
+  [Direction.EAST, 2, 3],
+  [Direction.SOUTH_WEST, 3, 1],
+  [Direction.SOUTH_EAST, 3, 3],
+];
+
+const VILLAGE_REVEAL_RESOURCE_IDS: readonly number[] = [
+  ResourcesIds.Wood,
+  ResourcesIds.Stone,
+  ResourcesIds.Coal,
+  ResourcesIds.Copper,
+  ResourcesIds.Obsidian,
+  ResourcesIds.Silver,
+  ResourcesIds.Ironwood,
+  ResourcesIds.ColdIron,
+  ResourcesIds.Gold,
+  ResourcesIds.Hartwood,
+  ResourcesIds.Diamonds,
+  ResourcesIds.Sapphire,
+  ResourcesIds.Ruby,
+  ResourcesIds.DeepCrystal,
+  ResourcesIds.Ignium,
+  ResourcesIds.EtherealSilica,
+  ResourcesIds.TrueIce,
+  ResourcesIds.TwilightQuartz,
+  ResourcesIds.AlchemicalSilver,
+  ResourcesIds.Adamantine,
+  ResourcesIds.Mithral,
+  ResourcesIds.Dragonhide,
+];
+
+const DIRECTION_SLOT_KEY_TO_ENUM: Record<string, Direction> = {
+  east: Direction.EAST,
+  northeast: Direction.NORTH_EAST,
+  northwest: Direction.NORTH_WEST,
+  west: Direction.WEST,
+  southwest: Direction.SOUTH_WEST,
+  southeast: Direction.SOUTH_EAST,
+};
+
+const normalizeDirectionSlotKey = (value: string): string => value.replace(/[\s_-]/g, "").toLowerCase();
+
+const parseDirectionSlotValue = (value: unknown): Direction | null => {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 5) {
+    return value as Direction;
+  }
+
+  if (typeof value === "string") {
+    const normalized = normalizeDirectionSlotKey(value);
+    return DIRECTION_SLOT_KEY_TO_ENUM[normalized] ?? null;
+  }
+
+  return null;
+};
+
+const parseAvailableVillageDirections = (slot: RealmVillageSlot): Set<Direction> => {
+  const parsed = new Set<Direction>();
+  for (const entry of slot.directions_left) {
+    const directEntryDirection = parseDirectionSlotValue(entry);
+    if (directEntryDirection != null) {
+      parsed.add(directEntryDirection);
+      continue;
+    }
+    if (!entry || typeof entry !== "object") continue;
+    for (const key of Object.keys(entry)) {
+      const direction = parseDirectionSlotValue(key);
+      if (direction != null) {
+        parsed.add(direction);
+      }
+    }
+  }
+  return parsed;
+};
+
+const unpackPackedResourceIds = (packedValue: string | number | bigint | null | undefined): number[] => {
+  if (packedValue == null) return [];
+
+  let value: bigint;
+  try {
+    value = typeof packedValue === "bigint" ? packedValue : BigInt(packedValue);
+  } catch {
+    return [];
+  }
+
+  if (value <= 0n) return [];
+
+  const resourceIds: number[] = [];
+  let current = value;
+  while (current > 0n) {
+    const id = Number(current & 0xffn);
+    resourceIds.unshift(id);
+    current >>= 8n;
+  }
+  return resourceIds;
+};
+
+const resolvePrimaryVillageResource = (packedValue: string | number | bigint | null | undefined): number | null => {
+  const resourceIds = unpackPackedResourceIds(packedValue);
+  for (const resourceId of resourceIds) {
+    if (resolveResourceLabel(resourceId)) {
+      return resourceId;
+    }
+  }
+  return null;
 };
 
 type SeasonPlacementValidationInput = {
@@ -246,8 +369,84 @@ const mapSeasonSettleError = (error: unknown): string => {
   return "Settlement transaction failed. Please try another placement.";
 };
 
+const mapVillageSettleError = (error: unknown): string => {
+  const raw = error instanceof Error ? error.message : String(error ?? "");
+  const message = raw.toLowerCase();
+
+  if (message.includes("connected entity is not a realm")) {
+    return "Choose one of your settled realms.";
+  }
+
+  if (message.includes("connected realm already has") || message.includes("slot is not available")) {
+    return "This direction slot is occupied. Pick another slot.";
+  }
+
+  if (message.includes("evp: village token can not be transferred")) {
+    return "Village pass transfer is restricted for this token.";
+  }
+
+  if (message.includes("season is over") || message.includes("settling") || message.includes("timing")) {
+    return "Season timing invalid. Village settlement is currently unavailable.";
+  }
+
+  if (
+    message.includes("village pass") ||
+    message.includes("erc721") ||
+    message.includes("owner") ||
+    message.includes("approved") ||
+    message.includes("transfer")
+  ) {
+    return "Village pass unavailable in this wallet or already consumed.";
+  }
+
+  return "Village settlement failed. Please try again.";
+};
+
 const getNormalizedErrorMessage = (error: unknown): string =>
   (error instanceof Error ? error.message : String(error ?? "")).toLowerCase();
+
+const isMissingEntrypointError = (message: string): boolean =>
+  message.includes("entry point not found") ||
+  message.includes("entrypoint not found") ||
+  message.includes("requested entrypoint was not found") ||
+  message.includes("unknown selector") ||
+  message.includes("invalid message selector");
+
+const doesErc721TokenExist = async (
+  provider: RpcProvider,
+  contractAddress: string,
+  tokenId: bigint,
+): Promise<boolean> => {
+  let missingEntrypointCount = 0;
+
+  for (const entrypoint of REALM_OWNER_LOOKUP_ENTRYPOINTS) {
+    try {
+      const result = await provider.callContract({
+        contractAddress,
+        entrypoint,
+        calldata: CallData.compile([uint256.bnToUint256(tokenId)]),
+      });
+      const ownerValue = result?.[0];
+      if (!ownerValue) return true;
+      return BigInt(ownerValue) !== 0n;
+    } catch (error) {
+      const normalized = getNormalizedErrorMessage(error);
+      if (isMissingEntrypointError(normalized)) {
+        missingEntrypointCount += 1;
+        continue;
+      }
+
+      // owner_of usually reverts for non-existent token IDs.
+      return false;
+    }
+  }
+
+  if (missingEntrypointCount === REALM_OWNER_LOOKUP_ENTRYPOINTS.length) {
+    throw new Error("Realm contract does not expose owner lookup.");
+  }
+
+  return false;
+};
 
 type SpireSettlementPlacement = {
   side: number;
@@ -440,6 +639,7 @@ const toPaddedFeltAddress = (address: string): string => `0x${BigInt(address).to
 // Types
 type BootstrapStatus = "idle" | "pending-world" | "loading" | "ready" | "error";
 type SettleStage = "idle" | "assigning" | "settling" | "done" | "error";
+type EternumSettlementMode = "realm" | "village";
 type ModalPhase =
   | "loading"
   | "forge"
@@ -447,8 +647,30 @@ type ModalPhase =
   | "settlement"
   | "season-pass-required"
   | "season-placement"
+  | "village-pass-required"
+  | "village-placement"
+  | "village-reveal"
   | "ready"
   | "error";
+
+type OwnedRealmOption = {
+  entityId: number;
+  realmId: number | null;
+  coordX: number;
+  coordY: number;
+  label: string;
+};
+
+type VillageDirectionSlot = {
+  direction: Direction;
+  isAvailable: boolean;
+};
+
+type VillageRevealResult = {
+  villageEntityId: number;
+  resourceId: number;
+  resourceLabel: string;
+};
 
 // Hyperstructure info type
 type HyperstructureInfo = {
@@ -468,6 +690,8 @@ interface GameEntryModalProps {
   worldName: string;
   chain: Chain;
   isSpectateMode?: boolean;
+  /** Eternum entry intent: direct play or settlement flow */
+  eternumEntryIntent?: "play" | "settle";
   /** If true, skip settlement and just forge hyperstructures, then close */
   isForgeMode?: boolean;
   /** Number of hyperstructures left to forge (for forge mode) */
@@ -676,9 +900,14 @@ const DEFAULT_SEASON_PLACEMENT: SeasonPlacement = {
 
 const SeasonPassRequiredPhase = ({
   onGetSeasonPass,
+  onSwitchToVillageMode,
+  showVillageShortcut,
   canUseSandboxMintFlow,
   mintRealmTokenIdInput,
   onMintRealmTokenIdInputChange,
+  onAutoSelectNextRealmTokenId,
+  isAutoSelectingNextRealmTokenId,
+  autoSelectNextRealmTokenIdError,
   onMintRealmAndSeasonPass,
   isMintingRealmAndSeasonPass,
   mintRealmAndSeasonPassError,
@@ -687,9 +916,14 @@ const SeasonPassRequiredPhase = ({
   seasonPassInventoryError,
 }: {
   onGetSeasonPass: () => void;
+  onSwitchToVillageMode?: () => void;
+  showVillageShortcut?: boolean;
   canUseSandboxMintFlow: boolean;
   mintRealmTokenIdInput: string;
   onMintRealmTokenIdInputChange: (value: string) => void;
+  onAutoSelectNextRealmTokenId: () => void;
+  isAutoSelectingNextRealmTokenId: boolean;
+  autoSelectNextRealmTokenIdError: string | null;
   onMintRealmAndSeasonPass: () => void;
   isMintingRealmAndSeasonPass: boolean;
   mintRealmAndSeasonPassError: string | null;
@@ -728,6 +962,11 @@ const SeasonPassRequiredPhase = ({
         </div>
       </Button>
       {seasonPassInventoryError && <p className="mt-2 text-[11px] text-amber-200/80">{seasonPassInventoryError}</p>}
+      {showVillageShortcut && onSwitchToVillageMode && (
+        <Button onClick={onSwitchToVillageMode} variant="outline" className="w-full h-9 mt-2" forceUppercase={false}>
+          Use Village Pass Instead
+        </Button>
+      )}
       {canUseSandboxMintFlow && (
         <div className="mt-3 w-full rounded-md border border-gold/25 bg-black/20 p-3 text-left">
           <p className="text-[11px] text-gold/70 mb-2">
@@ -745,6 +984,22 @@ const SeasonPassRequiredPhase = ({
             />
           </label>
           <Button
+            onClick={onAutoSelectNextRealmTokenId}
+            disabled={isAutoSelectingNextRealmTokenId || isMintingRealmAndSeasonPass}
+            variant="outline"
+            className="w-full h-9 mb-2"
+            forceUppercase={false}
+          >
+            <div className="flex items-center justify-center gap-2">
+              {isAutoSelectingNextRealmTokenId ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Sparkles className="w-4 h-4" />
+              )}
+              <span>{isAutoSelectingNextRealmTokenId ? "Finding..." : "Auto-select Next Free ID"}</span>
+            </div>
+          </Button>
+          <Button
             onClick={onMintRealmAndSeasonPass}
             disabled={isMintingRealmAndSeasonPass}
             className="w-full h-10 !text-brown !bg-emerald-400 rounded-md"
@@ -759,6 +1014,9 @@ const SeasonPassRequiredPhase = ({
               <span>{isMintingRealmAndSeasonPass ? "Minting..." : "Mint Realm + Season Pass"}</span>
             </div>
           </Button>
+          {autoSelectNextRealmTokenIdError && (
+            <p className="mt-2 text-[11px] text-amber-200/90">{autoSelectNextRealmTokenIdError}</p>
+          )}
           {mintRealmAndSeasonPassError && (
             <p className="mt-2 text-[11px] text-red-200/90">{mintRealmAndSeasonPassError}</p>
           )}
@@ -1185,6 +1443,355 @@ const SeasonPlacementPhase = ({
   );
 };
 
+const VillagePassRequiredPhase = ({
+  onGetVillagePass,
+  onSwitchToRealmMode,
+  showRealmShortcut,
+}: {
+  onGetVillagePass: () => void;
+  onSwitchToRealmMode?: () => void;
+  showRealmShortcut?: boolean;
+}) => {
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="mx-auto w-16 h-16 mb-3 rounded-full bg-red-500/20 flex items-center justify-center">
+        <AlertCircle className="w-8 h-8 text-red-300" />
+      </div>
+      <h2 className="text-lg font-semibold text-gold mb-2">Village Pass Required</h2>
+      <p className="text-xs text-gold/60 mb-4">
+        You need at least one Village Pass to settle a village in Eternum Seasons.
+      </p>
+      <Button onClick={onGetVillagePass} className="w-full h-11 !text-brown !bg-gold rounded-md" forceUppercase={false}>
+        <div className="flex items-center justify-center gap-2">
+          <ExternalLink className="w-4 h-4" />
+          <span>Get a Village Pass</span>
+        </div>
+      </Button>
+      {showRealmShortcut && onSwitchToRealmMode && (
+        <Button onClick={onSwitchToRealmMode} variant="outline" className="w-full h-9 mt-2" forceUppercase={false}>
+          Use Realm Pass Instead
+        </Button>
+      )}
+    </div>
+  );
+};
+
+const VillagePlacementPhase = ({
+  villagePassBalance,
+  villagePasses,
+  selectedVillagePassTokenId,
+  onSelectVillagePass,
+  settledRealms,
+  selectedRealmEntityId,
+  onSelectRealmEntityId,
+  directionSlots,
+  selectedDirection,
+  onSelectDirection,
+  onConfirmSettlement,
+  isSubmittingSettlement,
+  settlementError,
+  villagePassInventoryError,
+  villageSlotsError,
+}: {
+  villagePassBalance: bigint;
+  villagePasses: VillagePassInventoryItem[];
+  selectedVillagePassTokenId: bigint | null;
+  onSelectVillagePass: (tokenId: bigint) => void;
+  settledRealms: OwnedRealmOption[];
+  selectedRealmEntityId: number | null;
+  onSelectRealmEntityId: (realmEntityId: number | null) => void;
+  directionSlots: VillageDirectionSlot[];
+  selectedDirection: Direction | null;
+  onSelectDirection: (direction: Direction | null) => void;
+  onConfirmSettlement: () => void;
+  isSubmittingSettlement: boolean;
+  settlementError: string | null;
+  villagePassInventoryError: string | null;
+  villageSlotsError: string | null;
+}) => {
+  const selectedRealm = settledRealms.find((realm) => realm.entityId === selectedRealmEntityId) ?? null;
+  const directionSlotLookup = useMemo(
+    () => new Map(directionSlots.map((slot) => [slot.direction, slot])),
+    [directionSlots],
+  );
+  const selectedDirectionSlot = selectedDirection != null ? directionSlotLookup.get(selectedDirection) : null;
+  const canSubmit =
+    selectedVillagePassTokenId != null &&
+    selectedRealmEntityId != null &&
+    selectedDirection != null &&
+    selectedDirectionSlot?.isAvailable === true &&
+    !isSubmittingSettlement;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <img src="/images/logos/eternum-loader.png" className="w-12" alt="Village settlement" />
+        <div>
+          <h2 className="text-lg font-semibold text-gold">Settle Village Pass</h2>
+          <p className="text-xs text-gold/65">Attach each pass to one of your settled realms and choose a free slot.</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[minmax(300px,1fr)_minmax(0,1.5fr)]">
+        <section className="rounded-xl border border-gold/25 bg-gradient-to-b from-black/45 to-black/25 p-3 md:p-4">
+          <div>
+            <p className="text-sm font-semibold text-gold">Village Pass Selection</p>
+            <p className="text-[11px] text-gold/60">Select the token ID to consume for settlement.</p>
+          </div>
+
+          <div className="mt-3 space-y-2 max-h-64 overflow-y-auto scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
+            {villagePasses.map((pass) => {
+              const isSelected = selectedVillagePassTokenId === pass.tokenId;
+              return (
+                <div
+                  key={pass.tokenId.toString()}
+                  className={cn(
+                    "rounded-lg border p-2 transition-colors",
+                    isSelected ? "border-gold/55 bg-gold/15" : "border-gold/20 bg-black/25 hover:border-gold/35",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-sm text-gold">Village Pass #{pass.tokenId.toString()}</p>
+                    <Button
+                      onClick={() => onSelectVillagePass(pass.tokenId)}
+                      variant={isSelected ? "default" : "outline"}
+                      size="xs"
+                      forceUppercase={false}
+                      className={cn(isSelected ? "!bg-gold !text-brown" : "")}
+                    >
+                      {isSelected ? "Selected" : "Use"}
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {villagePasses.length === 0 && villagePassBalance > 0n && (
+            <p className="mt-3 text-[11px] text-amber-200/80">
+              Village pass detected, but token enumeration is unavailable for this contract.
+            </p>
+          )}
+          {villagePassInventoryError && (
+            <p className="mt-2 text-[11px] text-amber-200/80">{villagePassInventoryError}</p>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-gold/25 bg-gradient-to-b from-[#1a140b]/95 via-[#100d08]/95 to-[#0b0906]/95 p-3 md:p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-semibold text-gold">Realm + Direction</p>
+              <p className="text-[11px] text-gold/60">Available directions are highlighted in green.</p>
+            </div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-gold/30 bg-gold/10 px-3 py-1 text-[11px] text-gold/85">
+              <span className="font-semibold">Step 3 / 3</span>
+              <span className="text-gold/60">Village Placement</span>
+            </div>
+          </div>
+
+          <label className="mt-3 block text-xs text-gold/70">
+            Settled Realm
+            <select
+              value={selectedRealmEntityId ?? ""}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (!value) {
+                  onSelectRealmEntityId(null);
+                  return;
+                }
+                onSelectRealmEntityId(Number(value));
+              }}
+              className="mt-1 w-full rounded-md border border-gold/20 bg-black/30 px-2 py-1.5 text-sm text-gold"
+            >
+              <option value="">Select a realm</option>
+              {settledRealms.map((realm) => (
+                <option key={realm.entityId} value={realm.entityId}>
+                  {realm.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {settledRealms.length === 0 && (
+            <p className="mt-2 text-[11px] text-amber-200/85">
+              No settled realms found for this wallet. Settle a realm before attaching a village.
+            </p>
+          )}
+          {villageSlotsError && <p className="mt-2 text-[11px] text-amber-200/85">{villageSlotsError}</p>}
+
+          <div className="mt-4 rounded-lg border border-gold/20 bg-black/20 p-3">
+            <div className="grid grid-cols-3 grid-rows-3 gap-2">
+              {VILLAGE_DIRECTION_LAYOUT.map(([direction, row, column]) => {
+                const slot = directionSlotLookup.get(direction);
+                const isAvailable = slot?.isAvailable ?? false;
+                const isSelected = selectedDirection === direction;
+                return (
+                  <button
+                    key={direction}
+                    type="button"
+                    style={{ gridRow: row, gridColumn: column }}
+                    disabled={!isAvailable}
+                    onClick={() => onSelectDirection(direction)}
+                    className={cn(
+                      "rounded-md border px-2 py-2 text-xs transition-colors",
+                      isAvailable
+                        ? "border-emerald-500/40 bg-emerald-500/15 text-emerald-100 hover:bg-emerald-500/25"
+                        : "border-red-500/30 bg-red-500/10 text-red-200/80 cursor-not-allowed",
+                      isSelected && isAvailable && "border-gold/70 bg-gold/20 text-gold",
+                    )}
+                  >
+                    <span className="block font-semibold">{DirectionName[direction]}</span>
+                    <span className="text-[10px] opacity-80">{isAvailable ? "Free" : "Occupied"}</span>
+                  </button>
+                );
+              })}
+              <div className="col-start-2 row-start-2 flex items-center justify-center rounded-md border border-gold/25 bg-black/35 px-2 py-2 text-center text-[11px] text-gold/80">
+                {selectedRealm ? (
+                  <span>
+                    Realm #{selectedRealm.realmId ?? "?"}
+                    <br />
+                    Entity {selectedRealm.entityId}
+                  </span>
+                ) : (
+                  <span>Select realm</span>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {settlementError && <p className="text-[11px] text-red-200">{settlementError}</p>}
+
+      <div className="sticky bottom-0 z-10 rounded-xl border border-gold/30 bg-gradient-to-r from-[#1a1309]/95 via-[#20170c]/95 to-[#120d07]/95 px-3 py-3 shadow-[0_-10px_25px_rgba(0,0,0,0.35)] backdrop-blur-sm">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-gold/75">
+            <span className="rounded border border-gold/25 bg-black/25 px-2 py-1">
+              Pass: {selectedVillagePassTokenId != null ? `#${selectedVillagePassTokenId.toString()}` : "None"}
+            </span>
+            <span className="rounded border border-gold/25 bg-black/25 px-2 py-1">
+              Realm: {selectedRealm ? `#${selectedRealm.realmId ?? "?"}` : "None"}
+            </span>
+            <span className="rounded border border-gold/25 bg-black/25 px-2 py-1">
+              Direction: {selectedDirection != null ? DirectionName[selectedDirection] : "None"}
+            </span>
+          </div>
+          <Button
+            disabled={!canSubmit}
+            onClick={onConfirmSettlement}
+            className="h-11 w-full min-w-[190px] !rounded-md !bg-gold !text-brown md:w-auto"
+            forceUppercase={false}
+          >
+            <div className="flex items-center justify-center gap-2">
+              {isSubmittingSettlement ? <Loader2 className="h-4 w-4 animate-spin" /> : <Castle className="h-4 w-4" />}
+              <span>{isSubmittingSettlement ? "Settling Village..." : "Settle Village"}</span>
+            </div>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const VillageRevealPhase = ({
+  result,
+  onEnterGame,
+  onSettleAnotherVillage,
+}: {
+  result: VillageRevealResult;
+  onEnterGame: () => void;
+  onSettleAnotherVillage: () => void;
+}) => {
+  const reelLabels = useMemo(
+    () =>
+      VILLAGE_REVEAL_RESOURCE_IDS.map((resourceId) => resolveResourceLabel(resourceId)).filter(
+        (resourceLabel): resourceLabel is string => Boolean(resourceLabel),
+      ),
+    [],
+  );
+  const initialRevealLabel = reelLabels[0] ?? result.resourceLabel;
+  const [displayedResourceLabel, setDisplayedResourceLabel] = useState(initialRevealLabel);
+  const [spinning, setSpinning] = useState(true);
+
+  useEffect(() => {
+    const spinSequence = [...reelLabels.filter((label) => label !== result.resourceLabel), result.resourceLabel];
+    let tick = 0;
+    const intervalId = window.setInterval(() => {
+      setDisplayedResourceLabel(spinSequence[tick % spinSequence.length] ?? result.resourceLabel);
+      tick += 1;
+    }, 110);
+
+    const stopTimerId = window.setTimeout(() => {
+      window.clearInterval(intervalId);
+      setDisplayedResourceLabel(result.resourceLabel);
+      setSpinning(false);
+    }, 2600);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.clearTimeout(stopTimerId);
+    };
+  }, [result.resourceLabel, result.villageEntityId, reelLabels]);
+
+  return (
+    <div className="flex flex-col items-center text-center">
+      <div className="mx-auto w-16 h-16 mb-3 rounded-full bg-gold/20 flex items-center justify-center">
+        <TreasureChest className="w-8 h-8 fill-gold text-gold" />
+      </div>
+      <h2 className="text-lg font-semibold text-gold mb-1">
+        {spinning ? "Revealing Village Resource..." : "Village Resource Revealed"}
+      </h2>
+      <p className="text-xs text-gold/60 mb-4">
+        {spinning ? "Resolving on-chain assignment from Torii..." : `Your village produces ${displayedResourceLabel}.`}
+      </p>
+
+      <motion.div
+        className="w-36 rounded-xl border border-gold/35 bg-gradient-to-b from-black/45 to-black/25 px-4 py-5"
+        animate={spinning ? { rotateY: [0, 90, 180, 270, 360] } : { rotateY: 0 }}
+        transition={{
+          duration: spinning ? 0.45 : 0.2,
+          repeat: spinning ? Infinity : 0,
+          ease: "linear",
+        }}
+      >
+        <div className="flex flex-col items-center gap-2">
+          <ResourceIcon resource={displayedResourceLabel} size="xl" withTooltip={false} />
+          <p className="text-sm font-semibold text-gold">{displayedResourceLabel}</p>
+        </div>
+      </motion.div>
+
+      {!spinning && (
+        <>
+          <div className="mt-4 w-full rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-left">
+            <p className="text-xs text-emerald-100">
+              Your village produces <span className="font-semibold">{result.resourceLabel}</span>.
+            </p>
+            <p className="text-[11px] text-emerald-200/80 mt-1">Village entity #{result.villageEntityId}</p>
+          </div>
+          <Button
+            onClick={onEnterGame}
+            className="mt-4 w-full h-11 !text-brown !bg-gold rounded-md"
+            forceUppercase={false}
+          >
+            <div className="flex items-center justify-center gap-2">
+              <Play className="w-4 h-4" />
+              <span>Play</span>
+            </div>
+          </Button>
+          <Button
+            onClick={onSettleAnotherVillage}
+            variant="outline"
+            className="mt-2 w-full h-10"
+            forceUppercase={false}
+          >
+            Settle Another Village
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};
+
 /**
  * Hyperstructure initialization phase - shows hyperstructures that need to be initialized
  */
@@ -1470,6 +2077,7 @@ export const GameEntryModal = ({
   worldName,
   chain,
   isSpectateMode = false,
+  eternumEntryIntent = "play",
   isForgeMode = false,
   numHyperstructuresLeft: initialNumHyperstructuresLeft,
 }: GameEntryModalProps) => {
@@ -1523,12 +2131,21 @@ export const GameEntryModal = ({
   // Forge hyperstructures state (for creating new ones during registration)
   const [numHyperstructuresLeft, setNumHyperstructuresLeft] = useState(initialNumHyperstructuresLeft ?? 0);
   const [isForging, setIsForging] = useState(false);
+  const [eternumSettlementMode, setEternumSettlementMode] = useState<EternumSettlementMode>("realm");
   const [seasonPlacement, setSeasonPlacement] = useState<SeasonPlacement>(DEFAULT_SEASON_PLACEMENT);
   const [selectedSeasonPassTokenId, setSelectedSeasonPassTokenId] = useState<bigint | null>(null);
   const [isSubmittingSeasonSettlement, setIsSubmittingSeasonSettlement] = useState(false);
   const [seasonSettlementError, setSeasonSettlementError] = useState<string | null>(null);
   const [seasonSettlementComplete, setSeasonSettlementComplete] = useState(false);
+  const [selectedVillagePassTokenId, setSelectedVillagePassTokenId] = useState<bigint | null>(null);
+  const [selectedVillageRealmEntityId, setSelectedVillageRealmEntityId] = useState<number | null>(null);
+  const [selectedVillageDirection, setSelectedVillageDirection] = useState<Direction | null>(null);
+  const [isSubmittingVillageSettlement, setIsSubmittingVillageSettlement] = useState(false);
+  const [villageSettlementError, setVillageSettlementError] = useState<string | null>(null);
+  const [villageRevealResult, setVillageRevealResult] = useState<VillageRevealResult | null>(null);
   const [mintRealmTokenIdInput, setMintRealmTokenIdInput] = useState("1");
+  const [isAutoSelectingNextRealmTokenId, setIsAutoSelectingNextRealmTokenId] = useState(false);
+  const [autoSelectNextRealmTokenIdError, setAutoSelectNextRealmTokenIdError] = useState<string | null>(null);
   const [isMintingRealmAndSeasonPass, setIsMintingRealmAndSeasonPass] = useState(false);
   const [mintRealmAndSeasonPassError, setMintRealmAndSeasonPassError] = useState<string | null>(null);
   const hasEnteredGameRef = useRef(false);
@@ -1555,6 +2172,46 @@ export const GameEntryModal = ({
     refetchIntervalMs: 0,
   });
   const {
+    villagePassBalance,
+    villagePasses,
+    isLoading: isLoadingVillagePassInventory,
+    error: villagePassInventoryError,
+    refetch: refetchVillagePassInventory,
+  } = useVillagePassInventory({
+    chain,
+    ownerAddress: account?.address,
+    villagePassAddress,
+    rpcUrl: selectedWorldRpcUrl,
+    enabled: isOpen && isEternumMode,
+    refetchIntervalMs: 0,
+  });
+  const {
+    data: ownedStructures = [],
+    isLoading: isLoadingOwnedStructures,
+    error: ownedStructuresErrorRaw,
+    refetch: refetchOwnedStructures,
+  } = useQuery({
+    queryKey: ["eternumOwnedStructures", chain, worldName, account?.address],
+    enabled: isOpen && isEternumMode && bootstrapStatus === "ready" && Boolean(account?.address),
+    queryFn: async () => {
+      if (!account?.address) return [];
+      return await sqlApi.fetchPlayerStructures(account.address);
+    },
+    staleTime: 10_000,
+    refetchInterval: 15_000,
+  });
+  const {
+    data: realmVillageSlots = [],
+    error: villageSlotsErrorRaw,
+    refetch: refetchRealmVillageSlots,
+  } = useQuery({
+    queryKey: ["eternumRealmVillageSlots", chain, worldName],
+    enabled: isOpen && isEternumMode && bootstrapStatus === "ready",
+    queryFn: async () => await sqlApi.fetchRealmVillageSlots(),
+    staleTime: 10_000,
+    refetchInterval: 15_000,
+  });
+  const {
     data: seasonOccupiedCoordKeys = [],
     isLoading: isLoadingSeasonOccupiedSlots,
     error: seasonOccupiedSlotsErrorRaw,
@@ -1579,6 +2236,8 @@ export const GameEntryModal = ({
   });
   const seasonOccupiedSlotsError =
     seasonOccupiedSlotsErrorRaw instanceof Error ? seasonOccupiedSlotsErrorRaw.message : null;
+  const ownedStructuresError = ownedStructuresErrorRaw instanceof Error ? ownedStructuresErrorRaw.message : null;
+  const villageSlotsError = villageSlotsErrorRaw instanceof Error ? villageSlotsErrorRaw.message : null;
   const seasonPassInventoryWarning = useMemo(() => {
     if (!seasonPassInventoryError) return null;
     const normalized = seasonPassInventoryError.toLowerCase();
@@ -1587,13 +2246,83 @@ export const GameEntryModal = ({
     }
     return seasonPassInventoryError;
   }, [seasonPassInventoryError]);
+  const villagePassInventoryWarning = useMemo(() => {
+    if (!villagePassInventoryError) return null;
+    const normalized = villagePassInventoryError.toLowerCase();
+    if (normalized.includes("does not expose token enumeration")) {
+      return null;
+    }
+    return villagePassInventoryError;
+  }, [villagePassInventoryError]);
+  const ownedRealms = useMemo<OwnedRealmOption[]>(() => {
+    return (ownedStructures as PlayerStructure[])
+      .filter((structure) => structure.category === StructureType.Realm)
+      .map((structure) => {
+        const realmId = structure.realm_id ?? null;
+        return {
+          entityId: structure.entity_id,
+          realmId,
+          coordX: structure.coord_x,
+          coordY: structure.coord_y,
+          label:
+            realmId != null
+              ? `Realm #${realmId} · Entity ${structure.entity_id}`
+              : `Entity ${structure.entity_id} · (${structure.coord_x}, ${structure.coord_y})`,
+        };
+      })
+      .toSorted((left, right) => {
+        if (left.realmId != null && right.realmId != null && left.realmId !== right.realmId) {
+          return left.realmId - right.realmId;
+        }
+        return left.entityId - right.entityId;
+      });
+  }, [ownedStructures]);
+  const hasSettledRealm = ownedRealms.length > 0;
+  const ownedVillageIdSet = useMemo(
+    () =>
+      new Set(
+        (ownedStructures as PlayerStructure[])
+          .filter((structure) => structure.category === StructureType.Village)
+          .map((structure) => structure.entity_id),
+      ),
+    [ownedStructures],
+  );
+  const villageDirectionsByRealmEntityId = useMemo(() => {
+    const lookup = new Map<number, Set<Direction>>();
+    for (const slot of realmVillageSlots as RealmVillageSlot[]) {
+      lookup.set(slot.connected_realm_entity_id, parseAvailableVillageDirections(slot));
+    }
+    return lookup;
+  }, [realmVillageSlots]);
+  const selectedVillageAvailableDirections = useMemo(() => {
+    if (selectedVillageRealmEntityId == null) return new Set<Direction>();
+    return villageDirectionsByRealmEntityId.get(selectedVillageRealmEntityId) ?? new Set<Direction>();
+  }, [selectedVillageRealmEntityId, villageDirectionsByRealmEntityId]);
+  const villageDirectionSlots = useMemo<VillageDirectionSlot[]>(
+    () =>
+      ALL_VILLAGE_DIRECTIONS.map((direction) => ({
+        direction,
+        isAvailable: selectedVillageAvailableDirections.has(direction),
+      })),
+    [selectedVillageAvailableDirections],
+  );
 
   useEffect(() => {
     if (!isOpen) {
       hasEnteredGameRef.current = false;
+      setEternumSettlementMode("realm");
+      setSelectedSeasonPassTokenId(null);
+      setSelectedVillagePassTokenId(null);
+      setSelectedVillageRealmEntityId(null);
+      setSelectedVillageDirection(null);
       setIsSubmittingSeasonSettlement(false);
       setSeasonSettlementError(null);
       setSeasonSettlementComplete(false);
+      setIsSubmittingVillageSettlement(false);
+      setVillageSettlementError(null);
+      setVillageRevealResult(null);
+      setIsAutoSelectingNextRealmTokenId(false);
+      setAutoSelectNextRealmTokenIdError(null);
       setIsMintingRealmAndSeasonPass(false);
       setMintRealmAndSeasonPassError(null);
     }
@@ -1615,6 +2344,54 @@ export const GameEntryModal = ({
   }, [isEternumMode, seasonPasses]);
 
   useEffect(() => {
+    if (!isEternumMode) {
+      setSelectedVillagePassTokenId(null);
+      return;
+    }
+    if (villagePasses.length === 0) return;
+
+    setSelectedVillagePassTokenId((current) => {
+      if (current != null && villagePasses.some((pass) => pass.tokenId === current)) {
+        return current;
+      }
+      return villagePasses[0]?.tokenId ?? null;
+    });
+  }, [isEternumMode, villagePasses]);
+
+  useEffect(() => {
+    if (!isEternumMode) {
+      setSelectedVillageRealmEntityId(null);
+      return;
+    }
+    if (ownedRealms.length === 0) {
+      setSelectedVillageRealmEntityId(null);
+      return;
+    }
+
+    setSelectedVillageRealmEntityId((current) => {
+      if (current != null && ownedRealms.some((realm) => realm.entityId === current)) {
+        return current;
+      }
+      return ownedRealms[0]?.entityId ?? null;
+    });
+  }, [isEternumMode, ownedRealms]);
+
+  useEffect(() => {
+    if (!isEternumMode) {
+      setSelectedVillageDirection(null);
+      return;
+    }
+
+    setSelectedVillageDirection((current) => {
+      if (current != null && selectedVillageAvailableDirections.has(current)) {
+        return current;
+      }
+      const firstAvailableDirection = selectedVillageAvailableDirections.values().next().value as Direction | undefined;
+      return firstAvailableDirection ?? null;
+    });
+  }, [isEternumMode, selectedVillageAvailableDirections]);
+
+  useEffect(() => {
     if (!isEternumMode) return;
     const minimumLayer = Math.max(1, (worldMeta?.settlementLayersSkipped ?? 0) + 1);
     setSeasonPlacement((current) => {
@@ -1630,6 +2407,10 @@ export const GameEntryModal = ({
   useEffect(() => {
     setSeasonSettlementError(null);
   }, [selectedSeasonPassTokenId, seasonPlacement.side, seasonPlacement.layer, seasonPlacement.point]);
+
+  useEffect(() => {
+    setVillageSettlementError(null);
+  }, [selectedVillagePassTokenId, selectedVillageRealmEntityId, selectedVillageDirection]);
 
   // Update task status
   const updateTask = useCallback((taskId: string, status: BootstrapTask["status"]) => {
@@ -1665,8 +2446,14 @@ export const GameEntryModal = ({
       ? spiresMaxCount === 0 || spiresSettledCount >= spiresMaxCount
       : (spiresSettledCount ?? 0) > 0;
   const hasSeasonPass = seasonPassBalance > 0n || seasonPasses.length > 0;
+  const hasVillagePass = villagePassBalance > 0n || villagePasses.length > 0;
   const canAttemptSeasonSettle = seasonTimingValid && hasSeasonPass;
-  const isLoadingEternumPrereqs = isCheckingWorldAvailability || isLoadingSeasonPassInventory || !worldMeta;
+  const isLoadingEternumPrereqs =
+    isCheckingWorldAvailability ||
+    isLoadingSeasonPassInventory ||
+    isLoadingVillagePassInventory ||
+    isLoadingOwnedStructures ||
+    !worldMeta;
   const seasonPlacementValidationErrors = useMemo(
     () =>
       validateSeasonPlacement({
@@ -1713,6 +2500,18 @@ export const GameEntryModal = ({
     return [...seasonPlacementValidationErrors, "Destination occupied. Choose another side/layer/point."];
   }, [seasonPlacementValidationErrors, selectedSeasonPlacementIsOccupied]);
 
+  useEffect(() => {
+    if (!isEternumMode) {
+      setEternumSettlementMode("realm");
+      return;
+    }
+    setEternumSettlementMode((current) => {
+      if (current === "realm" && !hasSeasonPass && hasVillagePass) return "village";
+      if (current === "village" && !hasVillagePass && hasSeasonPass) return "realm";
+      return current;
+    });
+  }, [isEternumMode, hasSeasonPass, hasVillagePass]);
+
   // Both checks must complete before we can determine the final phase
   const checksComplete = settlementCheckComplete && hyperstructureCheckComplete;
 
@@ -1733,12 +2532,14 @@ export const GameEntryModal = ({
     } else if (isEternumMode) {
       if (isLoadingEternumPrereqs) {
         result = "loading";
-      } else if (!hasSeasonPass) {
-        result = "season-pass-required";
-      } else if (seasonSettlementComplete) {
+      } else if (villageRevealResult) {
+        result = "village-reveal";
+      } else if (eternumSettlementMode === "village") {
+        result = hasVillagePass ? "village-placement" : "village-pass-required";
+      } else if (seasonSettlementComplete || (hasSettledRealm && eternumEntryIntent === "play")) {
         result = "ready";
       } else {
-        result = "season-placement";
+        result = hasSeasonPass ? "season-placement" : "season-pass-required";
       }
     } else if (!checksComplete) {
       // Still checking settlement/hyperstructure status - stay in loading
@@ -1775,13 +2576,23 @@ export const GameEntryModal = ({
       settlementLayersSkipped: worldMeta?.settlementLayersSkipped,
       mapCenterOffset: worldMeta?.mapCenterOffset,
       seasonPassCount: seasonPasses.length,
+      villagePassCount: villagePasses.length,
       selectedSeasonPassTokenId: selectedSeasonPassTokenId?.toString() ?? null,
+      selectedVillagePassTokenId: selectedVillagePassTokenId?.toString() ?? null,
+      selectedVillageRealmEntityId,
+      selectedVillageDirection,
+      villageDirectionSlots,
+      villageRevealResult,
+      eternumSettlementMode,
+      eternumEntryIntent,
       seasonPlacement,
       seasonPlacementErrors,
       selectedSeasonPlacementIsOccupied,
       targetCoordPreview,
       seasonSettlementComplete,
+      hasSettledRealm,
       hasSeasonPass,
+      hasVillagePass,
       canAttemptSeasonSettle,
     });
 
@@ -1801,11 +2612,21 @@ export const GameEntryModal = ({
     isLoadingEternumPrereqs,
     isCheckingWorldAvailability,
     seasonSettlementComplete,
+    hasSettledRealm,
     hasSeasonPass,
+    hasVillagePass,
     worldMode,
     worldMeta,
     seasonPasses,
+    villagePasses,
     selectedSeasonPassTokenId,
+    selectedVillagePassTokenId,
+    selectedVillageRealmEntityId,
+    selectedVillageDirection,
+    villageDirectionSlots,
+    villageRevealResult,
+    eternumSettlementMode,
+    eternumEntryIntent,
     seasonPlacement,
     seasonPlacementErrors,
     selectedSeasonPlacementIsOccupied,
@@ -1903,6 +2724,45 @@ export const GameEntryModal = ({
       throw new Error(`Unable to confirm ${label}: no transaction wait method available`);
     },
     [setupResult, account],
+  );
+
+  const waitForVillageResourceReveal = useCallback(
+    async ({
+      ownerAddress,
+      existingVillageIds,
+      timeoutMs = 45_000,
+    }: {
+      ownerAddress: string;
+      existingVillageIds: Set<number>;
+      timeoutMs?: number;
+    }): Promise<VillageRevealResult> => {
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < timeoutMs) {
+        const structures = await sqlApi.fetchPlayerStructures(ownerAddress);
+        const newVillage = structures
+          .filter(
+            (structure) => structure.category === StructureType.Village && !existingVillageIds.has(structure.entity_id),
+          )
+          .toSorted((left, right) => right.entity_id - left.entity_id)[0];
+
+        if (newVillage) {
+          const resourceId = resolvePrimaryVillageResource(newVillage.resources_packed);
+          const resourceLabel = resourceId != null ? resolveResourceLabel(resourceId) : null;
+          if (resourceId != null && resourceLabel) {
+            return {
+              villageEntityId: newVillage.entity_id,
+              resourceId,
+              resourceLabel,
+            };
+          }
+        }
+
+        await new Promise((resolve) => window.setTimeout(resolve, 1500));
+      }
+
+      throw new Error("Village created but resource assignment is not indexed in Torii yet.");
+    },
+    [],
   );
 
   // Check settlement status after bootstrap completes
@@ -2116,11 +2976,18 @@ export const GameEntryModal = ({
         setHyperstructures([]);
         setNeedsHyperstructureInit(false);
         setHyperstructureCheckComplete(false);
+        setEternumSettlementMode("realm");
         setSeasonPlacement(DEFAULT_SEASON_PLACEMENT);
         setSelectedSeasonPassTokenId(null);
         setIsSubmittingSeasonSettlement(false);
         setSeasonSettlementError(null);
         setSeasonSettlementComplete(false);
+        setSelectedVillagePassTokenId(null);
+        setSelectedVillageRealmEntityId(null);
+        setSelectedVillageDirection(null);
+        setIsSubmittingVillageSettlement(false);
+        setVillageSettlementError(null);
+        setVillageRevealResult(null);
 
         // Apply world selection first
         debugLog(worldName, "Applying world selection...");
@@ -2191,11 +3058,18 @@ export const GameEntryModal = ({
     setHyperstructureCheckComplete(false);
     setIsInitializingHyperstructure(false);
     setCurrentInitializingId(null);
+    setEternumSettlementMode("realm");
     setSeasonPlacement(DEFAULT_SEASON_PLACEMENT);
     setSelectedSeasonPassTokenId(null);
     setIsSubmittingSeasonSettlement(false);
     setSeasonSettlementError(null);
     setSeasonSettlementComplete(false);
+    setSelectedVillagePassTokenId(null);
+    setSelectedVillageRealmEntityId(null);
+    setSelectedVillageDirection(null);
+    setIsSubmittingVillageSettlement(false);
+    setVillageSettlementError(null);
+    setVillageRevealResult(null);
     // Trigger re-bootstrap
     setTimeout(() => {
       setBootstrapStatus("loading");
@@ -2206,7 +3080,58 @@ export const GameEntryModal = ({
     window.open("https://empire.realms.world/trade", "_blank", "noopener,noreferrer");
   }, []);
 
+  const handleGetVillagePass = useCallback(() => {
+    window.open("https://empire.realms.world/trade", "_blank", "noopener,noreferrer");
+  }, []);
+
   const canUseSandboxMintFlow = isEternumMode && (chain === "slot" || chain === "slottest");
+
+  const handleAutoSelectNextRealmTokenId = useCallback(async () => {
+    if (!realmsAddress) {
+      setAutoSelectNextRealmTokenIdError("Realms contract is not configured for this world.");
+      return;
+    }
+
+    setIsAutoSelectingNextRealmTokenId(true);
+    setAutoSelectNextRealmTokenIdError(null);
+
+    try {
+      const baseRpcUrl = selectedWorldRpcUrl ?? getRpcUrlForChain(chain);
+      const provider = new RpcProvider({ nodeUrl: baseRpcUrl });
+
+      let startingRealmId = 1n;
+      const rawInput = mintRealmTokenIdInput.trim();
+      if (rawInput.length > 0) {
+        try {
+          const parsedInput = BigInt(rawInput);
+          if (parsedInput > 0n) {
+            startingRealmId = parsedInput;
+          }
+        } catch {
+          // Ignore invalid manual input and fall back to realm id 1.
+        }
+      }
+
+      let candidateRealmId = startingRealmId;
+      for (let attempt = 0; attempt < NEXT_FREE_REALM_ID_SCAN_LIMIT; attempt += 1) {
+        const tokenExists = await doesErc721TokenExist(provider, realmsAddress, candidateRealmId);
+        if (!tokenExists) {
+          setMintRealmTokenIdInput(candidateRealmId.toString());
+          setAutoSelectNextRealmTokenIdError(null);
+          return;
+        }
+
+        candidateRealmId += 1n;
+      }
+
+      setAutoSelectNextRealmTokenIdError(`No free realm ID found in the next ${NEXT_FREE_REALM_ID_SCAN_LIMIT} slots.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to auto-select next realm ID.";
+      setAutoSelectNextRealmTokenIdError(message);
+    } finally {
+      setIsAutoSelectingNextRealmTokenId(false);
+    }
+  }, [chain, mintRealmTokenIdInput, realmsAddress, selectedWorldRpcUrl]);
 
   const handleMintRealmAndSeasonPass = useCallback(async () => {
     if (!account?.address) {
@@ -2239,29 +3164,33 @@ export const GameEntryModal = ({
 
     setIsMintingRealmAndSeasonPass(true);
     setMintRealmAndSeasonPassError(null);
+    setAutoSelectNextRealmTokenIdError(null);
 
     try {
       const signer = account as unknown as Account;
-
-      try {
-        const mintRealmResult = await signer.execute({
-          contractAddress: realmsAddress,
-          entrypoint: "mint",
-          calldata: CallData.compile([uint256.bnToUint256(realmId)]),
-        });
-        await waitForSubmittedTransaction(mintRealmResult, "mint test realm");
-      } catch (realmMintError) {
-        if (!isRealmAlreadyMintedError(realmMintError)) {
-          throw realmMintError;
-        }
-      }
-
-      const mintSeasonPassResult = await signer.execute({
+      const buildMintRealmCall = () => ({
+        contractAddress: realmsAddress,
+        entrypoint: "mint",
+        calldata: CallData.compile([uint256.bnToUint256(realmId)]),
+      });
+      const buildMintSeasonPassCall = () => ({
         contractAddress: seasonPassAddress,
         entrypoint: "mint",
         calldata: CallData.compile([account.address, uint256.bnToUint256(realmId)]),
       });
-      await waitForSubmittedTransaction(mintSeasonPassResult, "mint season pass");
+
+      try {
+        const mintRealmAndPassResult = await signer.execute([buildMintRealmCall(), buildMintSeasonPassCall()]);
+        await waitForSubmittedTransaction(mintRealmAndPassResult, "mint realm + season pass");
+      } catch (mintError) {
+        if (!isRealmAlreadyMintedError(mintError)) {
+          throw mintError;
+        }
+
+        // Realm exists already; fall back to minting just the season pass.
+        const mintSeasonPassResult = await signer.execute(buildMintSeasonPassCall());
+        await waitForSubmittedTransaction(mintSeasonPassResult, "mint season pass");
+      }
 
       await refetchSeasonPassInventory();
       setSelectedSeasonPassTokenId(realmId);
@@ -2432,11 +3361,11 @@ export const GameEntryModal = ({
       ]);
       await waitForSubmittedTransaction(executeResult, "approve season pass + season realm create");
 
-      setSeasonSettlementComplete(true);
       setSeasonSettlementError(null);
-      setTimeout(() => {
-        handleEnterGame();
-      }, 500);
+      void refetchSeasonPassInventory();
+      void refetchOwnedStructures();
+
+      setSeasonSettlementComplete(true);
     } catch (error) {
       debugLog(worldName, "Season settlement failed:", error);
       setSeasonSettlementError(mapSeasonSettleError(error));
@@ -2462,9 +3391,106 @@ export const GameEntryModal = ({
     seasonPlacement.layer,
     seasonPlacement.point,
     waitForSubmittedTransaction,
-    handleEnterGame,
+    refetchSeasonPassInventory,
+    refetchOwnedStructures,
     queryClient,
   ]);
+
+  const handleVillageSettle = useCallback(async () => {
+    if (!account?.address) {
+      setVillageSettlementError("Connect your wallet first.");
+      return;
+    }
+    if (!setupResult) {
+      setVillageSettlementError("Game setup is still loading.");
+      return;
+    }
+    if (!seasonTimingValid) {
+      setVillageSettlementError("Season timing invalid. Village settlement is currently unavailable.");
+      return;
+    }
+    if (!villagePassAddress) {
+      setVillageSettlementError("Village pass contract not configured for this world.");
+      return;
+    }
+    if (!selectedVillagePassTokenId) {
+      setVillageSettlementError("Select a village pass token before settling.");
+      return;
+    }
+    if (selectedVillageRealmEntityId == null) {
+      setVillageSettlementError("Select one of your settled realms.");
+      return;
+    }
+    if (selectedVillageDirection == null) {
+      setVillageSettlementError("Select an available direction slot.");
+      return;
+    }
+    if (!selectedVillageAvailableDirections.has(selectedVillageDirection)) {
+      setVillageSettlementError("This direction slot is occupied. Choose another slot.");
+      return;
+    }
+
+    setIsSubmittingVillageSettlement(true);
+    setVillageSettlementError(null);
+
+    try {
+      const { systemCalls } = setupResult;
+      const existingVillageIds = new Set(ownedVillageIdSet);
+
+      const executeResult = await systemCalls.create_village({
+        signer: account,
+        village_pass_token_id: selectedVillagePassTokenId,
+        connected_realm: selectedVillageRealmEntityId,
+        direction: selectedVillageDirection,
+        village_pass_address: villagePassAddress,
+      });
+
+      await waitForSubmittedTransaction(executeResult, "village_systems.create");
+
+      const revealResult = await waitForVillageResourceReveal({
+        ownerAddress: account.address,
+        existingVillageIds,
+      });
+
+      setVillageRevealResult(revealResult);
+      setVillageSettlementError(null);
+      setEternumSettlementMode("village");
+
+      refetchVillagePassInventory();
+      void refetchOwnedStructures();
+      void refetchRealmVillageSlots();
+    } catch (error) {
+      debugLog(worldName, "Village settlement failed:", error);
+      setVillageSettlementError(mapVillageSettleError(error));
+    } finally {
+      setIsSubmittingVillageSettlement(false);
+    }
+  }, [
+    account,
+    setupResult,
+    seasonTimingValid,
+    villagePassAddress,
+    selectedVillagePassTokenId,
+    selectedVillageRealmEntityId,
+    selectedVillageDirection,
+    selectedVillageAvailableDirections,
+    ownedVillageIdSet,
+    waitForSubmittedTransaction,
+    waitForVillageResourceReveal,
+    refetchVillagePassInventory,
+    refetchOwnedStructures,
+    refetchRealmVillageSlots,
+    worldName,
+  ]);
+
+  const handleSettleAnotherVillage = useCallback(() => {
+    setVillageRevealResult(null);
+    setVillageSettlementError(null);
+    setEternumSettlementMode("village");
+    void refetchOwnedStructures();
+    void refetchRealmVillageSlots();
+    refetchVillagePassInventory();
+  }, [refetchOwnedStructures, refetchRealmVillageSlots, refetchVillagePassInventory]);
 
   // Settlement handler - calls actual Dojo system calls
   const handleSettle = useCallback(async () => {
@@ -2708,14 +3734,15 @@ export const GameEntryModal = ({
   // Auto-enter game when ready (spectate mode or already settled players)
   useEffect(() => {
     debugLog(worldName, "Auto-enter check - phase:", phase, "isSpectateMode:", isSpectateMode);
-    if (phase === "ready") {
+    const shouldAutoEnter = phase === "ready" && (!isEternumMode || eternumEntryIntent === "play");
+    if (shouldAutoEnter) {
       debugLog(worldName, "Auto-entering game...");
       const timer = setTimeout(() => {
         handleEnterGame();
       }, 500);
       return () => clearTimeout(timer);
     }
-  }, [phase, handleEnterGame, worldName, isSpectateMode]);
+  }, [phase, handleEnterGame, worldName, isSpectateMode, isEternumMode, eternumEntryIntent]);
 
   debugLog(worldName, "Render - isOpen:", isOpen, "phase:", phase, "bootstrapStatus:", bootstrapStatus);
 
@@ -2733,6 +3760,14 @@ export const GameEntryModal = ({
     }
   };
 
+  const showEternumSettlementModeToggle =
+    isEternumMode &&
+    (phase === "season-pass-required" ||
+      phase === "season-placement" ||
+      phase === "village-pass-required" ||
+      phase === "village-placement" ||
+      phase === "ready");
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-start justify-center pt-16 sm:pt-24 bg-black/70 backdrop-blur-sm"
@@ -2744,7 +3779,11 @@ export const GameEntryModal = ({
         exit={{ opacity: 0, scale: 0.95 }}
         className={cn(
           "relative mx-4 w-full rounded-xl border border-gold/40 bg-brown/95 shadow-2xl backdrop-blur-sm",
-          phase === "season-placement" ? "max-h-[88vh] max-w-6xl" : "max-w-md",
+          phase === "season-placement" || phase === "village-placement"
+            ? "max-h-[88vh] max-w-6xl"
+            : phase === "village-reveal"
+              ? "max-w-lg"
+              : "max-w-md",
         )}
         onClick={(e) => e.stopPropagation()}
       >
@@ -2775,10 +3814,40 @@ export const GameEntryModal = ({
         <div
           className={cn(
             "px-6 pb-6",
-            phase === "season-placement" &&
+            (phase === "season-placement" || phase === "village-placement") &&
               "max-h-[calc(88vh-86px)] overflow-y-auto pr-4 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent",
           )}
         >
+          {showEternumSettlementModeToggle && (
+            <div className="mb-3 flex items-center justify-center">
+              <div className="inline-flex rounded-lg border border-gold/25 bg-black/30 p-1">
+                <button
+                  type="button"
+                  onClick={() => setEternumSettlementMode("realm")}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-xs transition-colors",
+                    eternumSettlementMode === "realm"
+                      ? "bg-gold text-brown font-semibold"
+                      : "text-gold/75 hover:text-gold hover:bg-gold/10",
+                  )}
+                >
+                  Realm Pass
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEternumSettlementMode("village")}
+                  className={cn(
+                    "rounded-md px-3 py-1.5 text-xs transition-colors",
+                    eternumSettlementMode === "village"
+                      ? "bg-gold text-brown font-semibold"
+                      : "text-gold/75 hover:text-gold hover:bg-gold/10",
+                  )}
+                >
+                  Village Pass
+                </button>
+              </div>
+            </div>
+          )}
           <AnimatePresence mode="wait">
             {(phase === "loading" || phase === "error") && (
               <motion.div key="loading" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
@@ -2827,9 +3896,14 @@ export const GameEntryModal = ({
               >
                 <SeasonPassRequiredPhase
                   onGetSeasonPass={handleGetSeasonPass}
+                  onSwitchToVillageMode={() => setEternumSettlementMode("village")}
+                  showVillageShortcut={true}
                   canUseSandboxMintFlow={canUseSandboxMintFlow}
                   mintRealmTokenIdInput={mintRealmTokenIdInput}
                   onMintRealmTokenIdInputChange={setMintRealmTokenIdInput}
+                  onAutoSelectNextRealmTokenId={handleAutoSelectNextRealmTokenId}
+                  isAutoSelectingNextRealmTokenId={isAutoSelectingNextRealmTokenId}
+                  autoSelectNextRealmTokenIdError={autoSelectNextRealmTokenIdError}
                   onMintRealmAndSeasonPass={handleMintRealmAndSeasonPass}
                   isMintingRealmAndSeasonPass={isMintingRealmAndSeasonPass}
                   mintRealmAndSeasonPassError={mintRealmAndSeasonPassError}
@@ -2875,6 +3949,56 @@ export const GameEntryModal = ({
                 />
               </motion.div>
             )}
+            {phase === "village-pass-required" && (
+              <motion.div
+                key="village-pass-required"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <VillagePassRequiredPhase
+                  onGetVillagePass={handleGetVillagePass}
+                  onSwitchToRealmMode={() => setEternumSettlementMode("realm")}
+                  showRealmShortcut={true}
+                />
+              </motion.div>
+            )}
+            {phase === "village-placement" && (
+              <motion.div
+                key="village-placement"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <VillagePlacementPhase
+                  villagePassBalance={villagePassBalance}
+                  villagePasses={villagePasses}
+                  selectedVillagePassTokenId={selectedVillagePassTokenId}
+                  onSelectVillagePass={setSelectedVillagePassTokenId}
+                  settledRealms={ownedRealms}
+                  selectedRealmEntityId={selectedVillageRealmEntityId}
+                  onSelectRealmEntityId={setSelectedVillageRealmEntityId}
+                  directionSlots={villageDirectionSlots}
+                  selectedDirection={selectedVillageDirection}
+                  onSelectDirection={setSelectedVillageDirection}
+                  onConfirmSettlement={handleVillageSettle}
+                  isSubmittingSettlement={isSubmittingVillageSettlement}
+                  settlementError={villageSettlementError ?? ownedStructuresError}
+                  villagePassInventoryError={villagePassInventoryWarning}
+                  villageSlotsError={villageSlotsError}
+                />
+              </motion.div>
+            )}
+            {phase === "village-reveal" && villageRevealResult && (
+              <motion.div key="village-reveal" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+                <VillageRevealPhase
+                  key={villageRevealResult.villageEntityId}
+                  result={villageRevealResult}
+                  onEnterGame={handleEnterGame}
+                  onSettleAnotherVillage={handleSettleAnotherVillage}
+                />
+              </motion.div>
+            )}
             {phase === "ready" && (
               <motion.div
                 key="ready"
@@ -2896,8 +4020,18 @@ export const GameEntryModal = ({
                   >
                     <div className="flex items-center justify-center gap-2">
                       <Play className="w-4 h-4" />
-                      <span>Enter Game</span>
+                      <span>Play</span>
                     </div>
+                  </Button>
+                )}
+                {!isSpectateMode && isEternumMode && (
+                  <Button
+                    onClick={() => setEternumSettlementMode("village")}
+                    variant="outline"
+                    className="w-full h-10 mt-2"
+                    forceUppercase={false}
+                  >
+                    Settle Village
                   </Button>
                 )}
               </motion.div>

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -232,6 +232,7 @@ const buildGameResolutionSignature = (game: GameData): string => {
 interface GameCardProps {
   game: GameData;
   onPlay: () => void;
+  onSettle?: () => void;
   onSpectate: () => void;
   onSeeScore?: () => void;
   onClaimRewards?: () => void;
@@ -249,6 +250,7 @@ interface GameCardProps {
 const GameCard = ({
   game,
   onPlay,
+  onSettle,
   onSpectate,
   onSeeScore,
   onClaimRewards,
@@ -274,10 +276,14 @@ const GameCard = ({
   const isEnded = game.gameStatus === "ended";
   const isEternumMode = game.config?.mode === "eternum";
   const isBlitzMode = game.config?.mode !== "eternum";
+  const hasSettledEternumRealm = isEternumMode && game.config?.hasPlayerSettledRealm === true;
   const devModeOn = game.config?.devModeOn ?? false;
   const canPlayBlitz = isBlitzMode && isOngoing && game.isRegistered;
   const canOpenEternumEntry = isEternumMode && !isEnded;
   const canPlay = canPlayBlitz || canOpenEternumEntry;
+  const canPlayEternumDirect = canOpenEternumEntry && hasSettledEternumRealm;
+  const showEternumSettleShortcut = canOpenEternumEntry && hasSettledEternumRealm;
+  const eternumPrimaryActionLabel = canPlayEternumDirect ? "Play" : "Settle";
   // Can spectate ongoing or ended games
   const canSpectate = isOngoing || isEnded;
   // Can register during upcoming, or during ongoing if dev mode is on
@@ -577,16 +583,32 @@ const GameCard = ({
           {/* Left slot: Play OR Register (share same space) - hidden for ended games without registration */}
           {isEnded && !showRegistered ? null : canPlay ? (
             <button
-              onClick={() => runWithNetworkGuard(onPlay)}
+              onClick={() =>
+                runWithNetworkGuard(() => {
+                  if (canOpenEternumEntry) {
+                    if (canPlayEternumDirect) {
+                      onPlay();
+                    } else if (onSettle) {
+                      onSettle();
+                    } else {
+                      onPlay();
+                    }
+                    return;
+                  }
+                  onPlay();
+                })
+              }
               className={cn(
                 "flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-xs font-semibold",
                 canOpenEternumEntry
-                  ? "bg-amber-500 text-white hover:bg-amber-400 transition-colors"
+                  ? canPlayEternumDirect
+                    ? "bg-emerald-500 text-white hover:bg-emerald-400 transition-colors"
+                    : "bg-amber-500 text-white hover:bg-amber-400 transition-colors"
                   : "bg-emerald-500 text-white hover:bg-emerald-400 transition-colors",
               )}
             >
               <Play className="w-3 h-3" />
-              {canOpenEternumEntry ? "Settle" : "Play"}
+              {canOpenEternumEntry ? eternumPrimaryActionLabel : "Play"}
             </button>
           ) : isBlitzMode && game.isRegistered === null && playerAddress ? (
             // Loading state while checking registration status
@@ -636,6 +658,19 @@ const GameCard = ({
           ) : isBlitzMode && !playerAddress && !showRegistered && canRegisterPeriod ? (
             <div className="flex-1 text-center text-[10px] text-white/40 py-1">Connect wallet</div>
           ) : null}
+
+          {showEternumSettleShortcut && (
+            <button
+              onClick={() => runWithNetworkGuard(onSettle ?? onPlay)}
+              className={cn(
+                "flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-xs font-semibold",
+                "bg-amber-500/20 text-amber-200 border border-amber-500/40 hover:bg-amber-500/30 transition-colors",
+              )}
+            >
+              <Play className="w-3 h-3" />
+              Settle
+            </button>
+          )}
 
           {/* See Score button for ended games where player participated */}
           {isEnded && showRegistered && onSeeScore && (
@@ -775,6 +810,7 @@ const GameCard = ({
 };
 
 interface UnifiedGameGridProps {
+  onPlayGame?: (selection: WorldSelection) => void;
   onSelectGame: (selection: WorldSelection) => void;
   onSpectate: (selection: WorldSelection) => void;
   onSeeScore?: (selection: WorldSelection) => void;
@@ -811,6 +847,7 @@ interface UnifiedGameGridProps {
  * Unified game grid - combines games from mainnet and slot into a single view
  */
 export const UnifiedGameGrid = ({
+  onPlayGame,
   onSelectGame,
   onSpectate,
   onSeeScore,
@@ -1238,6 +1275,13 @@ export const UnifiedGameGrid = ({
                   key={game.worldKey}
                   game={game}
                   onPlay={() =>
+                    (onPlayGame ?? onSelectGame)({
+                      name: game.name,
+                      chain: game.chain,
+                      worldAddress: game.worldAddress ?? undefined,
+                    })
+                  }
+                  onSettle={() =>
                     onSelectGame({ name: game.name, chain: game.chain, worldAddress: game.worldAddress ?? undefined })
                   }
                   onSpectate={() =>
@@ -1292,6 +1336,13 @@ export const UnifiedGameGrid = ({
                   <GameCard
                     game={game}
                     onPlay={() =>
+                      (onPlayGame ?? onSelectGame)({
+                        name: game.name,
+                        chain: game.chain,
+                        worldAddress: game.worldAddress ?? undefined,
+                      })
+                    }
+                    onSettle={() =>
                       onSelectGame({ name: game.name, chain: game.chain, worldAddress: game.worldAddress ?? undefined })
                     }
                     onSpectate={() =>

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -92,6 +92,7 @@ const WRITTEN_GUIDES = [
  * Row 2: Practice Games (full width)
  */
 const LearnContent = ({
+  onPlayGame,
   onSelectGame,
   onSpectate,
   onForgeHyperstructures,
@@ -99,6 +100,7 @@ const LearnContent = ({
   onClaimRewards,
   onRegistrationComplete,
 }: {
+  onPlayGame: (selection: WorldSelection) => void;
   onSelectGame: (selection: WorldSelection) => void;
   onSpectate: (selection: WorldSelection) => void;
   onForgeHyperstructures: (selection: WorldSelection, numHyperstructuresLeft: number) => Promise<void> | void;
@@ -193,6 +195,7 @@ const LearnContent = ({
         </div>
       </div>
       <UnifiedGameGrid
+        onPlayGame={onPlayGame}
         onSelectGame={onSelectGame}
         onSpectate={onSpectate}
         onForgeHyperstructures={onForgeHyperstructures}
@@ -450,6 +453,7 @@ const ModeCoexistenceHero = ({
  * - Vertical scroll within each column
  */
 const PlayTabContent = ({
+  onPlayGame,
   onSelectGame,
   onSpectate,
   onSeeScore,
@@ -461,6 +465,7 @@ const PlayTabContent = ({
   disabled = false,
   onEndedGamesResolved,
 }: {
+  onPlayGame: (selection: WorldSelection) => void;
   onSelectGame: (selection: WorldSelection) => void;
   onSpectate: (selection: WorldSelection) => void;
   onSeeScore: (selection: WorldSelection) => void;
@@ -506,6 +511,7 @@ const PlayTabContent = ({
                 </div>
                 <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-emerald-500/20 scrollbar-track-transparent">
                   <UnifiedGameGrid
+                    onPlayGame={onPlayGame}
                     onSelectGame={onSelectGame}
                     onSpectate={onSpectate}
                     onForgeHyperstructures={onForgeHyperstructures}
@@ -540,6 +546,7 @@ const PlayTabContent = ({
                 </div>
                 <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-amber-500/20 scrollbar-track-transparent">
                   <UnifiedGameGrid
+                    onPlayGame={onPlayGame}
                     onSelectGame={onSelectGame}
                     onSpectate={onSpectate}
                     onForgeHyperstructures={onForgeHyperstructures}
@@ -565,6 +572,7 @@ const PlayTabContent = ({
                 </div>
                 <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
                   <UnifiedGameGrid
+                    onPlayGame={onPlayGame}
                     onSelectGame={onSelectGame}
                     onSpectate={onSpectate}
                     onSeeScore={onSeeScore}
@@ -613,6 +621,7 @@ const PlayTabContent = ({
               </div>
               <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-emerald-500/20 scrollbar-track-transparent">
                 <UnifiedGameGrid
+                  onPlayGame={onPlayGame}
                   onSelectGame={onSelectGame}
                   onSpectate={onSpectate}
                   onForgeHyperstructures={onForgeHyperstructures}
@@ -647,6 +656,7 @@ const PlayTabContent = ({
               </div>
               <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-amber-500/20 scrollbar-track-transparent">
                 <UnifiedGameGrid
+                  onPlayGame={onPlayGame}
                   onSelectGame={onSelectGame}
                   onSpectate={onSpectate}
                   onForgeHyperstructures={onForgeHyperstructures}
@@ -672,6 +682,7 @@ const PlayTabContent = ({
               </div>
               <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
                 <UnifiedGameGrid
+                  onPlayGame={onPlayGame}
                   onSelectGame={onSelectGame}
                   onSpectate={onSpectate}
                   onSeeScore={onSeeScore}
@@ -710,6 +721,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
   const [selectedWorld, setSelectedWorld] = useState<WorldSelection | null>(null);
   const [isSpectateMode, setIsSpectateMode] = useState(false);
   const [isForgeMode, setIsForgeMode] = useState(false);
+  const [eternumEntryIntent, setEternumEntryIntent] = useState<"play" | "settle">("play");
   const [numHyperstructuresLeft, setNumHyperstructuresLeft] = useState(0);
 
   // Review flow state
@@ -725,6 +737,14 @@ export const PlayView = ({ className }: PlayViewProps) => {
   const { isConnected } = useAccount();
   const setModal = useUIStore((state) => state.setModal);
 
+  const openGameEntryModal = useCallback((selection: WorldSelection, intent: "play" | "settle") => {
+    setSelectedWorld(selection);
+    setIsSpectateMode(false);
+    setIsForgeMode(false);
+    setEternumEntryIntent(intent);
+    setEntryModalOpen(true);
+  }, []);
+
   const handleSelectGame = useCallback(
     (selection: WorldSelection) => {
       const hasAccount = Boolean(account) || isConnected;
@@ -735,13 +755,25 @@ export const PlayView = ({ className }: PlayViewProps) => {
         return;
       }
 
-      // Open game entry modal - handles bootstrap, settlement, and game entry
-      setSelectedWorld(selection);
-      setIsSpectateMode(false);
-      setIsForgeMode(false);
-      setEntryModalOpen(true);
+      // Open settle flow
+      openGameEntryModal(selection, "settle");
     },
-    [account, isConnected, setModal],
+    [account, isConnected, setModal, openGameEntryModal],
+  );
+
+  const handlePlayGame = useCallback(
+    (selection: WorldSelection) => {
+      const hasAccount = Boolean(account) || isConnected;
+
+      if (!hasAccount) {
+        setModal(<SignInPromptModal />, true);
+        return;
+      }
+
+      // Open direct play flow
+      openGameEntryModal(selection, "play");
+    },
+    [account, isConnected, setModal, openGameEntryModal],
   );
 
   const handleSpectate = useCallback((selection: WorldSelection) => {
@@ -749,6 +781,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
     setSelectedWorld(selection);
     setIsSpectateMode(true);
     setIsForgeMode(false);
+    setEternumEntryIntent("play");
     setEntryModalOpen(true);
   }, []);
 
@@ -766,6 +799,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
       setSelectedWorld(selection);
       setIsSpectateMode(false);
       setIsForgeMode(true);
+      setEternumEntryIntent("play");
       setNumHyperstructuresLeft(numLeft);
       setEntryModalOpen(true);
     },
@@ -776,6 +810,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
     setEntryModalOpen(false);
     setSelectedWorld(null);
     setIsForgeMode(false);
+    setEternumEntryIntent("play");
     setNumHyperstructuresLeft(0);
   }, []);
 
@@ -844,6 +879,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
       case "learn":
         return (
           <LearnContent
+            onPlayGame={handlePlayGame}
             onSelectGame={handleSelectGame}
             onSpectate={handleSpectate}
             onForgeHyperstructures={handleForgeHyperstructures}
@@ -860,6 +896,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
       default:
         return (
           <PlayTabContent
+            onPlayGame={handlePlayGame}
             onSelectGame={handleSelectGame}
             onSpectate={handleSpectate}
             onSeeScore={handleSeeScore}
@@ -891,6 +928,7 @@ export const PlayView = ({ className }: PlayViewProps) => {
           chain={selectedWorld.chain}
           isSpectateMode={isSpectateMode}
           isForgeMode={isForgeMode}
+          eternumEntryIntent={eternumEntryIntent}
           numHyperstructuresLeft={numHyperstructuresLeft}
         />
       )}


### PR DESCRIPTION
Implements the Eternum landing settle extensions for realm/village passes, including village placement and Torii-backed resource reveal.\n\nUpdates landing cards and modal intent handling so Eternum has separate Play and Settle actions while keeping Settle always available for additional realms/villages.\n\nAdds a sandbox helper to auto-select the next free Realm ID before Mint Realm + Season Pass, and keeps the mint shortcut as a multicall with fallback to season-pass-only when the realm already exists.\n\nValidation run: pnpm run format, targeted eslint on touched landing files, and client tsc --noEmit.