### PR TITLE
Hide Research Lab from Blitz construction preview

### DIFF
--- a/client/apps/game/src/config/game-modes/index.blitz-building-exclusions.test.ts
+++ b/client/apps/game/src/config/game-modes/index.blitz-building-exclusions.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readGameModeSource = () => readFileSync(resolve(process.cwd(), "src/config/game-modes/index.ts"), "utf8");
+
+describe("Blitz building exclusions", () => {
+  it("keeps research lab out of blitz construction options", () => {
+    const source = readGameModeSource();
+
+    expect(source).toContain(
+      'const BLITZ_BUILDING_EXCLUSIONS = new Set<string>(["ResourceFish", "ResourceResearch"]);',
+    );
+  });
+});

--- a/client/apps/game/src/config/game-modes/index.ts
+++ b/client/apps/game/src/config/game-modes/index.ts
@@ -97,7 +97,7 @@ const BASE_BUILDING_EXCLUSIONS = new Set<string>([
   "Storehouse",
 ]);
 
-const BLITZ_BUILDING_EXCLUSIONS = new Set<string>(["ResourceFish"]);
+const BLITZ_BUILDING_EXCLUSIONS = new Set<string>(["ResourceFish", "ResourceResearch"]);
 
 const BLITZ_UNMANAGEABLE_RESOURCES = new Set<ResourcesIds>([ResourcesIds.Labor, ResourcesIds.Wheat]);
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -9,6 +9,13 @@ interface LatestFeature {
 
 export const latestFeatures: LatestFeature[] = [
   {
+    date: "2026-03-19",
+    title: "Blitz Research Lab Preview Fix",
+    description:
+      "Fixed Blitz construction previews so the Research Lab no longer appears in building options for Blitz games.",
+    type: "fix",
+  },
+  {
     date: "2026-03-18",
     title: "1v1 Capacity Display Fix",
     description:


### PR DESCRIPTION
This removes Research Lab from Blitz construction options by excluding `ResourceResearch` in Blitz mode building rules. It adds a regression test that locks the Blitz exclusion list so this option does not reappear. It also adds a March 19, 2026 latest-features fix entry describing the player-facing change. Verification: `pnpm run format`; targeted Vitest run currently fails in this environment with `ERR_REQUIRE_ESM` from `html-encoding-sniffer` before test execution.
