### PR TITLE
fix: block blitz army-to-structure troop transfers

### DIFF
--- a/client/apps/game/src/ui/features/military/components/transfer-troops-container.tsx
+++ b/client/apps/game/src/ui/features/military/components/transfer-troops-container.tsx
@@ -1,7 +1,10 @@
 import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import Button from "@/ui/design-system/atoms/button";
-import { resolveArmyToStructureTransferRestriction } from "@/ui/lib/structure-capabilities";
+import {
+  resolveArmyToArmyTransferRestriction,
+  resolveArmyToStructureTransferRestriction,
+} from "@/ui/lib/structure-capabilities";
 import { LoadingAnimation } from "@/ui/design-system/molecules/loading-animation";
 import { formatNumber } from "@/ui/utils/utils";
 
@@ -102,12 +105,14 @@ export const TransferTroopsContainer = ({
         getStructureFromToriiClient(toriiClient, selectedEntityId),
         getExplorerFromToriiClient(toriiClient, selectedEntityId),
       ]);
+      const explorerOwner = explorerData?.explorer?.owner ?? 0;
 
       return {
         structure: structureData.structure,
         structureResources: structureData.resources,
         explorer: explorerData.explorer,
         explorerResources: explorerData.resources,
+        explorerConnectedStructure: await getStructureFromToriiClient(toriiClient, explorerOwner),
       };
     },
     staleTime: 10000, // 10 seconds
