### PR TITLE
Allow first-party Realms origins on AMMv2 API

### DIFF
--- a/client/apps/amm-indexerv2/api/app.integration.test.ts
+++ b/client/apps/amm-indexerv2/api/app.integration.test.ts
@@ -240,4 +240,32 @@ describe("createAmmV2ApiApp", () => {
 
     expect(response.headers.get("access-control-allow-origin")).toBe("https://eternum.realms.world");
   });
+
+  it("allows first-party Realms browser origins without extra configuration", async () => {
+    const { db, close } = await createTestAmmV2Database();
+    cleanup.push(close);
+    const app = createAmmV2ApiApp({ db });
+
+    const response = await app.request("http://ammv2.local/api/v1/pairs", {
+      headers: {
+        Origin: "https://blitz.realms.world",
+      },
+    });
+
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://blitz.realms.world");
+  });
+
+  it("rejects lookalike browser origins", async () => {
+    const { db, close } = await createTestAmmV2Database();
+    cleanup.push(close);
+    const app = createAmmV2ApiApp({ db });
+
+    const response = await app.request("http://ammv2.local/api/v1/pairs", {
+      headers: {
+        Origin: "https://blitz.realms.world.attacker.example",
+      },
+    });
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
 });

--- a/client/apps/amm-indexerv2/api/app.ts
+++ b/client/apps/amm-indexerv2/api/app.ts
@@ -15,6 +15,7 @@ interface PaginationParams {
 
 const ONE_DAY_IN_MS = 86_400_000;
 const LOCAL_BROWSER_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
+const FIRST_PARTY_BROWSER_DOMAIN = "realms.world";
 
 export function createAmmV2ApiApp(params: CreateAmmV2ApiAppParams) {
   const app = new Hono();
@@ -226,7 +227,11 @@ function isAllowedBrowserOrigin(origin: string, allowedOrigins: Set<string>): bo
   }
 
   const parsedOrigin = new URL(normalizedOrigin);
-  return LOCAL_BROWSER_HOSTNAMES.has(parsedOrigin.hostname) || allowedOrigins.has(normalizedOrigin);
+  return (
+    LOCAL_BROWSER_HOSTNAMES.has(parsedOrigin.hostname) ||
+    isFirstPartyRealmsBrowserOrigin(parsedOrigin) ||
+    allowedOrigins.has(normalizedOrigin)
+  );
 }
 
 function normalizeBrowserOrigin(origin: string): string | null {
@@ -235,6 +240,14 @@ function normalizeBrowserOrigin(origin: string): string | null {
   } catch {
     return null;
   }
+}
+
+function isFirstPartyRealmsBrowserOrigin(origin: URL): boolean {
+  return origin.protocol === "https:" && matchesFirstPartyRealmsHostname(origin.hostname);
+}
+
+function matchesFirstPartyRealmsHostname(hostname: string): boolean {
+  return hostname === FIRST_PARTY_BROWSER_DOMAIN || hostname.endsWith(`.${FIRST_PARTY_BROWSER_DOMAIN}`);
 }
 
 function parsePagination(c: { req: { query: (key: string) => string | undefined } }): PaginationParams {


### PR DESCRIPTION
This updates the AMMv2 API CORS policy to allow secure first-party `*.realms.world` browser origins without requiring exact per-origin configuration, while preserving localhost and explicit allowlist support.
It also adds regression coverage for the `https://blitz.realms.world` allow case and a lookalike-host rejection case so the policy does not widen beyond first-party domains.
Verification: `pnpm run format`, `pnpm run knip`, and `pnpm --filter @bibliothecadao/amm-indexerv2 exec vitest run api/app.integration.test.ts -t "browser origins|lookalike"`.