### PR TITLE
Fix initial worldmap camera framing

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap-zoom-wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-wiring.test.ts
@@ -58,4 +58,11 @@ describe("worldmap zoom wiring", () => {
 
     expect(source).not.toMatch(/this\.worldmapScene\.requestChunkRefresh\(/);
   });
+
+  it("snaps the first worldmap entry to the intended medium camera band", () => {
+    const source = readSceneSource("worldmap.tsx");
+
+    expect(source).toMatch(/if \(!this\.hasInitialized\) \{\s*this\.alignInitialWorldmapCameraView\(\);\s*\}/);
+    expect(source).toMatch(/this\.zoomCoordinator\.syncToBand\(CameraView\.Medium/);
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-zoom/worldmap-zoom-coordinator.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom/worldmap-zoom-coordinator.test.ts
@@ -78,4 +78,22 @@ describe("WorldmapZoomCoordinator", () => {
     expect(snapshot.stableBand).toBe(CameraView.Close);
     expect(snapshot.status).toBe("idle");
   });
+
+  it("can sync the zoom state to a band without leaving an initial close-up transition behind", () => {
+    const coordinator = new WorldmapZoomCoordinator({
+      initialDistance: 10,
+      minDistance: 10,
+      maxDistance: 40,
+    });
+
+    coordinator.syncToBand(CameraView.Medium, 250);
+
+    expect(coordinator.getSnapshot()).toMatchObject({
+      actualDistance: 20,
+      targetDistance: 20,
+      resolvedBand: CameraView.Medium,
+      stableBand: CameraView.Medium,
+      status: "idle",
+    });
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-zoom/worldmap-zoom-coordinator.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom/worldmap-zoom-coordinator.ts
@@ -63,6 +63,35 @@ export class WorldmapZoomCoordinator {
     return this.getSnapshot();
   }
 
+  public syncToBand(band: CameraView, nowMs: number = 0): WorldmapCameraSnapshot {
+    return this.syncToDistance(resolveBandDistance(band), nowMs);
+  }
+
+  public syncToDistance(distance: number, nowMs: number = 0): WorldmapCameraSnapshot {
+    const nextDistance = clamp(distance, this.minDistance, this.maxDistance);
+    const nextBand = resolveDistanceBand(nextDistance);
+
+    this.bandState = {
+      resolvedBand: nextBand,
+      stableBand: nextBand,
+      settledFrameCount: 0,
+      lastZoomMovementAtMs: nowMs,
+    };
+    this.state = {
+      ...this.state,
+      actualDistance: nextDistance,
+      targetDistance: nextDistance,
+      status: "idle",
+      activeGestureId: null,
+      anchorMode: "screen_center",
+      anchorWorldPoint: null,
+      resolvedBand: nextBand,
+      stableBand: nextBand,
+    };
+
+    return this.getSnapshot();
+  }
+
   public tick(input: {
     cameraPosition: Vector3;
     target: Vector3;

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -251,7 +251,10 @@ import { computeMatrixCacheEvictions } from "./worldmap-matrix-cache-eviction";
 import { snapshotExploredTilesRegion, lookupSnapshotBiome } from "./explored-tiles-snapshot";
 import { createTerrainCacheGeneration, isTerrainCacheStale } from "./terrain-cache-generation";
 import { createProvisionalBiomeTracker, resolveArmySpawnBiome } from "./provisional-biome";
-import { resolveWorldmapCameraFieldOfViewDegrees } from "./worldmap-camera-view-profile";
+import {
+  resolveWorldmapCameraFieldOfViewDegrees,
+  resolveWorldmapCameraViewProfile,
+} from "./worldmap-camera-view-profile";
 
 interface CachedMatrixEntry {
   matrices: InstancedBufferAttribute | null;
@@ -1376,6 +1379,29 @@ export default class WorldmapScene extends WarpTravel {
     if (col !== undefined && row !== undefined) {
       this.moveCameraToColRow(col, row, 0);
     }
+    if (!this.hasInitialized) {
+      this.alignInitialWorldmapCameraView();
+    }
+  }
+
+  private alignInitialWorldmapCameraView(): void {
+    this.alignWorldmapCameraToBand(CameraView.Medium);
+    this.zoomCoordinator.syncToBand(CameraView.Medium, performance.now());
+    this.lastControlsCameraDistance = this.getCurrentCameraDistance();
+    this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
+  }
+
+  private alignWorldmapCameraToBand(view: CameraView): void {
+    const profile = resolveWorldmapCameraViewProfile(view);
+    const cameraHeight = Math.sin(profile.angleRadians) * profile.distance;
+    const cameraDepth = Math.cos(profile.angleRadians) * profile.distance;
+
+    this.controls.object.position.set(
+      this.controls.target.x,
+      this.controls.target.y + cameraHeight,
+      this.controls.target.z + cameraDepth,
+    );
+    this.notifyControlsChanged();
   }
 
   private focusCameraOnEvent(col: number, row: number, message: string) {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -9,6 +9,13 @@ interface LatestFeature {
 
 export const latestFeatures: LatestFeature[] = [
   {
+    date: "2026-03-23",
+    title: "Stable First Map Camera",
+    description:
+      "World map now opens in its intended tactical camera framing on the first load, so it no longer starts in a close-up offset view before settling after a scene switch.",
+    type: "fix",
+  },
+  {
     date: "2026-03-22",
     title: "Less Skewed Map Camera",
     description:


### PR DESCRIPTION
This fixes the world map's first-load camera framing so it opens in the intended medium tactical view instead of inheriting the shared renderer's close-up state.

It adds a zoom-coordinator sync path and uses it during the initial `moveCameraToURLLocation()` flow so the shared camera transform and zoom state start aligned.

The change also adds regression coverage for the first-entry camera path and records the UX fix in the latest features list.

Verification: `pnpm --dir client/apps/game exec vitest run src/three/scenes/worldmap-zoom/worldmap-zoom-coordinator.test.ts src/three/scenes/worldmap-zoom-wiring.test.ts`, `pnpm run format`, and `pnpm run knip` (with `node@20.19.0`; local Node `20.9.0` hit a `knip`/`oxc-parser` ESM error).