### PR TITLE
Fix soundscape bugs before adding more music

### DIFF
--- a/client/apps/game/src/audio/config/registry.ts
+++ b/client/apps/game/src/audio/config/registry.ts
@@ -849,6 +849,18 @@ const AUDIO_REGISTRY: Record<string, AudioAsset> = {
     volume: 0.4,
   },
 
+  // Birds - Night variations
+  "ambient.birds.night.1": {
+    id: "ambient.birds.night.1",
+    url: "/sound/ambient/birds_night_1.mp3",
+    category: AudioCategory.AMBIENT,
+    priority: 5,
+    poolSize: 1,
+    spatial: false,
+    loop: true,
+    volume: 0.4,
+  },
+
   // Crickets - Night variations
   "ambient.crickets.night.1": {
     id: "ambient.crickets.night.1",
@@ -903,16 +915,6 @@ const AUDIO_REGISTRY: Record<string, AudioAsset> = {
     spatial: false,
     loop: true,
     volume: 0.25,
-  },
-  "ambient.rain.light": {
-    id: "ambient.rain.light",
-    url: "/sound/ambient/rain_heavy.mp3", // Using rain_heavy as placeholder
-    category: AudioCategory.ENVIRONMENT,
-    priority: 6,
-    poolSize: 1,
-    spatial: false,
-    loop: true,
-    volume: 0.3, // Reduced volume to simulate lighter rain
   },
   "ambient.rain.heavy": {
     id: "ambient.rain.heavy",

--- a/client/apps/game/src/three/managers/ambience-manager.ts
+++ b/client/apps/game/src/three/managers/ambience-manager.ts
@@ -129,7 +129,7 @@ export class AmbienceManager {
 
     // Weather-based ambient sounds - rain should loop continuously
     {
-      assetId: "ambient.rain.light",
+      assetId: "ambient.rain.heavy",
       timeOfDay: [TimeOfDay.DAWN, TimeOfDay.DAY, TimeOfDay.DUSK, TimeOfDay.EVENING, TimeOfDay.NIGHT],
       weather: [WeatherType.RAIN],
       baseVolume: 0.1,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -2192,6 +2192,7 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     this.state.updateEntityActionSelectedEntityId(selectedEntityId);
+    AudioManager.getInstance().play("unit.selected");
 
     const armyActionManager = new ArmyActionManager(this.dojo.components, this.dojo.systemCalls, selectedEntityId);
 

--- a/client/apps/game/src/three/sound/utils.ts
+++ b/client/apps/game/src/three/sound/utils.ts
@@ -70,19 +70,6 @@ export const getResourceSoundId = (resourceId?: ResourcesIds): string => {
   return RESOURCE_SOUND_MAP[resourceId] ?? DEFAULT_RESOURCE_SOUND_ID;
 };
 
-/**
- * @deprecated Use AudioManager.getInstance().play() directly. This function bypasses the audio system.
- */
-const playSound = (sound: string, hasSound: boolean, volume: number) => {
-  const audio = new Audio("/sound/" + sound);
-  if (!hasSound) {
-    audio.volume = 0;
-  } else {
-    audio.volume = volume / 100;
-  }
-  audio.play();
-};
-
 const BUILDING_SOUNDS: Partial<Record<BuildingType, string>> = {
   [BuildingType.ResourceLabor]: "building.construct.military",
   [BuildingType.WorkersHut]: "building.construct.workhut",

--- a/client/apps/game/src/ui/features/cosmetics/chest-opening/hooks/use-chest-sounds.ts
+++ b/client/apps/game/src/ui/features/cosmetics/chest-opening/hooks/use-chest-sounds.ts
@@ -1,19 +1,9 @@
+import { useAudio } from "@/audio/hooks/useAudio";
+import { useCallback } from "react";
 import { AssetRarity } from "../utils/cosmetics";
-import { useCallback, useRef } from "react";
-
-// Sound file paths
-const SOUNDS = {
-  reveal: "/sound/ui/level-up.mp3",
-  victory: "/sound/events/battle_victory.mp3",
-} as const;
 
 // High rarities that trigger celebration sound
 const HIGH_RARITIES: AssetRarity[] = [AssetRarity.Epic, AssetRarity.Legendary, AssetRarity.Mythic];
-
-interface UseChestSoundsOptions {
-  enabled?: boolean;
-  volume?: number;
-}
 
 /**
  * Hook for playing chest opening sound effects.
@@ -21,67 +11,20 @@ interface UseChestSoundsOptions {
  * - Card reveal completion (standard chime)
  * - High-rarity celebration (victory fanfare)
  */
-export function useChestSounds({ enabled = true, volume = 0.5 }: UseChestSoundsOptions = {}) {
-  const audioCache = useRef<Map<string, HTMLAudioElement>>(new Map());
+export function useChestSounds() {
+  const { play, isReady } = useAudio();
 
-  // Get or create audio element for a sound
-  const getAudio = useCallback(
-    (src: string): HTMLAudioElement | null => {
-      if (!enabled) return null;
-
-      let audio = audioCache.current.get(src);
-      if (!audio) {
-        audio = new Audio(src);
-        audio.volume = volume;
-        audio.preload = "auto";
-        audioCache.current.set(src, audio);
-      }
-      return audio;
-    },
-    [enabled, volume],
-  );
-
-  // Play a sound effect
-  const playSound = useCallback(
-    (src: string, customVolume?: number) => {
-      if (!enabled) return;
-
-      const audio = getAudio(src);
-      if (!audio) return;
-
-      // Reset and play
-      audio.pause();
-      audio.currentTime = 0;
-      if (customVolume !== undefined) {
-        audio.volume = customVolume;
-      }
-      audio.play().catch(() => {
-        // Silently handle autoplay policy restrictions
-      });
-    },
-    [enabled, getAudio],
-  );
-
-  // Play reveal completion sound
-  const playReveal = useCallback(() => {
-    playSound(SOUNDS.reveal, 0.5);
-  }, [playSound]);
-
-  // Play victory/celebration sound for high-rarity pulls
-  const playVictory = useCallback(() => {
-    playSound(SOUNDS.victory, 0.6);
-  }, [playSound]);
-
-  // Play appropriate completion sound based on highest rarity
   const playCompletion = useCallback(
     (highestRarity: AssetRarity) => {
+      if (!isReady) return;
+
       if (HIGH_RARITIES.includes(highestRarity)) {
-        playVictory();
+        play("combat.victory");
       } else {
-        playReveal();
+        play("ui.levelup");
       }
     },
-    [playReveal, playVictory],
+    [isReady, play],
   );
 
   return {

--- a/client/apps/game/src/ui/features/story-events/story-event-toast-bridge.tsx
+++ b/client/apps/game/src/ui/features/story-events/story-event-toast-bridge.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { toast } from "sonner";
 
+import { AudioManager } from "@/audio/core/AudioManager";
 import { MAP_DATA_REFRESH_INTERVAL, MapDataStore, Position } from "@bibliothecadao/eternum";
 import { StructureType } from "@bibliothecadao/types";
 import { useDojo, useQuery } from "@bibliothecadao/react";
 
+import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useGoToStructure, useNavigateToMapView } from "@/hooks/helpers/use-navigate";
 import { type ProcessedStoryEvent, useStoryEvents } from "@/hooks/store/use-story-events-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
@@ -284,6 +286,25 @@ export function StoryEventToastBridge() {
         ),
         { duration: 12000 },
       );
+
+      // Play combat sounds when the player is involved in the battle
+      const playerAddress = useAccountStore.getState().account?.address?.toLowerCase();
+      if (playerAddress) {
+        const attackerAddr = String(event.battle_attacker_owner_address ?? "").toLowerCase();
+        const defenderAddr = String(event.battle_defender_owner_address ?? "").toLowerCase();
+        const isPlayerInvolved = attackerAddr === playerAddress || defenderAddr === playerAddress;
+
+        if (isPlayerInvolved) {
+          const winnerId = parseNumeric(event.battle_winner_id);
+          const attackerId = parseNumeric(event.battle_attacker_id);
+          const defenderId = parseNumeric(event.battle_defender_id);
+          const isPlayerAttacker = attackerAddr === playerAddress;
+          const playerEntityId = isPlayerAttacker ? attackerId : defenderId;
+          const isPlayerWinner = winnerId !== null && winnerId === playerEntityId;
+
+          AudioManager.getInstance().play(isPlayerWinner ? "combat.victory" : "combat.defeat");
+        }
+      }
     }
 
     // Prune old IDs to prevent unbounded memory growth


### PR DESCRIPTION
## Summary
- Register ambient.birds.night.1 (file exists, was unregistered causing silent failures)
- Migrate chest-opening sounds from raw HTMLAudioElement to AudioManager (respects mute/volume)
- Remove audio.rain.light entry (no asset file, consolidate to rain.heavy)
- Wire combat sounds: victory/defeat on battles, unit.selected on army clicks
- Delete deprecated playSound function (unused, bypassed audio system)

Sets a solid foundation for adding more music without audio system gaps.

## Test plan
- Mute audio, open chest cosmetics — confirm no sound plays
- Night cycle — confirm bird ambient sounds play
- Win/lose a battle — confirm victory/defeat sounds trigger
- Click army on worldmap — confirm selection sound plays