### PR TITLE
feat(game): overhaul MMR leaderboard UX

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/mmr-leaderboard.tsx
+++ b/client/apps/game/src/ui/features/landing/components/mmr-leaderboard.tsx
@@ -381,10 +381,7 @@ const shortAddr = (address: string): string => {
 };
 
 /** Fetch controller usernames from the Torii SQL controllers table */
-const fetchControllerUsernames = async (
-  toriiBaseUrl: string,
-  addresses: string[],
-): Promise<Map<string, string>> => {
+const fetchControllerUsernames = async (toriiBaseUrl: string, addresses: string[]): Promise<Map<string, string>> => {
   const map = new Map<string, string>();
   if (!toriiBaseUrl || addresses.length === 0) return map;
 
@@ -573,9 +570,7 @@ const PodiumCard = ({
       />
       <div className="flex items-center gap-1.5">
         <span className="text-sm font-medium text-gold">{displayName}</span>
-        {isCurrentUser && (
-          <span className="rounded bg-gold/20 px-1.5 py-0.5 text-[10px] font-bold text-gold">You</span>
-        )}
+        {isCurrentUser && <span className="rounded bg-gold/20 px-1.5 py-0.5 text-[10px] font-bold text-gold">You</span>}
       </div>
       <MMRTierBadge tier={tier} size="md" />
       <span className="text-lg font-bold text-gold">{formatMMR(entry.newMmr)}</span>
@@ -1085,7 +1080,9 @@ export const MMRLeaderboard = () => {
                                 className="h-8 w-8 rounded-full border border-gold/20 object-cover"
                                 loading="lazy"
                               />
-                              <span className="font-medium text-gold">{usernameMap.get(entry.address) ?? shortAddr(entry.address)}</span>
+                              <span className="font-medium text-gold">
+                                {usernameMap.get(entry.address) ?? shortAddr(entry.address)}
+                              </span>
                               {isUser && (
                                 <span className="rounded bg-gold/20 px-1.5 py-0.5 text-[10px] font-bold text-gold">
                                   You
@@ -1113,9 +1110,7 @@ export const MMRLeaderboard = () => {
                             {formatEventTimestamp(entry.updatedAtSeconds)}
                           </td>
                         </tr>
-                        {isExpanded && (
-                          <ExpandedRowDetail entry={entry} />
-                        )}
+                        {isExpanded && <ExpandedRowDetail entry={entry} />}
                       </Fragment>
                     );
                   })}

--- a/client/apps/game/src/ui/features/landing/views/score-to-beat-panel.tsx
+++ b/client/apps/game/src/ui/features/landing/views/score-to-beat-panel.tsx
@@ -218,10 +218,7 @@ const ScoreBar = ({ score, maxScore }: { score: number; maxScore: number }) => {
   const pct = maxScore > 0 ? Math.min(100, Math.round((score / maxScore) * 100)) : 0;
   return (
     <div className="h-1 w-full overflow-hidden rounded-full bg-gold/10">
-      <div
-        className="h-full rounded-full bg-gold/40 transition-all duration-500"
-        style={{ width: `${pct}%` }}
-      />
+      <div className="h-full rounded-full bg-gold/40 transition-all duration-500" style={{ width: `${pct}%` }} />
     </div>
   );
 };
@@ -282,7 +279,9 @@ const ScorePodiumCard = ({
       />
       <span className="mt-1 text-sm font-medium text-gold">{displayName}</span>
       <span className={`font-bold text-gold ${config.scoreSize}`}>{formatPoints(combinedPoints)}</span>
-      <span className="text-[10px] text-gold/40">{runsCount} {runsCount === 1 ? "run" : "runs"}</span>
+      <span className="text-[10px] text-gold/40">
+        {runsCount} {runsCount === 1 ? "run" : "runs"}
+      </span>
     </div>
   );
 };
@@ -292,7 +291,11 @@ const ExpandedRowDetail = ({
   entry,
   colSpan,
 }: {
-  entry: { address: string; runs: Array<{ endpoint: string; points: number }>; allRuns: Array<{ endpoint: string; points: number }> };
+  entry: {
+    address: string;
+    runs: Array<{ endpoint: string; points: number }>;
+    allRuns: Array<{ endpoint: string; points: number }>;
+  };
   colSpan: number;
 }) => {
   const [copied, setCopied] = useState(false);
@@ -314,10 +317,7 @@ const ExpandedRowDetail = ({
   }, [entry.allRuns]);
 
   // The best run endpoints for highlighting
-  const bestEndpoints = useMemo(
-    () => new Set(entry.runs.map((r) => describeEndpoint(r.endpoint))),
-    [entry.runs],
-  );
+  const bestEndpoints = useMemo(() => new Set(entry.runs.map((r) => describeEndpoint(r.endpoint))), [entry.runs]);
 
   return (
     <tr>
@@ -348,9 +348,7 @@ const ExpandedRowDetail = ({
                       <span
                         key={gameName}
                         className={`rounded px-2 py-1 text-xs ${
-                          isBest
-                            ? "border border-gold/20 bg-gold/15 text-gold"
-                            : "bg-gold/5 text-gold/50"
+                          isBest ? "border border-gold/20 bg-gold/15 text-gold" : "bg-gold/5 text-gold/50"
                         }`}
                       >
                         {gameName}: {formatPoints(score)}
@@ -707,9 +705,7 @@ export const ScoreToBeatPanel = () => {
                 loading="lazy"
               />
               <div>
-                <p className="text-lg font-semibold text-gold">
-                  {(topScoreToBeatLabel ?? "Unknown").trim()}
-                </p>
+                <p className="text-lg font-semibold text-gold">{(topScoreToBeatLabel ?? "Unknown").trim()}</p>
                 <p className="flex items-baseline gap-2 text-3xl font-bold text-gold">
                   {formatPoints(topScoreToBeat.combinedPoints)}
                   <span className="text-base font-normal text-gold/60">pts</span>
@@ -785,9 +781,7 @@ export const ScoreToBeatPanel = () => {
         >
           <span className="text-xs">{isGameSelectorOpen ? "\u25BE" : "\u25B8"}</span>
           <span className="font-medium">{gameLabel}</span>
-          {!isGameSelectorOpen && (
-            <span className="ml-1 text-xs text-gold/50">{collapsedSelectorSummary}</span>
-          )}
+          {!isGameSelectorOpen && <span className="ml-1 text-xs text-gold/50">{collapsedSelectorSummary}</span>}
         </button>
 
         {isGameSelectorOpen && (
@@ -1001,14 +995,14 @@ export const ScoreToBeatPanel = () => {
                               loading="lazy"
                             />
                             <div className="flex flex-col gap-1">
-                            <span className="font-medium text-gold">
-                              {entry.displayName ?? displayAddress(entry.address)}
-                            </span>
-                            {entry.displayName && (
-                              <span className="text-xs text-gold/40">{displayAddress(entry.address)}</span>
-                            )}
-                            {/* Relative score bar */}
-                            <ScoreBar score={entry.combinedPoints} maxScore={topScore} />
+                              <span className="font-medium text-gold">
+                                {entry.displayName ?? displayAddress(entry.address)}
+                              </span>
+                              {entry.displayName && (
+                                <span className="text-xs text-gold/40">{displayAddress(entry.address)}</span>
+                              )}
+                              {/* Relative score bar */}
+                              <ScoreBar score={entry.combinedPoints} maxScore={topScore} />
                             </div>
                           </div>
                         </td>
@@ -1016,9 +1010,7 @@ export const ScoreToBeatPanel = () => {
                           {formatPoints(entry.combinedPoints)}
                         </td>
                       </tr>
-                      {isExpanded && (
-                        <ExpandedRowDetail entry={entry} colSpan={3} />
-                      )}
+                      {isExpanded && <ExpandedRowDetail entry={entry} colSpan={3} />}
                     </Fragment>
                   );
                 })}


### PR DESCRIPTION
## Summary
- Adds a hero podium section for top 3 players with large avatars, gold/silver/bronze treatments, and tier badges
- Tier-colored rank badges for top 10, animated delta chips with shimmer on large MMR swings, and a progress bar per row showing distance to next tier
- Highlights the connected user's row with a "You" badge and a cross-page "Find Me" button that queries the player's rank and navigates to the correct page
- Expandable rows on click showing full address (copyable), tier progress detail, MMR change history, and relative timestamps
- Resolves player usernames directly from the Torii controllers table instead of relying on the Dojo SDK context
- Page size increased to 50 and container height increased for more visible entries

## Test plan
- [ ] Verify podium renders for top 3 on page 1 with rank sort, hides on other sorts/pages
- [ ] Verify "Find Me" navigates to the correct page and scrolls to user row
- [ ] Verify row expansion shows correct tier progress and copyable address
- [ ] Verify player usernames resolve from Torii controllers table