### PR TITLE
Fix stale structure passes during bounds updates

### DIFF
--- a/client/apps/game/src/three/managers/manager-update-convergence.test.ts
+++ b/client/apps/game/src/three/managers/manager-update-convergence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   MANAGER_UNCOMMITTED_CHUNK,
+  createAsyncPassFence,
   createCoalescedAsyncUpdateRunner,
   isCommittedManagerChunk,
   shouldAcceptManagerChunkRequest,
@@ -35,6 +36,32 @@ describe("createCoalescedAsyncUpdateRunner", () => {
 
     await triggerDuringRun();
     expect(calls.filter((entry) => entry === "drain").length).toBe(2);
+  });
+});
+
+describe("createAsyncPassFence", () => {
+  it("keeps a captured snapshot current until the fence is invalidated", () => {
+    const fence = createAsyncPassFence();
+    const snapshot = fence.capture();
+
+    expect(fence.isCurrent(snapshot)).toBe(true);
+
+    fence.invalidate();
+
+    expect(fence.isCurrent(snapshot)).toBe(false);
+  });
+
+  it("supersedes earlier snapshots when the fence is invalidated multiple times", () => {
+    const fence = createAsyncPassFence();
+    const initialSnapshot = fence.capture();
+
+    fence.invalidate();
+    const refreshedSnapshot = fence.capture();
+    fence.invalidate();
+
+    expect(fence.isCurrent(initialSnapshot)).toBe(false);
+    expect(fence.isCurrent(refreshedSnapshot)).toBe(false);
+    expect(fence.isCurrent(fence.capture())).toBe(true);
   });
 });
 

--- a/client/apps/game/src/three/managers/manager-update-convergence.ts
+++ b/client/apps/game/src/three/managers/manager-update-convergence.ts
@@ -2,6 +2,26 @@ import { shouldRunManagerUpdate } from "../scenes/worldmap-chunk-transition";
 
 export const MANAGER_UNCOMMITTED_CHUNK = "null";
 
