### PR TITLE
feat(game): polish landing page hero cards

### DIFF
--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -510,9 +510,7 @@ const ModeCoexistenceHero = ({
                 <div
                   className={cn(
                     "inline-flex items-center gap-1.5 mt-3 text-xs font-medium transition-all duration-500 ease-out delay-150",
-                    isEmphasized
-                      ? "text-gold translate-y-0 opacity-100"
-                      : "text-white/40 translate-y-3 opacity-0",
+                    isEmphasized ? "text-gold translate-y-0 opacity-100" : "text-white/40 translate-y-3 opacity-0",
                   )}
                 >
                   {mode === "season" ? "Enter Campaigns" : "Enter Blitz"}


### PR DESCRIPTION
## Summary
- Removed the wrapper card container and duplicate "Choose Your War" heading, subheading, and filter toggle buttons from the landing page hero section
- Mode selection cards now render directly on the page background with increased height and stronger visual differentiation (scale, gold ring, grayscale on deselected)
- Page background crossfades between Eternum and Blitz imagery when switching modes, using the existing DynamicBackground system
- Card text animates elegantly on selection with staggered slide-up reveals for subtitle, CTA, and chevron
- Updated card copy and switched text/tag colors from white to gold

## Test plan
- [ ] Verify landing page loads with cards visible directly on background (no wrapper card)
- [ ] Click between Eternum Seasons and Blitz — background should crossfade
- [ ] Selected card should scale up with gold ring; unselected should dim with grayscale
- [ ] Text should animate in/out smoothly on selection change
- [ ] Check mobile responsive layout (single column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)