### PR TITLE
Fix realtime torii availability build

### DIFF
--- a/client/apps/realtime-server/src/services/__tests__/torii-availability.test.ts
+++ b/client/apps/realtime-server/src/services/__tests__/torii-availability.test.ts
@@ -118,6 +118,12 @@ describe("ToriiAvailabilityService", () => {
       const availability = service.getAvailability();
       expect(availability["alpha"]).toBe(true);
       expect(availability["beta"]).toBe(false);
+
+      const factoryCall = mockFetch.mock.calls.find(([url]) => {
+        const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : (url as Request).url;
+        return urlStr.includes("/x/eternum-factory-mainnet/torii/sql");
+      });
+      expect(factoryCall).toBeDefined();
     });
 
     it("handles factory fetch failure gracefully", async () => {
@@ -199,9 +205,11 @@ describe("ToriiAvailabilityService", () => {
     it("does not start a second poll while the previous cycle is still running", async () => {
       vi.useFakeTimers();
 
-      let resolveFactoryFetch: ((value: Response) => void) | null = null;
+      const factoryFetchControl: { resolve: ((value: Response) => void) | null } = {
+        resolve: null,
+      };
       const factoryFetch = new Promise<Response>((resolve) => {
-        resolveFactoryFetch = resolve;
+        factoryFetchControl.resolve = resolve;
       });
 
       mockFetch.mockImplementation(() => factoryFetch);
@@ -218,7 +226,11 @@ describe("ToriiAvailabilityService", () => {
       await vi.advanceTimersByTimeAsync(3000);
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
-      resolveFactoryFetch?.(new Response(JSON.stringify([]), { status: 200 }));
+      const resolvePendingFactoryFetch = factoryFetchControl.resolve;
+      if (!resolvePendingFactoryFetch) {
+        throw new Error("Expected the factory fetch resolver to be assigned");
+      }
+      resolvePendingFactoryFetch(new Response(JSON.stringify([]), { status: 200 }));
       await Promise.resolve();
       service.stop();
       vi.useRealTimers();

--- a/client/apps/realtime-server/src/services/factory-worlds.ts
+++ b/client/apps/realtime-server/src/services/factory-worlds.ts
@@ -1,0 +1,111 @@
+const FACTORY_WORLDS_QUERY = `SELECT name, address FROM [wf-WorldDeployed] LIMIT 1000;`;
+const CARTRIDGE_API_BASE = "https://api.cartridge.gg";
+
+type FactoryRow = Record<string, unknown>;
+
+export async function fetchFactoryWorldNames(chain: string, timeoutMs: number): Promise<string[]> {
+  const baseUrl = resolveFactorySqlBaseUrl(chain);
+  if (!baseUrl) return [];
+
+  const rows = await fetchFactoryRows(baseUrl, FACTORY_WORLDS_QUERY, timeoutMs);
+
+  const names: string[] = [];
+  for (const row of rows) {
+    const nameFelt = extractNameFelt(row);
+    if (!nameFelt) continue;
+
+    const decodedName = decodePaddedFeltAscii(nameFelt);
+    if (decodedName) names.push(decodedName);
+  }
+
+  return names;
+}
+
+function resolveFactorySqlBaseUrl(chain: string): string {
+  switch (chain) {
+    case "mainnet":
+      return `${CARTRIDGE_API_BASE}/x/eternum-factory-mainnet/torii/sql`;
+    case "sepolia":
+      return `${CARTRIDGE_API_BASE}/x/eternum-factory-sepolia/torii/sql`;
+    case "slot":
+    case "slottest":
+    case "local":
+      return `${CARTRIDGE_API_BASE}/x/eternum-factory-slot-d/torii/sql`;
+    default:
+      return "";
+  }
+}
+
+async function fetchFactoryRows(factorySqlBaseUrl: string, query: string, timeoutMs: number): Promise<FactoryRow[]> {
+  const url = `${factorySqlBaseUrl}?query=${encodeURIComponent(query)}`;
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Factory query failed: ${response.status} ${response.statusText}`);
+  }
+
+  const rows = (await response.json()) as FactoryRow[];
+  if (!Array.isArray(rows)) {
+    throw new Error("Factory query returned unexpected payload");
+  }
+
+  return rows;
+}
+
+function extractNameFelt(row: FactoryRow): string | null {
+  const directName = row.name ?? row["data.name"];
+  if (typeof directName === "string") {
+    return directName;
+  }
+
+  const nestedData = asRecord(row.data);
+  if (nestedData && typeof nestedData.name === "string") {
+    return nestedData.name;
+  }
+
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value) return null;
+
+  if (typeof value === "string") {
+    try {
+      const parsedValue = JSON.parse(value);
+      if (parsedValue && typeof parsedValue === "object" && !Array.isArray(parsedValue)) {
+        return parsedValue as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return null;
+}
+
+function decodePaddedFeltAscii(hex: string): string {
+  if (!hex) return "";
+
+  const normalizedHex = hex.startsWith("0x") || hex.startsWith("0X") ? hex.slice(2) : hex;
+  if (!normalizedHex || normalizedHex === "0") return "";
+
+  let byteIndex = 0;
+  while (byteIndex + 1 < normalizedHex.length && normalizedHex.slice(byteIndex, byteIndex + 2) === "00") {
+    byteIndex += 2;
+  }
+
+  let output = "";
+  for (; byteIndex + 1 < normalizedHex.length; byteIndex += 2) {
+    const byteValue = Number.parseInt(normalizedHex.slice(byteIndex, byteIndex + 2), 16);
+    if (Number.isNaN(byteValue) || byteValue === 0) continue;
+    output += String.fromCharCode(byteValue);
+  }
+
+  return output;
+}

--- a/client/apps/realtime-server/src/services/torii-availability.ts
+++ b/client/apps/realtime-server/src/services/torii-availability.ts
@@ -1,38 +1,11 @@
-import {
-  decodePaddedFeltAscii,
-  extractNameFelt,
-  fetchFactoryRows,
-  getFactorySqlBaseUrl,
-} from "../../../../../common/factory/endpoints";
+import { fetchFactoryWorldNames } from "./factory-worlds";
 
 export interface WorldAvailabilityEntry {
   alive: boolean;
   lastChecked: number;
 }
 
-const FACTORY_WORLDS_QUERY = `SELECT name, address FROM [wf-WorldDeployed] LIMIT 1000;`;
-
 const CARTRIDGE_API_BASE = "https://api.cartridge.gg";
-
-/**
- * Fetch world names from a factory indexer.
- */
-async function fetchWorldNamesFromFactory(chain: string, timeoutMs: number): Promise<string[]> {
-  const baseUrl = getFactorySqlBaseUrl(chain);
-  if (!baseUrl) return [];
-
-  const rows = await fetchFactoryRows(baseUrl, FACTORY_WORLDS_QUERY, { timeoutMs });
-
-  const names: string[] = [];
-  for (const row of rows) {
-    const nameFelt = extractNameFelt(row);
-    if (!nameFelt) continue;
-    const decoded = decodePaddedFeltAscii(nameFelt);
-    if (decoded) names.push(decoded);
-  }
-
-  return names;
-}
 
 export class ToriiAvailabilityService {
   private cache = new Map<string, WorldAvailabilityEntry>();
@@ -108,7 +81,7 @@ export class ToriiAvailabilityService {
 
     for (const chain of this.factoryChains) {
       try {
-        const names = await fetchWorldNamesFromFactory(chain, this.factoryTimeoutMs);
+        const names = await fetchFactoryWorldNames(chain, this.factoryTimeoutMs);
         for (const name of names) {
           allNames.add(name);
         }


### PR DESCRIPTION
This fixes the realtime server build by moving factory world lookup into a local service helper instead of importing from the shared factory module. That removes the cross-root TypeScript import and the extra starknet dependency from the realtime server build path while keeping the poller flow readable. The torii availability tests now assert the mainnet factory URL and use a resolver pattern that type-checks cleanly under tsc. Verified with bun run test src/services/__tests__/torii-availability.test.ts, pnpm run build:packages, bun run build, pnpm run format, and pnpm run knip.