### PR TITLE
Polish the Agora pool rail and sorter

### DIFF
--- a/client/apps/game/src/ui/features/amm/amm-dashboard.tsx
+++ b/client/apps/game/src/ui/features/amm/amm-dashboard.tsx
@@ -62,7 +62,7 @@ function useAmmSelectionState() {
 
 const AmmDesktopPoolRail = () => {
   return (
-    <aside className="hidden min-h-0 lg:block lg:w-[300px] lg:self-stretch">
+    <aside className="hidden min-h-0 lg:block lg:h-full lg:w-[300px]">
       <AmmPoolList className="h-full" />
     </aside>
   );
@@ -359,13 +359,13 @@ const AmmDashboardContent = () => {
   const [mobilePickerOpen, setMobilePickerOpen] = useState(false);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 lg:flex lg:h-full lg:min-h-0 lg:flex-col lg:overflow-hidden">
       <AmmMobilePoolPicker open={mobilePickerOpen} onClose={() => setMobilePickerOpen(false)} />
 
-      <div className="grid gap-4 lg:grid-cols-[300px_minmax(0,1fr)]">
+      <div className="grid gap-4 lg:min-h-0 lg:flex-1 lg:grid-cols-[300px_minmax(0,1fr)] lg:overflow-hidden">
         <AmmDesktopPoolRail />
 
-        <div className="min-w-0 space-y-4">
+        <div className="min-w-0 space-y-4 lg:min-h-0 lg:overflow-y-auto lg:pr-1 lg:scrollbar-thin lg:scrollbar-thumb-gold/20 lg:scrollbar-track-transparent">
           <AmmSelectedPoolSummary
             activePool={activePool}
             isConfigured={isConfigured}

--- a/client/apps/game/src/ui/features/amm/amm-integration.source.test.ts
+++ b/client/apps/game/src/ui/features/amm/amm-integration.source.test.ts
@@ -126,10 +126,13 @@ describe("AMM feature wiring", () => {
 
     expect(poolListSource).toContain('label: "Default"');
     expect(poolListSource).toContain('useState<AmmPoolOrder>("default")');
-    expect(poolListSource).toContain("<select");
+    expect(poolListSource).toContain("<Select");
+    expect(poolListSource).toContain("<SelectTrigger");
+    expect(poolListSource).toContain("<SelectContent");
+    expect(poolListSource).toContain("<SelectItem");
   });
 
-  it("shows spot price, market cap, and tvl in each pool row", () => {
+  it("shows spot price, market cap, and tvl in each pool row without the old crowded labels", () => {
     const poolListSource = readSource("src/ui/features/amm/amm-pool-list.tsx");
     const poolRowSource = readSource("src/ui/features/amm/amm-pool-row.tsx");
 
@@ -137,7 +140,20 @@ describe("AMM feature wiring", () => {
     expect(poolRowSource).toContain("spotPrice");
     expect(poolRowSource).toContain("marketCap");
     expect(poolRowSource).toContain("TVL");
-    expect(poolRowSource).toContain("Spot Price");
+    expect(poolRowSource).not.toContain("Spot Price");
+    expect(poolRowSource).not.toContain("pairLabel");
+    expect(poolRowSource).not.toContain("vs LORDS");
+    expect(poolRowSource).toContain("text-right");
+  });
+
+  it("keeps the desktop pool rail inside a viewport-bounded shell", () => {
+    const ammViewSource = readSource("src/ui/features/landing/views/amm-view.tsx");
+    const dashboardSource = readSource("src/ui/features/amm/amm-dashboard.tsx");
+
+    expect(ammViewSource).toContain("lg:h-[calc(100vh-7.5rem)]");
+    expect(ammViewSource).toContain("lg:overflow-hidden");
+    expect(dashboardSource).toContain("lg:h-full");
+    expect(dashboardSource).toContain("lg:overflow-hidden");
   });
 
   it("adds reserve cards and a voyager fee link to the selected pool summary", () => {

--- a/client/apps/game/src/ui/features/amm/amm-pool-list.tsx
+++ b/client/apps/game/src/ui/features/amm/amm-pool-list.tsx
@@ -1,10 +1,11 @@
 import { Button } from "@/ui/design-system/atoms";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/design-system/atoms/select";
 import { useAmm } from "@/hooks/use-amm";
-import { computeSpotPrice, type Pool } from "@/services/amm";
 import { useAmmStore } from "@/hooks/store/use-amm-store";
-import { AmmPoolRow } from "./amm-pool-row";
+import { computeSpotPrice, type Pool } from "@/services/amm";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
+import { AmmPoolRow } from "./amm-pool-row";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { resolveAmmAssetPresentation } from "./amm-asset-presentation";
 import { formatAmmCompactAmount, formatAmmSpotPrice } from "./amm-format";
@@ -183,20 +184,25 @@ export const AmmPoolList = ({ className, onPoolSelect, showHeader = true }: AmmP
 
       <div className="mb-3">
         <div className="mb-1 px-1 text-[10px] uppercase tracking-[0.16em] text-gold/35">Order</div>
-        <select
-          value={poolOrder}
-          onChange={(event) => setPoolOrder(event.target.value as AmmPoolOrder)}
-          className="w-full rounded-xl border border-gold/10 bg-black/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-gold outline-none focus:border-gold/25"
-        >
-          {POOL_ORDER_OPTIONS.map((option) => (
-            <option key={option.orderBy} value={option.orderBy}>
-              {option.label}
-            </option>
-          ))}
-        </select>
+        <Select value={poolOrder} onValueChange={(value) => setPoolOrder(value as AmmPoolOrder)}>
+          <SelectTrigger className="w-full rounded-xl border border-gold/15 bg-black/40 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-gold shadow-[0_14px_40px_-28px_rgba(0,0,0,0.95)] hover:bg-gold/8 focus:border-gold/30">
+            <SelectValue placeholder="Sort pools" />
+          </SelectTrigger>
+          <SelectContent className="rounded-2xl border border-gold/20 bg-[#120d08]/95 p-1 text-gold shadow-[0_24px_60px_-28px_rgba(0,0,0,0.98)] backdrop-blur-[18px]">
+            {POOL_ORDER_OPTIONS.map((option) => (
+              <SelectItem
+                key={option.orderBy}
+                value={option.orderBy}
+                className="rounded-xl px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-gold/75 focus:bg-gold/12 focus:text-gold"
+              >
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+      <div className="min-h-0 flex-1 overflow-y-auto pr-1 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
         <div className="space-y-2">
           {filteredPools.length === 0 ? (
             <div className="py-4 text-center text-xs text-gold/35">No pools match</div>
@@ -212,7 +218,6 @@ export const AmmPoolList = ({ className, onPoolSelect, showHeader = true }: AmmP
                   key={pool.tokenAddress}
                   iconResource={asset.iconResource}
                   marketCap={marketCap}
-                  pairLabel="vs LORDS"
                   spotPrice={spotPrice}
                   tokenName={asset.displayName}
                   tvl={tvl}

--- a/client/apps/game/src/ui/features/amm/amm-pool-row.tsx
+++ b/client/apps/game/src/ui/features/amm/amm-pool-row.tsx
@@ -5,7 +5,6 @@ import { memo } from "react";
 interface AmmPoolRowProps {
   iconResource: string | null;
   marketCap: string;
-  pairLabel: string;
   spotPrice: string;
   tokenName: string;
   tvl: string;
@@ -14,12 +13,12 @@ interface AmmPoolRowProps {
 }
 
 export const AmmPoolRow = memo(
-  ({ iconResource, marketCap, pairLabel, spotPrice, tokenName, tvl, isSelected, onClick }: AmmPoolRowProps) => {
+  ({ iconResource, marketCap, spotPrice, tokenName, tvl, isSelected, onClick }: AmmPoolRowProps) => {
     return (
       <button
         type="button"
         className={cn(
-          "group flex min-h-[60px] w-full items-center gap-3 rounded-2xl border px-3 py-2 text-left transition-all duration-200",
+          "group flex min-h-[68px] w-full items-center gap-3 rounded-2xl border px-3 py-2.5 text-left transition-all duration-200",
           isSelected
             ? "border-gold/20 border-l-gold/60 border-l-2 bg-gold/12 shadow-[0_12px_30px_-24px_rgba(223,170,84,0.22)] backdrop-blur-[10px]"
             : "border-gold/10 bg-black/25 hover:border-gold/20 hover:bg-gold/8 backdrop-blur-[10px]",
@@ -37,20 +36,16 @@ export const AmmPoolRow = memo(
         </div>
 
         <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-3">
-            <span className="truncate text-sm font-semibold text-gold">{tokenName}</span>
-            <span className="shrink-0 text-right text-[10px] uppercase tracking-[0.12em] text-gold/55">
-              <span className="block text-gold/35">Spot Price</span>
-              <span className="text-xs font-medium text-gold">{spotPrice} LORDS</span>
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1">
+            <span className="truncate text-xs font-semibold uppercase tracking-[0.14em] text-gold">{tokenName}</span>
+            <span className="shrink-0 text-right text-xs font-semibold uppercase tracking-[0.14em] text-gold/80">
+              {spotPrice} LORDS
             </span>
-          </div>
-          <div className="mt-0.5 flex items-center justify-between gap-3 text-[11px] uppercase tracking-[0.12em]">
-            <span className="truncate text-gold/40">{pairLabel}</span>
-            <span className="min-w-0 text-right text-gold/60">
+            <span className="text-[10px] uppercase tracking-[0.14em] text-gold/30">Resource Pool</span>
+            <div className="flex flex-col items-end text-right text-[10px] uppercase tracking-[0.14em] text-gold/55">
               <span className="whitespace-nowrap">MCap {marketCap}</span>
-              <span className="mx-1 text-gold/25">•</span>
               <span className="whitespace-nowrap">TVL {tvl} LORDS</span>
-            </span>
+            </div>
           </div>
         </div>
       </button>

--- a/client/apps/game/src/ui/features/landing/views/amm-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/amm-view.tsx
@@ -15,7 +15,12 @@ const LoadingSpinner = () => (
 
 export const AmmView = ({ className }: AmmViewProps) => {
   return (
-    <div className={cn("flex w-full max-w-[1500px] flex-col pb-10", className)}>
+    <div
+      className={cn(
+        "flex w-full max-w-[1500px] flex-col pb-10 lg:h-[calc(100vh-7.5rem)] lg:min-h-0 lg:overflow-hidden lg:pb-0",
+        className,
+      )}
+    >
       <Suspense fallback={<LoadingSpinner />}>
         <AmmDashboard />
       </Suspense>

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -10,6 +10,13 @@ interface LatestFeature {
 export const latestFeatures: LatestFeature[] = [
   {
     date: "2026-03-30",
+    title: "Agora Pool Rail Polish",
+    description:
+      "The Agora pool rail now keeps its own desktop scroll, uses a themed sort control, and trims each pool row down to the essentials so market cap and TVL stay readable while you browse.",
+    type: "fix",
+  },
+  {
+    date: "2026-03-30",
     title: "Blitz Army Structure Lock",
     description:
       "Army transfer windows now immediately explain when Blitz blocks returns into camps, rifts, or hyperstructures, and when army-to-army swaps cross realm boundaries, so invalid troop moves are clear before you try to confirm them.",


### PR DESCRIPTION
This tightens the remaining AMM page review gaps from #4515 without changing any pricing or transaction behavior. The main goal here is readability: the desktop pool rail now stays inside a bounded shell, the ordering control uses the shared themed select, and each pool row is trimmed down so the key market metrics stay legible.

## What changed
- bounded the AMM landing view on desktop so the pool rail keeps its own scroll area instead of extending the whole page
- replaced the native pool ordering dropdown with the shared Radix select styling
- simplified pool rows by removing the extra `Spot Price` and `vs LORDS` copy and right-aligning `MCap` / `TVL`
- added a latest-features entry for the Agora polish pass
- extended the AMM source test to lock the new layout and sorter contract in place

## Verification
- `npx -y node@20.19.0 $(which pnpm) --dir client/apps/game test src/ui/features/amm/amm-integration.source.test.ts`
- `npx -y node@20.19.0 $(which pnpm) run format`
- `npx -y node@20.19.0 $(which pnpm) run knip`

## Not tested
- browser-level verification of the live Agora dashboard

Closes #4515