+export type AsyncPassSnapshot = {
+  version: number;
+};
+
+export function createAsyncPassFence(): {
+  capture: () => AsyncPassSnapshot;
+  invalidate: () => void;
+  isCurrent: (snapshot: AsyncPassSnapshot) => boolean;
+} {
+  let version = 0;
+
+  return {
+    capture: () => ({ version }),
+    invalidate: () => {
+      version += 1;
+    },
+    isCurrent: (snapshot) => snapshot.version === version,
+  };
+}
+
 export function isCommittedManagerChunk(chunkKey: string | null | undefined): chunkKey is string {
   if (!chunkKey || chunkKey === MANAGER_UNCOMMITTED_CHUNK) {
     return false;

--- a/client/apps/game/src/three/managers/structure-manager.deferred-bounds.test.ts
+++ b/client/apps/game/src/three/managers/structure-manager.deferred-bounds.test.ts
@@ -22,6 +22,19 @@ describe("StructureManager deferred bounds", () => {
     expect(methodBody).not.toContain("setWorldBounds");
   });
 
+  it("setChunkBounds invalidates any in-flight visible structure pass before deferring new bounds", () => {
+    const source = readSource("./structure-manager.ts");
+
+    const setChunkBoundsMatch = source.match(/public setChunkBounds\([^)]*\)\s*\{([\s\S]*?)\n  \}/);
+    expect(setChunkBoundsMatch).not.toBeNull();
+    const methodBody = setChunkBoundsMatch![1];
+
+    expect(methodBody).toContain("this.visibleStructurePassFence.invalidate()");
+    expect(methodBody.indexOf("this.visibleStructurePassFence.invalidate()")).toBeLessThan(
+      methodBody.indexOf("this.hasPendingModelBounds = true"),
+    );
+  });
+
   it("performVisibleStructuresUpdate applies pending model world bounds after instance rebuild", () => {
     const managerSource = readSource("./structure-manager.ts");
     const finalizerSource = readSource("./structure-visible-pass-finalizer.ts");

--- a/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
+++ b/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
@@ -146,6 +146,11 @@ vi.mock("./fx-manager", () => ({
 }));
 
 vi.mock("./manager-update-convergence", () => ({
+  createAsyncPassFence: vi.fn(() => ({
+    capture: vi.fn(() => ({ version: 0 })),
+    invalidate: vi.fn(),
+    isCurrent: vi.fn(() => true),
+  })),
   createCoalescedAsyncUpdateRunner: (fn: () => Promise<void>) => fn,
   isCommittedManagerChunk: vi.fn(() => true),
   MANAGER_UNCOMMITTED_CHUNK: "uncommitted",
@@ -161,6 +166,18 @@ vi.mock("./points-label-renderer", () => ({
 }));
 
 const { StructureManager } = await import("./structure-manager");
+
+function createVisibleStructurePassFence() {
+  let fenceVersion = 0;
+
+  return {
+    capture: vi.fn(() => ({ version: fenceVersion })),
+    invalidate: vi.fn(() => {
+      fenceVersion += 1;
+    }),
+    isCurrent: vi.fn((snapshot: { version: number }) => snapshot.version === fenceVersion),
+  };
+}
 
 function createStructureManagerSubject() {
   const subject = Object.create(StructureManager.prototype) as any;
@@ -197,6 +214,7 @@ function createStructureManagerSubject() {
     [1, labelA],
     [2, labelB],
   ]);
+  subject.visibleStructurePassFence = createVisibleStructurePassFence();
   subject.labelsGroup = { remove: removeLabelFromGroup };
   subject.labelPool = {
     release: releaseLabel,
@@ -284,9 +302,11 @@ function createOnUpdateSubject() {
   subject.pendingLabelUpdates = new Map();
   subject.components = undefined;
   subject.entityIdLabels = new Map();
+  subject.visibleStructurePassFence = createVisibleStructurePassFence();
   subject.updateTimedLabelTracking = vi.fn();
   subject.isInCurrentChunk = vi.fn(() => false);
-  subject.updateVisibleStructures = vi.fn();
+  subject.updateVisibleStructures = vi.fn().mockResolvedValue(undefined);
+  subject.runVisibleStructuresUpdate = subject.updateVisibleStructures;
   subject.structures = {
     getStructureByEntityId: vi.fn((entityId: number) => structuresById.get(entityId)),
     addStructure: vi.fn(
@@ -341,6 +361,40 @@ const BASE_STRUCTURE_UPDATE = {
   battleData: {},
 };
 
+function createVisibleStructurePassSubject() {
+  const subject = Object.create(StructureManager.prototype) as any;
+  const visibleStructurePassFence = createVisibleStructurePassFence();
+
+  subject.isDestroyed = false;
+  subject.currentChunk = "24,24";
+  subject.visibleStructureCount = 0;
+  subject.currentChunkBounds = undefined;
+  subject.hasPendingModelBounds = false;
+  subject.visibleStructurePassFence = visibleStructurePassFence;
+  subject.structureModels = new Map();
+  subject.cosmeticStructureModels = new Map();
+  subject.entityIdMaps = new Map();
+  subject.cosmeticEntityIdMaps = new Map();
+  subject.wonderEntityIdMaps = new Map();
+  subject.pointsRenderers = undefined;
+  subject.activeStructureAttachmentEntities = new Set();
+  subject.entityIdLabels = new Map();
+  subject.previousVisibleIds = new Set();
+  subject.previouslyActiveStructureModels = new Set();
+  subject.previouslyActiveCosmeticStructureModels = new Set();
+  subject.finalizeVisibleStructurePass = vi.fn();
+  subject.syncVisibleStructurePresentation = vi.fn();
+  subject.resolveVisibleStructureRotationY = vi.fn(() => 0);
+  subject.createVisibleStructureRenderPlan = vi.fn((visibleStructures: any[]) => ({
+    structuresByType: new Map([["Village", visibleStructures]]),
+    structuresByCosmeticId: new Map(),
+    missingStructureModels: [],
+    missingCosmeticModels: [],
+  }));
+
+  return { subject, visibleStructurePassFence };
+}
+
 describe("StructureManager destroy lifecycle", () => {
   it("runs a single visible-structure rebuild during chunk switches", async () => {
     const subject = Object.create(StructureManager.prototype) as any;
@@ -349,8 +403,10 @@ describe("StructureManager destroy lifecycle", () => {
     subject.latestTransitionToken = 0;
     subject.transitionChunkByToken = new Map();
     subject.chunkSwitchPromise = null;
+    subject.visibleStructurePassFence = createVisibleStructurePassFence();
     subject.pruneTransitionChunkHistory = vi.fn();
     subject.updateVisibleStructures = vi.fn().mockResolvedValue(undefined);
+    subject.runVisibleStructuresUpdate = subject.updateVisibleStructures;
 
     await subject.updateChunk("24,24");
 
@@ -416,6 +472,7 @@ describe("StructureManager destroy lifecycle", () => {
     subject.isDestroyed = false;
     subject.currentChunk = "24,24";
     subject.visibleStructureCount = 0;
+    subject.visibleStructurePassFence = createVisibleStructurePassFence();
     subject.structureModels = new Map();
     subject.cosmeticStructureModels = new Map();
     subject.entityIdMaps = new Map();
@@ -456,6 +513,153 @@ describe("StructureManager destroy lifecycle", () => {
 
     expect(setMatrixAt).not.toHaveBeenCalled();
     expect(setCount).not.toHaveBeenCalled();
+  });
+
+  it("drops a stale visible-structure pass when chunk bounds change during preload", async () => {
+    const { subject } = createVisibleStructurePassSubject();
+    const structureType = "Village";
+    const setCount = vi.fn();
+    let resolvePreload: (() => void) | undefined;
+
+    subject.structureModels.set(structureType, [{ setCount }]);
+    subject.getVisibleStructuresForChunk = vi.fn(() => [
+      {
+        entityId: 1,
+        hexCoords: { col: 0, row: 0 },
+        structureType,
+        plannedCount: 1,
+      },
+    ]);
+    subject.preloadVisibleStructureRenderPlan = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePreload = resolve;
+        }),
+    );
+    subject.bindVisibleStructureInstance = vi.fn(
+      (
+        _structureType: string,
+        structure: { plannedCount: number },
+        models: Array<{ setCount: (count: number) => void }>,
+        modelInstanceCounts: Map<unknown, number>,
+        nextActiveStructureModels: Set<unknown>,
+      ) => {
+        modelInstanceCounts.set(models[0], structure.plannedCount);
+        nextActiveStructureModels.add(models[0]);
+      },
+    );
+    subject.finalizeVisibleStructureModelPass = vi.fn(
+      (modelInstanceCounts: Map<{ setCount: (count: number) => void }, number>) => {
+        for (const [model, count] of modelInstanceCounts) {
+          model.setCount(count);
+        }
+      },
+    );
+
+    const updatePromise = subject.performVisibleStructuresUpdate();
+    subject.setChunkBounds({ box: {} as never, sphere: {} as never });
+    resolvePreload?.();
+    await updatePromise;
+
+    expect(subject.finalizeVisibleStructureModelPass).not.toHaveBeenCalled();
+    expect(subject.finalizeVisibleStructurePass).not.toHaveBeenCalled();
+    expect(setCount).not.toHaveBeenCalled();
+  });
+
+  it("discards an older visible refresh when a newer pass supersedes it", async () => {
+    const { subject, visibleStructurePassFence } = createVisibleStructurePassSubject();
+    const structureType = "Village";
+    const setCount = vi.fn();
+    const commitCounts: number[] = [];
+    let resolveFirstPreload: (() => void) | undefined;
+    let resolveSecondPreload: (() => void) | undefined;
+    let visibleStructures = [
+      {
+        entityId: 1,
+        hexCoords: { col: 0, row: 0 },
+        structureType,
+        plannedCount: 1,
+      },
+    ];
+
+    subject.structureModels.set(structureType, [{ setCount }]);
+    subject.getVisibleStructuresForChunk = vi.fn(() => visibleStructures);
+    subject.preloadVisibleStructureRenderPlan = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstPreload = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSecondPreload = resolve;
+          }),
+      );
+    subject.bindVisibleStructureInstance = vi.fn(
+      (
+        _structureType: string,
+        structure: { plannedCount: number },
+        models: Array<{ setCount: (count: number) => void }>,
+        modelInstanceCounts: Map<unknown, number>,
+        nextActiveStructureModels: Set<unknown>,
+      ) => {
+        modelInstanceCounts.set(models[0], structure.plannedCount);
+        nextActiveStructureModels.add(models[0]);
+      },
+    );
+    subject.finalizeVisibleStructureModelPass = vi.fn(
+      (modelInstanceCounts: Map<{ setCount: (count: number) => void }, number>) => {
+        for (const [model, count] of modelInstanceCounts) {
+          commitCounts.push(count);
+          model.setCount(count);
+        }
+      },
+    );
+
+    const firstUpdatePromise = subject.performVisibleStructuresUpdate();
+    visibleStructurePassFence.invalidate();
+    visibleStructures = [
+      {
+        entityId: 2,
+        hexCoords: { col: 1, row: 1 },
+        structureType,
+        plannedCount: 2,
+      },
+    ];
+    const secondUpdatePromise = subject.performVisibleStructuresUpdate();
+
+    resolveFirstPreload?.();
+    await Promise.resolve();
+    resolveSecondPreload?.();
+    await Promise.all([firstUpdatePromise, secondUpdatePromise]);
+
+    expect(commitCounts).toEqual([2]);
+    expect(setCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates the visible pass fence before queueing a refresh request", async () => {
+    const subject = Object.create(StructureManager.prototype) as any;
+    const invalidate = vi.fn();
+    const runVisibleStructuresUpdate = vi.fn().mockResolvedValue(undefined);
+
+    subject.visibleStructurePassFence = {
+      invalidate,
+    };
+    subject.runVisibleStructuresUpdate = runVisibleStructuresUpdate;
+
+    expect(typeof subject.requestVisibleStructuresRefresh).toBe("function");
+
+    if (typeof subject.requestVisibleStructuresRefresh !== "function") {
+      return;
+    }
+
+    await subject.requestVisibleStructuresRefresh();
+
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(runVisibleStructuresUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("keeps tile owner name when a building-only pending update exists", async () => {

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -46,6 +46,7 @@ import {
   runManagerChunkUpdateRuntime,
 } from "./manager-chunk-runtime";
 import {
+  createAsyncPassFence,
   createCoalescedAsyncUpdateRunner,
   isCommittedManagerChunk,
   MANAGER_UNCOMMITTED_CHUNK,
@@ -92,6 +93,13 @@ import {
 
 const INITIAL_STRUCTURE_CAPACITY = 64;
 const WONDER_MODEL_INDEX = 4;
+
+interface VisibleStructurePassSnapshot {
+  chunkKey: string;
+  passFenceSnapshot: {
+    version: number;
+  };
+}
 
 interface StructureInstanceBinding {
   modelIndex: number;
@@ -173,6 +181,7 @@ export class StructureManager {
   private needsSpatialReindex = false;
   private hasPendingModelBounds = false;
   private visibleStructureCount = 0;
+  private readonly visibleStructurePassFence = createAsyncPassFence();
   private previousVisibleIds: Set<ID> = new Set(); // Track visible structures for diff-based point cleanup
   private previouslyActiveStructureModels: Set<InstancedModel> = new Set();
   private previouslyActiveCosmeticStructureModels: Set<InstancedModel> = new Set();
@@ -260,7 +269,7 @@ export class StructureManager {
     this.renderChunkSize = renderChunkSize;
     this.structures = new StructureRecordStore({
       onRemove: this.handleStructureRecordRemoved,
-      onStructuresChanged: () => this.updateVisibleStructures(),
+      onStructuresChanged: () => this.requestVisibleStructuresRefresh(),
       isAddressMine: (address) => isAddressEqualToAccount(address),
     });
     this.labelsGroup = labelsGroup || new Group();
@@ -297,7 +306,7 @@ export class StructureManager {
     this.unsubscribeAccountStore = useAccountStore.subscribe(() => {
       this.structures.recheckOwnership();
       // Update labels when ownership changes
-      this.updateVisibleStructures();
+      this.requestVisibleStructuresRefresh();
     });
 
     // Initialize points-based icon renderers
@@ -444,7 +453,7 @@ export class StructureManager {
             console.log("[StructureManager] Points-based icon renderers initialized");
 
             if (isCommittedManagerChunk(this.currentChunk)) {
-              this.updateVisibleStructures();
+              this.requestVisibleStructuresRefresh();
             }
           }
         },
@@ -991,7 +1000,7 @@ export class StructureManager {
     }
 
     if (visibleUpdateMode === "rebuild" || shouldRebuildVisibleStructuresForStructureUpdate(visibleUpdateInput)) {
-      this.updateVisibleStructures();
+      this.requestVisibleStructuresRefresh();
     }
   }
 
@@ -1017,7 +1026,7 @@ export class StructureManager {
           return false;
         }
 
-        await this.updateVisibleStructures();
+        await this.requestVisibleStructuresRefresh();
       },
       isDestroyed: () => this.isDestroyed,
       onPreviousUpdateFailed: (error) => {
@@ -1080,11 +1089,13 @@ export class StructureManager {
         isVisible: (hexCoords) => this.isInCurrentChunk(hexCoords),
       })
     ) {
-      void this.updateVisibleStructures();
+      void this.requestVisibleStructuresRefresh();
     }
   }
 
-  private updateVisibleStructures(): Promise<void> {
+  private requestVisibleStructuresRefresh(): Promise<void> {
+    this.visibleStructurePassFence.invalidate();
+
     if (this.isDestroyed) {
       return Promise.resolve();
     }
@@ -1096,6 +1107,10 @@ export class StructureManager {
     return this.runVisibleStructuresUpdate().catch((error) => {
       console.error("Failed to update visible structures", error);
     });
+  }
+
+  private updateVisibleStructures(): Promise<void> {
+    return this.requestVisibleStructuresRefresh();
   }
 
   private resolveStructureAttachmentsForRender(structure: StructureInfo): CosmeticAttachmentTemplate[] {
@@ -1156,7 +1171,7 @@ export class StructureManager {
       : this.getInstanceIdFromEntityId(next.structureType, next.entityId);
 
     if (!model || instanceId === undefined) {
-      this.updateVisibleStructures();
+      this.requestVisibleStructuresRefresh();
       return;
     }
 
@@ -1179,20 +1194,21 @@ export class StructureManager {
       return;
     }
     try {
+      const visibleStructurePassSnapshot = this.captureVisibleStructurePassSnapshot();
       const visibleStructureIds = new Set<ID>();
       const attachmentRetain = new Set<number>();
 
       // Get visible structures from spatial index
-      const [startRow, startCol] = this.currentChunk?.split(",").map(Number) || [0, 0];
+      const [startRow, startCol] = visibleStructurePassSnapshot.chunkKey.split(",").map(Number);
       const visibleStructures = this.getVisibleStructuresForChunk(startRow, startCol);
-      this.visibleStructureCount = visibleStructures.length;
       const renderPlan = this.createVisibleStructureRenderPlan(visibleStructures);
       await this.preloadVisibleStructureRenderPlan(renderPlan);
 
-      if (this.isDestroyed) {
+      if (this.shouldDiscardVisibleStructurePass(visibleStructurePassSnapshot)) {
         return;
       }
 
+      this.visibleStructureCount = visibleStructures.length;
       this.wonderEntityIdMaps.clear();
 
       this.previouslyActiveStructureModels.forEach((model) => model.setCount(0));
@@ -1281,6 +1297,21 @@ export class StructureManager {
       hasStructureModel: (structureType) => this.structureModels.has(structureType),
       hasCosmeticModel: (cosmeticId) => this.cosmeticStructureModels.has(cosmeticId),
     });
+  }
+
+  private captureVisibleStructurePassSnapshot(): VisibleStructurePassSnapshot {
+    return {
+      chunkKey: this.currentChunk,
+      passFenceSnapshot: this.visibleStructurePassFence.capture(),
+    };
+  }
+
+  private shouldDiscardVisibleStructurePass(snapshot: VisibleStructurePassSnapshot): boolean {
+    return (
+      this.isDestroyed ||
+      this.currentChunk !== snapshot.chunkKey ||
+      !this.visibleStructurePassFence.isCurrent(snapshot.passFenceSnapshot)
+    );
   }
 
   private async preloadVisibleStructureRenderPlan(
@@ -1589,6 +1620,7 @@ export class StructureManager {
 
   public setChunkBounds(bounds?: { box: Box3; sphere: Sphere }) {
     this.currentChunkBounds = bounds ?? undefined;
+    this.visibleStructurePassFence.invalidate();
     // Model worldBounds are NOT applied here — they are deferred to
     // applyPendingModelBounds() which runs after instance data is rebuilt
     // in performVisibleStructuresUpdate. Applying bounds before instance
@@ -2010,7 +2042,7 @@ export class StructureManager {
         isAlly: structure.isAlly,
       })
     ) {
-      this.updateVisibleStructures();
+      this.requestVisibleStructuresRefresh();
     }
   }
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-10",
+    title: "Structure Ghosting Hardening",
+    description:
+      "World map structures now discard stale render passes when chunk bounds change mid-update, so old buildings stop flashing onto newly loaded terrain during fast chunk and zoom transitions.",
+    type: "fix",
+  },
+  {
     date: "2026-04-08",
     title: "Chunk Structure Sync Fix",
     description:


### PR DESCRIPTION
This hardens world-map structure rendering against stale async passes during chunk-bound and refresh transitions. It adds an async pass fence to the StructureManager, routes visible-structure rebuilds through fence-aware refresh requests, and discards preloaded work that no longer matches the current chunk or bounds. The diff also adds lifecycle and convergence coverage for stale-pass invalidation and superseded refreshes, plus a latest-features entry for the ghosting fix. Verification: pnpm run format, pnpm run knip, and pnpm --dir client/apps/game exec vitest run src/three/managers/manager-update-convergence.test.ts src/three/managers/structure-manager.deferred-bounds.test.ts src/three/managers/structure-manager.lifecycle.test.ts.