### PR TITLE
feat: add AMM market cap summary and pool ordering

### DIFF
--- a/client/apps/amm-indexerv2/api/app.integration.test.ts
+++ b/client/apps/amm-indexerv2/api/app.integration.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createAmmV2ApiApp } from "./app";
 import {
   buildBlock,
@@ -17,6 +17,8 @@ const FACTORY = "0xfac" as const;
 const PAIR = "0xaaa" as const;
 const TOKEN_0 = "0x01" as const;
 const TOKEN_1 = "0x02" as const;
+const LORDS = TOKEN_0;
+const RESOURCE = TOKEN_1;
 const ROUTER = "0x111" as const;
 const ALICE = "0xa1" as const;
 const BOB = "0xb1" as const;
@@ -25,7 +27,14 @@ const BURN = "0x1" as const;
 describe("createAmmV2ApiApp", () => {
   const cleanup: Array<() => Promise<void>> = [];
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:00:00.000Z"));
+  });
+
   afterEach(async () => {
+    vi.useRealTimers();
+
     while (cleanup.length > 0) {
       const close = cleanup.pop();
       if (close) {
@@ -208,6 +217,82 @@ describe("createAmmV2ApiApp", () => {
         amount1: "10800",
       },
     ]);
+  });
+
+  it("serves pair stats with resource token supply", async () => {
+    const { db, close } = await createTestAmmV2Database();
+    cleanup.push(close);
+    const indexedAt = new Date("2026-03-26T00:00:00.000Z");
+    const loadTokenTotalSupply = async (tokenAddress: string) => {
+      expect(tokenAddress).toBe("0x2");
+      return 123_456n;
+    };
+
+    await applyAmmV2BlockToDatabase({
+      txDb: db,
+      factoryAddress: FACTORY,
+      block: buildBlock(
+        [
+          buildPairCreatedEvent({
+            address: FACTORY,
+            token0: LORDS,
+            token1: RESOURCE,
+            pair: PAIR,
+            totalPairs: 1n,
+            eventIndex: 0,
+            transactionHash: "0xcreate",
+          }),
+          buildTransferEvent({
+            address: PAIR,
+            from: "0x0",
+            to: BURN,
+            amount: 1000n,
+            eventIndex: 1,
+            transactionHash: "0xmint",
+          }),
+          buildTransferEvent({
+            address: PAIR,
+            from: "0x0",
+            to: ALICE,
+            amount: 9000n,
+            eventIndex: 2,
+            transactionHash: "0xmint",
+          }),
+          buildSyncEvent({
+            address: PAIR,
+            reserve0: 20_000n,
+            reserve1: 40_000n,
+            eventIndex: 3,
+            transactionHash: "0xmint",
+          }),
+          buildMintEvent({
+            address: PAIR,
+            sender: ROUTER,
+            amount0: 20_000n,
+            amount1: 40_000n,
+            transactionSender: ALICE,
+            eventIndex: 4,
+            transactionHash: "0xmint",
+          }),
+        ],
+        12n,
+        indexedAt,
+      ),
+    });
+
+    const app = createAmmV2ApiApp({
+      db,
+      lordsAddress: LORDS,
+      loadTokenTotalSupply,
+    });
+
+    const statsResponse = await app.request(`http://ammv2.local/api/v1/pairs/${PAIR}/stats`);
+    const statsJson = await statsResponse.json();
+
+    expect(statsJson.data).toMatchObject({
+      pairAddress: PAIR,
+      resourceTokenSupply: "123456",
+    });
   });
 
   it("allows localhost browser origins", async () => {

--- a/client/apps/amm-indexerv2/api/app.ts
+++ b/client/apps/amm-indexerv2/api/app.ts
@@ -1,17 +1,23 @@
 import { and, count, desc, eq, gte, inArray, lte, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { RpcProvider } from "starknet";
 import * as schema from "../src/schema";
 
 interface CreateAmmV2ApiAppParams {
   allowedOrigins?: string[];
   db: any;
+  lordsAddress?: string;
+  loadTokenTotalSupply?: LoadTokenTotalSupply;
+  rpcUrl?: string;
 }
 
 interface PaginationParams {
   limit: number;
   offset: number;
 }
+
+type LoadTokenTotalSupply = (tokenAddress: string) => Promise<bigint | null>;
 
 const ONE_DAY_IN_MS = 86_400_000;
 const LOCAL_BROWSER_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
@@ -20,6 +26,8 @@ const FIRST_PARTY_BROWSER_DOMAIN = "realms.world";
 export function createAmmV2ApiApp(params: CreateAmmV2ApiAppParams) {
   const app = new Hono();
   const allowedBrowserOrigins = buildAllowedBrowserOriginSet(params.allowedOrigins ?? []);
+  const loadTokenTotalSupply = params.loadTokenTotalSupply ?? buildTokenTotalSupplyLoader(params.rpcUrl);
+  const lordsAddress = normalizeOptionalAddress(params.lordsAddress);
 
   app.use(
     "/api/*",
@@ -169,6 +177,7 @@ export function createAmmV2ApiApp(params: CreateAmmV2ApiAppParams) {
       .where(and(eq(schema.pairSwaps.pairAddress, pair.pairAddress), gte(schema.pairSwaps.blockTimestamp, oneDayAgo)));
     const reserve0 = BigInt(pair.reserve0);
     const reserve1 = BigInt(pair.reserve1);
+    const resourceTokenAddress = resolveResourceTokenAddress(pair, lordsAddress);
     const volume0 = recentSwaps.reduce(
       (sum: bigint, row: any) => sum + BigInt(row.amount0In) + BigInt(row.amount0Out),
       0n,
@@ -185,6 +194,7 @@ export function createAmmV2ApiApp(params: CreateAmmV2ApiAppParams) {
       (sum: bigint, row: any) => sum + computeLpFee(BigInt(row.amount1In), BigInt(row.feeAmount)),
       0n,
     );
+    const resourceTokenSupply = resourceTokenAddress !== null ? await loadTokenTotalSupply(resourceTokenAddress) : null;
 
     return jsonResponse(c, {
       data: {
@@ -201,6 +211,7 @@ export function createAmmV2ApiApp(params: CreateAmmV2ApiAppParams) {
         lpFees0_24h: lpFees0.toString(),
         lpFees1_24h: lpFees1.toString(),
         swapCount24h: recentSwaps.length,
+        resourceTokenSupply,
       },
     });
   });
@@ -434,6 +445,53 @@ function comparePositionsByLpBalance(left: { lpBalance: string }, right: { lpBal
 
 function normalizeOptionalAddress(value: string | undefined): string | undefined {
   return value ? normalizeAddress(value) : undefined;
+}
+
+function resolveResourceTokenAddress(
+  pair: { token0Address: string; token1Address: string },
+  lordsAddress: string | undefined,
+): string | null {
+  if (!lordsAddress) {
+    return null;
+  }
+
+  if (normalizeAddress(pair.token0Address) === lordsAddress) {
+    return normalizeAddress(pair.token1Address);
+  }
+
+  if (normalizeAddress(pair.token1Address) === lordsAddress) {
+    return normalizeAddress(pair.token0Address);
+  }
+
+  return null;
+}
+
+function buildTokenTotalSupplyLoader(rpcUrl: string | undefined): LoadTokenTotalSupply {
+  if (!rpcUrl) {
+    return async () => null;
+  }
+
+  const provider = new RpcProvider({ nodeUrl: rpcUrl });
+
+  return async (tokenAddress: string) => {
+    try {
+      const result = await provider.callContract({
+        contractAddress: tokenAddress,
+        entrypoint: "total_supply",
+        calldata: [],
+      });
+
+      return parseU256Result(result);
+    } catch {
+      return null;
+    }
+  };
+}
+
+function parseU256Result(values: Array<string | bigint>): bigint {
+  const low = BigInt(values[0] ?? "0x0");
+  const high = BigInt(values[1] ?? "0x0");
+  return low + (high << 128n);
 }
 
 function normalizeAddress(value: string): string {

--- a/client/apps/amm-indexerv2/api/game-client-parity.integration.test.ts
+++ b/client/apps/amm-indexerv2/api/game-client-parity.integration.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameAmmClient } from "../../game/src/services/amm/game-amm-client";
 import { createAmmV2ApiApp } from "./app";
 import { applyAmmV2BlockToDatabase } from "../indexers/ammv2-block-processor";
@@ -25,12 +25,19 @@ const BURN = "0x1" as const;
 const INDEXED_AT = new Date("2026-03-26T00:00:00.000Z");
 const EXPECTED_TIMESTAMP = Math.floor(INDEXED_AT.getTime() / 1000);
 const EXPECTED_PRICE = 22_000 / 36_000;
+const RESOURCE_SUPPLY = 36_000n;
 
 describe("AMMv2 game client parity", () => {
   const cleanup: Array<() => Promise<void>> = [];
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T12:00:00.000Z"));
+  });
+
   afterEach(async () => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
 
     while (cleanup.length > 0) {
       const close = cleanup.pop();
@@ -123,7 +130,14 @@ describe("AMMv2 game client parity", () => {
       ),
     });
 
-    const app = createAmmV2ApiApp({ db });
+    const app = createAmmV2ApiApp({
+      db,
+      lordsAddress: LORDS,
+      loadTokenTotalSupply: async (tokenAddress: string) => {
+        expect(tokenAddress).toBe("0x2");
+        return RESOURCE_SUPPLY;
+      },
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn((input: string | URL | Request, init?: RequestInit) => {
@@ -164,6 +178,8 @@ describe("AMMv2 game client parity", () => {
       fees24h: 6n,
       swapCount24h: 1,
       feeTo: "0x0",
+      resourceSupply: RESOURCE_SUPPLY,
+      marketCapLords: 22_000n,
     });
     expect(stats?.spotPrice).toBeCloseTo(EXPECTED_PRICE, 12);
 

--- a/client/apps/amm-indexerv2/api/server.ts
+++ b/client/apps/amm-indexerv2/api/server.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from "node:url";
+import { DEFAULT_STANDALONE_AMMV2_LORDS_ADDRESS } from "@bibliothecadao/ammv2-sdk";
 import { serve } from "@hono/node-server";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { createAmmV2DatabasePool, resolveAmmV2DatabaseConnectionString } from "../src/database-connection";
@@ -13,6 +14,8 @@ function createNodePgAmmV2ApiApp() {
   return createAmmV2ApiApp({
     db,
     allowedOrigins: resolveAllowedBrowserOrigins(process.env.AMMV2_API_ALLOWED_ORIGINS),
+    lordsAddress: process.env.AMMV2_LORDS_ADDRESS ?? DEFAULT_STANDALONE_AMMV2_LORDS_ADDRESS,
+    rpcUrl: process.env.RPC_URL,
   });
 }
 

--- a/client/apps/game/src/services/amm/game-amm-client.ts
+++ b/client/apps/game/src/services/amm/game-amm-client.ts
@@ -8,9 +8,11 @@ import {
   type CandleInterval,
   type PaginatedResponse,
   type PaginationOpts,
+  type PairStats,
   type PairSummary,
   type TimeRangeOpts,
 } from "@bibliothecadao/ammv2-sdk";
+import { computeMarketCapLords } from "./game-amm-market-cap";
 
 const FEE_DENOMINATOR = 1000n;
 
@@ -67,6 +69,8 @@ interface PoolStats {
   swapCount24h: number;
   spotPrice: number;
   feeTo: string;
+  resourceSupply: bigint | null;
+  marketCapLords: bigint | null;
 }
 
 interface UserPosition {
@@ -367,24 +371,13 @@ function mapPairToPool(pair: PairSummary, lordsAddress: string): Pool | null {
   };
 }
 
-function mapPairStats(
-  pair: PairSummary,
-  pairStats: {
-    volume0_24h: bigint;
-    volume1_24h: bigint;
-    lpFees0_24h: bigint;
-    lpFees1_24h: bigint;
-    swapCount24h: number;
-    feeTo: string;
-    spotPriceToken1PerToken0: number;
-    spotPriceToken0PerToken1: number;
-  },
-  lordsAddress: string,
-): PoolStats | null {
+function mapPairStats(pair: PairSummary, pairStats: PairStats, lordsAddress: string): PoolStats | null {
   const pairContext = resolveLordsPairContext(pair, lordsAddress);
   if (!pairContext) {
     return null;
   }
+
+  const spotPrice = pairContext.lordsIsToken0 ? pairStats.spotPriceToken0PerToken1 : pairStats.spotPriceToken1PerToken0;
 
   return {
     tokenAddress: pairContext.tokenAddress,
@@ -393,8 +386,10 @@ function mapPairStats(
     volume24h: pairContext.lordsIsToken0 ? pairStats.volume0_24h : pairStats.volume1_24h,
     fees24h: pairContext.lordsIsToken0 ? pairStats.lpFees0_24h : pairStats.lpFees1_24h,
     swapCount24h: pairStats.swapCount24h,
-    spotPrice: pairContext.lordsIsToken0 ? pairStats.spotPriceToken0PerToken1 : pairStats.spotPriceToken1PerToken0,
+    spotPrice,
     feeTo: pairStats.feeTo,
+    resourceSupply: pairStats.resourceTokenSupply,
+    marketCapLords: computeMarketCapLords(pairStats.resourceTokenSupply, spotPrice),
   };
 }
 

--- a/client/apps/game/src/services/amm/game-amm-market-cap.test.ts
+++ b/client/apps/game/src/services/amm/game-amm-market-cap.test.ts
@@ -1,0 +1,20 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { computeMarketCapLords } from "./game-amm-market-cap";
+
+describe("computeMarketCapLords", () => {
+  it("computes market cap in lords from raw supply and spot price", () => {
+    expect(computeMarketCapLords(36_000n, 22_000 / 36_000)).toBe(22_000n);
+  });
+
+  it("returns null when price is unavailable", () => {
+    expect(computeMarketCapLords(36_000n, Number.NaN)).toBeNull();
+    expect(computeMarketCapLords(36_000n, undefined)).toBeNull();
+  });
+
+  it("handles zero supply", () => {
+    expect(computeMarketCapLords(0n, 0.611111111111)).toBe(0n);
+  });
+});

--- a/client/apps/game/src/services/amm/game-amm-market-cap.ts
+++ b/client/apps/game/src/services/amm/game-amm-market-cap.ts
@@ -1,0 +1,31 @@
+const MARKET_CAP_PRICE_SCALE_DIGITS = 12;
+const MARKET_CAP_PRICE_SCALE = 10n ** BigInt(MARKET_CAP_PRICE_SCALE_DIGITS);
+
+export function computeMarketCapLords(resourceSupply: bigint | null, spotPrice: number | undefined): bigint | null {
+  if (resourceSupply === null) {
+    return null;
+  }
+
+  if (resourceSupply === 0n) {
+    return 0n;
+  }
+
+  if (spotPrice === undefined || !Number.isFinite(spotPrice) || spotPrice < 0) {
+    return null;
+  }
+
+  if (spotPrice === 0) {
+    return 0n;
+  }
+
+  return roundScaledAmount(resourceSupply, resolveScaledSpotPrice(spotPrice), MARKET_CAP_PRICE_SCALE);
+}
+
+function resolveScaledSpotPrice(spotPrice: number): bigint {
+  const [whole, fraction = ""] = spotPrice.toFixed(MARKET_CAP_PRICE_SCALE_DIGITS).split(".");
+  return BigInt(`${whole}${fraction}`);
+}
+
+function roundScaledAmount(amount: bigint, scaledMultiplier: bigint, scale: bigint): bigint {
+  return (amount * scaledMultiplier + scale / 2n) / scale;
+}

--- a/client/apps/game/src/ui/features/amm/amm-dashboard.tsx
+++ b/client/apps/game/src/ui/features/amm/amm-dashboard.tsx
@@ -89,8 +89,8 @@ const SummarySkeleton = () => (
   <div className="rounded-[28px] border border-gold/10 bg-black/25 p-4 backdrop-blur-[10px]">
     <div className="animate-pulse space-y-3">
       <div className="h-6 w-40 rounded bg-gold/10" />
-      <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-5">
-        {Array.from({ length: 5 }).map((_, index) => (
+      <div className="grid gap-2 grid-cols-2 md:grid-cols-4 xl:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, index) => (
           <div key={index} className="h-16 rounded-2xl bg-gold/8" />
         ))}
       </div>
@@ -157,6 +157,10 @@ const AmmSelectedPoolSummary = ({
   const feeBreakdown = resolveAmmFeeBreakdown(activePool);
   const metrics = [
     { label: "Spot Price", value: `${formatAmmSpotPrice(currentSpotPrice)} LORDS` },
+    {
+      label: "MCap",
+      value: statsQuery.data?.marketCapLords != null ? formatAmmCompactAmount(statsQuery.data.marketCapLords) : "--",
+    },
     { label: "TVL", value: formatAmmCompactAmount(activePool.lordsReserve * 2n) },
     { label: "24H Volume", value: statsQuery.data ? formatAmmCompactAmount(statsQuery.data.volume24h) : "--" },
     { label: "LP Fee", value: formatAmmPercent(feeBreakdown.lpFeePercent) },
@@ -198,7 +202,7 @@ const AmmSelectedPoolSummary = ({
         </button>
       </div>
 
-      <div className="mt-3 grid gap-1.5 grid-cols-2 md:grid-cols-3 xl:grid-cols-6">
+      <div className="mt-3 grid gap-1.5 grid-cols-2 md:grid-cols-4 xl:grid-cols-4">
         {metrics.map((metric, index) => (
           <div
             key={metric.label}

--- a/client/apps/game/src/ui/features/amm/amm-integration.source.test.ts
+++ b/client/apps/game/src/ui/features/amm/amm-integration.source.test.ts
@@ -103,4 +103,21 @@ describe("AMM feature wiring", () => {
     expect(addLiquiditySource).toContain("invalidateAmmReadQueries(queryClient)");
     expect(removeLiquiditySource).toContain("invalidateAmmReadQueries(queryClient)");
   });
+
+  it("renders mcap in the selected pool summary", () => {
+    const dashboardSource = readSource("src/ui/features/amm/amm-dashboard.tsx");
+
+    expect(dashboardSource).toContain('label: "MCap"');
+    expect(dashboardSource).toContain("statsQuery.data?.marketCapLords");
+    expect(dashboardSource).toContain("xl:grid-cols-4");
+  });
+
+  it("offers pool ordering controls for market cap, resource ids, and tvl", () => {
+    const poolListSource = readSource("src/ui/features/amm/amm-pool-list.tsx");
+
+    expect(poolListSource).toContain('label: "MCap"');
+    expect(poolListSource).toContain('label: "Resource IDs"');
+    expect(poolListSource).toContain('label: "TVL"');
+    expect(poolListSource).toContain('orderBy: "mcap"');
+  });
 });

--- a/client/apps/game/src/ui/features/amm/amm-model.test.ts
+++ b/client/apps/game/src/ui/features/amm/amm-model.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildAmmTokenOptions,
+  orderAmmPools,
   resolveAmmFeeBreakdown,
   resolveAmmPoolName,
   resolveAmmSwapRoute,
@@ -13,8 +14,11 @@ import {
 } from "./amm-model";
 
 const LORDS_ADDRESS = "0xlords";
+const STONE_ADDRESS = "0x439a1c010e3e1bb2d43d43411000893c0042bd88f6c701611a0ea914d426da4";
+const COAL_ADDRESS = "0xce635e3f241b0ae78c46a929d84a9101910188f9c4024eaa7559556503c31a";
+const WOOD_ADDRESS = "0x40d8907cec0f7ae9c364dfb12485a1314d84c129bf1898d2f3d4b7fcc7d44f4";
 
-function createPool(tokenAddress: string): Pool {
+function createPool(tokenAddress: string, overrides?: Partial<Pool>): Pool {
   return {
     pairAddress: `${tokenAddress}-pair`,
     tokenAddress,
@@ -26,6 +30,7 @@ function createPool(tokenAddress: string): Pool {
     feeNum: 3n,
     feeDenom: 1000n,
     feeTo: "0x0",
+    ...overrides,
   };
 }
 
@@ -112,5 +117,50 @@ describe("amm-model", () => {
     expect(feeBreakdown.totalFeePercent).toBeCloseTo(0.3);
     expect(feeBreakdown.lpFeePercent).toBeCloseTo(0.2);
     expect(feeBreakdown.protocolFeePercent).toBeCloseTo(0.1);
+  });
+
+  it("orders AMM pools by market cap", () => {
+    const stonePool = createPool(STONE_ADDRESS);
+    const coalPool = createPool(COAL_ADDRESS);
+    const woodPool = createPool(WOOD_ADDRESS);
+
+    const orderedPools = orderAmmPools([woodPool, stonePool, coalPool], {
+      lordsAddress: LORDS_ADDRESS,
+      orderBy: "mcap",
+      marketCapByTokenAddress: new Map([
+        [WOOD_ADDRESS, 5n],
+        [STONE_ADDRESS, 20n],
+        [COAL_ADDRESS, 10n],
+      ]),
+    });
+
+    expect(orderedPools.map((pool) => pool.tokenAddress)).toEqual([STONE_ADDRESS, COAL_ADDRESS, WOOD_ADDRESS]);
+  });
+
+  it("orders AMM pools by resource id", () => {
+    const orderedPools = orderAmmPools(
+      [WOOD_ADDRESS, COAL_ADDRESS, STONE_ADDRESS].map((address) => createPool(address)),
+      {
+        lordsAddress: LORDS_ADDRESS,
+        orderBy: "resourceIds",
+        marketCapByTokenAddress: new Map(),
+      },
+    );
+
+    expect(orderedPools.map((pool) => pool.tokenAddress)).toEqual([STONE_ADDRESS, COAL_ADDRESS, WOOD_ADDRESS]);
+  });
+
+  it("orders AMM pools by tvl", () => {
+    const lowTvlPool = createPool(STONE_ADDRESS, { lordsReserve: 100n });
+    const highTvlPool = createPool(COAL_ADDRESS, { lordsReserve: 400n });
+    const midTvlPool = createPool(WOOD_ADDRESS, { lordsReserve: 250n });
+
+    const orderedPools = orderAmmPools([lowTvlPool, highTvlPool, midTvlPool], {
+      lordsAddress: LORDS_ADDRESS,
+      orderBy: "tvl",
+      marketCapByTokenAddress: new Map(),
+    });
+
+    expect(orderedPools.map((pool) => pool.tokenAddress)).toEqual([COAL_ADDRESS, WOOD_ADDRESS, STONE_ADDRESS]);
   });
 });

--- a/client/apps/game/src/ui/features/amm/amm-model.ts
+++ b/client/apps/game/src/ui/features/amm/amm-model.ts
@@ -1,4 +1,5 @@
 import type { Pool } from "@/services/amm";
+import { findResourceIdByTrait } from "@bibliothecadao/types";
 
 import { resolveAmmAssetPresentation } from "./amm-asset-presentation";
 import type { TokenOption } from "./amm-token-input";
@@ -22,6 +23,14 @@ interface AmmFeeBreakdown {
   protocolFeePercent: number;
   totalFeePercent: number;
 }
+
+interface OrderAmmPoolsOptions {
+  lordsAddress: string;
+  orderBy: AmmPoolOrder;
+  marketCapByTokenAddress: Map<string, bigint | null>;
+}
+
+export type AmmPoolOrder = "mcap" | "resourceIds" | "tvl";
 
 const LP_FEE_SHARE = 2 / 3;
 const PROTOCOL_FEE_SHARE = 1 / 3;
@@ -68,6 +77,10 @@ export function resolveSelectedAmmPool(pools: Pool[], selectedPool: string | nul
   return pools.find((pool) => pool.tokenAddress === selectedPool) ?? pools[0];
 }
 
+export function orderAmmPools(pools: Pool[], options: OrderAmmPoolsOptions): Pool[] {
+  return [...pools].sort((leftPool, rightPool) => compareAmmPools(leftPool, rightPool, options));
+}
+
 export function resolveAmmSwapRoute(
   pools: Pool[],
   lordsAddress: string,
@@ -103,6 +116,72 @@ function buildAmmTokenOption(pool: Pool, lordsAddress: string): TokenOption {
     shortLabel: assetPresentation.shortLabel,
     iconResource: assetPresentation.iconResource,
   };
+}
+
+function compareAmmPools(leftPool: Pool, rightPool: Pool, options: OrderAmmPoolsOptions): number {
+  if (options.orderBy === "mcap") {
+    return (
+      compareBigIntDescending(
+        options.marketCapByTokenAddress.get(leftPool.tokenAddress) ?? null,
+        options.marketCapByTokenAddress.get(rightPool.tokenAddress) ?? null,
+      ) ||
+      compareBigIntDescending(resolvePoolTvl(leftPool), resolvePoolTvl(rightPool)) ||
+      compareResourceIdAscending(leftPool, rightPool, options.lordsAddress) ||
+      compareTokenAddressAscending(leftPool, rightPool)
+    );
+  }
+
+  if (options.orderBy === "tvl") {
+    return (
+      compareBigIntDescending(resolvePoolTvl(leftPool), resolvePoolTvl(rightPool)) ||
+      compareResourceIdAscending(leftPool, rightPool, options.lordsAddress) ||
+      compareTokenAddressAscending(leftPool, rightPool)
+    );
+  }
+
+  return (
+    compareResourceIdAscending(leftPool, rightPool, options.lordsAddress) ||
+    compareBigIntDescending(resolvePoolTvl(leftPool), resolvePoolTvl(rightPool)) ||
+    compareTokenAddressAscending(leftPool, rightPool)
+  );
+}
+
+function compareResourceIdAscending(leftPool: Pool, rightPool: Pool, lordsAddress: string): number {
+  return (
+    resolveAmmPoolResourceId(leftPool.tokenAddress, lordsAddress) -
+    resolveAmmPoolResourceId(rightPool.tokenAddress, lordsAddress)
+  );
+}
+
+function resolveAmmPoolResourceId(tokenAddress: string, lordsAddress: string): number {
+  const assetPresentation = resolveAmmAssetPresentation(tokenAddress, lordsAddress);
+  return assetPresentation.isLords
+    ? Number.MAX_SAFE_INTEGER
+    : (findResourceIdByTrait(assetPresentation.displayName) ?? Number.MAX_SAFE_INTEGER);
+}
+
+function resolvePoolTvl(pool: Pick<Pool, "lordsReserve">): bigint {
+  return pool.lordsReserve * 2n;
+}
+
+function compareBigIntDescending(leftValue: bigint | null, rightValue: bigint | null): number {
+  if (leftValue === rightValue) {
+    return 0;
+  }
+
+  if (leftValue === null) {
+    return 1;
+  }
+
+  if (rightValue === null) {
+    return -1;
+  }
+
+  return leftValue > rightValue ? -1 : 1;
+}
+
+function compareTokenAddressAscending(leftPool: Pool, rightPool: Pool): number {
+  return leftPool.tokenAddress.localeCompare(rightPool.tokenAddress);
 }
 
 function resolveTotalFeePercent(pool: Pick<Pool, "feeDenom" | "feeNum"> | null | undefined): number {

--- a/client/apps/game/src/ui/features/amm/amm-pool-list.tsx
+++ b/client/apps/game/src/ui/features/amm/amm-pool-list.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { resolveAmmAssetPresentation } from "./amm-asset-presentation";
 import { formatAmmCompactAmount, formatAmmSpotPrice } from "./amm-format";
+import { orderAmmPools, type AmmPoolOrder } from "./amm-model";
 import { AMM_READ_QUERY_OPTIONS } from "./amm-queries";
 
 interface AmmPoolListProps {
@@ -15,6 +16,12 @@ interface AmmPoolListProps {
   onPoolSelect?: (tokenAddress: string) => void;
   showHeader?: boolean;
 }
+
+const POOL_ORDER_OPTIONS: Array<{ orderBy: AmmPoolOrder; label: string }> = [
+  { orderBy: "mcap", label: "MCap" },
+  { orderBy: "resourceIds", label: "Resource IDs" },
+  { orderBy: "tvl", label: "TVL" },
+];
 
 const LoadingSkeleton = () => (
   <div className="space-y-2">
@@ -36,6 +43,7 @@ export const AmmPoolList = ({ className, onPoolSelect, showHeader = true }: AmmP
   const { client, config, isConfigured } = useAmm();
   const selectedPool = useAmmStore((s) => s.selectedPool);
   const setSelectedPool = useAmmStore((s) => s.setSelectedPool);
+  const [poolOrder, setPoolOrder] = useState<AmmPoolOrder>("resourceIds");
 
   const {
     data: pools,
@@ -49,23 +57,54 @@ export const AmmPoolList = ({ className, onPoolSelect, showHeader = true }: AmmP
     ...AMM_READ_QUERY_OPTIONS,
   });
 
-  useEffect(() => {
-    if (!selectedPool && pools && pools.length > 0) {
-      setSelectedPool(pools[0].tokenAddress);
-    }
-  }, [pools, selectedPool, setSelectedPool]);
+  const { data: marketCapByTokenAddress } = useQuery({
+    queryKey: ["amm-pool-ordering", pools?.map((pool) => pool.tokenAddress).join(",")],
+    queryFn: async () => {
+      if (!client || !pools) {
+        return new Map<string, bigint | null>();
+      }
+
+      const marketCapEntries = await Promise.all(
+        pools.map(async (pool) => {
+          const stats = await client.api.getPoolStats(pool.tokenAddress);
+          return [pool.tokenAddress, stats?.marketCapLords ?? null] as const;
+        }),
+      );
+
+      return new Map(marketCapEntries);
+    },
+    enabled: Boolean(client) && Boolean(pools?.length),
+    ...AMM_READ_QUERY_OPTIONS,
+  });
 
   const [search, setSearch] = useState("");
 
+  const orderedPools = useMemo(() => {
+    if (!pools) {
+      return [];
+    }
+
+    return orderAmmPools(pools, {
+      lordsAddress: config.lordsAddress,
+      orderBy: poolOrder,
+      marketCapByTokenAddress: marketCapByTokenAddress ?? new Map<string, bigint | null>(),
+    });
+  }, [config.lordsAddress, marketCapByTokenAddress, poolOrder, pools]);
+
+  useEffect(() => {
+    if (!selectedPool && orderedPools.length > 0) {
+      setSelectedPool(orderedPools[0].tokenAddress);
+    }
+  }, [orderedPools, selectedPool, setSelectedPool]);
+
   const filteredPools = useMemo(() => {
-    if (!pools) return [];
-    if (!search.trim()) return pools;
+    if (!search.trim()) return orderedPools;
     const term = search.trim().toLowerCase();
-    return pools.filter((pool) => {
+    return orderedPools.filter((pool) => {
       const asset = resolveAmmAssetPresentation(pool.tokenAddress, config.lordsAddress);
       return asset.displayName.toLowerCase().includes(term);
     });
-  }, [pools, search, config.lordsAddress]);
+  }, [orderedPools, search, config.lordsAddress]);
 
   if (!isConfigured || !client) {
     return (
@@ -135,6 +174,27 @@ export const AmmPoolList = ({ className, onPoolSelect, showHeader = true }: AmmP
         onChange={(e) => setSearch(e.target.value)}
         className="mb-2 w-full rounded-xl border border-gold/10 bg-black/30 px-3 py-2 text-xs text-gold placeholder:text-gold/30 outline-none focus:border-gold/25"
       />
+
+      <div className="mb-3">
+        <div className="mb-1 px-1 text-[10px] uppercase tracking-[0.16em] text-gold/35">Order</div>
+        <div className="grid grid-cols-3 gap-1">
+          {POOL_ORDER_OPTIONS.map((option) => (
+            <button
+              key={option.orderBy}
+              type="button"
+              className={cn(
+                "rounded-xl border px-2 py-2 text-[10px] font-semibold uppercase tracking-[0.12em] transition-colors",
+                poolOrder === option.orderBy
+                  ? "border-gold/25 bg-gold/15 text-gold"
+                  : "border-gold/10 bg-black/20 text-gold/55 hover:border-gold/20 hover:text-gold",
+              )}
+              onClick={() => setPoolOrder(option.orderBy)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       <div className="space-y-2">
         {filteredPools.length === 0 ? (

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -9,6 +9,13 @@ interface LatestFeature {
 
 export const latestFeatures: LatestFeature[] = [
   {
+    date: "2026-03-27",
+    title: "AMM Market Cap Summary",
+    description:
+      "The Agora AMM summary now shows each selected resource's market cap in LORDS, and the pool rail can be reordered by market cap, resource ID, or TVL so you can scan markets the way you want.",
+    type: "improvement",
+  },
+  {
     date: "2026-03-26",
     title: "Agora Fee Split Labels",
     description:

--- a/packages/ammv2-sdk/src/api/codec.ts
+++ b/packages/ammv2-sdk/src/api/codec.ts
@@ -77,6 +77,7 @@ export type RawPairStats = {
   lpFees0_24h: string | number;
   lpFees1_24h: string | number;
   swapCount24h: number;
+  resourceTokenSupply: string | number | null;
 };
 
 export type RawUserPairPosition = {
@@ -94,6 +95,8 @@ export type RawUserPairPosition = {
 
 const toBigInt = (value: string | number | bigint): bigint => BigInt(value);
 const toNumber = (value: string | number): number => Number(value);
+const toNullableBigInt = (value: string | number | bigint | null | undefined): bigint | null =>
+  value === null || value === undefined ? null : BigInt(value);
 
 const toUnixSeconds = (value: string | number): number =>
   typeof value === "number" ? value : Math.floor(new Date(value).getTime() / 1000);
@@ -181,6 +184,7 @@ export function decodePairStats(raw: RawPairStats): PairStats {
     lpFees0_24h: toBigInt(raw.lpFees0_24h),
     lpFees1_24h: toBigInt(raw.lpFees1_24h),
     swapCount24h: raw.swapCount24h,
+    resourceTokenSupply: toNullableBigInt(raw.resourceTokenSupply),
   };
 }
 

--- a/packages/ammv2-sdk/src/types.ts
+++ b/packages/ammv2-sdk/src/types.ts
@@ -64,6 +64,7 @@ export interface PairStats {
   lpFees0_24h: bigint;
   lpFees1_24h: bigint;
   swapCount24h: number;
+  resourceTokenSupply: bigint | null;
 }
 
 export interface UserPairPosition {

--- a/packages/ammv2-sdk/tests/api-client.test.ts
+++ b/packages/ammv2-sdk/tests/api-client.test.ts
@@ -163,4 +163,37 @@ describe("AmmV2ApiClient", () => {
       },
     ]);
   });
+
+  it("decodes pair stats with resource token supply", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValue(
+      okJson({
+        data: {
+          pairAddress: "0xpair",
+          reserve0: "1000",
+          reserve1: "500",
+          totalLpSupply: "100",
+          feeAmount: "997",
+          feeTo: "0xfee",
+          spotPriceToken1PerToken0: 0.5,
+          spotPriceToken0PerToken1: 2,
+          volume0_24h: "10",
+          volume1_24h: "20",
+          lpFees0_24h: "1",
+          lpFees1_24h: "0",
+          swapCount24h: 4,
+          resourceTokenSupply: "123456",
+        },
+      }) as Response,
+    );
+
+    const client = new AmmV2ApiClient("https://ammv2.example");
+    const stats = await client.getPairStats("0xpair");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://ammv2.example/api/v1/pairs/0xpair/stats");
+    expect(stats).toMatchObject({
+      pairAddress: "0xpair",
+      resourceTokenSupply: 123_456n,
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add live resource token supply to the AMMv2 stats API and carry it through the SDK and game AMM client.
- Show MCap in the Agora summary card with safe null handling and deterministic bigint market-cap math.
- Add left-rail pool ordering options for MCap, Resource IDs, and TVL, and document the change in latest features.

## Testing
- `pnpm test api/app.integration.test.ts`
- `pnpm test api/game-client-parity.integration.test.ts`
- `pnpm test tests/api-client.test.ts`
- `pnpm test src/services/amm/game-amm-market-cap.test.ts`
- `pnpm test src/ui/features/amm/amm-model.test.ts`
- `pnpm test src/ui/features/amm/amm-integration.source.test.ts`
- `pnpm run format`
- `pnpm run knip`