### PR TITLE
Fix realtime server cache response build

### DIFF
--- a/client/apps/realtime-server/src/http/middleware/rate-limit.ts
+++ b/client/apps/realtime-server/src/http/middleware/rate-limit.ts
@@ -77,11 +77,4 @@ function startRateLimitCleanup(): void {
   );
 }
 
-function stopRateLimitCleanup(): void {
-  if (cleanupIntervalId) {
-    clearInterval(cleanupIntervalId);
-    cleanupIntervalId = null;
-  }
-}
-
 startRateLimitCleanup();

--- a/client/apps/realtime-server/src/http/routes/__tests__/cache-response.test.ts
+++ b/client/apps/realtime-server/src/http/routes/__tests__/cache-response.test.ts
@@ -1,0 +1,37 @@
+import { brotliDecompressSync } from "zlib";
+import { describe, expect, it } from "vitest";
+
+import { createCachedJsonResponse, createJsonPayload } from "../cache-response";
+
+describe("createCachedJsonResponse", () => {
+  it("returns brotli-compressed JSON when the client accepts br", async () => {
+    const payload = createJsonPayload({
+      message: "x".repeat(2_048),
+    });
+
+    const response = createCachedJsonResponse({
+      payload,
+      acceptEncoding: "gzip, br",
+      status: 202,
+    });
+
+    expect(response.status).toBe(202);
+    expect(response.headers.get("Content-Type")).toBe("application/json; charset=utf-8");
+    expect(response.headers.get("Content-Encoding")).toBe("br");
+    expect(response.headers.get("Vary")).toBe("Accept-Encoding");
+
+    const compressedBody = new Uint8Array(await response.arrayBuffer());
+    const decompressedBody = brotliDecompressSync(compressedBody).toString();
+
+    expect(decompressedBody).toContain("message");
+  });
+
+  it("returns plain JSON when compression is not requested", async () => {
+    const response = createCachedJsonResponse({
+      payload: createJsonPayload({ ok: true }),
+    });
+
+    expect(response.headers.get("Content-Encoding")).toBeNull();
+    expect(await response.text()).toBe('{"ok":true}');
+  });
+});

--- a/client/apps/realtime-server/src/http/routes/cache-response.ts
+++ b/client/apps/realtime-server/src/http/routes/cache-response.ts
@@ -1,0 +1,86 @@
+import { brotliCompressSync, gzipSync } from "zlib";
+
+export type SerializedJson = string;
+
+export type CachedJsonPayload = {
+  json: SerializedJson;
+  size: number;
+  br?: Uint8Array;
+  gzip?: Uint8Array;
+};
+
+const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+const COMPRESSION_THRESHOLD_BYTES = 1024;
+const VARY_HEADER = "Vary";
+const ACCEPT_ENCODING_HEADER = "Accept-Encoding";
+
+type ResponseHeadersSource = Headers | Record<string, string> | Array<[string, string]>;
+
+export const createJsonPayload = (value: unknown): CachedJsonPayload => {
+  const json = JSON.stringify(value);
+  return { json, size: Buffer.byteLength(json) };
+};
+
+const getCompressedPayload = (payload: CachedJsonPayload, encoding: "br" | "gzip"): Uint8Array => {
+  if (encoding === "br") {
+    if (!payload.br) {
+      payload.br = brotliCompressSync(payload.json);
+    }
+    return payload.br;
+  }
+
+  if (!payload.gzip) {
+    payload.gzip = gzipSync(payload.json);
+  }
+  return payload.gzip;
+};
+
+const appendVaryHeader = (headers: Headers, value: string) => {
+  const existing = headers.get(VARY_HEADER);
+  if (!existing) {
+    headers.set(VARY_HEADER, value);
+    return;
+  }
+
+  const existingValues = existing
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  if (existingValues.includes(value.toLowerCase())) {
+    return;
+  }
+
+  headers.set(VARY_HEADER, `${existing}, ${value}`);
+};
+
+export const createCachedJsonResponse = ({
+  payload,
+  status = 200,
+  acceptEncoding,
+  headers,
+}: {
+  payload: CachedJsonPayload;
+  status?: number;
+  acceptEncoding?: string | null;
+  headers?: ResponseHeadersSource;
+}): Response => {
+  const responseHeaders = new Headers(headers);
+  responseHeaders.set("Content-Type", JSON_CONTENT_TYPE);
+  appendVaryHeader(responseHeaders, ACCEPT_ENCODING_HEADER);
+
+  const normalizedEncoding = acceptEncoding?.toLowerCase() ?? "";
+
+  if (payload.size >= COMPRESSION_THRESHOLD_BYTES) {
+    if (normalizedEncoding.includes("br")) {
+      responseHeaders.set("Content-Encoding", "br");
+      return new Response(getCompressedPayload(payload, "br"), { status, headers: responseHeaders });
+    }
+    if (normalizedEncoding.includes("gzip")) {
+      responseHeaders.set("Content-Encoding", "gzip");
+      return new Response(getCompressedPayload(payload, "gzip"), { status, headers: responseHeaders });
+    }
+  }
+
+  responseHeaders.delete("Content-Encoding");
+  return new Response(payload.json, { status, headers: responseHeaders });
+};

