### PR TITLE
chore: add amm-indexerv2 root start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "start": "pnpm run start:amm-indexerv2",
+    "start:amm-indexerv2": "pnpm --dir ./client/apps/amm-indexerv2 start",
     "build": "pnpm --dir ./client/apps/game build",
     "build:docs": "cd client/apps/game-docs && pnpm build",
     "build:landing": "pnpm --dir ./client/apps/landing build",


### PR DESCRIPTION
## Summary
- add a root `start` script that delegates to `start:amm-indexerv2`
- add a root `start:amm-indexerv2` script that runs `client/apps/amm-indexerv2`
- this lets Railway start the AMM v2 indexer from the monorepo root with `pnpm start`

## Verification
- `pnpm run format` failed because local `node_modules` are not installed and `prettier` was unavailable
- `pnpm run knip` failed for the same reason while loading local tooling, including a missing `@eslint/js`
