### PR TITLE
fix(game): unsuppress armies when deferred removal is cancelled

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -3216,6 +3216,8 @@ export default class WorldmapScene extends WarpTravel {
           if (lastUpdate > meta.scheduledAt) {
             this.pendingArmyRemovalMeta.delete(entityId);
             this.pendingArmyRemovals.delete(entityId);
+            this.armyManager.unsuppressArmy(entityId);
+            this.requestChunkRefresh(true, "default");
             return;
           }
 
@@ -3266,14 +3268,21 @@ export default class WorldmapScene extends WarpTravel {
     const deferred = Array.from(this.deferredChunkRemovals.entries());
     this.deferredChunkRemovals.clear();
 
+    let anyUnsuppressed = false;
     deferred.forEach(([entityId, { reason, scheduledAt }]) => {
       const lastUpdate = this.armyLastUpdateAt.get(entityId) ?? 0;
       if (lastUpdate > scheduledAt) {
+        this.armyManager.unsuppressArmy(entityId);
+        anyUnsuppressed = true;
         return;
       }
 
       this.scheduleArmyRemoval(entityId, reason);
     });
+
+    if (anyUnsuppressed) {
+      this.requestChunkRefresh(true, "default");
+    }
   }
 
   private cancelPendingArmyRemoval(entityId: ID) {


### PR DESCRIPTION
## Summary
- Fixes ghost troops that become permanently unselectable after zooming/panning
- Two code paths in `scheduleArmyRemoval` and `retryDeferredChunkRemovals` cancel a pending army removal when the army receives a newer update, but forget to call `unsuppressArmy()` — leaving armies permanently hidden in the `suppressedArmies` set
- Adds `unsuppressArmy()` calls and triggers a chunk refresh so the army re-enters the visible rendering set

## Root Cause
When an army is scheduled for removal, `hideArmyVisual()` immediately suppresses it. If the removal is later cancelled (because the army got a fresh update), the army stays suppressed forever. Zoom/pan exacerbates this by causing chunk switches during pending removal timeouts, hitting the deferral path which also leaks suppressions. Over time, more armies accumulate in `suppressedArmies` until all troops become unresponsive.

## Test plan
- [x] Existing `worldmap-army-suppression.test.ts` passes
- [x] Existing `army-manager.suppression.test.ts` passes (9 tests)
- [ ] Manual: zoom in/out rapidly while armies are moving — verify no ghost troops appear
- [ ] Manual: explore into new territory, zoom out and back — verify all armies remain selectable