### PR TITLE
feat(game): handle structure removal via world update listener

### DIFF
--- a/client/apps/eternum-mobile/src/shared/lib/three/entity-managers/structure-manager.ts
+++ b/client/apps/eternum-mobile/src/shared/lib/three/entity-managers/structure-manager.ts
@@ -1,4 +1,10 @@
-import { ActionPaths, Position, StructureActionManager, StructureTileSystemUpdate } from "@bibliothecadao/eternum";
+import {
+  ActionPaths,
+  Position,
+  StructureActionManager,
+  StructureTileSystemUpdate,
+  StructureTileUpsertUpdate,
+} from "@bibliothecadao/eternum";
 import { DojoResult } from "@bibliothecadao/react";
 import { HexEntityInfo, ID, StructureType } from "@bibliothecadao/types";
 import * as THREE from "three";
@@ -350,12 +356,30 @@ export class StructureManager extends EntityManager<StructureObject> {
 
   // Structure-specific methods moved from HexagonMap
   public handleSystemUpdate(update: StructureTileSystemUpdate): void {
+    if (update.kind === "removed") {
+      const normalizedPreviousHex = new Position({
+        x: update.previousHexCoords.col,
+        y: update.previousHexCoords.row,
+      }).getNormalized();
+      this.structureHexes.get(normalizedPreviousHex.x)?.delete(normalizedPreviousHex.y);
+      if (this.structureHexes.get(normalizedPreviousHex.x)?.size === 0) {
+        this.structureHexes.delete(normalizedPreviousHex.x);
+      }
+      this.removeObject(update.entityId);
+
+      if (this.biomeRefreshCallback) {
+        this.biomeRefreshCallback();
+      }
+      return;
+    }
+
+    const upsert: StructureTileUpsertUpdate = update;
     const {
       hexCoords: { col, row },
       owner: { address },
       entityId,
       structureType,
-    } = update;
+    } = upsert;
 
     const normalized = new Position({ x: col, y: row }).getNormalized();
 
@@ -371,15 +395,15 @@ export class StructureManager extends EntityManager<StructureObject> {
       owner: address || 0n,
       type: "structure",
       structureType: structureType.toString(),
-      ownerName: update.owner.ownerName,
-      guildName: update.owner.guildName,
-      guardArmies: update.guardArmies,
-      activeProductions: update.activeProductions,
-      hyperstructureRealmCount: update.hyperstructureRealmCount,
-      stage: update.stage,
-      initialized: update.initialized,
-      level: update.level,
-      hasWonder: update.hasWonder,
+      ownerName: upsert.owner.ownerName,
+      guildName: upsert.owner.guildName,
+      guardArmies: upsert.guardArmies,
+      activeProductions: upsert.activeProductions,
+      hyperstructureRealmCount: upsert.hyperstructureRealmCount,
+      stage: upsert.stage,
+      initialized: upsert.initialized,
+      level: upsert.level,
+      hasWonder: upsert.hasWonder,
     };
     this.updateObject(structure);
 

--- a/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
+++ b/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/three/utils/utils", () => ({
 
 vi.mock("@/ui/config", () => ({
   FELT_CENTER: () => 0,
+  IS_FLAT_MODE: false,
 }));
 
 vi.mock("@bibliothecadao/types", () => {
@@ -57,6 +58,20 @@ vi.mock("@bibliothecadao/types", () => {
       has: () => true,
     },
   );
+});
+
+vi.mock("@bibliothecadao/eternum", () => {
+  const enumProxy = new Proxy(
+    {},
+    {
+      get: (_, key) => key,
+    },
+  );
+
+  return new Proxy({ StructureProgress: enumProxy } as Record<string, unknown>, {
+    get: (target, prop) => (prop in target ? target[prop as string] : enumProxy),
+    has: () => true,
+  });
 });
 
 vi.mock("@dojoengine/recs", () => ({
@@ -84,8 +99,11 @@ vi.mock("../cosmetics", () => ({
     hydrateFromBlitzComponent: vi.fn(),
   },
   resolveStructureCosmetic: vi.fn(() => ({
-    cosmeticId: "default",
-    registryEntry: undefined,
+    skin: {
+      cosmeticId: "default",
+      assetPaths: [],
+      isFallback: true,
+    },
     attachments: [],
   })),
   resolveStructureMountTransforms: vi.fn(() => []),
@@ -120,6 +138,11 @@ vi.mock("../utils/labels/label-pool", () => ({
 
 vi.mock("./fx-manager", () => ({
   FXManager: class MockFXManager {},
+}));
+
+vi.mock("@/three/perf/worldmap-render-diagnostics", () => ({
+  recordWorldmapRenderDuration: vi.fn(),
+  setWorldmapRenderGauge: vi.fn(),
 }));
 
 vi.mock("./manager-update-convergence", () => ({
@@ -303,6 +326,46 @@ function createOnUpdateSubject() {
   return { subject, structuresById };
 }
 
+function createRemoveStructureSubject() {
+  const subject = Object.create(StructureManager.prototype) as any;
+  const removePoint = vi.fn();
+  const removeEntityIdLabel = vi.fn();
+  const removeAttachments = vi.fn();
+  const removedStructure = {
+    entityId: 7,
+    hexCoords: { col: 10, row: 15 },
+    structureType: "Village",
+    isMine: false,
+    isAlly: false,
+  };
+
+  subject.structures = {
+    removeStructure: vi.fn(() => removedStructure),
+  };
+  subject.structureHexCoords = new Map([[10, new Set([15])]]);
+  subject.chunkToStructures = new Map([["0,0", new Set([7])]]);
+  subject.chunkStride = 24;
+  subject.removeEntityIdLabel = removeEntityIdLabel;
+  subject.attachmentManager = { removeAttachments };
+  subject.activeStructureAttachmentEntities = new Set([7]);
+  subject.structureAttachmentSignatures = new Map([[7, "sig"]]);
+  subject.structuresWithActiveBattleTimer = new Set([7]);
+  subject.wonderEntityIdMaps = new Map([[0, 7]]);
+  subject.previousVisibleIds = new Set([7]);
+  subject.pointsRenderers = { any: { removePoint } };
+  subject.getRendererForStructure = vi.fn(() => ({ removePoint }));
+  subject.isInCurrentChunk = vi.fn(() => true);
+  subject.updateVisibleStructures = vi.fn();
+  subject.frustumVisibilityDirty = false;
+
+  return {
+    subject,
+    removeAttachments,
+    removeEntityIdLabel,
+    removePoint,
+  };
+}
+
 const BASE_STRUCTURE_UPDATE = {
   entityId: 7,
   structureName: "Camp",
@@ -319,6 +382,22 @@ const BASE_STRUCTURE_UPDATE = {
 };
 
 describe("StructureManager destroy lifecycle", () => {
+  it("removes stale structure state and refreshes visible presentation when a visible structure is deleted", () => {
+    const fixture = createRemoveStructureSubject();
+
+    fixture.subject.removeStructure(7, { col: 10, row: 15 });
+
+    expect(fixture.subject.structures.removeStructure).toHaveBeenCalledWith(7);
+    expect(fixture.subject.structureHexCoords.has(10)).toBe(false);
+    expect(fixture.subject.chunkToStructures.has("0,0")).toBe(false);
+    expect(fixture.removeEntityIdLabel).toHaveBeenCalledWith(7);
+    expect(fixture.removeAttachments).toHaveBeenCalledWith(7);
+    expect(fixture.removePoint).toHaveBeenCalledWith(7);
+    expect(fixture.subject.structuresWithActiveBattleTimer.has(7)).toBe(false);
+    expect(fixture.subject.previousVisibleIds.has(7)).toBe(false);
+    expect(fixture.subject.updateVisibleStructures).toHaveBeenCalledTimes(1);
+  });
+
   it("runs a single visible-structure rebuild during chunk switches", async () => {
     const subject = Object.create(StructureManager.prototype) as any;
 

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -7,7 +7,7 @@ import { CameraView, HexagonScene } from "@/three/scenes/hexagon-scene";
 import { gltfLoader, isAddressEqualToAccount } from "@/three/utils/utils";
 import { FELT_CENTER } from "@/ui/config";
 import type { SetupResult } from "@bibliothecadao/dojo";
-import { StructureTileSystemUpdate } from "@bibliothecadao/eternum";
+import type { StructureTileUpsertUpdate } from "@bibliothecadao/eternum";
 import { BuildingType, ClientComponents, ID, StructureType } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
@@ -764,7 +764,7 @@ export class StructureManager {
     return gltfs.map((gltf) => new InstancedModel(gltf, INITIAL_STRUCTURE_CAPACITY, false, cosmeticId));
   }
 
-  async onUpdate(update: StructureTileSystemUpdate) {
+  async onUpdate(update: StructureTileUpsertUpdate) {
     // console.log("[UPDATE STRUCTURE SYSTEM ON UPDATE]", update);
     const { entityId: rawEntityId, hexCoords, structureType, stage, level, owner, hasWonder } = update;
     const entityId = normalizeEntityId(rawEntityId);
@@ -1016,6 +1016,62 @@ export class StructureManager {
 
     if (visibleUpdateMode === "rebuild" || shouldRebuildVisibleStructuresForStructureUpdate(visibleUpdateInput)) {
       this.updateVisibleStructures();
+    }
+  }
+
+  public removeStructure(entityId: ID, previousHexCoords?: { col: number; row: number }): void {
+    const normalizedEntityId = normalizeEntityId(entityId);
+    if (normalizedEntityId === undefined) {
+      return;
+    }
+
+    const removedStructure = this.structures.removeStructure(normalizedEntityId);
+    const resolvedHexCoords = removedStructure?.hexCoords ?? previousHexCoords;
+
+    if (resolvedHexCoords) {
+      const columnRows = this.structureHexCoords.get(resolvedHexCoords.col);
+      if (columnRows) {
+        columnRows.delete(resolvedHexCoords.row);
+        if (columnRows.size === 0) {
+          this.structureHexCoords.delete(resolvedHexCoords.col);
+        }
+      }
+
+      const spatialKey = this.getSpatialKey(resolvedHexCoords.col, resolvedHexCoords.row);
+      const spatialBucket = this.chunkToStructures.get(spatialKey);
+      if (spatialBucket) {
+        spatialBucket.delete(normalizedEntityId);
+        if (spatialBucket.size === 0) {
+          this.chunkToStructures.delete(spatialKey);
+        }
+      }
+    }
+
+    this.removeEntityIdLabel(normalizedEntityId);
+
+    if (this.pointsRenderers) {
+      if (removedStructure) {
+        this.getRendererForStructure(removedStructure)?.removePoint(normalizedEntityId);
+      } else {
+        Object.values(this.pointsRenderers).forEach((renderer) => renderer.removePoint(normalizedEntityId));
+      }
+    }
+
+    this.attachmentManager.removeAttachments(normalizedEntityId);
+    this.activeStructureAttachmentEntities.delete(normalizedEntityId);
+    this.structureAttachmentSignatures.delete(normalizedEntityId);
+    this.structuresWithActiveBattleTimer.delete(normalizedEntityId);
+    this.previousVisibleIds.delete(normalizedEntityId);
+    this.wonderEntityIdMaps.forEach((mappedEntityId, instanceId) => {
+      if (mappedEntityId === normalizedEntityId) {
+        this.wonderEntityIdMaps.delete(instanceId);
+      }
+    });
+
+    this.frustumVisibilityDirty = true;
+
+    if (resolvedHexCoords && this.isInCurrentChunk(resolvedHexCoords)) {
+      void this.updateVisibleStructures();
     }
   }
 

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
@@ -6,6 +6,7 @@ export type WorldmapRenderDurationMetric =
   | "updateManagersForChunk"
   | "executeRenderForChunk"
   | "performVisibleStructuresUpdate"
+  | "structureCommitMs"
   | "terrainPreparedMs"
   | "chunkTerrainReadyMs"
   | "chunkTerrainCommitMs"
@@ -32,6 +33,8 @@ export type WorldmapRenderCounter =
   | "zoomTransitionsCompleted"
   | "zoomTransitionsCancelled"
   | "terrainVisibleCommits"
+  | "structureVisibleCommits"
+  | "removedStructureUpdates"
   | "duplicateTileAuthoritativeUpdates"
   | "terrainVisibleOverlapRepairCount"
   | "terrainVisibleReplaceCount"
@@ -41,7 +44,8 @@ export type WorldmapRenderCounter =
   | "preparedChunkPrewarmHits"
   | "preparedChunkPrewarmMisses"
   | "postCommitManagerCatchUpImmediate"
-  | "postCommitManagerCatchUpDeferred";
+  | "postCommitManagerCatchUpDeferred"
+  | "structureSyncCommitFallbacks";
 
 export interface WorldmapZoomTelemetrySummary {
   controlsChangeEvents: number;
@@ -97,6 +101,7 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     updateManagersForChunk: createDurationStats(),
     executeRenderForChunk: createDurationStats(),
     performVisibleStructuresUpdate: createDurationStats(),
+    structureCommitMs: createDurationStats(),
     terrainPreparedMs: createDurationStats(),
     chunkTerrainReadyMs: createDurationStats(),
     chunkTerrainCommitMs: createDurationStats(),
@@ -129,6 +134,8 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     zoomTransitionsCompleted: 0,
     zoomTransitionsCancelled: 0,
     terrainVisibleCommits: 0,
+    structureVisibleCommits: 0,
+    removedStructureUpdates: 0,
     duplicateTileAuthoritativeUpdates: 0,
     terrainVisibleOverlapRepairCount: 0,
     terrainVisibleReplaceCount: 0,
@@ -139,6 +146,7 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     preparedChunkPrewarmMisses: 0,
     postCommitManagerCatchUpImmediate: 0,
     postCommitManagerCatchUpDeferred: 0,
+    structureSyncCommitFallbacks: 0,
   },
   forceRefreshReasons: {
     default: 0,

--- a/client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.test.ts
+++ b/client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.test.ts
@@ -19,6 +19,10 @@ describe("finalizeWarpTravelChunkSwitch", () => {
       [string, { force: boolean; transitionToken: number }],
       void
     >();
+    const commitVisibleStructures = createControlledAsyncCall<
+      [string, { box: unknown; sphere: unknown } | undefined, { force: boolean; transitionToken: number }],
+      void
+    >();
     const applyPreparedTerrain = vi.fn();
     const updatePinnedChunks = vi.fn();
     const unregisterChunk = vi.fn();
@@ -49,7 +53,7 @@ describe("finalizeWarpTravelChunkSwitch", () => {
       clearSceneChunkBounds,
       forceVisibilityUpdate,
       updateCurrentChunkBounds,
-
+      commitVisibleStructures: commitVisibleStructures.fn,
       scheduleManagerCatchUp: scheduleManagerCatchUp.fn,
       unregisterPreviousChunkOnNextFrame,
     });
@@ -65,6 +69,7 @@ describe("finalizeWarpTravelChunkSwitch", () => {
     });
     expect(applyPreparedTerrain).not.toHaveBeenCalled();
     expect(forceVisibilityUpdate).toHaveBeenCalledTimes(1);
+    expect(commitVisibleStructures.calls).toEqual([]);
     expect(scheduleManagerCatchUp.calls).toEqual([]);
     expect(clearSceneChunkBounds).not.toHaveBeenCalled();
   });
@@ -72,6 +77,10 @@ describe("finalizeWarpTravelChunkSwitch", () => {
   it("drops stale prepared chunks without committing manager updates", async () => {
     const scheduleManagerCatchUp = createControlledAsyncCall<
       [string, { force: boolean; transitionToken: number }],
+      void
+    >();
+    const commitVisibleStructures = createControlledAsyncCall<
+      [string, { box: unknown; sphere: unknown } | undefined, { force: boolean; transitionToken: number }],
       void
     >();
     const applyPreparedTerrain = vi.fn();
@@ -99,7 +108,7 @@ describe("finalizeWarpTravelChunkSwitch", () => {
       clearSceneChunkBounds: vi.fn(),
       forceVisibilityUpdate: vi.fn(),
       updateCurrentChunkBounds: vi.fn(),
-
+      commitVisibleStructures: commitVisibleStructures.fn,
       scheduleManagerCatchUp: scheduleManagerCatchUp.fn,
       unregisterPreviousChunkOnNextFrame: vi.fn(),
     });
@@ -109,11 +118,16 @@ describe("finalizeWarpTravelChunkSwitch", () => {
     });
     expect(applyPreparedTerrain).not.toHaveBeenCalled();
     expect(unregisterChunk).toHaveBeenCalledWith("24,24");
+    expect(commitVisibleStructures.calls).toEqual([]);
     expect(scheduleManagerCatchUp.calls).toEqual([]);
   });
 
-  it("commits prepared terrain before deferred manager catch-up completes", async () => {
+  it("commits visible structures before terrain and deferred manager catch-up completes", async () => {
     const managerCatchUp = createControlledAsyncCall<[string, { force: boolean; transitionToken: number }], void>();
+    const commitVisibleStructures = createControlledAsyncCall<
+      [string, { box: unknown; sphere: unknown } | undefined, { force: boolean; transitionToken: number }],
+      void
+    >();
     const phaseOrder: string[] = [];
     const applyPreparedTerrain = vi.fn(() => {
       phaseOrder.push("terrain");
@@ -156,19 +170,34 @@ describe("finalizeWarpTravelChunkSwitch", () => {
         phaseOrder.push(`bounds:${startRow},${startCol}`);
         updateCurrentChunkBounds(startRow, startCol);
       }),
+      commitVisibleStructures: vi.fn(
+        async (
+          ...args: [string, { box: unknown; sphere: unknown } | undefined, { force: boolean; transitionToken: number }]
+        ) => {
+          phaseOrder.push("structures");
+          return commitVisibleStructures.fn(...args);
+        },
+      ),
       scheduleManagerCatchUp,
       unregisterPreviousChunkOnNextFrame,
     });
 
+    expect(commitVisibleStructures.calls).toEqual([["24,24", undefined, { force: true, transitionToken: 17 }]]);
+    expect(applyPreparedTerrain).not.toHaveBeenCalled();
+    commitVisibleStructures.resolveNext();
+    await resultPromise;
     expect(updateCurrentChunkBounds).toHaveBeenCalledWith(24, 24);
     expect(forceVisibilityUpdate).toHaveBeenCalledTimes(1);
     expect(scheduleManagerCatchUp).toHaveBeenCalledWith("24,24", { force: true, transitionToken: 17 });
     expect(managerCatchUp.calls).toEqual([["24,24", { force: true, transitionToken: 17 }]]);
-    expect(phaseOrder).toEqual(["authority", "terrain", "bounds:24,24", "visibility", "manager-scheduled"]);
-    await expect(resultPromise).resolves.toEqual({
-      status: "committed",
-    });
-
+    expect(phaseOrder).toEqual([
+      "authority",
+      "structures",
+      "terrain",
+      "bounds:24,24",
+      "visibility",
+      "manager-scheduled",
+    ]);
     managerCatchUp.resolveNext();
     await Promise.resolve();
     expect(unregisterPreviousChunkOnNextFrame).toHaveBeenCalledWith("0,0");
@@ -178,6 +207,9 @@ describe("finalizeWarpTravelChunkSwitch", () => {
     let currentChunk = "0,0";
     const setCurrentChunk = vi.fn((chunkKey: string) => {
       currentChunk = chunkKey;
+    });
+    const commitVisibleStructures = vi.fn(async (chunkKey: string) => {
+      expect(currentChunk).toBe(chunkKey);
     });
     const scheduleManagerCatchUp = vi.fn(async (chunkKey: string) => {
       expect(currentChunk).toBe(chunkKey);
@@ -205,11 +237,15 @@ describe("finalizeWarpTravelChunkSwitch", () => {
       clearSceneChunkBounds: vi.fn(),
       forceVisibilityUpdate: vi.fn(),
       updateCurrentChunkBounds: vi.fn(),
-
+      commitVisibleStructures,
       scheduleManagerCatchUp,
       unregisterPreviousChunkOnNextFrame: vi.fn(),
     });
 
+    expect(commitVisibleStructures).toHaveBeenCalledWith("24,24", undefined, {
+      force: false,
+      transitionToken: 19,
+    });
     expect(scheduleManagerCatchUp).toHaveBeenCalledWith("24,24", {
       force: false,
       transitionToken: 19,

--- a/client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.ts
+++ b/client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.ts
@@ -27,6 +27,11 @@ interface FinalizeWarpTravelChunkSwitchInput {
   clearSceneChunkBounds: () => void;
   forceVisibilityUpdate: () => void;
   updateCurrentChunkBounds: (startRow: number, startCol: number) => void;
+  commitVisibleStructures: (
+    chunkKey: string,
+    bounds: { box: unknown; sphere: unknown } | undefined,
+    options: { force: boolean; transitionToken: number },
+  ) => Promise<void>;
   scheduleManagerCatchUp: (chunkKey: string, options: { force: boolean; transitionToken: number }) => void;
   unregisterPreviousChunkOnNextFrame: (chunkKey: string) => void;
 }
@@ -79,6 +84,10 @@ export async function finalizeWarpTravelChunkSwitch(
   }
 
   input.setCurrentChunk(input.targetChunk);
+  await input.commitVisibleStructures(input.targetChunk, undefined, {
+    force: input.force,
+    transitionToken: input.transitionToken,
+  });
   if (input.preparedTerrain !== null && input.preparedTerrain !== undefined) {
     input.applyPreparedTerrain(input.preparedTerrain);
   }

--- a/client/apps/game/src/three/scenes/worldmap-fast-commit-manager-catchup.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-fast-commit-manager-catchup.test.ts
@@ -13,7 +13,7 @@ describe("worldmap fast commit manager catch-up wiring", () => {
     const finalizeSource = readSceneSource("./warp-travel-chunk-switch-commit.ts");
 
     expect(finalizeSource).toMatch(/scheduleManagerCatchUp\(/);
-    expect(finalizeSource).not.toMatch(/await input\.updateManagersForChunk\(/);
+    expect(finalizeSource).toMatch(/await input\.commitVisibleStructures\(/);
   });
 
   it("defers same-chunk refresh manager catch-up after terrain commit", () => {
@@ -21,5 +21,6 @@ describe("worldmap fast commit manager catch-up wiring", () => {
 
     expect(worldmapSource).toMatch(/deferManagerCatchUpForChunk\(/);
     expect(worldmapSource).toMatch(/WORLDMAP_STREAMING_ROLLOUT\.stagedPathEnabled/);
+    expect(worldmapSource).toMatch(/await this\.commitVisibleStructuresForChunk\(/);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-refresh-bounds-ordering.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-refresh-bounds-ordering.test.ts
@@ -15,6 +15,17 @@ function extractRefreshCurrentChunkMethod(source: string): string {
 }
 
 describe("worldmap refresh bounds ordering", () => {
+  it("commits visible structures before prepared terrain commit in refreshCurrentChunk", () => {
+    const methodSource = extractRefreshCurrentChunkMethod(readWorldmapSource());
+
+    const structureCommitIndex = methodSource.indexOf("await this.commitVisibleStructuresForChunk(");
+    const applyPreparedTerrainIndex = methodSource.indexOf("this.applyPreparedTerrainChunk(preparedTerrain);");
+
+    expect(structureCommitIndex).toBeGreaterThanOrEqual(0);
+    expect(applyPreparedTerrainIndex).toBeGreaterThanOrEqual(0);
+    expect(structureCommitIndex).toBeLessThan(applyPreparedTerrainIndex);
+  });
+
   it("updates current chunk bounds only after prepared terrain commit in refreshCurrentChunk", () => {
     const methodSource = extractRefreshCurrentChunkMethod(readWorldmapSource());
 
@@ -34,7 +45,7 @@ describe("worldmap refresh bounds ordering", () => {
     const methodSource = extractRefreshCurrentChunkMethod(readWorldmapSource());
 
     expect(methodSource).toMatch(
-      /if \(commitDecision\.shouldCommit && preparedTerrain\) \{[\s\S]*?this\.applyPreparedTerrainChunk\(preparedTerrain\);[\s\S]*?this\.updateCurrentChunkBounds\(startRow, startCol\);/s,
+      /if \(commitDecision\.shouldCommit && preparedTerrain\) \{[\s\S]*?await this\.commitVisibleStructuresForChunk\([\s\S]*?this\.applyPreparedTerrainChunk\(preparedTerrain\);[\s\S]*?this\.updateCurrentChunkBounds\(startRow, startCol\);/s,
     );
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-structure-removal.wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-structure-removal.wiring.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readWorldmapSource(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, "worldmap.tsx"), "utf8");
+}
+
+describe("worldmap structure removal wiring", () => {
+  it("routes removed structure tile updates through a dedicated removal helper", () => {
+    const source = readWorldmapSource();
+
+    expect(source).toMatch(/if \(value\.kind === "removed"\) \{\s*this\.handleRemovedStructureTileUpdate\(value\);/s);
+  });
+
+  it("removal helper clears local structure state and requests visible reconciliation", () => {
+    const source = readWorldmapSource();
+
+    expect(source).toMatch(
+      /private handleRemovedStructureTileUpdate\(value: StructureTileRemovedUpdate\)[\s\S]*?this\.structuresPositions\.delete\(value\.entityId\)/s,
+    );
+    expect(source).toMatch(
+      /private handleRemovedStructureTileUpdate\(value: StructureTileRemovedUpdate\)[\s\S]*?gameWorkerManager\.updateStructureHex\([^,]+,[^,]+,\s*null\)/s,
+    );
+    expect(source).toMatch(
+      /private handleRemovedStructureTileUpdate\(value: StructureTileRemovedUpdate\)[\s\S]*?this\.invalidateAllChunkCachesContainingHex\(/s,
+    );
+    expect(source).toMatch(
+      /private handleRemovedStructureTileUpdate\(value: StructureTileRemovedUpdate\)[\s\S]*?this\.structureManager\.removeStructure\(value\.entityId,\s*previousHex\)/s,
+    );
+    expect(source).toMatch(
+      /private handleRemovedStructureTileUpdate\(value: StructureTileRemovedUpdate\)[\s\S]*?this\.scheduleTileRefreshIfAffectsCurrentRenderBounds\(/s,
+    );
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -51,6 +51,8 @@ import {
   getTileAt,
   SelectableArmy,
   StructureActionManager,
+  type StructureTileRemovedUpdate,
+  type StructureTileUpsertUpdate,
   TileSystemUpdate,
 } from "@bibliothecadao/eternum";
 import {
@@ -1039,51 +1041,12 @@ export default class WorldmapScene extends WarpTravel {
     this.addWorldUpdateSubscription(
       this.worldUpdateListener.Structure.onTileUpdate(async (value) => {
         this.incrementToriiBoundsCounter("structureTiles");
-        const positions = this.updateStructureHexes(value);
-
-        const optimisticStructure = this.structureManager.structures.removeStructure(
-          Number(DUMMY_HYPERSTRUCTURE_ENTITY_ID),
-        );
-        if (optimisticStructure) {
-          this.dojo.components.Structure.removeOverride(DUMMY_HYPERSTRUCTURE_ENTITY_ID.toString());
-          this.structureManager.structureHexCoords
-            .get(optimisticStructure.hexCoords.col)
-            ?.delete(optimisticStructure.hexCoords.row);
-          this.structureManager.updateChunk(this.currentChunk);
+        if (value.kind === "removed") {
+          this.handleRemovedStructureTileUpdate(value);
+          return;
         }
 
-        await this.trackStructureHydrationUpdate(value, this.structureManager.onUpdate(value));
-
-        const newCount = this.structureManager.getTotalStructures();
-        const countChanged = this.totalStructures !== newCount;
-
-        // Debug: Track structure count changes
-        if (import.meta.env.DEV && countChanged) {
-          console.log(
-            `[Structure.onTileUpdate] Count changed: ${this.totalStructures} -> ${newCount}, entityId: ${value.entityId}`,
-          );
-        }
-
-        const structureTileActions = resolveStructureTileUpdateActions({
-          hasPositions: Boolean(positions),
-          countChanged,
-        });
-
-        if (structureTileActions.shouldScheduleTileRefresh && positions) {
-          this.scheduleTileRefreshIfAffectsCurrentRenderBounds(positions.oldPos ?? null, positions.newPos);
-        }
-
-        if (structureTileActions.shouldUpdateTotalStructures) {
-          this.totalStructures = newCount;
-        }
-
-        if (structureTileActions.shouldClearCache) {
-          this.clearCache();
-        }
-
-        if (structureTileActions.shouldRefreshVisibleChunks) {
-          this.requestChunkRefresh(true, "structure_count_change");
-        }
+        await this.handleUpsertStructureTileUpdate(value);
       }),
     );
 
@@ -2813,7 +2776,8 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private clearSceneChunkBounds(): void {
-    this.applySceneChunkBounds(undefined);
+    this.applyTerrainChunkBounds(undefined);
+    this.stageStructureChunkBounds(undefined);
   }
 
   private forceVisibilityManagerUpdate(): void {
@@ -3345,6 +3309,75 @@ export default class WorldmapScene extends WarpTravel {
     gameWorkerManager.updateStructureHex(newPos.col, newPos.row, structureInfo);
     this.invalidateAllChunkCachesContainingHex(newPos.col, newPos.row);
     return { oldPos, newPos };
+  }
+
+  private handleRemovedStructureTileUpdate(value: StructureTileRemovedUpdate): void {
+    const normalizedPreviousHex = new Position({
+      x: value.previousHexCoords.col,
+      y: value.previousHexCoords.row,
+    }).getNormalized();
+    const previousHex = {
+      col: normalizedPreviousHex.x,
+      row: normalizedPreviousHex.y,
+    };
+
+    this.structuresPositions.delete(value.entityId);
+    this.structureHexes.get(previousHex.col)?.delete(previousHex.row);
+    if (this.structureHexes.get(previousHex.col)?.size === 0) {
+      this.structureHexes.delete(previousHex.col);
+    }
+    gameWorkerManager.updateStructureHex(previousHex.col, previousHex.row, null);
+    this.invalidateAllChunkCachesContainingHex(previousHex.col, previousHex.row);
+    this.structureManager.removeStructure(value.entityId, previousHex);
+    this.removeEntityFromTracking(value.entityId);
+    this.totalStructures = this.structureManager.getTotalStructures();
+    this.scheduleTileRefreshIfAffectsCurrentRenderBounds(previousHex, null);
+    incrementWorldmapRenderCounter("removedStructureUpdates");
+  }
+
+  private async handleUpsertStructureTileUpdate(value: StructureTileUpsertUpdate): Promise<void> {
+    const positions = this.updateStructureHexes(value);
+
+    const optimisticStructure = this.structureManager.structures.getStructureByEntityId(
+      Number(DUMMY_HYPERSTRUCTURE_ENTITY_ID),
+    );
+    if (optimisticStructure) {
+      this.dojo.components.Structure.removeOverride(DUMMY_HYPERSTRUCTURE_ENTITY_ID.toString());
+      this.structureManager.removeStructure(Number(DUMMY_HYPERSTRUCTURE_ENTITY_ID), optimisticStructure.hexCoords);
+      this.structureManager.updateChunk(this.currentChunk);
+    }
+
+    await this.trackStructureHydrationUpdate(value, this.structureManager.onUpdate(value));
+
+    const newCount = this.structureManager.getTotalStructures();
+    const countChanged = this.totalStructures !== newCount;
+
+    if (import.meta.env.DEV && countChanged) {
+      console.log(
+        `[Structure.onTileUpdate] Count changed: ${this.totalStructures} -> ${newCount}, entityId: ${value.entityId}`,
+      );
+    }
+
+    const structureTileActions = resolveStructureTileUpdateActions({
+      hasPositions: Boolean(positions),
+      countChanged,
+    });
+
+    if (structureTileActions.shouldScheduleTileRefresh && positions) {
+      this.scheduleTileRefreshIfAffectsCurrentRenderBounds(positions.oldPos ?? null, positions.newPos);
+    }
+
+    if (structureTileActions.shouldUpdateTotalStructures) {
+      this.totalStructures = newCount;
+    }
+
+    if (structureTileActions.shouldClearCache) {
+      this.clearCache();
+    }
+
+    if (structureTileActions.shouldRefreshVisibleChunks) {
+      this.requestChunkRefresh(true, "structure_count_change");
+    }
   }
 
   // update chest hexes on the map
@@ -3926,10 +3959,7 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     const uploadWork = classifyWorldmapUploadWork({
-      matrixInstanceCount:
-        this.armyManager.getVisibleCount() +
-        this.structureManager.getVisibleCount() +
-        this.chestManager.getVisibleCount(),
+      matrixInstanceCount: this.armyManager.getVisibleCount() + this.chestManager.getVisibleCount(),
       colorInstanceCount: 0,
       isCachedReplay: false,
       stage: "visible_commit",
@@ -5629,19 +5659,51 @@ export default class WorldmapScene extends WarpTravel {
     return { box, sphere };
   }
 
-  private applySceneChunkBounds(bounds: { box: Box3; sphere: Sphere } | undefined): void {
+  private stageStructureChunkBounds(bounds: { box: Box3; sphere: Sphere } | undefined): void {
+    this.structureManager.setChunkBounds(bounds);
+  }
+
+  private applyTerrainChunkBounds(bounds: { box: Box3; sphere: Sphere } | undefined): void {
     this.currentChunkBounds = bounds;
     this.biomeModels.forEach((biome) => biome.setWorldBounds(bounds));
-    this.structureManager.setChunkBounds(bounds);
   }
 
   private updateCurrentChunkBounds(startRow: number, startCol: number) {
     const bounds = this.computeChunkBounds(startRow, startCol);
-    this.applySceneChunkBounds(bounds);
+    this.applyTerrainChunkBounds(bounds);
 
     // Register chunk bounds with centralized visibility manager
     const chunkKey = `${startRow},${startCol}`;
     this.visibilityManager?.registerChunk(chunkKey, bounds);
+  }
+
+  private resolveChunkBoundsForChunkKey(chunkKey: string): { box: Box3; sphere: Sphere } | undefined {
+    const [startRow, startCol] = chunkKey.split(",").map(Number);
+    if (!Number.isFinite(startRow) || !Number.isFinite(startCol)) {
+      return undefined;
+    }
+
+    return this.computeChunkBounds(startRow, startCol);
+  }
+
+  private async commitVisibleStructuresForChunk(
+    chunkKey: string,
+    bounds?: { box: Box3; sphere: Sphere },
+    options?: { force?: boolean; transitionToken?: number },
+  ): Promise<void> {
+    const resolvedBounds = bounds ?? this.resolveChunkBoundsForChunkKey(chunkKey);
+    this.stageStructureChunkBounds(resolvedBounds);
+
+    const startedAt = performance.now();
+    try {
+      await this.structureManager.updateChunk(chunkKey, options);
+      incrementWorldmapRenderCounter("structureVisibleCommits");
+    } catch (error) {
+      incrementWorldmapRenderCounter("structureSyncCommitFallbacks");
+      throw error;
+    } finally {
+      recordWorldmapRenderDuration("structureCommitMs", performance.now() - startedAt);
+    }
   }
 
   private worldToChunkCoordinates(x: number, z: number): { chunkX: number; chunkZ: number } {
@@ -6111,7 +6173,7 @@ export default class WorldmapScene extends WarpTravel {
         computeChunkBounds: (targetStartRow, targetStartCol) => this.computeChunkBounds(targetStartRow, targetStartCol),
         registerChunk: (targetChunkKey, bounds) => this.visibilityManager?.registerChunk(targetChunkKey, bounds),
         combineChunkBounds: (previousBounds, nextBounds) => this.combineChunkBounds(previousBounds, nextBounds),
-        applySceneChunkBounds: (bounds) => this.applySceneChunkBounds(bounds),
+        applySceneChunkBounds: (bounds) => this.applyTerrainChunkBounds(bounds),
       });
 
       // Load surrounding pinned chunks for better UX.
@@ -6234,6 +6296,12 @@ export default class WorldmapScene extends WarpTravel {
         forceVisibilityUpdate: () => this.forceVisibilityManagerUpdate(),
         updateCurrentChunkBounds: (targetStartRow, targetStartCol) =>
           this.updateCurrentChunkBounds(targetStartRow, targetStartCol),
+        commitVisibleStructures: (targetChunkKey, bounds, managerOptions) =>
+          this.commitVisibleStructuresForChunk(
+            targetChunkKey,
+            bounds as { box: Box3; sphere: Sphere } | undefined,
+            managerOptions,
+          ),
         scheduleManagerCatchUp: (targetChunkKey, managerOptions) => {
           if (WORLDMAP_STREAMING_ROLLOUT.stagedPathEnabled) {
             this.deferManagerCatchUpForChunk(targetChunkKey, managerOptions);
@@ -6371,6 +6439,7 @@ export default class WorldmapScene extends WarpTravel {
 
       if (commitDecision.shouldCommit && preparedTerrain) {
         const terrainCommitStartedAt = performance.now();
+        await this.commitVisibleStructuresForChunk(chunkKey, undefined, { force: true, transitionToken });
         this.applyPreparedTerrainChunk(preparedTerrain);
         this.updateCurrentChunkBounds(startRow, startCol);
         const commitCompletedAt = performance.now();
@@ -6436,11 +6505,6 @@ export default class WorldmapScene extends WarpTravel {
           {
             label: "army",
             updateChunk: (targetChunkKey, targetOptions) => this.armyManager.updateChunk(targetChunkKey, targetOptions),
-          },
-          {
-            label: "structure",
-            updateChunk: (targetChunkKey, targetOptions) =>
-              this.structureManager.updateChunk(targetChunkKey, targetOptions),
           },
           {
             label: "chest",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -10,6 +10,13 @@ interface LatestFeature {
 export const latestFeatures: LatestFeature[] = [
   {
     date: "2026-03-26",
+    title: "Stable Edge Building Rendering",
+    description:
+      "Buildings at chunk boundaries now switch cleanly with the terrain refresh flow, preventing ghosted structures from lingering at the edge of the visible world.",
+    type: "fix",
+  },
+  {
+    date: "2026-03-26",
     title: "Instant Explorer Map Pins",
     description:
       "Auto-Explore now enables the explorer location shortcut as soon as a new automation entry appears, instead of waiting for the next position refresh cycle.",

--- a/packages/core/src/systems/types.ts
+++ b/packages/core/src/systems/types.ts
@@ -65,7 +65,8 @@ export type ExplorerTroopsSystemUpdate = {
   battleCooldownEnd: number;
 };
 
-export type StructureTileSystemUpdate = {
+export type StructureTileUpsertUpdate = {
+  kind: "upsert";
   entityId: ID;
   structureName: string;
   hexCoords: HexPosition;
@@ -93,6 +94,15 @@ export type StructureTileSystemUpdate = {
     latestDefenderCoordY: number | null;
   };
 };
+
+export type StructureTileRemovedUpdate = {
+  kind: "removed";
+  entityId: ID;
+  previousHexCoords: HexPosition;
+  structureType: StructureType;
+};
+
+export type StructureTileSystemUpdate = StructureTileUpsertUpdate | StructureTileRemovedUpdate;
 
 export type StructureSystemUpdate = {
   entityId: ID;

--- a/packages/core/src/systems/world-update-listener.test.ts
+++ b/packages/core/src/systems/world-update-listener.test.ts
@@ -206,4 +206,51 @@ describe("WorldUpdateListener army tile bootstrap", () => {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback.mock.calls[0][0].structureName).toBe("Realm of Testing");
   });
+
+  it("emits a removed structure update when a structure leaves a tile and no Structure component remains", async () => {
+    isComponentUpdateMock.mockReturnValue(true);
+    tileOptToTileMock.mockReturnValue({
+      occupier_type: 1,
+      occupier_id: 921,
+      col: 10,
+      row: 15,
+    });
+    getStructureInfoFromTileOccupierMock.mockReturnValue({
+      type: 4,
+      stage: 0,
+      level: 1,
+      hasWonder: false,
+    });
+    getComponentValueMock.mockReturnValue(undefined);
+
+    const listener = new WorldUpdateListener(
+      {
+        network: { world: {} },
+        components: {
+          TileOpt: {},
+          Hyperstructure: {},
+          Structure: {},
+          AddressName: {},
+        },
+      } as any,
+      {} as any,
+    );
+
+    const callback = vi.fn();
+    listener.Structure.onTileUpdate(callback);
+
+    const handleUpdate = defineComponentSystemMock.mock.calls[0][2];
+    await handleUpdate({
+      value: [undefined, {}],
+      entity: "0x123",
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0]).toEqual({
+      kind: "removed",
+      entityId: 921,
+      previousHexCoords: { col: 10, row: 15 },
+      structureType: 4,
+    });
+  });
 });

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -415,11 +415,39 @@ export class WorldUpdateListener {
             if (isComponentUpdate(update, this.setup.components.TileOpt)) {
               const [currentStateOpt, _prevStateOpt] = update.value;
               const currentState = currentStateOpt ? tileOptToTile(currentStateOpt) : undefined;
-              // const _prevState = _prevStateOpt ? tileOptToTile(_prevStateOpt) : undefined;
+              const _prevState = _prevStateOpt ? tileOptToTile(_prevStateOpt) : undefined;
 
               const structureInfo = currentState && getStructureInfoFromTileOccupier(currentState?.occupier_type);
+              const previousStructureInfo = _prevState && getStructureInfoFromTileOccupier(_prevState?.occupier_type);
 
-              if (!structureInfo) return;
+              if (!structureInfo) {
+                if (!previousStructureInfo || !_prevState) {
+                  return;
+                }
+
+                try {
+                  const structureComponent = getComponentValue(
+                    this.setup.components.Structure,
+                    getEntityIdFromKeys([BigInt(_prevState.occupier_id)]),
+                  );
+
+                  if (structureComponent) {
+                    return;
+                  }
+                } catch (_error) {
+                  // Treat lookup failures as absent structure state so the removal can converge.
+                }
+
+                return {
+                  kind: "removed" as const,
+                  entityId: _prevState.occupier_id,
+                  previousHexCoords: {
+                    col: _prevState.col,
+                    row: _prevState.row,
+                  },
+                  structureType: previousStructureInfo.type,
+                };
+              }
 
               const hyperstructure = getComponentValue(
                 this.setup.components.Hyperstructure,
@@ -504,6 +532,7 @@ export class WorldUpdateListener {
                   : undefined;
 
                 return {
+                  kind: "upsert" as const,
                   entityId: rawOccupierId,
                   structureName,
                   hexCoords: {


### PR DESCRIPTION
## Summary
- Adds a `removed` variant to `StructureTileSystemUpdate` so the world update listener can detect and propagate structure tile deletions from on-chain state.
- Wires removal handling through `worldmap.tsx`, `structure-manager.ts`, and the mobile `structure-manager.ts` so structures are cleaned up from the 3D scene when their backing entity is removed.
- Includes new tests for the removal path (lifecycle, wiring, warp-travel chunk switch) and updates existing tests to cover the new update kind.
- Cleans up a no-op `applySceneChunkBounds` wrapper and tightens types for `bounds` in the warp-travel interface.

## Test plan
- [ ] Verify structure removal triggers cleanup in the 3D scene
- [ ] Run `pnpm --dir client/apps/game test` to confirm all new and updated tests pass
- [ ] Confirm mobile structure manager handles the `removed` kind without errors