### PR TITLE
Open first game load on the world map

### DIFF
--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -10,6 +10,13 @@ interface LatestFeature {
 export const latestFeatures: LatestFeature[] = [
   {
     date: "2026-03-30",
+    title: "World Map First Entry",
+    description:
+      "Entering a game now opens on the world map centered on your realm instead of dropping straight into local realm view, so first load starts with broader context.",
+    type: "fix",
+  },
+  {
+    date: "2026-03-30",
     title: "Torii Stream Timeout Recovery",
     description:
       "World map chunk streaming now times out and cleans up stuck Torii subscription handoffs, so chunk traversal can recover from a bad stream swap instead of locking the map in place.",

--- a/client/apps/game/src/ui/layouts/game-loading-overlay.test.tsx
+++ b/client/apps/game/src/ui/layouts/game-loading-overlay.test.tsx
@@ -1,0 +1,103 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigateMock = vi.fn();
+const setShowBlankOverlayMock = vi.fn();
+const setStructureEntityIdMock = vi.fn();
+const usePlayerStructuresMock = vi.fn();
+
+const uiStoreState = {
+  isSpectating: false,
+  loadingStates: {},
+  setShowBlankOverlay: setShowBlankOverlayMock,
+};
+
+const useUIStoreMock = Object.assign(
+  vi.fn((selector: (state: typeof uiStoreState) => unknown) => selector(uiStoreState)),
+  {
+    getState: () => ({
+      setStructureEntityId: setStructureEntityIdMock,
+    }),
+  },
+);
+
+vi.mock("@/hooks/store/use-ui-store", () => ({
+  useUIStore: useUIStoreMock,
+}));
+
+vi.mock("@bibliothecadao/react", () => ({
+  usePlayerStructures: () => usePlayerStructuresMock(),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  Position: class MockPosition {
+    private readonly x: number;
+    private readonly y: number;
+
+    constructor({ x, y }: { x: number; y: number }) {
+      this.x = x;
+      this.y = y;
+    }
+
+    getNormalized() {
+      return { x: this.x, y: this.y };
+    }
+  },
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => navigateMock,
+}));
+
+vi.mock("@/ui/layouts/bootstrap-loading/bootstrap-loading-panel", () => ({
+  BootstrapLoadingPanel: () => <div data-testid="bootstrap-loading-panel" />,
+}));
+
+const { GameLoadingOverlay } = await import("./game-loading-overlay");
+
+describe("GameLoadingOverlay", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    navigateMock.mockReset();
+    setShowBlankOverlayMock.mockReset();
+    setStructureEntityIdMock.mockReset();
+    usePlayerStructuresMock.mockReset();
+    uiStoreState.isSpectating = false;
+    uiStoreState.loadingStates = {};
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("opens player first load on the world map while selecting the first synced realm", async () => {
+    usePlayerStructuresMock.mockReturnValue([
+      {
+        entityId: 77,
+        position: { x: 4, y: 9 },
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<GameLoadingOverlay />);
+    });
+
+    expect(setStructureEntityIdMock).toHaveBeenCalledWith(77, {
+      spectator: false,
+      worldMapPosition: { col: 4, row: 9 },
+    });
+    expect(navigateMock).toHaveBeenCalledWith("/play/map?col=4&row=9");
+    expect(container.textContent).toContain("Entering World View");
+  });
+});

--- a/client/apps/game/src/ui/layouts/game-loading-overlay.tsx
+++ b/client/apps/game/src/ui/layouts/game-loading-overlay.tsx
@@ -5,29 +5,24 @@ import { usePlayerStructures } from "@bibliothecadao/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { BootstrapTask } from "@/hooks/context/use-eager-bootstrap";
 import { BootstrapLoadingPanel } from "@/ui/layouts/bootstrap-loading/bootstrap-loading-panel";
-import {
-  getSceneWarmupProgress,
-  resolveEntryOverlayPhase,
-  waitForHexceptionGridReady,
-} from "./game-loading-overlay.utils";
+import { getSceneWarmupProgress, resolveEntryOverlayPhase } from "./game-loading-overlay.utils";
 import { useNavigate } from "react-router-dom";
 
 const SAFETY_TIMEOUT_MS = 15_000;
 const SLOW_THRESHOLD_MS = 8_000;
 const TICK_INTERVAL_MS = 250;
 const HANDOFF_PROGRESS = 76;
-const POST_HEX_READY_DELAY_MS = 250;
-const HEXCEPTION_READY_TIMEOUT_MS = 6_000;
-// Time to wait after tile data loads before dismissing (spectator path).
-// Longer because the bounds subscription still needs to stream Structure
-// entities and the WorldUpdateListener needs to process them into visuals.
-const POST_MAP_LOAD_DELAY_MS = 3_000;
+// Time to wait after tile data loads before dismissing.
+// The bounds subscription still needs to stream structures and the
+// world update listener needs to process them into visible state.
+const POST_WORLD_MAP_LOAD_DELAY_MS = 3_000;
 
 /**
  * Loading overlay shown while game data syncs after <World> mounts.
  *
  * For players:
- *   Waits for structures in RECS, navigates to the player's realm, then dismisses.
+ *   Waits for structures in RECS, navigates to the player's realm on the world map,
+ *   then dismisses once the map finishes its initial fetch.
  *
  * For spectators:
  *   Waits for the world map's initial Torii fetch to complete, then dismisses.
@@ -44,8 +39,8 @@ export const GameLoadingOverlay = () => {
   const startedAt = useRef(0);
   const hasStartedPlayerFlow = useRef(false);
   const hasStartedSpectatorFlow = useRef(false);
-  const hasQueuedSpectatorReady = useRef(false);
-  const spectatorReadyTimeoutId = useRef<number | null>(null);
+  const hasQueuedWorldMapReady = useRef(false);
+  const worldMapReadyTimeoutId = useRef<number | null>(null);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [isReady, setIsReady] = useState(false);
   const navigate = useNavigate();
@@ -69,7 +64,7 @@ export const GameLoadingOverlay = () => {
     return () => window.clearInterval(interval);
   }, []);
 
-  // --- Player path: navigate to first structure once it appears in RECS ---
+  // --- Player path: navigate to the world map centered on the first synced structure ---
   useEffect(() => {
     if (hasDismissed.current || isSpectating || hasStartedPlayerFlow.current) return;
     if (playerStructures.length === 0) return;
@@ -85,24 +80,22 @@ export const GameLoadingOverlay = () => {
       worldMapPosition: { col: normalized.x, row: normalized.y },
     });
 
-    const targetCoords = { col: normalized.x, row: normalized.y };
-    const ready = waitForHexceptionGridReady(targetCoords, HEXCEPTION_READY_TIMEOUT_MS);
-
-    const url = `/play/hex?col=${normalized.x}&row=${normalized.y}`;
+    const url = `/play/map?col=${normalized.x}&row=${normalized.y}`;
     navigate(url);
     window.dispatchEvent(new Event("urlChanged"));
-
-    void ready.then(() => {
-      setIsReady(true);
-      dismiss(POST_HEX_READY_DELAY_MS);
-    });
   }, [playerStructures, isSpectating, navigate, dismiss]);
 
-  // --- Spectator path: dismiss once the world map finishes its initial fetch ---
+  // --- World-map path: dismiss once the initial map fetch completes ---
   useEffect(() => {
-    if (hasDismissed.current || !isSpectating) return;
-    if (!hasStartedSpectatorFlow.current) {
+    if (hasDismissed.current) return;
+
+    if (isSpectating && !hasStartedSpectatorFlow.current) {
       hasStartedSpectatorFlow.current = true;
+    }
+
+    const hasStartedWorldMapFlow = isSpectating ? hasStartedSpectatorFlow.current : hasStartedPlayerFlow.current;
+    if (!hasStartedWorldMapFlow) {
+      return;
     }
 
     if (mapLoading) {
@@ -112,20 +105,20 @@ export const GameLoadingOverlay = () => {
     // Map loading went true → false: initial tile fetch complete.
     // Wait additional time for the bounds subscription to stream
     // Structure entities and for the map to render them.
-    if (hasSeenMapLoading.current && !mapLoading && !hasQueuedSpectatorReady.current) {
-      hasQueuedSpectatorReady.current = true;
-      spectatorReadyTimeoutId.current = window.setTimeout(() => {
-        spectatorReadyTimeoutId.current = null;
+    if (hasSeenMapLoading.current && !mapLoading && !hasQueuedWorldMapReady.current) {
+      hasQueuedWorldMapReady.current = true;
+      worldMapReadyTimeoutId.current = window.setTimeout(() => {
+        worldMapReadyTimeoutId.current = null;
         setIsReady(true);
       }, 0);
-      dismiss(POST_MAP_LOAD_DELAY_MS);
+      dismiss(POST_WORLD_MAP_LOAD_DELAY_MS);
     }
   }, [mapLoading, isSpectating, dismiss]);
 
   useEffect(() => {
     return () => {
-      if (spectatorReadyTimeoutId.current !== null) {
-        window.clearTimeout(spectatorReadyTimeoutId.current);
+      if (worldMapReadyTimeoutId.current !== null) {
+        window.clearTimeout(worldMapReadyTimeoutId.current);
       }
     };
   }, []);
@@ -156,16 +149,16 @@ export const GameLoadingOverlay = () => {
   }, [phase, elapsedMs]);
 
   const statements = useMemo(() => {
-    if (phase === "ready") return ["Realm ready!"];
-    if (phase === "slow") return ["Taking longer than usual, still syncing...", "Still assembling your realm..."];
-    if (phase === "handoff") return ["Opening your realm portal..."];
-    return ["Rendering your realm...", "Placing structures...", "Waking your armies..."];
+    if (phase === "ready") return ["World view ready!"];
+    if (phase === "slow") return ["Taking longer than usual, still syncing...", "Still charting nearby territory..."];
+    if (phase === "handoff") return ["Opening your world map..."];
+    return ["Rendering the world map...", "Charting nearby territory...", "Locating your realm..."];
   }, [phase]);
 
   const tasks = useMemo<BootstrapTask[]>(() => {
     if (phase === "ready") {
       return [
-        { id: "handoff", label: "Transitioning to the realm", status: "complete" },
+        { id: "handoff", label: "Transitioning to the world map", status: "complete" },
         { id: "render", label: "Rendering terrain and structures", status: "complete" },
         { id: "final", label: "Final checks", status: "complete" },
       ];
@@ -173,7 +166,7 @@ export const GameLoadingOverlay = () => {
 
     if (phase === "handoff") {
       return [
-        { id: "handoff", label: "Transitioning to the realm", status: "running" },
+        { id: "handoff", label: "Transitioning to the world map", status: "running" },
         { id: "render", label: "Rendering terrain and structures", status: "pending" },
         { id: "final", label: "Final checks", status: "pending" },
       ];
@@ -181,20 +174,20 @@ export const GameLoadingOverlay = () => {
 
     if (phase === "slow") {
       return [
-        { id: "handoff", label: "Transitioning to the realm", status: "complete" },
+        { id: "handoff", label: "Transitioning to the world map", status: "complete" },
         { id: "render", label: "Rendering terrain and structures", status: "running" },
         { id: "final", label: "Final checks", status: "running" },
       ];
     }
 
     return [
-      { id: "handoff", label: "Transitioning to the realm", status: "complete" },
+      { id: "handoff", label: "Transitioning to the world map", status: "complete" },
       { id: "render", label: "Rendering terrain and structures", status: "running" },
       { id: "final", label: "Final checks", status: "pending" },
     ];
   }, [phase]);
 
-  const overlayTitle = isSpectating ? "Entering World View" : "Entering Realm";
+  const overlayTitle = "Entering World View";
 
   return (
     <div className="absolute inset-0 z-[110] flex items-center justify-center bg-black/95 backdrop-blur-sm">

--- a/docs/prd-player-first-load-world-map.md
+++ b/docs/prd-player-first-load-world-map.md
@@ -1,0 +1,39 @@
+# PRD: Player First Load Opens World Map
+
+## Problem
+
+When a player enters the game, the loading handoff currently redirects straight into the player's realm hex view. That
+skips the broader world context and makes first load feel like a forced drill-down instead of an arrival into the game
+world.
+
+## Goal
+
+On first load, players should land on the world map centered on their first synced realm instead of opening directly
+inside that realm.
+
+## Non-Goals
+
+- Changing spectator entry behavior
+- Changing which owned structure becomes the default controlled structure
+- Changing later in-session navigation between map and hex views
+
+## Desired Behavior
+
+1. Entering the game still waits for owned structures to sync.
+2. The first synced owned structure is still stored as the selected controlled structure.
+3. Once that structure is known, player entry navigates to `/play/map` using that structure's normalized coordinates.
+4. The loading overlay copy describes world-map entry rather than realm entry.
+
+## Acceptance Criteria
+
+- A player first load no longer redirects to `/play/hex`.
+- A player first load redirects to `/play/map?col=<x>&row=<y>` for the first synced owned structure.
+- The selected controlled structure remains set to that owned structure.
+- Spectator behavior is unchanged.
+
+## TDD Plan
+
+1. Add a component test for `GameLoadingOverlay` that renders the player path with a synced owned structure.
+2. Verify the test fails because the current implementation navigates to `/play/hex` and shows realm-specific copy.
+3. Update the loading overlay to route players to `/play/map` and refresh the copy.
+4. Re-run the test and the required repo checks.


### PR DESCRIPTION
This changes the initial player handoff so entering a game opens on the world map centered on the first synced owned realm instead of dropping straight into local realm view.

The goal here is the small UX correction only: preserve the player's default controlled realm, but start the session with broader world context.

## What changed
- route player first-load handoff to `/play/map` once the first owned structure is synced
- keep the selected controlled structure pointed at that realm while waiting for map loading to finish
- update the loading overlay copy so it describes world-map entry instead of realm entry
- add a focused overlay test that covers the player first-load path
- add a short PRD capturing the intended behavior and acceptance criteria

## Verification
- `pnpm --dir client/apps/game test src/ui/layouts/game-loading-overlay.test.tsx`
- `pnpm run format`
- `pnpm run knip`

## Not changed
- spectator entry behavior
- later in-session navigation between map and hex views