### PR TITLE
fix: add camps to assets sidebar and transfer view

### DIFF
--- a/client/apps/game/src/ui/features/economy/trading/transfer-view.tsx
+++ b/client/apps/game/src/ui/features/economy/trading/transfer-view.tsx
@@ -25,7 +25,8 @@ export const TransferView = () => {
     hyperstructures: EntityIdFormat[];
     fragmentMines: EntityIdFormat[];
     banks: EntityIdFormat[];
-  }>({ villages: [], realms: [], hyperstructures: [], fragmentMines: [], banks: [] });
+    camps: EntityIdFormat[];
+  }>({ villages: [], realms: [], hyperstructures: [], fragmentMines: [], banks: [], camps: [] });
 
   useEffect(() => {
     const fetch = async () => {
@@ -36,6 +37,7 @@ export const TransferView = () => {
         hyperstructures: result.filter((a) => a.category === StructureType.Hyperstructure),
         fragmentMines: result.filter((a) => a.category === StructureType.FragmentMine),
         banks: result.filter((a) => a.category === StructureType.Bank),
+        camps: result.filter((a) => a.category === StructureType.Camp),
       });
     };
     fetch();
@@ -95,6 +97,12 @@ export const TransferView = () => {
         name: "Your Banks",
       },
       {
+        entities: playerStructures
+          .filter((structure) => structure.structure.base.category === StructureType.Camp)
+          .map(mapToEntityIdFormat),
+        name: "Your Camps",
+      },
+      {
         entities: otherStructures.realms.filter((a) =>
           guildOnly ? playersInPlayersGuildAddress.includes(a.owner) : !playersInPlayersGuildAddress.includes(a.owner),
         ),
@@ -123,6 +131,12 @@ export const TransferView = () => {
           guildOnly ? playersInPlayersGuildAddress.includes(a.owner) : !playersInPlayersGuildAddress.includes(a.owner),
         ),
         name: "Other Banks",
+      },
+      {
+        entities: otherStructures.camps.filter((a) =>
+          guildOnly ? playersInPlayersGuildAddress.includes(a.owner) : !playersInPlayersGuildAddress.includes(a.owner),
+        ),
+        name: "Other Camps",
       },
     ],
     [playerStructures, otherStructures, guildOnly, playersInPlayersGuildAddress],

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -244,7 +244,7 @@ const LeftPanelHeader = memo(
         {
           key: "villages",
           label: mode.labels.villages,
-          categories: [StructureType.Village],
+          categories: [StructureType.Village, StructureType.Camp],
           icon: VILLAGE_ICON_BY_KEY[mode.ui.villageIconKey],
         },
         {


### PR DESCRIPTION
## Summary
- Captured camps were not appearing in the assets sidebar or the transfer panel
- Added `StructureType.Camp` to the villages tab in the left command sidebar so camps show up in assets
- Added camps to the transfer view state, API filtering, and entity lists ("Your Camps" and "Other Camps" sections)

## Test plan
- [ ] Capture a camp on the map in Blitz mode
- [ ] Verify the camp appears in the villages/camps tab in the left sidebar
- [ ] Open the transfer panel and verify the camp appears under "Your Camps"
- [ ] Verify other players' camps appear under "Other Camps"