### PR TITLE
feat(game): switch blitz to mixtapes

### DIFF
--- a/client/apps/game/src/audio/config/route-tracks.test.ts
+++ b/client/apps/game/src/audio/config/route-tracks.test.ts
@@ -57,6 +57,14 @@ describe("matchRoutePlaylist", () => {
     mockedGetGameModeId.mockReturnValue("blitz");
     const match = matchRoutePlaylist("/play");
     expect(match.key).toBe("play:blitz");
+    expect(match.mode).toBe("shuffle");
+    expect(match.tracks).toEqual([
+      "music.monophonic_mixtape_09",
+      "music.monophonic_mixtape_10",
+      "music.monophonic_mixtape_11",
+      "music.monophonic_mixtape_12",
+      "music.monophonic_mixtape_13",
+    ]);
   });
 
   it("falls back to main play playlist when not in blitz", () => {

--- a/client/apps/game/src/audio/config/route-tracks.ts
+++ b/client/apps/game/src/audio/config/route-tracks.ts
@@ -96,7 +96,13 @@ const ROUTE_TRACK_DEFINITIONS: RouteTrackDefinition[] = [
     key: "play:blitz",
     priority: 90,
     mode: "shuffle",
-    tracks: ["music.blitz", "music.order_of_anger", "music.order_of_rage", "music.light_through_darkness"],
+    tracks: [
+      "music.monophonic_mixtape_09",
+      "music.monophonic_mixtape_10",
+      "music.monophonic_mixtape_11",
+      "music.monophonic_mixtape_12",
+      "music.monophonic_mixtape_13",
+    ],
     match: (context) => context.modeId === "blitz" && createStartsWithMatcher("/play")(context),
   },
   {


### PR DESCRIPTION
## Summary
Switch the blitz `/play` playlist from the combat tracks to all five monophonic mixtapes while keeping shuffle mode.
Add a route-track test that locks the blitz playlist to the mixtape set.

## Verification
Ran `pnpm run format`, `pnpm run knip`, and `pnpm --dir client/apps/game test src/audio/config/route-tracks.test.ts`.