### PR TITLE
feat: refactor bottom-right panel for smaller screens

### DIFF
--- a/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
@@ -106,11 +106,11 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
 
   return (
     <div
-      className="grid h-full min-h-0 grid-cols-1 gap-2 overflow-hidden"
+      className="grid h-full min-h-0 grid-cols-1 gap-2 overflow-y-auto overflow-x-hidden"
       style={{ gridTemplateColumns, gridTemplateRows, gridAutoRows }}
     >
       {isSpire ? (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
           <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
             <SpireTravelPanel onTravelToEtherealLayer={handleTravelToEtherealLayer} />
           </EntityDetailSection>
@@ -119,7 +119,7 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
           </EntityDetailSection>
         </div>
       ) : isStructure ? (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
           <StructureBannerEntityDetail
             structureEntityId={occupierEntityId}
             maxInventory={14}
@@ -136,7 +136,7 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
           </EntityDetailSection>
         </div>
       ) : isChest ? (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
           <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
             <RelicCrateSummaryPanel crateEntityId={occupierEntityId} />
           </EntityDetailSection>
@@ -147,7 +147,7 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
       ) : isQuest ? (
         <QuestEntityDetail questEntityId={occupierEntityId} className="h-full min-h-0" {...sharedDetailProps} />
       ) : (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 md:grid-cols-[1.15fr_0.85fr]">
+        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
           <ArmyBannerEntityDetail
             armyEntityId={occupierEntityId}
             showButtons={false}

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
@@ -127,13 +127,13 @@ const PanelFrame = ({ title, children, headerAction, className, attached = false
     )}
     style={{ height: BOTTOM_PANEL_HEIGHT }}
   >
-    <header className="flex items-center justify-between gap-2 border-b border-gold/20 px-3 py-1.5">
+    <header className="flex items-center justify-between gap-2 border-b border-gold/20 px-2 py-1 lg:px-3 lg:py-1.5">
       <p className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.35em] text-gold/70">
         {title}
       </p>
       {headerAction ? <div className="shrink-0">{headerAction}</div> : null}
     </header>
-    <div className="flex-1 min-h-0 overflow-hidden px-2.5 py-2">{children}</div>
+    <div className="flex-1 min-h-0 overflow-hidden px-1.5 py-1 lg:px-2.5 lg:py-2">{children}</div>
   </section>
 );
 
@@ -1007,7 +1007,7 @@ export const BottomRightPanel = memo(() => {
       aria-hidden={!shouldShow}
       style={{ bottom: BOTTOM_PANEL_MARGIN }}
     >
-      <div className="relative w-full min-h-[44px] md:ml-auto md:w-[44%] lg:w-[36%] xl:w-[32%]">
+      <div className="relative w-full min-h-[44px] md:ml-auto md:w-[55%] lg:w-[44%] xl:w-[36%] 2xl:w-[32%]">
         <PanelTabs
           tabs={availableTabs}
           activeTab={activeTab}

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/constants.ts
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/constants.ts
@@ -1,2 +1,2 @@
-export const BOTTOM_PANEL_HEIGHT = "clamp(284px, 40vh, 344px)";
+export const BOTTOM_PANEL_HEIGHT = "clamp(220px, 35vh, 344px)";
 export const BOTTOM_PANEL_MARGIN = "0px";


### PR DESCRIPTION
## Summary
- Widens the bottom-right panel at `md`/`lg` breakpoints so content isn't cramped on smaller screens (55% at md, 44% at lg, 36% at xl, 32% at 2xl)
- Defers the two-column entity grid (army banner + biome card) from `md` to `lg` breakpoint — stacks vertically with scroll on narrower viewports
- Lowers panel height floor from 284px to 220px and 40vh to 35vh, freeing vertical space on short viewports (e.g., 768px tall laptops)
- Compacts header and content padding at smaller breakpoints

## Test plan
- [ ] Verify army tile view at 1024x768 — content stacks vertically, scrollable
- [ ] Verify army tile view at 1366x768 — two-column layout appears
- [ ] Verify structure/spire/chest tiles behave the same
- [ ] Verify minimap tab still fills panel correctly
- [ ] Verify local tile (building details) panel unaffected
- [ ] Verify panel at 1920x1080 — no visual regression

Closes #4114

🤖 Generated with [Claude Code](https://claude.com/claude-code)