@@ -153,20 +158,29 @@ export const TransferTroopsContainer = ({
   const selectedStructure = selectedEntityData?.structure;
   const selectedExplorerTroops = selectedEntityData?.explorer;
   const selectedExplorerResources = selectedEntityData?.explorerResources;
+  const selectedExplorerConnectedStructure = selectedEntityData?.explorerConnectedStructure?.structure;
   const targetStructure = targetEntityData?.structure;
   const targetExplorerTroops = targetEntityData?.explorer;
   const targetExplorerConnectedStructure = targetEntityData?.explorerConnectedStructure?.structure;
-  const armyToStructureTransferRestriction = useMemo(() => {
-    if (transferDirection !== TransferDirection.ExplorerToStructure) {
-      return null;
+  const transferRestriction = useMemo(() => {
+    if (transferDirection === TransferDirection.ExplorerToStructure) {
+      return resolveArmyToStructureTransferRestriction({
+        modeId: mode.id,
+        destination: targetStructure,
+      });
     }
 
-    return resolveArmyToStructureTransferRestriction({
-      modeId: mode.id,
-      destination: targetStructure,
-    });
-  }, [mode.id, targetStructure, transferDirection]);
-  const isArmyToStructureTransferBlocked = armyToStructureTransferRestriction !== null;
+    if (transferDirection === TransferDirection.ExplorerToExplorer) {
+      return resolveArmyToArmyTransferRestriction({
+        modeId: mode.id,
+        source: selectedExplorerConnectedStructure,
+        destination: targetExplorerConnectedStructure,
+      });
+    }
+
+    return null;
+  }, [mode.id, selectedExplorerConnectedStructure, targetExplorerConnectedStructure, targetStructure, transferDirection]);
+  const isTransferBlocked = transferRestriction !== null;
 
   const troopCapacityLimit = useMemo(() => {
     const tier = (targetExplorerTroops?.troops?.tier as TroopTier) ?? TroopTier.T1;
@@ -772,7 +786,7 @@ export const TransferTroopsContainer = ({
   // Handle transfer
   const handleTransfer = async () => {
     if (!selectedHex || !targetEntityId) return;
-    if (isArmyToStructureTransferBlocked) return;
+    if (isTransferBlocked) return;
 
     const direction = getDirectionBetweenAdjacentHexes(
       { col: selectedHex.x, row: selectedHex.y },
@@ -896,7 +910,7 @@ export const TransferTroopsContainer = ({
   };
 
   const isTroopsTransferDisabled = (() => {
-    if (isArmyToStructureTransferBlocked) return true;
+    if (isTransferBlocked) return true;
     if (troopAmount === 0) return true;
 
     if (guardSelectionRequired && guardSlot === null) {
@@ -1027,7 +1041,7 @@ export const TransferTroopsContainer = ({
 
   const getDisabledMessage = () => {
     if (loading) return "Processing transfer...";
-    if (armyToStructureTransferRestriction) return armyToStructureTransferRestriction;
+    if (transferRestriction) return transferRestriction;
     if (troopAmount === 0) return "Please select an amount of troops to transfer";
 
     if (guardSelectionRequired && guardSlot === null) {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -12,7 +12,7 @@ export const latestFeatures: LatestFeature[] = [
     date: "2026-03-30",
     title: "Blitz Army Structure Lock",
     description:
-      "Army transfer windows now immediately explain when Blitz does not allow returning troops into camps, rifts, or hyperstructures, so blocked moves are clear before you try to confirm them.",
+      "Army transfer windows now immediately explain when Blitz blocks returns into camps, rifts, or hyperstructures, and when army-to-army swaps cross realm boundaries, so invalid troop moves are clear before you try to confirm them.",
     type: "fix",
   },
   {

--- a/client/apps/game/src/ui/lib/structure-capabilities.test.ts
+++ b/client/apps/game/src/ui/lib/structure-capabilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { StructureType } from "@bibliothecadao/types";
 import {
+  resolveArmyToArmyTransferRestriction,
   canTransferMilitaryInventoryBetweenStructures,
   canTransferMilitaryInventoryFromStructure,
   isVillageLikeStructureCategory,
@@ -15,12 +16,14 @@ const createStructure = ({
   fieldArmySlots = 0,
   guardArmySlots = 0,
   villageRealm,
+  realmId,
 }: {
   category: StructureType;
   entityId: number;
   fieldArmySlots?: number;
   guardArmySlots?: number;
   villageRealm?: number;
+  realmId?: number;
 }): StructureCapabilityTarget => ({
   category,
   entity_id: entityId,
@@ -29,7 +32,10 @@ const createStructure = ({
     troop_max_explorer_count: fieldArmySlots,
     troop_max_guard_count: guardArmySlots,
   },
-  metadata: villageRealm ? { village_realm: villageRealm } : {},
+  metadata: {
+    ...(villageRealm ? { village_realm: villageRealm } : {}),
+    ...(realmId ? { realm_id: realmId } : {}),
+  },
 });
 
 describe("resolveStructureUiCapabilities", () => {
@@ -143,6 +149,51 @@ describe("Blitz military transfer rules", () => {
       "cannot transfer army to structure",
     );
     expect(resolveArmyToStructureTransferRestriction({ modeId: "eternum", destination: camp })).toBeNull();
+  });
+
+  it("blocks explorer to explorer troop transfers across different realms", () => {
+    const sameRealmCamp = createStructure({
+      category: StructureType.Camp,
+      entityId: 31,
+      fieldArmySlots: 1,
+      guardArmySlots: 1,
+      realmId: 30,
+    });
+    const sameRealmHyperstructure = createStructure({
+      category: StructureType.Hyperstructure,
+      entityId: 32,
+      guardArmySlots: 4,
+      realmId: 30,
+    });
+    const otherRealmCamp = createStructure({
+      category: StructureType.Camp,
+      entityId: 41,
+      fieldArmySlots: 1,
+      guardArmySlots: 1,
+      realmId: 40,
+    });
+
+    expect(
+      resolveArmyToArmyTransferRestriction({
+        modeId: "blitz",
+        source: sameRealmCamp,
+        destination: sameRealmHyperstructure,
+      }),
+    ).toBeNull();
+    expect(
+      resolveArmyToArmyTransferRestriction({
+        modeId: "blitz",
+        source: sameRealmCamp,
+        destination: otherRealmCamp,
+      }),
+    ).toBe("you can only transfer between armies from the same realm");
+    expect(
+      resolveArmyToArmyTransferRestriction({
+        modeId: "eternum",
+        source: sameRealmCamp,
+        destination: otherRealmCamp,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/client/apps/game/src/ui/lib/structure-capabilities.ts
+++ b/client/apps/game/src/ui/lib/structure-capabilities.ts
@@ -13,6 +13,7 @@ type StructureBaseLike = {
 };
 
 type StructureMetadataLike = {
+  realm_id?: ID | bigint | number;
   village_realm?: ID | bigint | number;
 };
 
@@ -80,6 +81,25 @@ const getStructureCategory = (structure: StructureCapabilityTarget): StructureTy
 
 const getStructureEntityId = (structure: StructureCapabilityTarget): number | null =>
   normalizeEntityId(structure?.entity_id);
+
+const getStructureRealmId = (structure: StructureCapabilityTarget): number | null => {
+  const explicitRealmId = normalizeEntityId(structure?.metadata?.realm_id);
+  if (explicitRealmId !== null && explicitRealmId > 0) {
+    return explicitRealmId;
+  }
+
+  const villageRealmId = normalizeEntityId(structure?.metadata?.village_realm);
+  if (villageRealmId !== null && villageRealmId > 0) {
+    return villageRealmId;
+  }
+
+  const category = getStructureCategory(structure);
+  if (category === StructureType.Realm) {
+    return getStructureEntityId(structure);
+  }
+
+  return null;
+};
 
 const isInventoryStructureCategory = (category: StructureType | null) =>
   category !== null && INVENTORY_STRUCTURE_CATEGORIES.has(category);
@@ -176,6 +196,32 @@ export const resolveArmyToStructureTransferRestriction = ({
   }
 
   return "cannot transfer army to structure";
+};
+
+export const resolveArmyToArmyTransferRestriction = ({
+  modeId,
+  source,
+  destination,
+}: {
+  modeId: GameModeId;
+  source: StructureCapabilityTarget;
+  destination: StructureCapabilityTarget;
+}) => {
+  if (modeId !== "blitz") {
+    return null;
+  }
+
+  const sourceRealmId = getStructureRealmId(source);
+  const destinationRealmId = getStructureRealmId(destination);
+  if (sourceRealmId === null || destinationRealmId === null) {
+    return null;
+  }
+
+  if (sourceRealmId === destinationRealmId) {
+    return null;
+  }
+
+  return "you can only transfer between armies from the same realm";
 };
 
 const getStructureByEntityId = (


### PR DESCRIPTION
## Summary
This blocks Blitz army-to-structure troop returns when the destination is a camp, essence rift, or hyperstructure, while leaving the transfer UI in place and showing the message "cannot transfer army to structure" in the modal.
The restriction is centralized in the shared structure capability helpers, and the troop transfer container now disables confirmation as soon as that blocked path is opened.
This PR also adds a focused unit test for the new Blitz rule and a latest-features entry documenting the UX change.
Verification in this workspace was limited because `client/apps/game` dependencies are not installed: the targeted Vitest run, `pnpm run format`, and `pnpm run knip` all failed due missing local packages and tools.