### PR TITLE
Fix army stamina sync across map and detail UI

### DIFF
--- a/client/apps/game/src/hooks/helpers/use-block-timestamp.ts
+++ b/client/apps/game/src/hooks/helpers/use-block-timestamp.ts
@@ -1,10 +1,18 @@
 import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
+import { useShallow } from "zustand/react/shallow";
 
-export const useBlockTimestamp = () => {
-  const currentBlockTimestamp = useBlockTimestampStore((state) => state.currentBlockTimestamp);
-  const currentDefaultTick = useBlockTimestampStore((state) => state.currentDefaultTick);
-  const currentArmiesTick = useBlockTimestampStore((state) => state.currentArmiesTick);
-  const armiesTickTimeRemaining = useBlockTimestampStore((state) => state.armiesTickTimeRemaining);
+export const useCurrentBlockTimestamp = () => useBlockTimestampStore((state) => state.currentBlockTimestamp);
 
-  return { currentBlockTimestamp, currentDefaultTick, currentArmiesTick, armiesTickTimeRemaining };
-};
+export const useCurrentDefaultTick = () => useBlockTimestampStore((state) => state.currentDefaultTick);
+
+export const useCurrentArmiesTick = () => useBlockTimestampStore((state) => state.currentArmiesTick);
+
+export const useBlockTimestamp = () =>
+  useBlockTimestampStore(
+    useShallow((state) => ({
+      currentBlockTimestamp: state.currentBlockTimestamp,
+      currentDefaultTick: state.currentDefaultTick,
+      currentArmiesTick: state.currentArmiesTick,
+      armiesTickTimeRemaining: state.armiesTickTimeRemaining,
+    })),
+  );

--- a/client/apps/game/src/three/ARMY_STAMINA_SYNC_PRD_TDD.md
+++ b/client/apps/game/src/three/ARMY_STAMINA_SYNC_PRD_TDD.md
@@ -1,0 +1,125 @@
+# Army Stamina Sync PRD / TDD
+
+## Status
+
+- Status: In progress
+- Scope:
+  - `client/apps/game/src/three/managers/army-manager.ts`
+  - `client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts`
+  - `client/apps/game/src/ui/shared/components/block-timestamp-poller.tsx`
+  - shared stamina helpers in `client/apps/game/src/**`
+- Primary goal: make the world map army label and the selected-army UI stamina bar resolve from the same live troop
+  state on the same tick cadence
+
+## Why This Exists
+
+Players can see different stamina values for the same army depending on where they look:
+
+1. the world map label can tick forward before the selected-army UI bar
+2. the selected-army UI can keep using a stale Torii explorer snapshot after troop stamina has already changed in the
+   live component store
+3. the world map label's passive stamina recompute ignores stamina regen boosts even though `StaminaManager` supports
+   them
+
+That creates three visible failure modes:
+
+1. same army, same moment, different displayed stamina
+2. map label updates after a move/attack/explore while the detail panel stays stale
+3. boosted armies drift apart because the map label recomputes with zeroed boosts
+
+## Product Goals
+
+### User goals
+
+1. The world map label and selected-army detail bar show the same stamina for the same army.
+2. Passive stamina regen appears to advance consistently across map and UI.
+3. Live stamina spends and boosted regen show up without waiting for manual refresh.
+
+### Engineering goals
+
+1. One shared stamina resolution path chooses live troop state before stale snapshots.
+2. `ArmyManager` passive recompute uses the same troop source as the selected-army UI.
+3. The selected-army UI tick cadence matches the world label cadence closely enough that players do not see drift.
+
+## Non-goals
+
+1. Reworking every stamina consumer in the client.
+2. Replacing Torii explorer/resource fetches outside stamina-sensitive rendering.
+3. Rewriting the full chain-time system.
+
+## Current-State Diagnosis
+
+### Data-source split
+
+1. `WorldUpdateListener` can seed army map updates from live `ExplorerTroops`.
+2. `ArmyManager` later passively recomputes from cached `onChainStamina` plus zeroed boosts.
+3. `useArmyEntityDetail` derives stamina from the Torii-fetched `explorer.troops` snapshot.
+
+Result:
+
+- map and UI can be mathematically correct against different inputs
+
+### Tick-cadence split
+
+1. `ArmyManager` checks stamina tick changes every second.
+2. `BlockTimestampPoller` only refreshes `useBlockTimestampStore` every 10 seconds.
+
+Result:
+
+- the selected-army UI can lag one or more armies ticks behind the world label
+
+## Proposed Design
+
+### Shared troop preference
+
+Introduce a shared helper that resolves display stamina from:
+
+1. live `ExplorerTroops` when available
+2. fallback snapshot troops when live troops are unavailable
+3. cached army data only as a final fallback for map-only paths
+
+### Boost-aware passive recompute
+
+Refactor `ArmyManager` passive stamina recompute so it:
+
+1. asks for live explorer troops by entity id when components are available
+2. uses those live troops for regen math, including boosts
+3. falls back to cached category/tier/count/on-chain stamina only when live troops are unavailable
+
+### Faster UI tick cadence
+
+Bring the timestamp poller cadence down to one second so UI consumers using `useBlockTimestampStore` stop visibly
+lagging the world label.
+
+## TDD Plan
+
+## Red
+
+1. Add a selected-army detail hook test that fails until the hook prefers live component troops over a stale Torii
+   snapshot.
+2. Add an `ArmyManager` passive recompute test that fails until recompute consults live troop state instead of only the
+   cached zero-boost snapshot.
+3. Add a `BlockTimestampPoller` runtime test that fails until the poller refreshes once per second.
+
+## Green
+
+1. Add the shared troop/stamina resolver.
+2. Use it in `useArmyEntityDetail`.
+3. Use it in `ArmyManager` passive recompute and explicit troop-update recompute.
+4. Reduce `BlockTimestampPoller` interval to one second.
+
+## Refactor
+
+1. Keep top-level orchestration in `ArmyManager` readable by extracting any inline fallback troop construction.
+2. Re-read exported helpers and hook flow so the stamina source is obvious without descending into implementation
+   details.
+
+## Verification Plan
+
+1. Run the focused stamina sync tests.
+2. Run `pnpm run format`.
+3. Run `pnpm run knip`.
+4. Manually verify:
+   - select an army on the world map and compare label stamina with the side panel
+   - wait for passive regen and confirm both surfaces advance together
+   - test an army with stamina regen boost and confirm both surfaces stay aligned