--- a/client/apps/realtime-server/src/http/routes/cache.ts
+++ b/client/apps/realtime-server/src/http/routes/cache.ts
@@ -1,7 +1,7 @@
-import { brotliCompressSync, gzipSync } from "zlib";
 import { Hono, type Context } from "hono";
 
 import type { AppEnv } from "../middleware/auth";
+import { createCachedJsonResponse, createJsonPayload, type CachedJsonPayload } from "./cache-response";
 import {
   ALL_TILES_QUERY,
   buildLeaderboardQuery,
@@ -14,15 +14,6 @@ import {
 } from "../../services/torii-queries";
 
 type CacheStatus = "hit" | "stale" | "miss";
-
-type SerializedJson = string;
-
-type CachedJsonPayload = {
-  json: SerializedJson;
-  size: number;
-  br?: Uint8Array;
-  gzip?: Uint8Array;
-};
 
 type CacheEntry<T> = {
   value: T;
@@ -215,76 +206,17 @@ const startCacheCleanup = () => {
   );
 };
 
-const stopCacheCleanup = () => {
-  if (cacheCleanupIntervalId) {
-    clearInterval(cacheCleanupIntervalId);
-    cacheCleanupIntervalId = null;
-  }
-};
-
 if (cacheEnabled) {
   startCacheCleanup();
 }
 
-const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
-const COMPRESSION_THRESHOLD_BYTES = 1024;
-const VARY_HEADER = "Vary";
-const ACCEPT_ENCODING_HEADER = "Accept-Encoding";
-
-const createJsonPayload = (value: unknown): CachedJsonPayload => {
-  const json = JSON.stringify(value);
-  return { json, size: Buffer.byteLength(json) };
-};
-
-const getCompressedPayload = (payload: CachedJsonPayload, encoding: "br" | "gzip"): Uint8Array => {
-  if (encoding === "br") {
-    if (!payload.br) {
-      payload.br = brotliCompressSync(payload.json);
-    }
-    return payload.br;
-  }
-
-  if (!payload.gzip) {
-    payload.gzip = gzipSync(payload.json);
-  }
-  return payload.gzip;
-};
-
-const appendVaryHeader = (c: Context, value: string) => {
-  const existing = c.res.headers.get(VARY_HEADER);
-  if (!existing) {
-    c.header(VARY_HEADER, value);
-    return;
-  }
-
-  const existingValues = existing
-    .split(",")
-    .map((entry) => entry.trim().toLowerCase())
-    .filter(Boolean);
-  if (existingValues.includes(value.toLowerCase())) {
-    return;
-  }
-
-  c.header(VARY_HEADER, `${existing}, ${value}`);
-};
-
 const sendJsonBody = (c: Context, payload: CachedJsonPayload, status: number = 200) => {
-  c.header("Content-Type", JSON_CONTENT_TYPE);
-  appendVaryHeader(c, ACCEPT_ENCODING_HEADER);
-
-  if (payload.size >= COMPRESSION_THRESHOLD_BYTES) {
-    const acceptEncoding = c.req.header(ACCEPT_ENCODING_HEADER)?.toLowerCase() ?? "";
-    if (acceptEncoding.includes("br")) {
-      c.header("Content-Encoding", "br");
-      return c.body(getCompressedPayload(payload, "br"), status);
-    }
-    if (acceptEncoding.includes("gzip")) {
-      c.header("Content-Encoding", "gzip");
-      return c.body(getCompressedPayload(payload, "gzip"), status);
-    }
-  }
-
-  return c.body(payload.json, status);
+  return createCachedJsonResponse({
+    payload,
+    status,
+    acceptEncoding: c.req.header("Accept-Encoding"),
+    headers: c.res.headers,
+  });
 };
 
 const logCacheMetrics = ({


### PR DESCRIPTION
This fixes the realtime server build break in the cache route.

The cache response logic now lives in a small helper that returns typed JSON and compressed responses cleanly, which removes the Hono c.body() overload errors.

It also deletes the unused cache and rate-limit cleanup stubs and adds a focused regression test for compressed and plain JSON responses.

Verified with pnpm --dir client/apps/realtime-server exec vitest run src/http/routes/__tests__/cache-response.test.ts, pnpm run build:packages, pnpm --dir client/apps/realtime-server run build, pnpm run format, and pnpm run knip.