### PR TITLE
Fix stale structure owner labels after sync races

### DIFF
--- a/packages/core/src/systems/world-update-listener.test.ts
+++ b/packages/core/src/systems/world-update-listener.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   defineComponentSystemMock,
   mapDataStoreRefreshMock,
+  mapDataStoreGetStructureByIdMock,
+  mapDataStoreUpdateStructureGuardsMock,
   isComponentUpdateMock,
   getComponentValueMock,
   tileOptToTileMock,
@@ -10,10 +12,13 @@ const {
   getIsBlitzMock,
   getStructureInfoFromTileOccupierMock,
   enhanceStructureDataMock,
+  getPlayerNameMock,
   updateStructureOwnerMock,
 } = vi.hoisted(() => ({
   defineComponentSystemMock: vi.fn(),
   mapDataStoreRefreshMock: vi.fn().mockResolvedValue(undefined),
+  mapDataStoreGetStructureByIdMock: vi.fn(),
+  mapDataStoreUpdateStructureGuardsMock: vi.fn(),
   isComponentUpdateMock: vi.fn(() => false),
   getComponentValueMock: vi.fn(() => undefined),
   tileOptToTileMock: vi.fn(),
@@ -26,6 +31,7 @@ const {
     activeProductions: [],
     battleData: undefined,
   })),
+  getPlayerNameMock: vi.fn(async () => ""),
   updateStructureOwnerMock: vi.fn(),
 }));
 
@@ -44,6 +50,8 @@ vi.mock("../stores/map-data-store", () => ({
   MapDataStore: {
     getInstance: () => ({
       refresh: mapDataStoreRefreshMock,
+      getStructureById: mapDataStoreGetStructureByIdMock,
+      updateStructureGuards: mapDataStoreUpdateStructureGuardsMock,
     }),
   },
 }));
@@ -69,16 +77,21 @@ vi.mock("./data-enhancer", () => ({
   DataEnhancer: class {
     constructor(_mapDataStore: unknown) {}
     enhanceStructureData = enhanceStructureDataMock;
+    getPlayerName = getPlayerNameMock;
     updateStructureOwner = updateStructureOwnerMock;
   },
 }));
 
 import { WorldUpdateListener } from "./world-update-listener";
 
