### PR TITLE
Patch indexer maintenance from fresh run-store state

### DIFF
--- a/config/deployer/clean/cli/indexer-maintenance.ts
+++ b/config/deployer/clean/cli/indexer-maintenance.ts
@@ -7,7 +7,6 @@ import {
   ensureSlotIndexerDeployment,
   ensureSlotIndexerTier,
   listSlotToriiDeploymentNames,
-  resolveIndexerArtifactState,
   resolveSlotToriiLiveStates,
   resolveSlotToriiLiveState,
 } from "../indexing/slot-torii";
@@ -26,18 +25,17 @@ import {
   recordFactoryRunMaintenanceIndex,
   recordFactorySeriesMaintenanceIndex,
 } from "../run-store/maintenance-index";
-import type {
-  FactoryRotationRunRecord,
-  FactoryRunArtifacts,
-  FactoryRunRecord,
-  FactorySeriesRunRecord,
-} from "../run-store/types";
-import type {
-  DeploymentEnvironmentId,
-  IndexerTier,
-  SeriesLaunchGameArtifacts,
-  SeriesLaunchGameSummary,
-} from "../types";
+import {
+  applyIndexerMaintenanceRunUpdates,
+  type DeleteFailureIndexerMaintenanceRunUpdate,
+  type DeleteSuccessIndexerMaintenanceRunUpdate,
+  type IndexerMaintenanceRunUpdate,
+  type RefreshIndexerMaintenanceRunUpdate,
+  type TierFailureIndexerMaintenanceRunUpdate,
+  type TierSuccessIndexerMaintenanceRunUpdate,
+} from "../run-store/indexer-maintenance-updates";
+import type { FactoryRotationRunRecord, FactoryRunRecord, FactorySeriesRunRecord } from "../run-store/types";
+import type { DeploymentEnvironmentId, IndexerTier } from "../types";
 import { parseArgs } from "./args";
 
 type IndexerMaintenanceRunKind = "game" | "series" | "rotation";
@@ -195,75 +193,6 @@ function groupOperationsByRecordPath(operations: IndexerMaintenanceOperation[]) 
   return groups;
 }
 
-function buildTierSuccessArtifacts(
-  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
-  tier: IndexerTier,
-  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
-): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
-  return {
-    ...currentArtifacts,
-    ...resolveIndexerArtifactState(liveState, { fallbackTier: tier }),
-    pendingIndexerTierTarget: undefined,
-    pendingIndexerTierRequestedAt: undefined,
-    lastIndexerTierDispatchTarget: undefined,
-    lastIndexerTierDispatchFailedAt: undefined,
-    lastIndexerTierDispatchError: undefined,
-  };
-}
-
-function buildDeleteSuccessArtifacts(
-  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
-  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
-): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
-  return {
-    ...currentArtifacts,
-    ...resolveIndexerArtifactState(liveState),
-    indexerCreated: false,
-    indexerTier: undefined,
-    indexerUrl: undefined,
-    indexerVersion: undefined,
-    indexerBranch: undefined,
-    pendingIndexerTierTarget: undefined,
-    pendingIndexerTierRequestedAt: undefined,
-    lastIndexerTierDispatchTarget: undefined,
-    lastIndexerTierDispatchFailedAt: undefined,
-    lastIndexerTierDispatchError: undefined,
-  };
-}
-
-function buildTierFailureArtifacts(
-  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
-  tier: IndexerTier,
-  failedAt: string,
-  errorMessage: string,
-  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
-): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
-  return {
-    ...currentArtifacts,
-    ...resolveIndexerArtifactState(liveState),
-    pendingIndexerTierTarget: tier,
-    pendingIndexerTierRequestedAt: failedAt,
-    lastIndexerTierDispatchTarget: tier,
-    lastIndexerTierDispatchFailedAt: failedAt,
-    lastIndexerTierDispatchError: errorMessage,
-  };
-}
-
-function buildDeleteFailureArtifacts(
-  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
-  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
-): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
-  return {
-    ...currentArtifacts,
-    ...resolveIndexerArtifactState(liveState),
-    pendingIndexerTierTarget: undefined,
-    pendingIndexerTierRequestedAt: undefined,
-    lastIndexerTierDispatchTarget: undefined,
-    lastIndexerTierDispatchFailedAt: undefined,
-    lastIndexerTierDispatchError: undefined,
-  };
-}
-
 function buildAlreadyMatchedMessage(gameName: string, tier: IndexerTier) {
   return `Indexer tier already matched ${tier} for ${gameName}`;
 }
@@ -318,137 +247,89 @@ function buildFailureMessage(operation: IndexerMaintenanceOperation, errorMessag
   return `Indexer maintenance failed for ${operation.gameName}: ${errorMessage}`;
 }
 
