### PR TITLE
Remove dead tutorial input guards from game

### DIFF
--- a/client/apps/game/src/three/scenes/hexception.tsx
+++ b/client/apps/game/src/three/scenes/hexception.tsx
@@ -609,11 +609,6 @@ export default class HexceptionScene extends HexagonScene {
   }
 
   protected async onHexagonClick(hexCoords: HexPosition | null): Promise<void> {
-    const overlay = document.querySelector(".shepherd-modal-is-visible");
-    const overlayClick = document.querySelector(".allow-modal-click");
-    if (overlay && !overlayClick) {
-      return;
-    }
     if (hexCoords === null) return;
 
     const normalizedCoords = { col: hexCoords.col, row: hexCoords.row };
@@ -811,12 +806,6 @@ export default class HexceptionScene extends HexagonScene {
     void hexCoords;
   }
   protected onHexagonDoubleClick(hexCoords: HexPosition): void {
-    const overlay = document.querySelector(".shepherd-modal-is-visible");
-    const overlayClick = document.querySelector(".allow-modal-click");
-    if (overlay && !overlayClick) {
-      return;
-    }
-
     if (!hexCoords) {
       return;
     }

--- a/client/apps/game/src/three/scenes/worldmap-selection-routing.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-selection-routing.test.ts
@@ -2,20 +2,13 @@ import { describe, expect, it } from "vitest";
 import { resolveWorldmapHexClickPlan } from "./worldmap-selection-routing";
 
 describe("resolveWorldmapHexClickPlan", () => {
-  it("ignores clicks while a shepherd overlay blocks interaction", () => {
-    expect(
-      resolveWorldmapHexClickPlan({
-        hasBlockingOverlay: true,
-        hexCoords: { col: 1, row: 1 },
-        accountAddress: 7n,
-      }),
-    ).toEqual({ kind: "ignore" });
+  it("ignores clicks when there is no target hex", () => {
+    expect(resolveWorldmapHexClickPlan({ hexCoords: null, accountAddress: 7n })).toEqual({ kind: "ignore" });
   });
 
   it("selects the player's own army", () => {
     expect(
       resolveWorldmapHexClickPlan({
-        hasBlockingOverlay: false,
         hexCoords: { col: 1, row: 1 },
         accountAddress: 7n,
         army: { id: 101, owner: 7n },
@@ -33,7 +26,6 @@ describe("resolveWorldmapHexClickPlan", () => {
   it("selects the player's own structure when no owned army is present", () => {
     expect(
       resolveWorldmapHexClickPlan({
-        hasBlockingOverlay: false,
         hexCoords: { col: 1, row: 1 },
         accountAddress: 7n,
         structure: { id: 202, owner: 7n },
@@ -51,7 +43,6 @@ describe("resolveWorldmapHexClickPlan", () => {
   it("clears entity selection for chests and empty tiles", () => {
     expect(
       resolveWorldmapHexClickPlan({
-        hasBlockingOverlay: false,
         hexCoords: { col: 1, row: 1 },
         accountAddress: 7n,
         chest: { id: 303 },
@@ -66,7 +57,6 @@ describe("resolveWorldmapHexClickPlan", () => {
 
     expect(
       resolveWorldmapHexClickPlan({
-        hasBlockingOverlay: false,
         hexCoords: { col: 1, row: 1 },
         accountAddress: 7n,
       }),

--- a/client/apps/game/src/three/scenes/worldmap-selection-routing.ts
+++ b/client/apps/game/src/three/scenes/worldmap-selection-routing.ts
@@ -10,7 +10,6 @@ interface ChestSummary {
 }
 
 interface ResolveWorldmapHexClickPlanInput {
-  hasBlockingOverlay: boolean;
   hexCoords: HexPosition | null;
   accountAddress?: bigint;
   army?: OwnedEntitySummary;
@@ -27,14 +26,13 @@ type WorldmapHexClickPlan =
     };
 
 export function resolveWorldmapHexClickPlan({
-  hasBlockingOverlay,
   hexCoords,
   accountAddress,
   army,
   structure,
   chest,
 }: ResolveWorldmapHexClickPlanInput): WorldmapHexClickPlan {
-  if (hasBlockingOverlay || !hexCoords) {
+  if (!hexCoords) {
     return { kind: "ignore" };
   }
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -2017,14 +2017,11 @@ export default class WorldmapScene extends WarpTravel {
 
   // hexcoords is normalized
   protected onHexagonClick(hexCoords: HexPosition | null) {
-    const overlay = document.querySelector(".shepherd-modal-is-visible");
-    const overlayClick = document.querySelector(".allow-modal-click");
     const accountAddress = ContractAddress(useAccountStore.getState().account?.address || "");
     const { army, structure, chest } = hexCoords
       ? this.getHexagonEntity(hexCoords)
       : { army: undefined, structure: undefined, chest: undefined };
     const clickPlan = resolveWorldmapHexClickPlan({
-      hasBlockingOverlay: Boolean(overlay && !overlayClick),
       hexCoords,
       accountAddress,
       army: army ? { id: army.id, owner: army.owner } : undefined,
@@ -2084,12 +2081,6 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   protected onHexagonRightClick(event: MouseEvent, hexCoords: HexPosition | null): void {
-    const overlay = document.querySelector(".shepherd-modal-overlay-container");
-    const overlayClick = document.querySelector(".allow-modal-click");
-    if (overlay && !overlayClick) {
-      return;
-    }
-
     // Check if account exists before allowing actions
     const account = useAccountStore.getState().account;
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-09",
+    title: "Canvas Guard Cleanup",
+    description:
+      "Game entry no longer carries dead tutorial overlay guards, so the world canvas stops falling into a non-interactive state from stale legacy DOM classes.",
+    type: "fix",
+  },
+  {
     date: "2026-04-08",
     title: "Chunk Structure Sync Fix",
     description:


### PR DESCRIPTION
This removes the legacy Shepherd-derived overlay checks from worldmap and hex interactions, which could suppress canvas input even though the client no longer ships that tutorial system.
The click-routing boundary now only ignores null hex targets, and the latest-features entry plus routing test now match that simpler behavior.
Verification: `pnpm dlx vitest run client/apps/game/src/three/scenes/worldmap-selection-routing.test.ts` and `pnpm dlx prettier --write` on the touched files.
Repo-required `pnpm run format` and `pnpm run knip` are blocked in this workspace because installed dependencies are missing.