+const encodeAddressName = (value: string): bigint => BigInt(`0x${Buffer.from(value, "utf8").toString("hex")}`);
+
 describe("WorldUpdateListener army tile bootstrap", () => {
   beforeEach(() => {
     defineComponentSystemMock.mockClear();
     mapDataStoreRefreshMock.mockClear();
+    mapDataStoreGetStructureByIdMock.mockReset();
+    mapDataStoreUpdateStructureGuardsMock.mockReset();
     isComponentUpdateMock.mockReset();
     isComponentUpdateMock.mockReturnValue(false);
     getComponentValueMock.mockReset();
@@ -90,6 +103,8 @@ describe("WorldUpdateListener army tile bootstrap", () => {
     getIsBlitzMock.mockReturnValue(true);
     getStructureInfoFromTileOccupierMock.mockReset();
     enhanceStructureDataMock.mockClear();
+    getPlayerNameMock.mockReset();
+    getPlayerNameMock.mockResolvedValue("");
     updateStructureOwnerMock.mockClear();
   });
 
@@ -206,4 +221,155 @@ describe("WorldUpdateListener army tile bootstrap", () => {
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback.mock.calls[0][0].structureName).toBe("Realm of Testing");
   });
+
+  it("re-resolves a non-zero owner when cached data still says The Vanguard", async () => {
+    isComponentUpdateMock.mockReturnValue(true);
+    tileOptToTileMock.mockReturnValue({
+      occupier_type: 1,
+      occupier_id: 921,
+      col: 10,
+      row: 15,
+    });
+    getStructureInfoFromTileOccupierMock.mockReturnValue({
+      type: 4,
+      stage: 0,
+      level: 1,
+      hasWonder: false,
+    });
+    enhanceStructureDataMock.mockResolvedValue({
+      owner: { address: 123n, ownerName: "The Vanguard", guildName: "" },
+      guardArmies: [],
+      activeProductions: [],
+      battleData: undefined,
+      structureName: "Realm of Testing",
+    });
+    getComponentValueMock.mockImplementation((component) => {
+      if (component === structureComponents.Structure) {
+        return {
+          owner: 123n,
+          troop_guards: null,
+        };
+      }
+
+      if (component === structureComponents.AddressName) {
+        return {
+          name: encodeAddressName("Alice"),
+        };
+      }
+
+      return undefined;
+    });
+
+    const listener = new WorldUpdateListener(
+      {
+        network: { world: {} },
+        components: structureComponents,
+      } as any,
+      {} as any,
+    );
+
+    const callback = vi.fn();
+    listener.Structure.onTileUpdate(callback);
+
+    const handleUpdate = defineComponentSystemMock.mock.calls[0][2];
+    await handleUpdate({
+      value: [{}, undefined],
+      entity: "0x123",
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0].owner).toEqual({
+      address: 123n,
+      ownerName: "Alice",
+      guildName: "",
+    });
+  });
+
+  it("drops a stale tile hydration result when a newer structure update arrives", async () => {
+    isComponentUpdateMock.mockReturnValue(true);
+    tileOptToTileMock.mockReturnValue({
+      occupier_type: 1,
+      occupier_id: 921,
+      col: 10,
+      row: 15,
+    });
+    getStructureInfoFromTileOccupierMock.mockReturnValue({
+      type: 4,
+      stage: 0,
+      level: 1,
+      hasWonder: false,
+    });
+    getPlayerNameMock.mockResolvedValue("Alice");
+
+    let resolveTileUpdate!: (value: {
+      owner: { address: bigint; ownerName: string; guildName: string };
+      guardArmies: never[];
+      activeProductions: never[];
+      battleData: undefined;
+    }) => void;
+    enhanceStructureDataMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveTileUpdate = resolve;
+        }),
+    );
+
+    const listener = new WorldUpdateListener(
+      {
+        network: { world: {} },
+        components: structureComponents,
+      } as any,
+      {} as any,
+    );
+
+    const tileCallback = vi.fn();
+    const structureCallback = vi.fn();
+    listener.Structure.onTileUpdate(tileCallback);
+    listener.Structure.onStructureUpdate(structureCallback);
+
+    const tileHandleUpdate = defineComponentSystemMock.mock.calls[0][2];
+    const structureHandleUpdate = defineComponentSystemMock.mock.calls[1][2];
+
+    const pendingTileUpdate = tileHandleUpdate({
+      value: [{}, undefined],
+      entity: "0x123",
+    });
+
+    const pendingStructureUpdate = structureHandleUpdate({
+      value: [
+        {
+          entity_id: 921,
+          owner: 123n,
+          troop_guards: null,
+          base: { coord_x: 10, coord_y: 15 },
+        },
+        undefined,
+      ],
+      entity: "0x123",
+    });
+
+    resolveTileUpdate({
+      owner: { address: 0n, ownerName: "The Vanguard", guildName: "" },
+      guardArmies: [],
+      activeProductions: [],
+      battleData: undefined,
+    });
+
+    await Promise.all([pendingTileUpdate, pendingStructureUpdate]);
+
+    expect(tileCallback).not.toHaveBeenCalled();
+    expect(structureCallback).toHaveBeenCalledTimes(1);
+    expect(structureCallback.mock.calls[0][0].owner).toEqual({
+      address: 123n,
+      ownerName: "Alice",
+      guildName: "",
+    });
+  });
 });
+
+const structureComponents = {
+  TileOpt: {},
+  Hyperstructure: {},
+  Structure: {},
+  AddressName: {},
+};

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -147,6 +147,40 @@ export class WorldUpdateListener {
     );
   }
 