-function updateSeriesLikeGame(
-  games: SeriesLaunchGameSummary[],
+function buildRefreshRunUpdate(
   operation: IndexerMaintenanceOperation,
-  updateGame: (game: SeriesLaunchGameSummary) => SeriesLaunchGameSummary,
-) {
-  let didUpdate = false;
-  const nextGames = games.map((game) => {
-    if (game.gameName !== operation.gameName) {
-      return game;
-    }
-
-    didUpdate = true;
-    return updateGame(game);
-  });
-
-  if (!didUpdate) {
-    throw new Error(`Could not find ${operation.gameName} in ${operation.recordPath}`);
-  }
-
-  return nextGames;
-}
-
-function buildRefreshedArtifacts(
-  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  message: string,
   liveState: ReturnType<typeof resolveSlotToriiLiveState>,
-) {
+): RefreshIndexerMaintenanceRunUpdate {
   return {
-    ...currentArtifacts,
-    ...resolveIndexerArtifactState(liveState),
-    pendingIndexerTierTarget: liveState.state === "existing" ? undefined : currentArtifacts.pendingIndexerTierTarget,
-    pendingIndexerTierRequestedAt:
-      liveState.state === "existing" ? undefined : currentArtifacts.pendingIndexerTierRequestedAt,
-    lastIndexerTierDispatchTarget:
-      liveState.state === "existing" ? undefined : currentArtifacts.lastIndexerTierDispatchTarget,
-    lastIndexerTierDispatchFailedAt:
-      liveState.state === "existing" ? undefined : currentArtifacts.lastIndexerTierDispatchFailedAt,
-    lastIndexerTierDispatchError:
-      liveState.state === "existing" ? undefined : currentArtifacts.lastIndexerTierDispatchError,
+    kind: "refresh",
+    target: resolveRunUpdateTarget(operation),
+    message,
+    updatedAt: new Date().toISOString(),
+    liveState,
   };
 }
 
-function updateRunRecordForSuccess(
-  run: IndexerMaintenanceRunRecord,
+function buildTierSuccessRunUpdate(
   operation: IndexerMaintenanceOperation,
   message: string,
-  nextArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
-) {
-  if (!run) {
-    return null;
-  }
-
-  switch (run.kind) {
-    case "game":
-      return {
-        ...run,
-        updatedAt: new Date().toISOString(),
-        artifacts: nextArtifacts as FactoryRunArtifacts,
-      } satisfies FactoryRunRecord;
-    case "series":
-      return {
-        ...run,
-        updatedAt: new Date().toISOString(),
-        summary: {
-          ...run.summary,
-          games: updateSeriesLikeGame(run.summary.games, operation, (game) => ({
-            ...game,
-            latestEvent: message,
-            artifacts: nextArtifacts as SeriesLaunchGameArtifacts,
-          })),
-        },
-      } satisfies FactorySeriesRunRecord;
-    case "rotation":
-      return {
-        ...run,
-        updatedAt: new Date().toISOString(),
-        summary: {
-          ...run.summary,
-          games: updateSeriesLikeGame(run.summary.games, operation, (game) => ({
-            ...game,
-            latestEvent: message,
-            artifacts: nextArtifacts as SeriesLaunchGameArtifacts,
-          })),
-        },
-      } satisfies FactoryRotationRunRecord;
-  }
+  tier: IndexerTier,
+  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
+): TierSuccessIndexerMaintenanceRunUpdate {
+  return {
+    kind: "tier-success",
+    target: resolveRunUpdateTarget(operation),
+    message,
+    updatedAt: new Date().toISOString(),
+    tier,
+    liveState,
+  };
 }
 
-function updateRunRecordForFailure(
-  run: IndexerMaintenanceRunRecord,
+function buildTierFailureRunUpdate(
   operation: IndexerMaintenanceOperation,
   message: string,
-  nextArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
-) {
-  if (!run) {
-    return null;
-  }
+  tier: IndexerTier,
+  failedAt: string,
+  errorMessage: string,
+  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
+): TierFailureIndexerMaintenanceRunUpdate {
+  return {
+    kind: "tier-failure",
+    target: resolveRunUpdateTarget(operation),
+    message,
+    updatedAt: failedAt,
+    tier,
+    failedAt,
+    errorMessage,
+    liveState,
+  };
+}
 
-  switch (run.kind) {
-    case "game":
-      return {
-        ...run,
-        updatedAt: new Date().toISOString(),
-        artifacts: nextArtifacts as FactoryRunArtifacts,
-      } satisfies FactoryRunRecord;
-    case "series":
-      return {
-        ...run,
-        updatedAt: new Date().toISOString(),
-        summary: {
-          ...run.summary,
-          games: updateSeriesLikeGame(run.summary.games, operation, (game) => ({
-            ...game,
-            latestEvent: message,
-            artifacts: nextArtifacts as SeriesLaunchGameArtifacts,
-          })),
-        },
-      } satisfies FactorySeriesRunRecord;
-    case "rotation":
-      return {
-        ...run,
-        updatedAt: new Date().toISOString(),
-        summary: {
-          ...run.summary,
-          games: updateSeriesLikeGame(run.summary.games, operation, (game) => ({
-            ...game,
-            latestEvent: message,
-            artifacts: nextArtifacts as SeriesLaunchGameArtifacts,
-          })),
-        },
-      } satisfies FactoryRotationRunRecord;
-  }
+function buildDeleteSuccessRunUpdate(
+  operation: IndexerMaintenanceOperation,
+  message: string,
+  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
+): DeleteSuccessIndexerMaintenanceRunUpdate {
+  return {
+    kind: "delete-success",
+    target: resolveRunUpdateTarget(operation),
+    message,
+    updatedAt: new Date().toISOString(),
+    liveState,
+  };
+}
+
+function buildDeleteFailureRunUpdate(
+  operation: IndexerMaintenanceOperation,
+  message: string,
+  liveState: ReturnType<typeof resolveSlotToriiLiveState>,
+): DeleteFailureIndexerMaintenanceRunUpdate {
+  return {
+    kind: "delete-failure",
+    target: resolveRunUpdateTarget(operation),
+    message,
+    updatedAt: new Date().toISOString(),
+    liveState,
+  };
+}
+
+function resolveRunUpdateTarget(operation: IndexerMaintenanceOperation) {
+  return {
+    gameName: operation.gameName,
+    recordPath: operation.recordPath,
+  };
 }
 
 function resolveTierForOperation(operation: IndexerMaintenanceOperation): IndexerTier {
@@ -457,25 +338,6 @@ function resolveTierForOperation(operation: IndexerMaintenanceOperation): Indexe
   }
 
   return operation.tier;
-}
-
-function resolveCurrentArtifacts(run: IndexerMaintenanceRunRecord, operation: IndexerMaintenanceOperation) {
-  if (!run) {
-    return {};
-  }
-
-  switch (run.kind) {
-    case "game":
-      return run.artifacts;
-    case "series":
-    case "rotation": {
-      const matchingGame = run.summary.games.find((game) => game.gameName === operation.gameName);
-      if (!matchingGame) {
-        throw new Error(`Could not find ${operation.gameName} in ${operation.recordPath}`);
-      }
-      return matchingGame.artifacts;
-    }
-  }
 }
 
 function buildRunStoreCommitMessage(operation: IndexerMaintenanceOperation) {
@@ -564,39 +426,30 @@ async function recordUpdatedMaintenanceIndex(
   }
 }
 
-async function applyOperationToRun(
-  run: IndexerMaintenanceRunRecord,
-  operation: IndexerMaintenanceOperation,
-): Promise<{
-  run: IndexerMaintenanceRunRecord;
+async function runIndexerMaintenanceOperation(operation: IndexerMaintenanceOperation): Promise<{
+  update?: IndexerMaintenanceRunUpdate;
   result: IndexerMaintenanceResult;
 }> {
   if (operation.action === "inspect-account") {
-    return applyInspectAccountOperation(run, operation);
+    return runInspectAccountOperation(operation);
   }
 
   if (operation.action === "inspect") {
-    return applyInspectOperationToRun(run, operation);
+    return runInspectOperation(operation);
   }
 
   if (operation.action === "create") {
-    return applyCreateOperationToRun(run, operation);
+    return runCreateOperation(operation);
   }
 
-  return operation.action === "delete"
-    ? applyDeleteOperationToRun(run, operation)
-    : applyTierOperationToRun(run, operation);
+  return operation.action === "delete" ? runDeleteOperation(operation) : runTierOperation(operation);
 }
 
-async function applyInspectAccountOperation(
-  run: IndexerMaintenanceRunRecord,
-  operation: IndexerMaintenanceOperation,
-): Promise<{
-  run: IndexerMaintenanceRunRecord;
+async function runInspectAccountOperation(operation: IndexerMaintenanceOperation): Promise<{
+  update?: IndexerMaintenanceRunUpdate;
   result: IndexerMaintenanceResult;
 }> {
   return {
-    run,
     result: {
       operation,
       outcome: "inspected",
@@ -605,11 +458,8 @@ async function applyInspectAccountOperation(
   };
 }
 
-async function applyInspectOperationToRun(
-  run: IndexerMaintenanceRunRecord,
-  operation: IndexerMaintenanceOperation,
-): Promise<{
-  run: IndexerMaintenanceRunRecord;
+async function runInspectOperation(operation: IndexerMaintenanceOperation): Promise<{
+  update: RefreshIndexerMaintenanceRunUpdate;
   result: IndexerMaintenanceResult;
 }> {
   const gameName = operation.gameName!;
@@ -617,10 +467,9 @@ async function applyInspectOperationToRun(
     onProgress: (message) => console.error(message),
   });
   const message = buildIndexerInspectedMessage(gameName, liveState);
-  const nextArtifacts = buildRefreshedArtifacts(resolveCurrentArtifacts(run, operation), liveState);
 
   return {
-    run: updateRunRecordForSuccess(run, operation, message, nextArtifacts),
+    update: buildRefreshRunUpdate(operation, message, liveState),
     result: {
       operation,
       outcome: "inspected",
@@ -630,11 +479,8 @@ async function applyInspectOperationToRun(
   };
 }
 
-async function applyCreateOperationToRun(
-  run: IndexerMaintenanceRunRecord,
-  operation: IndexerMaintenanceOperation,
-): Promise<{
-  run: IndexerMaintenanceRunRecord;
+async function runCreateOperation(operation: IndexerMaintenanceOperation): Promise<{
+  update: RefreshIndexerMaintenanceRunUpdate;
   result: IndexerMaintenanceResult;
 }> {
   const gameName = operation.gameName!;
@@ -653,10 +499,9 @@ async function applyCreateOperationToRun(
       createdIndexer.action === "already-live"
         ? buildIndexerAlreadyLiveMessage(gameName)
         : buildIndexerCreatedMessage(gameName);
-    const nextArtifacts = buildRefreshedArtifacts(resolveCurrentArtifacts(run, operation), createdIndexer.liveState);
 
     return {
-      run: updateRunRecordForSuccess(run, operation, message, nextArtifacts),
+      update: buildRefreshRunUpdate(operation, message, createdIndexer.liveState),
       result: {
         operation,
         outcome: createdIndexer.action === "already-live" ? "already-live" : "created",
@@ -671,10 +516,9 @@ async function applyCreateOperationToRun(
     });
     const errorMessage = error instanceof Error ? error.message : String(error);
     const message = buildFailureMessage(operation, errorMessage);
-    const nextArtifacts = buildRefreshedArtifacts(resolveCurrentArtifacts(run, operation), liveState);
 
     return {
-      run: updateRunRecordForFailure(run, operation, message, nextArtifacts),
+      update: buildRefreshRunUpdate(operation, message, liveState),
       result: {
         operation,
         outcome: "failed",
@@ -685,11 +529,8 @@ async function applyCreateOperationToRun(
   }
 }
 
-async function applyTierOperationToRun(
-  run: IndexerMaintenanceRunRecord,
-  operation: IndexerMaintenanceOperation,
-): Promise<{
-  run: IndexerMaintenanceRunRecord;
+async function runTierOperation(operation: IndexerMaintenanceOperation): Promise<{
+  update: TierSuccessIndexerMaintenanceRunUpdate | TierFailureIndexerMaintenanceRunUpdate;
   result: IndexerMaintenanceResult;
 }> {
   const tier = resolveTierForOperation(operation);
@@ -704,16 +545,9 @@ async function applyTierOperationToRun(
         ? `Torii deployment "${operation.gameName}" does not exist`
         : liveState.describeError || `Unable to verify the Torii deployment state for "${operation.gameName}"`;
     const message = buildFailureMessage(operation, errorMessage);
-    const nextArtifacts = buildTierFailureArtifacts(
-      resolveCurrentArtifacts(run, operation),
-      tier,
-      failedAt,
-      errorMessage,
-      liveState,
-    );
 
     return {
-      run: updateRunRecordForFailure(run, operation, message, nextArtifacts),
+      update: buildTierFailureRunUpdate(operation, message, tier, failedAt, errorMessage, liveState),
       result: {
         operation,
         outcome: "failed",
@@ -724,9 +558,8 @@ async function applyTierOperationToRun(
 
   if (liveState.currentTier === tier) {
     const message = buildAlreadyMatchedMessage(operation.gameName, tier);
-    const nextArtifacts = buildTierSuccessArtifacts(resolveCurrentArtifacts(run, operation), tier, liveState);
     return {
-      run: updateRunRecordForSuccess(run, operation, message, nextArtifacts),
+      update: buildTierSuccessRunUpdate(operation, message, tier, liveState),
       result: {
         operation,
         outcome: "tier-already-matched",
@@ -742,14 +575,9 @@ async function applyTierOperationToRun(
     onProgress: (message) => console.error(message),
   });
   const message = buildTierUpdatedMessage(operation.gameName, updatedIndexer.previousTier, tier);
-  const nextArtifacts = buildTierSuccessArtifacts(
-    resolveCurrentArtifacts(run, operation),
-    tier,
-    updatedIndexer.liveState,
-  );
 
   return {
-    run: updateRunRecordForSuccess(run, operation, message, nextArtifacts),
+    update: buildTierSuccessRunUpdate(operation, message, tier, updatedIndexer.liveState),
     result: {
       operation,
       outcome: "tier-updated",
@@ -760,14 +588,10 @@ async function applyTierOperationToRun(
   };
 }
 
-async function applyDeleteOperationToRun(
-  run: IndexerMaintenanceRunRecord,
-  operation: IndexerMaintenanceOperation,
-): Promise<{
-  run: IndexerMaintenanceRunRecord;
+async function runDeleteOperation(operation: IndexerMaintenanceOperation): Promise<{
+  update: DeleteSuccessIndexerMaintenanceRunUpdate | DeleteFailureIndexerMaintenanceRunUpdate;
   result: IndexerMaintenanceResult;
 }> {
-  const currentArtifacts = resolveCurrentArtifacts(run, operation);
   const currentState = resolveSlotToriiLiveState(operation.gameName, {
     onProgress: (message) => console.error(message),
   });
@@ -776,10 +600,9 @@ async function applyDeleteOperationToRun(
     const errorMessage =
       currentState.describeError || `Unable to verify the Torii deployment state for "${operation.gameName}"`;
     const message = buildFailureMessage(operation, errorMessage);
-    const nextArtifacts = buildDeleteFailureArtifacts(currentArtifacts, currentState);
 
     return {
-      run: updateRunRecordForFailure(run, operation, message, nextArtifacts),
+      update: buildDeleteFailureRunUpdate(operation, message, currentState),
       result: {
         operation,
         outcome: "failed",
@@ -796,10 +619,9 @@ async function applyDeleteOperationToRun(
 
     if (deleteResult.action === "already-missing") {
       const message = buildIndexerAlreadyMissingMessage(operation.gameName);
-      const nextArtifacts = buildDeleteSuccessArtifacts(currentArtifacts, deleteResult.liveState);
 
       return {
-        run: updateRunRecordForSuccess(run, operation, message, nextArtifacts),
+        update: buildDeleteSuccessRunUpdate(operation, message, deleteResult.liveState),
         result: {
           operation,
           outcome: "already-missing",
@@ -810,10 +632,9 @@ async function applyDeleteOperationToRun(
     }
 
     const message = buildIndexerDeletedMessage(operation.gameName);
-    const nextArtifacts = buildDeleteSuccessArtifacts(currentArtifacts, deleteResult.liveState);
 
     return {
-      run: updateRunRecordForSuccess(run, operation, message, nextArtifacts),
+      update: buildDeleteSuccessRunUpdate(operation, message, deleteResult.liveState),
       result: {
         operation,
         outcome: "deleted",
@@ -827,10 +648,9 @@ async function applyDeleteOperationToRun(
     });
     const errorMessage = error instanceof Error ? error.message : String(error);
     const message = buildFailureMessage(operation, errorMessage);
-    const nextArtifacts = buildDeleteFailureArtifacts(currentArtifacts, failedState);
 
     return {
-      run: updateRunRecordForFailure(run, operation, message, nextArtifacts),
+      update: buildDeleteFailureRunUpdate(operation, message, failedState),
       result: {
         operation,
         outcome: "failed",
@@ -854,26 +674,57 @@ async function processOperationGroup(
     return removeStaleRunMaintenanceIndexEntry(config, operations);
   }
 
-  let nextRun: IndexerMaintenanceRunRecord = currentRun;
   const results: IndexerMaintenanceResult[] = [];
+  const updates: IndexerMaintenanceRunUpdate[] = [];
 
   for (const operation of operations) {
-    const applied = await applyOperationToRun(nextRun, operation);
-    nextRun = applied.run;
+    const applied = await runIndexerMaintenanceOperation(operation);
+    if (applied.update) {
+      updates.push(applied.update);
+    }
     results.push(applied.result);
   }
 
-  if (recordPath && nextRun) {
-    await updateGitHubBranchJsonFile<Exclude<IndexerMaintenanceRunRecord, null>>(
+  if (recordPath && currentRun) {
+    const nextRun = await updateGitHubBranchJsonFile<Exclude<IndexerMaintenanceRunRecord, null>>(
       config,
       recordPath,
-      () => nextRun as Exclude<IndexerMaintenanceRunRecord, null>,
+      (latestRun) => {
+        if (!latestRun) {
+          throw new Error(`Could not find run record at ${recordPath}`);
+        }
+
+        return applyIndexerMaintenanceRunUpdates(latestRun, updates) as Exclude<IndexerMaintenanceRunRecord, null>;
+      },
       buildRunStoreCommitMessage(operations[operations.length - 1]!),
     );
+
     await recordUpdatedMaintenanceIndex(config, nextRun);
   }
 
   return results;
+}
+
+export async function runIndexerMaintenance(args: IndexerMaintenanceCliArgs) {
+  const config = requireGitHubBranchStoreConfig();
+  const groupedOperations = groupOperationsByRecordPath(args.operations);
+  const results: IndexerMaintenanceResult[] = [];
+
+  for (const [groupKey, operations] of groupedOperations.entries()) {
+    const operationResults = await processOperationGroup(config, groupKey, operations);
+    results.push(...operationResults);
+  }
+
+  await updateLiveIndexerSnapshots(config, args.operations);
+  writeWorkflowSummary(results);
+}
+
+async function main() {
+  await runIndexerMaintenance(resolveCliArgs());
+}
+
+if (import.meta.main) {
+  await main();
 }
 
 function resolveSummaryTargetName(result: IndexerMaintenanceResult) {
@@ -952,20 +803,3 @@ async function updateLiveIndexerSnapshots(
     `factory-runs: refresh live indexer states for ${gameNames.join(", ")}`,
   );
 }
-
-async function main() {
-  const args = resolveCliArgs();
-  const config = requireGitHubBranchStoreConfig();
-  const groupedOperations = groupOperationsByRecordPath(args.operations);
-  const results: IndexerMaintenanceResult[] = [];
-
-  for (const [groupKey, operations] of groupedOperations.entries()) {
-    const operationResults = await processOperationGroup(config, groupKey, operations);
-    results.push(...operationResults);
-  }
-
-  await updateLiveIndexerSnapshots(config, args.operations);
-  writeWorkflowSummary(results);
-}
-
-await main();

--- a/config/deployer/clean/run-store/indexer-maintenance-updates.ts
+++ b/config/deployer/clean/run-store/indexer-maintenance-updates.ts
@@ -1,0 +1,241 @@
+import { resolveIndexerArtifactState, resolveSlotToriiLiveState } from "../indexing/slot-torii";
+import type { IndexerTier, SeriesLaunchGameArtifacts, SeriesLaunchGameSummary } from "../types";
+import type { FactoryRotationRunRecord, FactoryRunArtifacts, FactoryRunRecord, FactorySeriesRunRecord } from "./types";
+
+type SlotToriiLiveState = ReturnType<typeof resolveSlotToriiLiveState>;
+type IndexerMaintenanceRunRecord = FactoryRunRecord | FactorySeriesRunRecord | FactoryRotationRunRecord | null;
+
+interface IndexerMaintenanceRunTarget {
+  gameName?: string;
+  recordPath?: string;
+}
+
+interface BaseIndexerMaintenanceRunUpdate {
+  target: IndexerMaintenanceRunTarget;
+  message: string;
+  updatedAt: string;
+}
+
+export interface RefreshIndexerMaintenanceRunUpdate extends BaseIndexerMaintenanceRunUpdate {
+  kind: "refresh";
+  liveState: SlotToriiLiveState;
+}
+
+export interface TierSuccessIndexerMaintenanceRunUpdate extends BaseIndexerMaintenanceRunUpdate {
+  kind: "tier-success";
+  tier: IndexerTier;
+  liveState: SlotToriiLiveState;
+}
+
+export interface TierFailureIndexerMaintenanceRunUpdate extends BaseIndexerMaintenanceRunUpdate {
+  kind: "tier-failure";
+  tier: IndexerTier;
+  failedAt: string;
+  errorMessage: string;
+  liveState: SlotToriiLiveState;
+}
+
+export interface DeleteSuccessIndexerMaintenanceRunUpdate extends BaseIndexerMaintenanceRunUpdate {
+  kind: "delete-success";
+  liveState: SlotToriiLiveState;
+}
+
+export interface DeleteFailureIndexerMaintenanceRunUpdate extends BaseIndexerMaintenanceRunUpdate {
+  kind: "delete-failure";
+  liveState: SlotToriiLiveState;
+}
+
+export type IndexerMaintenanceRunUpdate =
+  | RefreshIndexerMaintenanceRunUpdate
+  | TierSuccessIndexerMaintenanceRunUpdate
+  | TierFailureIndexerMaintenanceRunUpdate
+  | DeleteSuccessIndexerMaintenanceRunUpdate
+  | DeleteFailureIndexerMaintenanceRunUpdate;
+
+export function applyIndexerMaintenanceRunUpdates(
+  run: IndexerMaintenanceRunRecord,
+  updates: IndexerMaintenanceRunUpdate[],
+): IndexerMaintenanceRunRecord {
+  return updates.reduce<IndexerMaintenanceRunRecord>(
+    (currentRun, update) => applyIndexerMaintenanceRunUpdate(currentRun, update),
+    run,
+  );
+}
+
+export function applyIndexerMaintenanceRunUpdate(
+  run: IndexerMaintenanceRunRecord,
+  update: IndexerMaintenanceRunUpdate,
+): IndexerMaintenanceRunRecord {
+  if (!run) {
+    return null;
+  }
+
+  switch (run.kind) {
+    case "game":
+      return {
+        ...run,
+        updatedAt: update.updatedAt,
+        artifacts: buildNextArtifacts(run.artifacts, update) as FactoryRunArtifacts,
+      } satisfies FactoryRunRecord;
+    case "series":
+      return {
+        ...run,
+        updatedAt: update.updatedAt,
+        summary: {
+          ...run.summary,
+          games: updateSeriesLikeGame(run.summary.games, update, (game) => ({
+            ...game,
+            latestEvent: update.message,
+            artifacts: buildNextArtifacts(game.artifacts, update) as SeriesLaunchGameArtifacts,
+          })),
+        },
+      } satisfies FactorySeriesRunRecord;
+    case "rotation":
+      return {
+        ...run,
+        updatedAt: update.updatedAt,
+        summary: {
+          ...run.summary,
+          games: updateSeriesLikeGame(run.summary.games, update, (game) => ({
+            ...game,
+            latestEvent: update.message,
+            artifacts: buildNextArtifacts(game.artifacts, update) as SeriesLaunchGameArtifacts,
+          })),
+        },
+      } satisfies FactoryRotationRunRecord;
+  }
+}
+
+function buildNextArtifacts(
+  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  update: IndexerMaintenanceRunUpdate,
+): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
+  switch (update.kind) {
+    case "refresh":
+      return buildRefreshedArtifacts(currentArtifacts, update.liveState);
+    case "tier-success":
+      return buildTierSuccessArtifacts(currentArtifacts, update.tier, update.liveState);
+    case "tier-failure":
+      return buildTierFailureArtifacts(
+        currentArtifacts,
+        update.tier,
+        update.failedAt,
+        update.errorMessage,
+        update.liveState,
+      );
+    case "delete-success":
+      return buildDeleteSuccessArtifacts(currentArtifacts, update.liveState);
+    case "delete-failure":
+      return buildDeleteFailureArtifacts(currentArtifacts, update.liveState);
+  }
+}
+
+function buildRefreshedArtifacts(
+  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  liveState: SlotToriiLiveState,
+): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
+  return {
+    ...currentArtifacts,
+    ...resolveIndexerArtifactState(liveState),
+    pendingIndexerTierTarget: liveState.state === "existing" ? undefined : currentArtifacts.pendingIndexerTierTarget,
+    pendingIndexerTierRequestedAt:
+      liveState.state === "existing" ? undefined : currentArtifacts.pendingIndexerTierRequestedAt,
+    lastIndexerTierDispatchTarget:
+      liveState.state === "existing" ? undefined : currentArtifacts.lastIndexerTierDispatchTarget,
+    lastIndexerTierDispatchFailedAt:
+      liveState.state === "existing" ? undefined : currentArtifacts.lastIndexerTierDispatchFailedAt,
+    lastIndexerTierDispatchError:
+      liveState.state === "existing" ? undefined : currentArtifacts.lastIndexerTierDispatchError,
+  };
+}
+
+function buildTierSuccessArtifacts(
+  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  tier: IndexerTier,
+  liveState: SlotToriiLiveState,
+): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
+  return {
+    ...currentArtifacts,
+    ...resolveIndexerArtifactState(liveState, { fallbackTier: tier }),
+    pendingIndexerTierTarget: undefined,
+    pendingIndexerTierRequestedAt: undefined,
+    lastIndexerTierDispatchTarget: undefined,
+    lastIndexerTierDispatchFailedAt: undefined,
+    lastIndexerTierDispatchError: undefined,
+  };
+}
+
+function buildTierFailureArtifacts(
+  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  tier: IndexerTier,
+  failedAt: string,
+  errorMessage: string,
+  liveState: SlotToriiLiveState,
+): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
+  return {
+    ...currentArtifacts,
+    ...resolveIndexerArtifactState(liveState),
+    pendingIndexerTierTarget: tier,
+    pendingIndexerTierRequestedAt: failedAt,
+    lastIndexerTierDispatchTarget: tier,
+    lastIndexerTierDispatchFailedAt: failedAt,
+    lastIndexerTierDispatchError: errorMessage,
+  };
+}
+
+function buildDeleteSuccessArtifacts(
+  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  liveState: SlotToriiLiveState,
+): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
+  return {
+    ...currentArtifacts,
+    ...resolveIndexerArtifactState(liveState),
+    indexerCreated: false,
+    indexerTier: undefined,
+    indexerUrl: undefined,
+    indexerVersion: undefined,
+    indexerBranch: undefined,
+    pendingIndexerTierTarget: undefined,
+    pendingIndexerTierRequestedAt: undefined,
+    lastIndexerTierDispatchTarget: undefined,
+    lastIndexerTierDispatchFailedAt: undefined,
+    lastIndexerTierDispatchError: undefined,
+  };
+}
+
+function buildDeleteFailureArtifacts(
+  currentArtifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+  liveState: SlotToriiLiveState,
+): FactoryRunArtifacts | SeriesLaunchGameArtifacts {
+  return {
+    ...currentArtifacts,
+    ...resolveIndexerArtifactState(liveState),
+    pendingIndexerTierTarget: undefined,
+    pendingIndexerTierRequestedAt: undefined,
+    lastIndexerTierDispatchTarget: undefined,
+    lastIndexerTierDispatchFailedAt: undefined,
+    lastIndexerTierDispatchError: undefined,
+  };
+}
+
+function updateSeriesLikeGame(
+  games: SeriesLaunchGameSummary[],
+  update: IndexerMaintenanceRunUpdate,
+  updateGame: (game: SeriesLaunchGameSummary) => SeriesLaunchGameSummary,
+) {
+  let didUpdate = false;
+  const nextGames = games.map((game) => {
+    if (game.gameName !== update.target.gameName) {
+      return game;
+    }
+
+    didUpdate = true;
+    return updateGame(game);
+  });
+
+  if (!didUpdate) {
+    throw new Error(`Could not find ${update.target.gameName} in ${update.target.recordPath}`);
+  }
+
+  return nextGames;
+}

--- a/config/deployer/clean/tests/indexer-maintenance-updates.test.ts
+++ b/config/deployer/clean/tests/indexer-maintenance-updates.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { applyIndexerMaintenanceRunUpdates } from "../run-store/indexer-maintenance-updates";
+import type { FactoryRotationRunRecord } from "../run-store/types";
+
+describe("indexer maintenance run updates", () => {
+  test("updates only the targeted rotation child and preserves fresher sibling state", () => {
+    const run = buildRotationRunRecord();
+
+    const nextRun = applyIndexerMaintenanceRunUpdates(run, [
+      {
+        kind: "tier-success",
+        target: {
+          gameName: "bltz-warzone-05",
+          recordPath: "runs/mainnet/blitz/rotations/bltz-warzone.json",
+        },
+        message: "Indexer tier updated basic -> pro for bltz-warzone-05",
+        updatedAt: "2026-03-25T14:32:40.000Z",
+        tier: "pro",
+        liveState: {
+          state: "existing",
+          currentTier: "pro",
+          url: "https://api.cartridge.gg/x/bltz-warzone-05/torii",
+          version: "v1.8.15",
+          branch: "main",
+          describedAt: "2026-03-25T14:32:40.000Z",
+          stateSource: "describe",
+        },
+      },
+    ]);
+
+    expect(nextRun?.kind).toBe("rotation");
+
+    const updatedGames = (nextRun as FactoryRotationRunRecord).summary.games;
+    const updatedWarzone05 = updatedGames.find((game) => game.gameName === "bltz-warzone-05");
+    const preservedWarzone10 = updatedGames.find((game) => game.gameName === "bltz-warzone-10");
+
+    expect(updatedWarzone05).toMatchObject({
+      gameName: "bltz-warzone-05",
+      latestEvent: "Indexer tier updated basic -> pro for bltz-warzone-05",
+      artifacts: {
+        indexerTier: "pro",
+        indexerUrl: "https://api.cartridge.gg/x/bltz-warzone-05/torii",
+      },
+    });
+
+    expect(preservedWarzone10).toMatchObject({
+      gameName: "bltz-warzone-10",
+      currentStepId: null,
+      latestEvent: "Create indexers succeeded",
+      status: "succeeded",
+      artifacts: {
+        indexerCreated: true,
+        indexerTier: "basic",
+        indexerUrl: "https://api.cartridge.gg/x/bltz-warzone-10/torii",
+      },
+    });
+  });
+});
+
+function buildRotationRunRecord(): FactoryRotationRunRecord {
+  return {
+    version: 1,
+    kind: "rotation",
+    runId: "rotation:mainnet.blitz:bltz-warzone",
+    environment: "mainnet.blitz",
+    chain: "mainnet",
+    gameType: "blitz",
+    rotationName: "bltz-warzone",
+    seriesName: "bltz-warzone",
+    status: "running",
+    executionMode: "fast_trial",
+    requestedLaunchStep: "full",
+    inputPath: "inputs/mainnet/blitz/rotations/bltz-warzone/1-1.json",
+    latestLaunchRequestId: "1-1",
+    currentStepId: "sync-paymaster",
+    createdAt: "2026-03-25T14:32:01.000Z",
+    updatedAt: "2026-03-25T14:32:35.000Z",
+    workflow: {
+      workflowName: "Game Launch",
+    },
+    autoRetry: {
+      enabled: true,
+      intervalMinutes: 15,
+    },
+    evaluation: {
+      intervalMinutes: 5,
+    },
+    steps: [],
+    summary: {
+      environment: "mainnet.blitz",
+      chain: "mainnet",
+      gameType: "blitz",
+      rotationName: "bltz-warzone",
+      seriesName: "bltz-warzone",
+      firstGameStartTime: 1774504800,
+      firstGameStartTimeIso: "2026-03-25T06:00:00.000Z",
+      gameIntervalMinutes: 120,
+      maxGames: 12,
+      advanceWindowGames: 3,
+      evaluationIntervalMinutes: 5,
+      rpcUrl: "https://rpc.example",
+      factoryAddress: "0x123",
+      autoRetryEnabled: true,
+      autoRetryIntervalMinutes: 15,
+      dryRun: false,
+      configMode: "batched",
+      seriesCreated: true,
+      games: [
+        {
+          gameName: "bltz-warzone-05",
+          startTime: 1774519200,
+          startTimeIso: "2026-03-25T10:00:00.000Z",
+          durationSeconds: 3600,
+          seriesGameNumber: 5,
+          currentStepId: "create-indexers",
+          latestEvent: "Create indexers succeeded",
+          status: "succeeded",
+          configSteps: [],
+          steps: [],
+          artifacts: {
+            indexerCreated: true,
+            indexerTier: "basic",
+            indexerUrl: "https://api.cartridge.gg/x/bltz-warzone-05/torii",
+          },
+        },
+        {
+          gameName: "bltz-warzone-10",
+          startTime: 1774537200,
+          startTimeIso: "2026-03-26T15:00:00.000Z",
+          durationSeconds: 3600,
+          seriesGameNumber: 10,
+          currentStepId: null,
+          latestEvent: "Create indexers succeeded",
+          status: "succeeded",
+          configSteps: [],
+          steps: [],
+          artifacts: {
+            indexerCreated: true,
+            indexerTier: "basic",
+            indexerUrl: "https://api.cartridge.gg/x/bltz-warzone-10/torii",
+          },
+        },
+      ],
+    },
+    artifacts: {
+      summaryPath: "runs/mainnet/blitz/rotations/bltz-warzone.summary.json",
+      seriesCreated: true,
+    },
+  };
+}


### PR DESCRIPTION
This fixes the stale run-store overwrite we saw on grouped indexer maintenance.

The problem was that indexer maintenance would read a series or rotation run once, perform a Slot action for one game, and then write a precomputed parent record back to `factory-runs`. If another workflow advanced a sibling game in the meantime, that later maintenance write could reintroduce stale sibling state.

This changes the maintenance path to work from fresh remote state at write time:
- keep the Slot side effects in the CLI flow
- record the result as a child-level maintenance update
- apply those updates inside the final `updateGitHubBranchJsonFile(...)` callback against the latest remote run record
- patch only the targeted child game for series and rotation records

I also added a focused regression that proves a later maintenance update for one rotation child preserves fresher sibling state.

Verification:
- `pnpm run format`
- `bun test config/deployer/clean/tests/indexer-maintenance-updates.test.ts`
- `bun config/deployer/clean/cli/indexer-maintenance.ts --help`
- `pnpm run knip`

Not tested:
- a live end-to-end maintenance workflow run against GitHub Actions and `factory-runs`
