### PR TITLE
Disable random biome lighting variants on hex tiles

### DIFF
--- a/client/apps/game/src/three/constants/scene-constants.ts
+++ b/client/apps/game/src/three/constants/scene-constants.ts
@@ -181,22 +181,10 @@ export const buildingModelPaths = (isBlitz: boolean) => {
   };
 };
 
-const biomesWithAltVersions: Set<BiomeType> = new Set([
-  BiomeType.TemperateDeciduousForest,
-  BiomeType.Grassland,
-  BiomeType.Shrubland,
-]);
-
 export function getBiomeVariant(biome: BiomeType | "Outline" | "Empty", col: number, row: number): string {
-  if (biome !== "Outline" && biome !== "Empty" && biomesWithAltVersions.has(biome as BiomeType)) {
-    const hash = Math.sin(col * 12.9898 + row * 78.233) * 43758.5453;
-    const random = hash - Math.floor(hash);
-
-    if (random < 0.5) {
-      return `${biome}Alt`;
-    }
-  }
-
+  // Preserve a stable biome surface and avoid per-tile lighting variance from alt biome meshes.
+  void col;
+  void row;
   return biome as string;
 }
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -10,6 +10,13 @@ interface LatestFeature {
 export const latestFeatures: LatestFeature[] = [
   {
     date: "2026-03-26",
+    title: "Unified Hex Biome Lighting",
+    description:
+      "Biome tiles now use a consistent surface style instead of mixing random lit and unlit variants, making the world map easier to read at a glance.",
+    type: "fix",
+  },
+  {
+    date: "2026-03-26",
     title: "Passive Army Stamina Refresh",
     description:
       "Army stamina shown above units now keeps updating after chain-time corrections instead of waiting for another army action to refresh the display.",


### PR DESCRIPTION
This removes per-tile biome variant randomization so hexes render with a consistent biome surface instead of mixed lit and unlit variants.

It also adds a latest-features entry documenting the map readability fix.

Verification: pnpm run format passed.
Verification: pnpm run knip fails in this environment due a missing optional native oxc-parser binding installed via npx knip.