+  private shouldResolveOwnerNameFromAddress(
+    ownerAddress: bigint | undefined,
+    ownerName: string | undefined,
+  ): ownerAddress is bigint {
+    if (ownerAddress === undefined || ownerAddress === 0n) {
+      return false;
+    }
+
+    const trimmedOwnerName = ownerName?.trim() ?? "";
+    return trimmedOwnerName.length === 0 || trimmedOwnerName === BANDITS_NAME;
+  }
+
+  private resolveOwnerNameFromAddress(ownerAddress: bigint | undefined, fallbackOwnerName: string | undefined): string {
+    let resolvedOwnerName = fallbackOwnerName?.trim() ?? "";
+
+    if (this.shouldResolveOwnerNameFromAddress(ownerAddress, resolvedOwnerName) && this.setup.components.AddressName) {
+      try {
+        const addressName = getComponentValue(this.setup.components.AddressName, getEntityIdFromKeys([ownerAddress]));
+
+        if (addressName?.name) {
+          resolvedOwnerName = shortString.decodeShortString(addressName.name.toString());
+        }
+      } catch (error) {
+        console.warn(`Failed to decode address name for owner ${ownerAddress}:`, error);
+      }
+    }
+
+    if ((ownerAddress === undefined || ownerAddress === 0n) && resolvedOwnerName.length === 0) {
+      return BANDITS_NAME;
+    }
+
+    return resolvedOwnerName;
+  }
+
   private setupSystem<T>(
     component: Component,
     callback: (value: T) => void,
@@ -464,28 +498,8 @@ export class WorldUpdateListener {
                   this.mapDataStore.updateStructureGuards(rawOccupierId, guardArmies, battleCooldownEnd);
                 }
 
-                let ownerAddress = structureComponent?.owner ?? enhancedData.owner.address ?? 0n;
-                let ownerName = enhancedData.owner.ownerName;
-
-                if ((!ownerName || ownerName.length === 0) && ownerAddress && ownerAddress !== 0n) {
-                  try {
-                    const addressName = getComponentValue(
-                      this.setup.components.AddressName,
-                      getEntityIdFromKeys([ownerAddress]),
-                    );
-
-                    if (addressName?.name) {
-                      ownerName = shortString.decodeShortString(addressName.name.toString());
-                    }
-                  } catch (error) {
-                    console.warn(`Failed to decode address name for owner ${ownerAddress}:`, error);
-                  }
-                }
-
-                ownerName = ownerName || "";
-                if (ownerAddress === 0n && ownerName.length === 0) {
-                  ownerName = BANDITS_NAME;
-                }
+                const ownerAddress = structureComponent?.owner ?? enhancedData.owner.address ?? 0n;
+                const ownerName = this.resolveOwnerNameFromAddress(ownerAddress, enhancedData.owner.ownerName);
 
                 this.dataEnhancer.updateStructureOwner(rawOccupierId, ownerAddress, ownerName);
 
@@ -559,11 +573,6 @@ export class WorldUpdateListener {
                   ? ownerValue.toString()
                   : (ownerValue ?? "0");
 
-              let playerName = await this.dataEnhancer.getPlayerName(ownerString);
-              if (ownerValue === 0n && (!playerName || playerName.length === 0)) {
-                playerName = BANDITS_NAME;
-              }
-
               const entityId = this.resolveEntityId(currentState.entity_id as ID | undefined, update.entity, () => {
                 const componentState = getComponentValue(this.setup.components.Structure, update.entity) as
                   | { entity_id?: ID }
@@ -576,38 +585,47 @@ export class WorldUpdateListener {
                 return;
               }
 
-              this.dataEnhancer.updateStructureOwner(entityId, ownerValue, playerName);
+              return (
+                (await this.processSequentialUpdate(entityId, async () => {
+                  const playerName = this.resolveOwnerNameFromAddress(
+                    ownerValue,
+                    await this.dataEnhancer.getPlayerName(ownerString),
+                  );
 
-              const baseCoords = currentState.base ?? { coord_x: 0, coord_y: 0 };
-              let col = baseCoords.coord_x ?? 0;
-              let row = baseCoords.coord_y ?? 0;
+                  this.dataEnhancer.updateStructureOwner(entityId, ownerValue, playerName);
 
-              // Fall back to mapDataStore if coords are 0,0 (partial update, e.g. ownership change)
-              if (col === 0 && row === 0) {
-                const existing = this.mapDataStore.getStructureById(entityId);
-                if (existing) {
-                  col = existing.coordX;
-                  row = existing.coordY;
-                }
-              }
+                  const baseCoords = currentState.base ?? { coord_x: 0, coord_y: 0 };
+                  let col = baseCoords.coord_x ?? 0;
+                  let row = baseCoords.coord_y ?? 0;
 
-              const battleCooldownEnd = this.getBattleCooldownEnd(troopGuards);
+                  // Fall back to mapDataStore if coords are 0,0 (partial update, e.g. ownership change)
+                  if (col === 0 && row === 0) {
+                    const existing = this.mapDataStore.getStructureById(entityId);
+                    if (existing) {
+                      col = existing.coordX;
+                      row = existing.coordY;
+                    }
+                  }
 
-              this.mapDataStore.updateStructureGuards(entityId, guardArmies, battleCooldownEnd);
+                  const battleCooldownEnd = this.getBattleCooldownEnd(troopGuards);
 
-              const structureSystemUpdate: StructureSystemUpdate = {
-                entityId,
-                guardArmies,
-                owner: {
-                  address: currentState.owner,
-                  ownerName: playerName,
-                  guildName: "",
-                },
-                hexCoords: { col, row },
-                battleCooldownEnd,
-              };
+                  this.mapDataStore.updateStructureGuards(entityId, guardArmies, battleCooldownEnd);
 
-              return structureSystemUpdate;
+                  const structureSystemUpdate: StructureSystemUpdate = {
+                    entityId,
+                    guardArmies,
+                    owner: {
+                      address: currentState.owner,
+                      ownerName: playerName,
+                      guildName: "",
+                    },
+                    hexCoords: { col, row },
+                    battleCooldownEnd,
+                  };
+
+                  return structureSystemUpdate;
+                })) ?? undefined
+              );
             }
           },
           false,


### PR DESCRIPTION
This fixes the structure owner desync where the world hover label could keep showing "The Vanguard" after a realm already had a real owner.

It makes tile hydration and live structure-owner updates share the same per-entity sequencing so an older chunk result cannot overwrite a newer owner update. It also forces non-zero owners to re-resolve through AddressName when cached data still carries the unowned fallback, and adds regression tests for both the stale-cache and stale-hydration cases. Verification: attempted `pnpm run format`, `pnpm run knip`, and targeted tests, but this workspace is missing local dependencies/node_modules, so those commands could not complete.