### PR TITLE
fix(game): restore factory SQL exports

### DIFF
--- a/client/apps/game/src/hooks/use-factory-series-index.ts
+++ b/client/apps/game/src/hooks/use-factory-series-index.ts
@@ -27,6 +27,13 @@ export interface FactorySeriesIndex {
   games: FactorySeriesGame[];
 }
 
+const buildFactorySeriesIndex = (chain: Chain, paddedName: string, name: string): FactorySeriesIndex => ({
+  chain,
+  name,
+  paddedName,
+  games: [],
+});
+
 const asRecord = (value: unknown): Record<string, unknown> | null => {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -66,14 +73,7 @@ const fetchSeriesIndex = async (chain: Chain): Promise<FactorySeriesIndex[]> => 
     if (!seriesName || !worldName) continue;
 
     const gameNumber = extractGameNumberFromRow(row);
-    const existing =
-      bySeries.get(seriesFelt) ??
-      ({
-        chain,
-        name: seriesName,
-        paddedName: seriesFelt,
-        games: [],
-      } satisfies FactorySeriesIndex);
+    const existing = bySeries.get(seriesFelt) ?? buildFactorySeriesIndex(chain, seriesFelt, seriesName);
 
     const hasGame = existing.games.some((game) => game.worldName === worldName);
     if (!hasGame) {

--- a/client/apps/game/src/runtime/world/factory-sql.ts
+++ b/client/apps/game/src/runtime/world/factory-sql.ts
@@ -1,4 +1,4 @@
-import { decodePaddedFeltAscii, extractNameFelt, fetchFactoryRows } from "../../../../../../common/factory/endpoints";
+export { decodePaddedFeltAscii, extractNameFelt, fetchFactoryRows } from "../../../../../../common/factory/endpoints";
 
 const asRecord = (value: unknown): Record<string, unknown> | null => {
   if (!value) return null;


### PR DESCRIPTION
This restores the factory SQL helper exports that the new series hooks import, which removes the preview-build TypeScript failures on the factory admin path. It also extracts a small factory series index builder so the accumulator stays concretely typed instead of collapsing to `never` during query aggregation. Verified with `pnpm run format`, `pnpm run knip`, `pnpm run build:packages`, and `npx -y node@20.19.0 $(which pnpm) --dir ./client/apps/game build --mode preview`.