### PR TITLE
Tighten biome bonus cards in tile panel

### DIFF
--- a/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.test.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.test.tsx
@@ -100,6 +100,8 @@ describe("BiomeSummaryCard", () => {
     const bonusCards = container.querySelectorAll('[data-bonus-card="true"]');
     expect(bonusCards).toHaveLength(3);
     expect(Array.from(bonusCards).every((card) => card.className.includes("w-full"))).toBe(true);
+    expect(Array.from(bonusCards).every((card) => card.className.includes("min-h-[64px]"))).toBe(true);
+    expect(Array.from(bonusCards).every((card) => card.className.includes("p-1.5"))).toBe(true);
 
     expect(container.textContent).toContain("Penalty");
     expect(container.textContent).toContain("Neutral");

--- a/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.test.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.test.tsx
@@ -100,8 +100,8 @@ describe("BiomeSummaryCard", () => {
     const bonusCards = container.querySelectorAll('[data-bonus-card="true"]');
     expect(bonusCards).toHaveLength(3);
     expect(Array.from(bonusCards).every((card) => card.className.includes("w-full"))).toBe(true);
-    expect(Array.from(bonusCards).every((card) => card.className.includes("min-h-[64px]"))).toBe(true);
-    expect(Array.from(bonusCards).every((card) => card.className.includes("p-1.5"))).toBe(true);
+    expect(Array.from(bonusCards).every((card) => card.className.includes("p-1"))).toBe(true);
+    expect(Array.from(bonusCards).every((card) => !card.className.includes("min-h-["))).toBe(true);
 
     expect(container.textContent).toContain("Penalty");
     expect(container.textContent).toContain("Neutral");

--- a/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
@@ -129,10 +129,10 @@ export const BiomeSummaryCard = ({ biome, onSimulateBattle, showSimulateAction =
             key={troopType}
             data-bonus-card="true"
             role="listitem"
-            className={`flex min-h-[64px] w-full min-w-0 items-center gap-1.5 rounded-xl border p-1.5 text-left ${tone.cardClassName}`}
+            className={`flex w-full min-w-0 items-center gap-1.5 rounded-xl border p-1 text-left ${tone.cardClassName}`}
           >
             <div
-              className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border ${tone.iconWrapClassName}`}
+              className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border ${tone.iconWrapClassName}`}
             >
               <ResourceIcon resource={config.resourceName} size="sm" withTooltip={false} />
             </div>

--- a/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/unoccupied-tile-quadrants.tsx
@@ -129,10 +129,10 @@ export const BiomeSummaryCard = ({ biome, onSimulateBattle, showSimulateAction =
             key={troopType}
             data-bonus-card="true"
             role="listitem"
-            className={`flex min-h-[74px] w-full min-w-0 items-center gap-2 rounded-xl border px-2 py-2 text-left ${tone.cardClassName}`}
+            className={`flex min-h-[64px] w-full min-w-0 items-center gap-1.5 rounded-xl border p-1.5 text-left ${tone.cardClassName}`}
           >
             <div
-              className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border ${tone.iconWrapClassName}`}
+              className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border ${tone.iconWrapClassName}`}
             >
               <ResourceIcon resource={config.resourceName} size="sm" withTooltip={false} />
             </div>

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-09",
+    title: "Biome Card Tightening",
+    description:
+      "Biome combat cards now use tighter spacing in the world action panel, so troop bonuses stay easier to scan without the terrain section crowding the rest of the tile details.",
+    type: "fix",
+  },
+  {
     date: "2026-04-08",
     title: "Chunk Structure Sync Fix",
     description:


### PR DESCRIPTION
This tightens the biome bonus cards in the world tile action panel so the biome section no longer feels oversized relative to the surrounding UI.
It reduces the card padding and minimum height, shrinks the icon wrapper slightly, and records the UX fix in the latest features feed.
The component test now asserts the compact card sizing so the layout does not drift back.
Verification: pnpm --dir client/apps/game test -- src/ui/features/world/components/actions/unoccupied-tile-quadrants.test.tsx, pnpm run format, and pnpm run knip under Node 20.19.0.