### PR TITLE
fix(game): populate leaderboard during game, not just at end

### DIFF
--- a/client/apps/game/src/config/polling.ts
+++ b/client/apps/game/src/config/polling.ts
@@ -8,5 +8,5 @@ export const POLLING_INTERVALS = {
   resourceArrivalsMs: toNumber(import.meta.env.VITE_POLL_RESOURCE_ARRIVALS_MS, 40_000),
   storyEventsMs: toNumber(import.meta.env.VITE_POLL_STORY_EVENTS_MS, 6_000),
   storyEventsStaleMs: toNumber(import.meta.env.VITE_POLL_STORY_EVENTS_STALE_MS, 60_000),
-  autoRegisterPointsMs: toNumber(import.meta.env.VITE_POLL_AUTO_REGISTER_POINTS_MS, 300_000),
+  autoRegisterPointsMs: toNumber(import.meta.env.VITE_POLL_AUTO_REGISTER_POINTS_MS, 60_000),
 };

--- a/client/apps/game/src/ui/features/social/player/players-panel.tsx
+++ b/client/apps/game/src/ui/features/social/player/players-panel.tsx
@@ -89,8 +89,14 @@ export const PlayersPanel = ({
 
   useEffect(() => {
     void fetchLeaderboardEntries({ limit: SOCIAL_LEADERBOARD_LIMIT });
+
+    const interval = window.setInterval(() => {
+      void fetchLeaderboardEntries({ limit: SOCIAL_LEADERBOARD_LIMIT });
+    }, 60_000);
+
+    return () => window.clearInterval(interval);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only fetch on initial mount - store handles caching/staleness
+  }, []); // Fetch on mount and auto-refresh every 60s
 
   const playersWithStructures: PlayerCustom[] = useMemo(() => {
     // Sort players by points in descending order

--- a/client/apps/game/src/ui/store-managers.tsx
+++ b/client/apps/game/src/ui/store-managers.tsx
@@ -384,9 +384,9 @@ const AutoRegisterPointsStoreManager = () => {
 
       log(`Registered: ${registeredPoints}, Unregistered: ${unregisteredPoints}`);
 
-      // Check condition: unregistered > registered
-      if (unregisteredPoints <= registeredPoints) {
-        log("Skipped: unregistered <= registered");
+      // Check condition: any unregistered points to claim
+      if (unregisteredPoints <= 0) {
+        log("Skipped: no unregistered points");
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fixed auto-register threshold: now registers points whenever unregistered > 0 (previously required unregistered > registered, causing most mid-game points to never be written on-chain)
- Reduced auto-register polling interval from 300s to 60s for more frequent on-chain point updates
- Added 60s auto-refresh to the social panel leaderboard, which previously only fetched once on mount and went stale

## Test plan
- [ ] Verify leaderboard populates during mid-game with hyperstructure shareholders
- [ ] Confirm auto-register fires when player has any unregistered points
- [ ] Check social panel leaderboard refreshes automatically without manual click

🤖 Generated with [Claude Code](https://claude.com/claude-code)