### PR TITLE
fix: align 1v1 registration capacity display

### DIFF
--- a/client/apps/game/src/hooks/registration-capacity.test.ts
+++ b/client/apps/game/src/hooks/registration-capacity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isRegistrationCapacityReached, resolveEffectiveRegistrationCountMax } from "./registration-capacity";
+
+describe("registration-capacity", () => {
+  it("forces blitz two-player worlds to capacity 2", () => {
+    expect(
+      resolveEffectiveRegistrationCountMax({
+        mode: "blitz",
+        registrationCountMax: 24,
+        twoPlayerMode: true,
+      }),
+    ).toBe(2);
+  });
+
+  it("uses configured max for non-two-player blitz worlds", () => {
+    expect(
+      resolveEffectiveRegistrationCountMax({
+        mode: "blitz",
+        registrationCountMax: 24,
+        twoPlayerMode: false,
+      }),
+    ).toBe(24);
+  });
+
+  it("returns null when max capacity is not known", () => {
+    expect(
+      resolveEffectiveRegistrationCountMax({
+        mode: "blitz",
+        registrationCountMax: null,
+        twoPlayerMode: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("detects when registration reaches capacity", () => {
+    expect(isRegistrationCapacityReached(2, 2)).toBe(true);
+    expect(isRegistrationCapacityReached(1, 2)).toBe(false);
+    expect(isRegistrationCapacityReached(5, null)).toBe(false);
+  });
+});

--- a/client/apps/game/src/hooks/registration-capacity.ts
+++ b/client/apps/game/src/hooks/registration-capacity.ts
@@ -1,0 +1,22 @@
+interface RegistrationCapacityConfig {
+  mode: "blitz" | "eternum" | "unknown";
+  registrationCountMax: number | null;
+  twoPlayerMode: boolean;
+}
+
+const TWO_PLAYER_MODE_REGISTRATION_CAPACITY = 2;
+
+export const resolveEffectiveRegistrationCountMax = (
+  config: Pick<RegistrationCapacityConfig, "mode" | "registrationCountMax" | "twoPlayerMode"> | null | undefined,
+): number | null => {
+  if (!config) return null;
+  if (config.mode === "blitz" && config.twoPlayerMode) {
+    return TWO_PLAYER_MODE_REGISTRATION_CAPACITY;
+  }
+  return config.registrationCountMax;
+};
+
+export const isRegistrationCapacityReached = (
+  registrationCount: number,
+  registrationCountMax: number | null,
+): boolean => registrationCountMax !== null && registrationCount >= registrationCountMax;

--- a/client/apps/game/src/hooks/use-world-availability.registration-capacity.test.ts
+++ b/client/apps/game/src/hooks/use-world-availability.registration-capacity.test.ts
@@ -8,7 +8,9 @@ describe("World availability registration capacity metadata", () => {
     const source = readFileSync(resolve(process.cwd(), "src/hooks/use-world-availability.ts"), "utf8");
 
     expect(source).toContain('"blitz_registration_config.registration_count_max" AS registration_count_max');
+    expect(source).toContain('"blitz_settlement_config.two_player_mode" AS two_player_mode');
     expect(source).toContain("registrationCountMax");
+    expect(source).toContain("twoPlayerMode");
   });
 
   it("includes eternum settled players, realms, and villages counts", () => {

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -157,6 +157,7 @@ export interface WorldConfigMeta {
   villagePassAddress: string | null;
   registrationCount: number | null;
   registrationCountMax: number | null;
+  twoPlayerMode: boolean;
   // Blitz registration config
   entryTokenAddress: string | null;
   feeTokenAddress: string | null;
@@ -311,6 +312,7 @@ const fetchWorldConfigMeta = async (
     villagePassAddress: null,
     registrationCount: null,
     registrationCountMax: null,
+    twoPlayerMode: false,
     entryTokenAddress: null,
     feeTokenAddress: null,
     feeAmount: 0n,
@@ -373,7 +375,7 @@ const fetchWorldConfigMeta = async (
         if (row.registration_end_at != null)
           meta.registrationEndAt = parseMaybeHexToNumber(row.registration_end_at) ?? null;
 
-        const twoPlayerMode = parseMaybeBool(row.two_player_mode) ?? false;
+        meta.twoPlayerMode = parseMaybeBool(row.two_player_mode) ?? false;
 
         // Calculate hyperstructures left from max_ring_count
         const maxRingCount = parseMaybeHexToNumber(row.max_ring_count) ?? 0;
@@ -385,14 +387,18 @@ const fetchWorldConfigMeta = async (
             if (globalsResponse.ok) {
               const [globalsRow] = (await globalsResponse.json()) as Record<string, unknown>[];
               const createdCount = parseMaybeHexToNumber(globalsRow?.created_count) ?? 0;
-              meta.numHyperstructuresLeft = calculateHyperstructuresLeft(maxRingCount, createdCount, twoPlayerMode);
+              meta.numHyperstructuresLeft = calculateHyperstructuresLeft(
+                maxRingCount,
+                createdCount,
+                meta.twoPlayerMode,
+              );
             } else {
               // If no globals exist yet, all hyperstructures are available
-              meta.numHyperstructuresLeft = calculateHyperstructuresLeft(maxRingCount, 0, twoPlayerMode);
+              meta.numHyperstructuresLeft = calculateHyperstructuresLeft(maxRingCount, 0, meta.twoPlayerMode);
             }
           } catch {
             // If query fails, calculate based on zero created
-            meta.numHyperstructuresLeft = calculateHyperstructuresLeft(maxRingCount, 0, twoPlayerMode);
+            meta.numHyperstructuresLeft = calculateHyperstructuresLeft(maxRingCount, 0, meta.twoPlayerMode);
           }
         }
       }

--- a/client/apps/game/src/hooks/use-world-registration.ts
+++ b/client/apps/game/src/hooks/use-world-registration.ts
@@ -13,6 +13,7 @@ import { useAccount } from "@starknet-react/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Account, CallData, RpcProvider, uint256, type Call } from "starknet";
 import { env } from "../../env";
+import { isRegistrationCapacityReached, resolveEffectiveRegistrationCountMax } from "./registration-capacity";
 import { useUsername } from "./use-username";
 import type { WorldConfigMeta } from "./use-world-availability";
 
@@ -182,8 +183,8 @@ export const useWorldRegistration = ({
   const feeAmount = config?.feeAmount ?? 0n;
   const devModeOn = config?.devModeOn ?? false;
   const registrationCount = config?.registrationCount ?? 0;
-  const registrationCountMax = config?.registrationCountMax ?? null;
-  const isRegistrationFull = registrationCountMax !== null && registrationCount >= registrationCountMax;
+  const registrationCountMax = resolveEffectiveRegistrationCountMax(config);
+  const isRegistrationFull = isRegistrationCapacityReached(registrationCount, registrationCountMax);
   const requiresFeeBalanceForRegistration = chain === "mainnet";
   const needsFeeBalanceCheck = requiresFeeBalanceForRegistration && Boolean(config?.feeTokenAddress && feeAmount > 0n);
 

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.registration-capacity.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.registration-capacity.test.ts
@@ -20,7 +20,8 @@ describe("Game card registration capacity", () => {
       "utf8",
     );
 
-    expect(source).toContain("const registrationCountMax = game.config?.registrationCountMax ?? null;");
+    expect(source).toContain("resolveEffectiveRegistrationCountMax");
+    expect(source).toContain("const registrationCountMax = resolveEffectiveRegistrationCountMax(game.config);");
     expect(source).toContain("`${registrationCount}/${registrationCountMax} players`");
   });
 

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -1,6 +1,7 @@
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { useFactoryWorlds } from "@/hooks/use-factory-worlds";
+import { resolveEffectiveRegistrationCountMax } from "@/hooks/registration-capacity";
 import {
   getAvailabilityStatus,
   getWorldKey,
@@ -224,6 +225,7 @@ const buildGameResolutionSignature = (game: GameData): string => {
     config?.devModeOn ? "1" : "0",
     config?.mmrEnabled ? "1" : "0",
     config?.registrationCountMax ?? "",
+    config?.twoPlayerMode ? "1" : "0",
     config?.numHyperstructuresLeft ?? "",
     config?.winnerJackpotAmount?.toString() ?? "",
   ].join(":");
@@ -429,7 +431,7 @@ const GameCard = ({
   const showRegistered = game.isRegistered || registrationStage === "done";
   const canClaimRewards = isEnded && showRegistered && Boolean(claimSummary?.canClaimNow) && Boolean(onClaimRewards);
   const registrationCount = game.registrationCount ?? 0;
-  const registrationCountMax = game.config?.registrationCountMax ?? null;
+  const registrationCountMax = resolveEffectiveRegistrationCountMax(game.config);
   const registrationLabel =
     registrationCountMax !== null
       ? `${registrationCount}/${registrationCountMax} players`

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -9,6 +9,13 @@ interface LatestFeature {
 
 export const latestFeatures: LatestFeature[] = [
   {
+    date: "2026-03-18",
+    title: "1v1 Capacity Display Fix",
+    description:
+      "Blitz 1v1 game cards and registration checks now use the true two-player cap, so the lobby count and Register availability stay aligned with onchain settlement limits.",
+    type: "fix",
+  },
+  {
     date: "2026-03-17",
     title: "Spire and Mine Tile Actions",
     description:


### PR DESCRIPTION
This updates game landing registration capacity to respect blitz two-player mode so 1v1 worlds show and enforce a max of 2 when it differs from registration_count_max. It threads two_player_mode through world availability metadata, adds a shared capacity resolver reused by game-card display and registration gating, and updates related capacity tests. It also adds a latest-features entry documenting the fix. Validation: pnpm run format passed; pnpm run knip still reports existing unused export/type items in client/apps/game/src/three/*, and targeted vitest is currently blocked by an existing ERR_REQUIRE_ESM dependency issue in this environment.