--- a/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
@@ -2,6 +2,10 @@
 
 import { describe, expect, it, vi } from "vitest";
 
+interface NavigatorWithBattery extends Navigator {
+  getBattery?: () => Promise<{ level: number; charging: boolean }>;
+}
+
 const { getBlockTimestampMock, getComponentValueMock, getEntityIdFromKeysMock, getStaminaMock } = vi.hoisted(() => ({
   getBlockTimestampMock: vi.fn(() => ({
     currentBlockTimestamp: 0,
@@ -31,8 +35,9 @@ vi.hoisted(() => {
     currentUrl.createObjectURL = vi.fn(() => "blob:test");
   }
 
-  if (globalThis.navigator && typeof globalThis.navigator.getBattery !== "function") {
-    Object.defineProperty(globalThis.navigator, "getBattery", {
+  const navigatorWithBattery = globalThis.navigator as NavigatorWithBattery | undefined;
+  if (navigatorWithBattery && typeof navigatorWithBattery.getBattery !== "function") {
+    Object.defineProperty(navigatorWithBattery, "getBattery", {
       value: vi.fn(async () => ({ level: 1, charging: true })),
       configurable: true,
     });

--- a/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+
+const { getBlockTimestampMock, getComponentValueMock, getEntityIdFromKeysMock, getStaminaMock } = vi.hoisted(() => ({
+  getBlockTimestampMock: vi.fn(() => ({
+    currentBlockTimestamp: 0,
+    currentDefaultTick: 0,
+    currentArmiesTick: 5,
+  })),
+  getComponentValueMock: vi.fn(),
+  getEntityIdFromKeysMock: vi.fn(() => 1),
+  getStaminaMock: vi.fn(),
+}));
+
+vi.hoisted(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [],
+      text: async () => "",
+      arrayBuffer: async () => new ArrayBuffer(0),
+      blob: async () => new Blob(),
+    })),
+  );
+
+  const currentUrl = globalThis.URL;
+  if (currentUrl && typeof currentUrl.createObjectURL !== "function") {
+    currentUrl.createObjectURL = vi.fn(() => "blob:test");
+  }
+
+  if (globalThis.navigator && typeof globalThis.navigator.getBattery !== "function") {
+    Object.defineProperty(globalThis.navigator, "getBattery", {
+      value: vi.fn(async () => ({ level: 1, charging: true })),
+      configurable: true,
+    });
+  }
+});
+
+vi.mock("@bibliothecadao/eternum", async () => {
+  const actual = await vi.importActual<object>("@bibliothecadao/eternum");
+  return {
+    ...actual,
+    getBlockTimestamp: getBlockTimestampMock,
+    StaminaManager: {
+      getStamina: getStaminaMock,
+      getMaxStamina: vi.fn(() => 120),
+    },
+  };
+});
+
+vi.mock("@dojoengine/recs", async () => {
+  const actual = await vi.importActual<object>("@dojoengine/recs");
+  return {
+    ...actual,
+    getComponentValue: getComponentValueMock,
+  };
+});
+
+vi.mock("@dojoengine/utils", async () => {
+  const actual = await vi.importActual<object>("@dojoengine/utils");
+  return {
+    ...actual,
+    getEntityIdFromKeys: getEntityIdFromKeysMock,
+  };
+});
+
+import { ArmyManager } from "./army-manager";
+
+describe("ArmyManager stamina sync", () => {
+  it("recomputes passive stamina from live explorer troops when available", () => {
+    const army = {
+      entityId: 1,
+      troopCount: 10,
+      category: "Knight",
+      tier: 1,
+      onChainStamina: { amount: 10n, updatedTick: 1 },
+      currentStamina: 0,
+    };
+
+    const liveTroops = {
+      category: "Knight",
+      tier: 1,
+      count: 10n,
+      stamina: {
+        amount: 10n,
+        updated_tick: 1n,
+      },
+      boosts: {
+        incr_stamina_regen_percent_num: 5000,
+        incr_stamina_regen_tick_count: 4,
+        incr_explore_reward_percent_num: 0,
+        incr_explore_reward_end_tick: 0,
+        incr_damage_dealt_percent_num: 0,
+        incr_damage_dealt_end_tick: 0,
+        decr_damage_gotten_percent_num: 0,
+        decr_damage_gotten_end_tick: 0,
+      },
+      battle_cooldown_end: 0,
+    };
+
+    getComponentValueMock.mockReturnValue({
+      troops: liveTroops,
+    });
+
+    getStaminaMock.mockImplementation((troops: typeof liveTroops) => ({
+      amount: troops.boosts.incr_stamina_regen_percent_num > 0 ? 50n : 30n,
+      updated_tick: 5n,
+    }));
+
+    const fakeManager = {
+      armies: new Map([[1, army]]),
+      entityIdLabels: new Map(),
+      components: {
+        ExplorerTroops: {},
+      },
+      resolveLiveExplorerTroops(entityId: number) {
+        return ArmyManager.prototype["resolveLiveExplorerTroops"].call(this, entityId);
+      },
+      updateArmyLabelData: vi.fn(),
+    };
+
+    ArmyManager.prototype["recomputeStaminaForAllArmies"].call(fakeManager);
+
+    expect(getComponentValueMock).toHaveBeenCalled();
+    expect(army.currentStamina).toBe(50);
+  });
+});

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1641,12 +1641,13 @@ export class ArmyManager {
       attackTowardDegrees: attackTowardDegrees ?? undefined,
       pendingUpdate,
       resolveCurrentStamina: ({ troopCount, onChainStamina, category, tier }) =>
-        this.calculateArmyCurrentStamina({
+        this.resolveArmyStaminaSnapshot({
+          entityId: params.entityId,
           troopCount,
           onChainStamina,
           category,
           tier,
-        }),
+        })?.current ?? finalCurrentStamina,
     });
     finalTroopCount = pendingSpawnState.troopCount;
     finalCurrentStamina = pendingSpawnState.currentStamina;

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1,4 +1,5 @@
 import { useAccountStore } from "@/hooks/store/use-account-store";
+import { getExplorerStaminaSnapshot } from "@/utils/explorer-stamina";
 import { ArmyModel } from "@/three/managers/army-model";
 import { CameraView, HexagonScene } from "@/three/scenes/hexagon-scene";
 import { playerColorManager, PlayerColorProfile } from "@/three/systems/player-colors";
@@ -2644,39 +2645,32 @@ ${
     `);
   }
 
-  private calculateArmyCurrentStamina(input: {
+  private resolveLiveExplorerTroops(entityId: ID) {
+    if (!this.components) {
+      return null;
+    }
+
+    return getComponentValue(this.components.ExplorerTroops, getEntityIdFromKeys([BigInt(entityId)]))?.troops ?? null;
+  }
+
+  private resolveArmyStaminaSnapshot(input: {
+    entityId: ID;
     troopCount: number;
     onChainStamina: { amount: bigint; updatedTick: number };
     category: TroopType;
     tier: TroopTier;
-  }): number {
+  }): { current: number; max: number } | null {
     const { currentArmiesTick } = getBlockTimestamp();
-
-    return Number(
-      StaminaManager.getStamina(
-        {
-          category: input.category,
-          tier: input.tier,
-          count: BigInt(input.troopCount),
-          stamina: {
-            amount: BigInt(input.onChainStamina.amount),
-            updated_tick: BigInt(input.onChainStamina.updatedTick),
-          },
-          boosts: {
-            incr_stamina_regen_percent_num: 0,
-            incr_stamina_regen_tick_count: 0,
-            incr_explore_reward_percent_num: 0,
-            incr_explore_reward_end_tick: 0,
-            incr_damage_dealt_percent_num: 0,
-            incr_damage_dealt_end_tick: 0,
-            decr_damage_gotten_percent_num: 0,
-            decr_damage_gotten_end_tick: 0,
-          },
-          battle_cooldown_end: 0,
-        },
-        currentArmiesTick,
-      ).amount,
-    );
+    return getExplorerStaminaSnapshot({
+      currentArmiesTick,
+      liveTroops: this.resolveLiveExplorerTroops(input.entityId),
+      fallbackArmy: {
+        category: input.category,
+        tier: input.tier,
+        troopCount: input.troopCount,
+        onChainStamina: input.onChainStamina,
+      },
+    });
   }
 
   /**
@@ -2687,36 +2681,20 @@ ${
 
     // Update all army data in cache
     this.armies.forEach((army, entityId) => {
-      // getBlockTimestamp may change during iteration; preserve existing behavior by
-      // keeping the loop-local tick for the refresh pass.
-      const updatedStamina = Number(
-        StaminaManager.getStamina(
-          {
-            category: army.category,
-            tier: army.tier,
-            count: BigInt(army.troopCount),
-            stamina: {
-              amount: BigInt(army.onChainStamina.amount),
-              updated_tick: BigInt(army.onChainStamina.updatedTick),
-            },
-            boosts: {
-              incr_stamina_regen_percent_num: 0,
-              incr_stamina_regen_tick_count: 0,
-              incr_explore_reward_percent_num: 0,
-              incr_explore_reward_end_tick: 0,
-              incr_damage_dealt_percent_num: 0,
-              incr_damage_dealt_end_tick: 0,
-              decr_damage_gotten_percent_num: 0,
-              decr_damage_gotten_end_tick: 0,
-            },
-            battle_cooldown_end: 0,
-          },
-          currentArmiesTick,
-        ).amount,
-      );
+      const staminaSnapshot = getExplorerStaminaSnapshot({
+        currentArmiesTick,
+        liveTroops: this.resolveLiveExplorerTroops(entityId),
+        fallbackArmy: {
+          category: army.category,
+          tier: army.tier,
+          troopCount: army.troopCount,
+          onChainStamina: army.onChainStamina,
+        },
+      });
 
       // Update cached army data with new stamina
-      army.currentStamina = updatedStamina;
+      army.currentStamina = staminaSnapshot?.current ?? army.currentStamina;
+      army.maxStamina = staminaSnapshot?.max ?? army.maxStamina;
 
       // Update visible label if it exists
       const label = this.entityIdLabels.get(entityId);
@@ -2825,13 +2803,17 @@ ${
 
     // Update cached army data
     army.troopCount = update.troopCount;
+    army.onChainStamina = update.onChainStamina;
 
-    army.currentStamina = this.calculateArmyCurrentStamina({
+    const staminaSnapshot = this.resolveArmyStaminaSnapshot({
+      entityId: update.entityId,
       troopCount: update.troopCount,
       onChainStamina: update.onChainStamina,
       category: army.category,
       tier: army.tier,
     });
+    army.currentStamina = staminaSnapshot?.current ?? army.currentStamina;
+    army.maxStamina = staminaSnapshot?.max ?? army.maxStamina;
 
     army.troopCount = update.troopCount;
 
@@ -2852,7 +2834,6 @@ ${
       ownerStructureId,
     });
 
-    army.onChainStamina = update.onChainStamina;
     army.battleCooldownEnd = update.battleCooldownEnd;
     army.battleTimerLeft = getBattleTimerLeft(update.battleCooldownEnd);
 

--- a/client/apps/game/src/ui/features/economy/resources/entity-resource-table/entity-resource-table-new.tsx
+++ b/client/apps/game/src/ui/features/economy/resources/entity-resource-table/entity-resource-table-new.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useGoToStructure } from "@/hooks/helpers/use-navigate";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { Button } from "@/ui/design-system/atoms";
@@ -166,7 +166,7 @@ export const EntityResourceTableNew = React.memo(({ entityId }: EntityResourceTa
 
   const mode = useGameModeConfig();
   const goToStructure = useGoToStructure(setup);
-  const { currentDefaultTick } = useBlockTimestamp();
+  const currentDefaultTick = useCurrentDefaultTick();
 
   const selectedStructureId = entityId && entityId !== 0 ? Number(entityId) : null;
 

--- a/client/apps/game/src/ui/features/economy/resources/realm-transfer.tsx
+++ b/client/apps/game/src/ui/features/economy/resources/realm-transfer.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 
@@ -45,7 +45,7 @@ export const RealmTransfer = memo(({ resource }: { resource: ResourcesIds }) => 
     account: { account },
   } = useDojo();
 
-  const { currentDefaultTick: tick } = useBlockTimestamp();
+  const tick = useCurrentDefaultTick();
 
   const selectedStructureEntityId = useUIStore((state) => state.structureEntityId);
 

--- a/client/apps/game/src/ui/features/economy/trading/market-order-panel.tsx
+++ b/client/apps/game/src/ui/features/economy/trading/market-order-panel.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentBlockTimestamp, useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useUISound } from "@/audio";
 import Button from "@/ui/design-system/atoms/button";
 import { NumberInput } from "@/ui/design-system/atoms/number-input";
@@ -39,7 +39,7 @@ const MarketResource = memo(
     bidPrice: number;
     ammPrice: number;
   }) => {
-    const { currentDefaultTick } = useBlockTimestamp();
+    const currentDefaultTick = useCurrentDefaultTick();
     const resourceManager = useResourceManager(entityId);
 
     const balance = useMemo(() => {
@@ -280,7 +280,7 @@ const OrderRow = memo(
 
     const playTradeExecuteSound = useUISound("ui.trade_execute");
 
-    const { currentDefaultTick } = useBlockTimestamp();
+    const currentDefaultTick = useCurrentDefaultTick();
 
     const resourceManager = useResourceManager(entityId);
 
@@ -535,7 +535,7 @@ const OrderCreation = memo(
     const [lords, setLords] = useState(100);
     const [bid, setBid] = useState(String(lords / resource));
     const [showConfirmation, setShowConfirmation] = useState(false);
-    const { currentBlockTimestamp } = useBlockTimestamp();
+    const currentBlockTimestamp = useCurrentBlockTimestamp();
 
     const playTradePlaceSound = useUISound("ui.trade_place");
 
@@ -645,7 +645,7 @@ const OrderCreation = memo(
       return calculateDonkeysNeeded(orderWeightKg);
     }, [orderWeightKg]);
 
-    const { currentDefaultTick } = useBlockTimestamp();
+    const currentDefaultTick = useCurrentDefaultTick();
 
     const resourceManager = useResourceManager(entityId);
 

--- a/client/apps/game/src/ui/features/economy/trading/market-resource-row.tsx
+++ b/client/apps/game/src/ui/features/economy/trading/market-resource-row.tsx
@@ -1,6 +1,6 @@
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { currencyFormat, formatNumber } from "@/ui/utils/utils";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useResourceManager } from "@bibliothecadao/react";
 import { findResourceById, ResourcesIds, ID } from "@bibliothecadao/types";
 import { memo, useMemo } from "react";
@@ -18,7 +18,7 @@ interface MarketResourceRowProps {
 
 export const MarketResourceRow = memo(
   ({ entityId, resourceId, active, onClick, askPrice, bidPrice, ammPrice }: MarketResourceRowProps) => {
-    const { currentDefaultTick } = useBlockTimestamp();
+    const currentDefaultTick = useCurrentDefaultTick();
     const resourceManager = useResourceManager(entityId);
 
     const balance = useMemo(() => {

--- a/client/apps/game/src/ui/features/economy/trading/unified-trade-panel.tsx
+++ b/client/apps/game/src/ui/features/economy/trading/unified-trade-panel.tsx
@@ -1,5 +1,5 @@
 import { useMarketStore } from "@/hooks/store/use-market-store";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { comparePrices } from "@/hooks/helpers/use-best-price";
 import { NumberInput } from "@/ui/design-system/atoms/number-input";
 import Button from "@/ui/design-system/atoms/button";
@@ -38,7 +38,7 @@ interface UnifiedTradePanelProps {
 
 export const UnifiedTradePanel = memo(({ resourceId, entityId, askOffers, bidOffers }: UnifiedTradePanelProps) => {
   const dojo = useDojo();
-  const { currentDefaultTick } = useBlockTimestamp();
+  const currentDefaultTick = useCurrentDefaultTick();
   const resourceManager = useResourceManager(entityId);
 
   const tradeDirection = useMarketStore((state) => state.tradeDirection);

--- a/client/apps/game/src/ui/features/economy/transfers/transfer-automation-panel.tsx
+++ b/client/apps/game/src/ui/features/economy/transfers/transfer-automation-panel.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useTransferAutomationStore } from "@/hooks/store/use-transfer-automation-store";
 import { useTransferPanelDraftStore } from "@/hooks/store/use-transfer-panel-draft-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
@@ -80,7 +80,7 @@ interface TransferAutomationPanelProps {
 
 export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationPanelProps) => {
   const playerStructures = useUIStore((s) => s.playerStructures);
-  const { currentDefaultTick } = useBlockTimestamp();
+  const currentDefaultTick = useCurrentDefaultTick();
   const mode = useGameModeConfig();
   const { favorites } = useFavoriteStructures();
   const favoriteDestinationIds = useMemo(() => new Set(favorites), [favorites]);

--- a/client/apps/game/src/ui/features/infrastructure/bridge/bridge.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/bridge/bridge.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as Controller } from "@/assets/icons/controller.svg";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useResourceBalance } from "@/hooks/use-resource-balance";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 
@@ -494,7 +494,7 @@ export const Bridge = ({ structures }: BridgeProps) => {
   };
 
   const resourceManager = useResourceManager(selectedStructureId || 0);
-  const { currentDefaultTick: currentTick } = useBlockTimestamp();
+  const currentTick = useCurrentDefaultTick();
 
   const isBridgeButtonDisabled = useMemo(() => {
     if (!selectedStructureId || isBridgePending) return true;

--- a/client/apps/game/src/ui/features/military/battle/combat-container.tsx
+++ b/client/apps/game/src/ui/features/military/battle/combat-container.tsx
@@ -1,6 +1,6 @@
 import { env } from "@/../env";
 import { playUnitCommandSound } from "@/audio/unit-command-audio";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import {
@@ -113,7 +113,7 @@ export const CombatContainer = ({
 
   const [loading, setLoading] = useState(false);
   const [selectedGuardSlot, setSelectedGuardSlot] = useState<number | null>(null);
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
 
   const accountName = useAccountStore((state) => state.accountName);
 

--- a/client/apps/game/src/ui/features/military/components/army-list.tsx
+++ b/client/apps/game/src/ui/features/military/components/army-list.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { sqlApi } from "@/services/api";
 
@@ -16,7 +16,7 @@ import { ArmyChip } from "./army-chip";
 import { CompactDefenseDisplay } from "./compact-defense-display";
 
 export const ArmyList = ({ structure }: { structure: ComponentValue<ClientComponents["Structure"]["schema"]> }) => {
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
   const setTooltip = useUIStore((state) => state.setTooltip);
   const structureId = Number(structure?.entity_id ?? 0);
 

--- a/client/apps/game/src/ui/features/military/components/compact-defense-display.tsx
+++ b/client/apps/game/src/ui/features/military/components/compact-defense-display.tsx
@@ -1,5 +1,5 @@
 import { useUIStore } from "@/hooks/store/use-ui-store";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { getTierStyle } from "@/ui/utils/tier-styles";
@@ -52,7 +52,7 @@ export const CompactDefenseDisplay = ({
   const {
     setup: { components },
   } = useDojo();
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
   const isBanner = variant === "banner";
   const canOpenModal = Boolean(canManageDefense && structureId && structureId > 0);
   const structureComponent = useMemo(() => {

--- a/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx
+++ b/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx
@@ -1,6 +1,6 @@
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { useOwnedMilitaryStructureInfos } from "@/hooks/helpers/use-owned-structure-info";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import {
   createPendingWorldmapFxKey,
   dispatchPendingWorldmapFxStart,
@@ -111,7 +111,7 @@ export const UnifiedArmyCreationModal = ({
   const [troopCount, setTroopCount] = useState(0);
   const [guardSlot, setGuardSlot] = useState(initialGuardSlot ?? 0);
   const [armyType, setArmyType] = useState(isExplorer);
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
   const currentDefaultTick = getBlockTimestamp().currentDefaultTick;
   const previousStructureIdRef = useRef<number | null>(null);
 

--- a/client/apps/game/src/ui/features/world/components/actions/attack-info.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/attack-info.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { ActionPath, configManager } from "@bibliothecadao/eternum";
 import { useStaminaManager } from "@bibliothecadao/react";
 import { ID } from "@bibliothecadao/types";
@@ -14,7 +14,7 @@ interface AttackInfoProps {
 }
 
 export const AttackInfo = memo(({ selectedEntityId }: AttackInfoProps) => {
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
   const staminaManager = useStaminaManager(selectedEntityId);
   const stamina = useMemo(() => staminaManager.getStamina(currentArmiesTick), [currentArmiesTick, staminaManager]);
 

--- a/client/apps/game/src/ui/features/world/components/actions/stamina-summary.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/stamina-summary.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { configManager } from "@bibliothecadao/eternum";
 import type { ActionPath } from "@bibliothecadao/eternum";
 import type { ID } from "@bibliothecadao/types";
@@ -15,7 +15,7 @@ interface StaminaSummaryProps {
 }
 
 export const StaminaSummary = ({ selectedEntityId, isExplored, path }: StaminaSummaryProps) => {
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
   const staminaManager = useStaminaManager(selectedEntityId || 0);
   const stamina = useMemo(() => staminaManager.getStamina(currentArmiesTick), [currentArmiesTick, staminaManager]);
 

--- a/client/apps/game/src/ui/features/world/components/entities/banner/structure-banner-entity-detail.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/banner/structure-banner-entity-detail.tsx
@@ -12,7 +12,7 @@ import { Tabs } from "@/ui/design-system/atoms/tab";
 import { CompactDefenseDisplay } from "@/ui/features/military";
 import { HyperstructureVPDisplay } from "@/ui/features/world/components/hyperstructures/hyperstructure-vp-display";
 import { useGameModeConfig, useResolvedWorldGameMode } from "@/config/game-modes/use-game-mode-config";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { buildVillageTimerSummary } from "@/ui/shared/lib/village-timers";
 import { TRANSFER_POPUP_NAME } from "@/ui/features/economy/transfers/transfer-automation-popup";
@@ -72,7 +72,7 @@ const StructureBannerEntityDetailContent = memo(
     const mode = useGameModeConfig();
     const resolvedWorldMode = useResolvedWorldGameMode();
     const isEternumMode = resolvedWorldMode === "eternum";
-    const { currentBlockTimestamp } = useBlockTimestamp();
+    const currentBlockTimestamp = useCurrentBlockTimestamp();
     const openPopup = useUIStore((state) => state.openPopup);
     const isTransferPopupOpen = useUIStore((state) => state.isPopupOpen(TRANSFER_POPUP_NAME));
     const setTransferPanelSourceId = useUIStore((state) => state.setTransferPanelSourceId);

--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx
@@ -1,0 +1,190 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useArmyEntityDetail } from "./use-army-entity-detail";
+
+const {
+  useQueryMock,
+  useDojoMock,
+  useComponentValueMock,
+  getStaminaMock,
+  getMaxStaminaMock,
+  getAddressNameMock,
+  getCharacterNameMock,
+} = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+  useDojoMock: vi.fn(),
+  useComponentValueMock: vi.fn(),
+  getStaminaMock: vi.fn(),
+  getMaxStaminaMock: vi.fn(),
+  getAddressNameMock: vi.fn(),
+  getCharacterNameMock: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock("@bibliothecadao/react", () => ({
+  useDojo: useDojoMock,
+}));
+
+vi.mock("@dojoengine/react", () => ({
+  useComponentValue: useComponentValueMock,
+}));
+
+vi.mock("@/hooks/helpers/use-block-timestamp", () => ({
+  useBlockTimestamp: () => ({
+    currentBlockTimestamp: 0,
+    currentDefaultTick: 0,
+    currentArmiesTick: 5,
+    armiesTickTimeRemaining: 0,
+  }),
+}));
+
+vi.mock("@/config/game-modes/use-game-mode-config", () => ({
+  useGameModeConfig: () => ({
+    structure: {
+      getName: () => ({ name: "Field Deployment" }),
+    },
+  }),
+}));
+
+vi.mock("@/utils/agent", () => ({
+  getCharacterName: getCharacterNameMock,
+}));
+
+vi.mock("@bibliothecadao/torii", () => ({
+  getExplorerFromToriiClient: vi.fn(),
+  getStructureFromToriiClient: vi.fn(),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  ContractAddress: (value: string | bigint) => value,
+  getAddressName: getAddressNameMock,
+  getArmyRelicEffects: () => [],
+  getBlockTimestamp: () => ({
+    currentBlockTimestamp: 0,
+    currentDefaultTick: 0,
+    currentArmiesTick: 5,
+  }),
+  getGuildFromPlayerAddress: () => undefined,
+  StaminaManager: {
+    getStamina: getStaminaMock,
+    getMaxStamina: getMaxStaminaMock,
+  },
+}));
+
+const snapshotTroops = {
+  category: "Knight",
+  tier: 1,
+  count: 10n,
+  stamina: { amount: 80n, updated_tick: 1n },
+  boosts: {
+    incr_stamina_regen_percent_num: 0,
+    incr_stamina_regen_tick_count: 0,
+    incr_explore_reward_percent_num: 0,
+    incr_explore_reward_end_tick: 0,
+    incr_damage_dealt_percent_num: 0,
+    incr_damage_dealt_end_tick: 0,
+    decr_damage_gotten_percent_num: 0,
+    decr_damage_gotten_end_tick: 0,
+  },
+  battle_cooldown_end: 0,
+};
+
+const liveTroops = {
+  ...snapshotTroops,
+  stamina: { amount: 20n, updated_tick: 5n },
+};
+
+const Probe = () => {
+  const { derivedData } = useArmyEntityDetail({ armyEntityId: 1 as never });
+  return <div>{derivedData ? `${Number(derivedData.stamina.amount)}/${derivedData.maxStamina}` : "loading"}</div>;
+};
+
+describe("useArmyEntityDetail stamina sync", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    useDojoMock.mockReturnValue({
+      network: { toriiClient: {} },
+      account: { account: { address: "0x123" } },
+      setup: {
+        components: {
+          ExplorerTroops: {},
+        },
+        systemCalls: {
+          explorer_delete: vi.fn(),
+        },
+      },
+    });
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: [string] }) => {
+      if (queryKey[0] === "explorer") {
+        return {
+          data: {
+            explorer: {
+              troops: snapshotTroops,
+              owner: "0x123",
+            },
+            resources: [],
+            relicEffects: [],
+          },
+          isLoading: false,
+          refetch: vi.fn(),
+        };
+      }
+
+      return {
+        data: {
+          structure: {
+            owner: "0x123",
+          },
+          resources: [],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+    });
+
+    useComponentValueMock.mockReturnValue({
+      troops: liveTroops,
+    });
+
+    getStaminaMock.mockImplementation((troops: typeof snapshotTroops) => {
+      if (troops === liveTroops) {
+        return { amount: 20n, updated_tick: 5n };
+      }
+
+      return { amount: 80n, updated_tick: 5n };
+    });
+    getMaxStaminaMock.mockReturnValue(120);
+    getAddressNameMock.mockReturnValue("Alice");
+    getCharacterNameMock.mockReturnValue("Knight");
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("prefers live troop stamina over the stale Torii snapshot", async () => {
+    await act(async () => {
+      root.render(<Probe />);
+    });
+
+    expect(container.textContent).toContain("20/120");
+  });
+});

--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
@@ -1,15 +1,12 @@
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { getCharacterName } from "@/utils/agent";
-import {
-  getAddressName,
-  getArmyRelicEffects,
-  getBlockTimestamp,
-  getGuildFromPlayerAddress,
-  StaminaManager,
-} from "@bibliothecadao/eternum";
+import { getExplorerStaminaSnapshot } from "@/utils/explorer-stamina";
+import { getAddressName, getArmyRelicEffects, getGuildFromPlayerAddress } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@bibliothecadao/torii";
 import { ArmyInfo, ContractAddress, HexPosition, ID, TroopTier, TroopType } from "@bibliothecadao/types";
+import { useComponentValue } from "@dojoengine/react";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useQuery } from "@tanstack/react-query";
 import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useCallback, useMemo, useState } from "react";
@@ -48,6 +45,10 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
   const [isLoadingDelete, setIsLoadingDelete] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const liveExplorerTroops = useComponentValue(
+    components.ExplorerTroops,
+    getEntityIdFromKeys([BigInt(armyEntityId)]),
+  )?.troops;
 
   const {
     data: explorerData,
@@ -57,18 +58,27 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
     queryKey: ["explorer", String(armyEntityId)],
     queryFn: async () => {
       if (!toriiClient || !armyEntityId) return undefined;
-      const explorer = await getExplorerFromToriiClient(toriiClient, armyEntityId);
-      const relicEffects = explorer.explorer
-        ? getArmyRelicEffects(explorer.explorer.troops, getBlockTimestamp().currentArmiesTick)
-        : [];
-      return { ...explorer, relicEffects };
+      return getExplorerFromToriiClient(toriiClient, armyEntityId);
     },
     staleTime: 5000,
   });
 
   const explorer = explorerData?.explorer;
   const explorerResources = explorerData?.resources;
-  const relicEffects = explorerData?.relicEffects ?? [];
+  const staminaSnapshot = useMemo(
+    () =>
+      getExplorerStaminaSnapshot({
+        currentArmiesTick,
+        snapshotTroops: explorer?.troops,
+        liveTroops: liveExplorerTroops,
+      }),
+    [currentArmiesTick, explorer?.troops, liveExplorerTroops],
+  );
+  const currentTroops = staminaSnapshot?.troops ?? null;
+  const relicEffects = useMemo(
+    () => (currentTroops ? getArmyRelicEffects(currentTroops, currentArmiesTick) : []),
+    [currentArmiesTick, currentTroops],
+  );
 
   const {
     data: structureData,
@@ -106,11 +116,8 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
   const derivedData: DerivedArmyData | undefined = useMemo(() => {
     if (!explorer) return undefined;
 
-    const stamina = StaminaManager.getStamina(explorer.troops, currentArmiesTick);
-    const maxStamina = StaminaManager.getMaxStamina(
-      explorer.troops.category as TroopType,
-      explorer.troops.tier as TroopTier,
-    );
+    const stamina = staminaSnapshot?.stamina ?? { amount: 0n, updated_tick: 0n };
+    const maxStamina = staminaSnapshot?.max ?? 0;
 
     const guild = structure ? getGuildFromPlayerAddress(ContractAddress(structure.owner), components) : undefined;
     const isMine = structure?.owner === userAddress;
@@ -129,7 +136,7 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
       isMine: Boolean(isMine),
       structureOwnerName,
     };
-  }, [explorer, structure, components, userAddress, armyEntityId, mode, currentArmiesTick]);
+  }, [explorer, structure, components, userAddress, armyEntityId, mode, staminaSnapshot]);
 
   const alignmentBadge: AlignmentBadge | undefined = useMemo(() => {
     if (!derivedData) return undefined;

--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
@@ -8,7 +8,7 @@ import { ArmyInfo, ContractAddress, HexPosition, ID, TroopTier, TroopType } from
 import { useComponentValue } from "@dojoengine/react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useQuery } from "@tanstack/react-query";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { useCallback, useMemo, useState } from "react";
 
 interface UseArmyEntityDetailOptions {
@@ -40,7 +40,7 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
   } = useDojo();
   const mode = useGameModeConfig();
 
-  const { currentArmiesTick } = useBlockTimestamp();
+  const currentArmiesTick = useCurrentArmiesTick();
   const userAddress = ContractAddress(account.address);
   const [isLoadingDelete, setIsLoadingDelete] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(0);

--- a/client/apps/game/src/ui/features/world/components/hyperstructures/co-owners.tsx
+++ b/client/apps/game/src/ui/features/world/components/hyperstructures/co-owners.tsx
@@ -1,5 +1,5 @@
 import { ReactComponent as Trash } from "@/assets/icons/common/trashcan.svg";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import Button from "@/ui/design-system/atoms/button";
 import { NumberInput } from "@/ui/design-system/atoms/number-input";
@@ -58,7 +58,7 @@ const CoOwnersRows = ({
 
   const setTooltip = useUIStore((state) => state.setTooltip);
 
-  const { currentBlockTimestamp } = useBlockTimestamp();
+  const currentBlockTimestamp = useCurrentBlockTimestamp();
 
   const hyperstructureConfig = useMemo(() => {
     return getComponentValue(WorldConfig, getEntityIdFromKeys([WORLD_CONFIG_ID]));

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -1,6 +1,6 @@
 import type { VillageIconKey } from "@/config/game-modes";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { useGoToStructure } from "@/hooks/helpers/use-navigate";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
@@ -521,7 +521,7 @@ const StructureListItem = memo(
     const liveStructure = useComponentValue(components.Structure, entityKey as any);
     const liveStructureBuildings = useComponentValue(components.StructureBuildings, entityKey as any);
     const productionBoostBonus = useComponentValue(components.ProductionBoostBonus, entityKey as any);
-    const { currentArmiesTick } = useBlockTimestamp();
+    const currentArmiesTick = useCurrentArmiesTick();
 
     const activeRelicEffects = useMemo(() => {
       const structureRelics = productionBoostBonus

--- a/client/apps/game/src/ui/features/world/containers/top-header/tick-progress.tsx
+++ b/client/apps/game/src/ui/features/world/containers/top-header/tick-progress.tsx
@@ -1,6 +1,6 @@
 import { useUISound } from "@/audio";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { configManager, formatTime } from "@bibliothecadao/eternum";
@@ -20,7 +20,7 @@ export const TickProgress = memo(() => {
   const setTooltip = useUIStore((state) => state.setTooltip);
   const setCycleProgress = useUIStore((state) => state.setCycleProgress);
   const setCycleTime = useUIStore((state) => state.setCycleTime);
-  const { currentBlockTimestamp } = useBlockTimestamp();
+  const currentBlockTimestamp = useCurrentBlockTimestamp();
   const mode = useGameModeConfig();
   const cycleTime = configManager.getTick(TickIds.Armies);
   const hasValidCycle = cycleTime > 0;

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-10",
+    title: "Army Stamina Alignment",
+    description:
+      "World map army labels and selected-army stamina bars now stay aligned more reliably, including passive regen and live troop-state updates that previously drifted apart.",
+    type: "fix",
+  },
+  {
     date: "2026-04-09",
     title: "Canvas Guard Cleanup",
     description:

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts
@@ -1,5 +1,5 @@
 import { getStructuresDataFromTorii } from "@/dojo/queries";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import {
   type RealmUpgradeAction,
   type RealmUpgradeActionStatus,
@@ -166,7 +166,7 @@ const isRealmUpgradeLoadingState = (upgradeActionState: RealmUpgradeActionStatus
 
 export const useStructureUpgrade = (structureEntityId: number | null): StructureUpgradeResult | null => {
   const { setup, account, network } = useDojo();
-  const { currentDefaultTick } = useBlockTimestamp();
+  const currentDefaultTick = useCurrentDefaultTick();
   const pendingUpgrade = useRealmUpgradeStore((state) =>
     structureEntityId ? (state.upgradesByRealm[structureEntityId] ?? null) : null,
   );

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-details.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-details.tsx
@@ -1,5 +1,5 @@
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { isVillageLikeStructureCategory } from "@/lib/structure-type-utils";
 
@@ -24,7 +24,7 @@ import CrownIcon from "lucide-react/dist/esm/icons/crown";
 
 const RealmVillageDetails = () => {
   const dojo = useDojo();
-  const { currentBlockTimestamp } = useBlockTimestamp();
+  const currentBlockTimestamp = useCurrentBlockTimestamp();
   const structureEntityId = useUIStore((state) => state.structureEntityId);
   const setTooltip = useUIStore((state) => state.setTooltip);
   const mode = useGameModeConfig();

--- a/client/apps/game/src/ui/shared/components/block-timestamp-poller.test.tsx
+++ b/client/apps/game/src/ui/shared/components/block-timestamp-poller.test.tsx
@@ -1,0 +1,70 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
+
+import { BlockTimestampPoller } from "./block-timestamp-poller";
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  configManager: {
+    getTick: () => 1,
+  },
+  getBlockTimestamp: () => ({
+    currentBlockTimestamp: 0,
+    currentDefaultTick: 0,
+    currentArmiesTick: 0,
+  }),
+}));
+
+describe("BlockTimestampPoller", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let tickMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    tickMock = vi.fn();
+
+    useBlockTimestampStore.setState({
+      currentBlockTimestamp: 0,
+      currentDefaultTick: 0,
+      currentArmiesTick: 0,
+      armiesTickTimeRemaining: 0,
+      tick: tickMock,
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.useRealTimers();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("refreshes the block timestamp store every second", async () => {
+    await act(async () => {
+      root.render(<BlockTimestampPoller />);
+    });
+
+    expect(tickMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(999);
+    });
+
+    expect(tickMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(tickMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/apps/game/src/ui/shared/components/block-timestamp-poller.tsx
+++ b/client/apps/game/src/ui/shared/components/block-timestamp-poller.tsx
@@ -1,7 +1,7 @@
 import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
 import { useEffect } from "react";
 
-const POLL_INTERVAL_MS = 10_000;
+const POLL_INTERVAL_MS = 1_000;
 
 export const BlockTimestampPoller = () => {
   const tick = useBlockTimestampStore((state) => state.tick);

--- a/client/apps/game/src/ui/shared/components/endgame-modal.tsx
+++ b/client/apps/game/src/ui/shared/components/endgame-modal.tsx
@@ -1,4 +1,4 @@
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { resetBootstrap } from "@/init/bootstrap";
 import { getActiveWorld } from "@/runtime/world";
@@ -23,7 +23,7 @@ export const EndgameModal = () => {
   const navigate = useNavigate();
   const setModal = useUIStore((state) => state.setModal);
   const gameEndAt = useUIStore((state) => state.gameEndAt);
-  const { currentBlockTimestamp } = useBlockTimestamp();
+  const currentBlockTimestamp = useCurrentBlockTimestamp();
 
   const [closedReviewKeys, setClosedReviewKeys] = useState<Record<string, true>>({});
   const [reviewOpenKey, setReviewOpenKey] = useState<string | null>(null);

--- a/client/apps/game/src/utils/explorer-stamina.ts
+++ b/client/apps/game/src/utils/explorer-stamina.ts
@@ -1,0 +1,73 @@
+import { StaminaManager } from "@bibliothecadao/eternum";
+import { Troops, TroopTier, TroopType } from "@bibliothecadao/types";
+
+interface ExplorerArmyFallback {
+  category: TroopType;
+  tier: TroopTier;
+  troopCount: number;
+  onChainStamina: { amount: bigint; updatedTick: number };
+}
+
+interface ExplorerStaminaSnapshotInput {
+  currentArmiesTick: number;
+  snapshotTroops?: Troops | null;
+  liveTroops?: Troops | null;
+  fallbackArmy?: ExplorerArmyFallback | null;
+}
+
+const resolveExplorerTroopsForStamina = (input: {
+  snapshotTroops?: Troops | null;
+  liveTroops?: Troops | null;
+  fallbackArmy?: ExplorerArmyFallback | null;
+}): Troops | null => {
+  if (input.liveTroops) {
+    return input.liveTroops;
+  }
+
+  if (input.snapshotTroops) {
+    return input.snapshotTroops;
+  }
+
+  if (!input.fallbackArmy) {
+    return null;
+  }
+
+  return {
+    category: input.fallbackArmy.category,
+    tier: input.fallbackArmy.tier,
+    count: BigInt(input.fallbackArmy.troopCount),
+    stamina: {
+      amount: input.fallbackArmy.onChainStamina.amount,
+      updated_tick: BigInt(input.fallbackArmy.onChainStamina.updatedTick),
+    },
+    boosts: {
+      incr_damage_dealt_percent_num: 0,
+      incr_damage_dealt_end_tick: 0,
+      decr_damage_gotten_percent_num: 0,
+      decr_damage_gotten_end_tick: 0,
+      incr_stamina_regen_percent_num: 0,
+      incr_stamina_regen_tick_count: 0,
+      incr_explore_reward_percent_num: 0,
+      incr_explore_reward_end_tick: 0,
+    },
+    battle_cooldown_end: 0,
+  };
+};
+
+export const getExplorerStaminaSnapshot = (
+  input: ExplorerStaminaSnapshotInput,
+): { current: number; max: number; stamina: { amount: bigint; updated_tick: bigint }; troops: Troops } | null => {
+  const troops = resolveExplorerTroopsForStamina(input);
+  if (!troops) {
+    return null;
+  }
+
+  const stamina = StaminaManager.getStamina(troops, input.currentArmiesTick);
+
+  return {
+    current: Number(stamina.amount),
+    max: StaminaManager.getMaxStamina(troops.category as TroopType, troops.tier as TroopTier),
+    stamina,
+    troops,
+  };
+};


### PR DESCRIPTION
This aligns army stamina display across the world label and selected-army detail panel by resolving both from the same live troop source instead of mixing cached map data with stale Torii snapshots. It also moves the block timestamp poller to a one-second cadence so passive regen advances in the UI at the same pace as the map label, and updates ArmyManager passive recompute to preserve live boosted stamina math. The change includes a PRD/TDD note, focused regression tests for the poller, army detail hook, and ArmyManager recompute path, and a latest-features entry for the fix. Verification: focused Vitest stamina sync suite, pnpm run format, and pnpm run knip.