### PR TITLE
fix(game): refresh army stamina after tick corrections

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -56,6 +56,7 @@ import { FXManager } from "./fx-manager";
 import { PathRenderer } from "./path-renderer";
 import { PlayerIndicatorManager } from "./player-indicator-manager";
 import { resolveArmyPointLabelSize } from "./army-point-label-policy";
+import { resolveArmyStaminaTickRefresh } from "./army-stamina-tick-policy";
 import { resolvePointLabelTextureFlipY } from "./point-label-texture-policy";
 import { PointsLabelRenderer } from "./points-label-renderer";
 import { resolveArmySlotCompactionPlan } from "./army-slot-compaction";
@@ -348,8 +349,12 @@ export class ArmyManager {
   private scheduleTickCheck() {
     this.tickCheckTimeout = setTimeout(() => {
       const { currentArmiesTick } = getBlockTimestamp();
-      if (currentArmiesTick > this.lastKnownArmiesTick) {
-        this.lastKnownArmiesTick = currentArmiesTick;
+      const tickRefresh = resolveArmyStaminaTickRefresh({
+        currentTick: currentArmiesTick,
+        previousTick: this.lastKnownArmiesTick,
+      });
+      if (tickRefresh.shouldRecompute) {
+        this.lastKnownArmiesTick = tickRefresh.nextTrackedTick;
         this.recomputeStaminaForAllArmies();
       }
       // Update battle timers every second

--- a/client/apps/game/src/three/managers/army-stamina-tick-policy.test.ts
+++ b/client/apps/game/src/three/managers/army-stamina-tick-policy.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveArmyStaminaTickRefresh } from "./army-stamina-tick-policy";
+
+describe("resolveArmyStaminaTickRefresh", () => {
+  it("recomputes when the armies tick advances", () => {
+    expect(
+      resolveArmyStaminaTickRefresh({
+        currentTick: 11,
+        previousTick: 10,
+      }),
+    ).toEqual({
+      shouldRecompute: true,
+      nextTrackedTick: 11,
+    });
+  });
+
+  it("skips recompute when the armies tick is unchanged", () => {
+    expect(
+      resolveArmyStaminaTickRefresh({
+        currentTick: 11,
+        previousTick: 11,
+      }),
+    ).toEqual({
+      shouldRecompute: false,
+      nextTrackedTick: 11,
+    });
+  });
+
+  it("recomputes when the tracked tick must correct backward to chain time", () => {
+    expect(
+      resolveArmyStaminaTickRefresh({
+        currentTick: 11,
+        previousTick: 15,
+      }),
+    ).toEqual({
+      shouldRecompute: true,
+      nextTrackedTick: 11,
+    });
+  });
+});

--- a/client/apps/game/src/three/managers/army-stamina-tick-policy.ts
+++ b/client/apps/game/src/three/managers/army-stamina-tick-policy.ts
@@ -1,0 +1,20 @@
+export const resolveArmyStaminaTickRefresh = (input: { currentTick: number; previousTick: number }) => {
+  if (!Number.isFinite(input.currentTick)) {
+    return {
+      shouldRecompute: false,
+      nextTrackedTick: input.previousTick,
+    };
+  }
+
+  if (!Number.isFinite(input.previousTick)) {
+    return {
+      shouldRecompute: true,
+      nextTrackedTick: input.currentTick,
+    };
+  }
+
+  return {
+    shouldRecompute: input.currentTick !== input.previousTick,
+    nextTrackedTick: input.currentTick,
+  };
+};

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -10,6 +10,13 @@ interface LatestFeature {
 export const latestFeatures: LatestFeature[] = [
   {
     date: "2026-03-26",
+    title: "Passive Army Stamina Refresh",
+    description:
+      "Army stamina shown above units now keeps updating after chain-time corrections instead of waiting for another army action to refresh the display.",
+    type: "fix",
+  },
+  {
+    date: "2026-03-26",
     title: "Instant Explorer Map Pins",
     description:
       "Auto-Explore now enables the explorer location shortcut as soon as a new automation entry appears, instead of waiting for the next position refresh cycle.",


### PR DESCRIPTION
This fixes a worldmap-only stamina display bug where passive army recharge could stall until you triggered another action.
The root cause was the army manager only refreshing stamina when the tracked armies tick moved forward; after the client clock corrected back down to chain time, the passive recharge loop could stop updating visible unit stamina.
The fix makes the worldmap army timer refresh on any armies-tick change, including backward corrections, and adds a focused regression test for that case.
Verification: `npx -y node@20.19.0 $(which pnpm) --dir client/apps/game test -- --run src/three/managers/army-stamina-tick-policy.test.ts`, `pnpm run format`, `npx -y node@20.19.0 $(which pnpm) run knip`.