### PR TITLE
fix(game): restore live ticks for resource actions

### DIFF
--- a/client/apps/game/src/hooks/helpers/use-block-timestamp.source.test.ts
+++ b/client/apps/game/src/hooks/helpers/use-block-timestamp.source.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const actionOrientedFiles = [
+  "client/apps/game/src/ui/features/economy/resources/entity-resource-table/entity-resource-table-new.tsx",
+  "client/apps/game/src/ui/features/economy/resources/realm-transfer.tsx",
+  "client/apps/game/src/ui/features/economy/trading/market-order-panel.tsx",
+  "client/apps/game/src/ui/features/economy/trading/unified-trade-panel.tsx",
+  "client/apps/game/src/ui/features/economy/transfers/transfer-automation-panel.tsx",
+  "client/apps/game/src/ui/features/infrastructure/bridge/bridge.tsx",
+  "client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts",
+];
+
+describe("action-oriented default tick usage", () => {
+  it("uses the live default tick hook instead of the coarse hook", () => {
+    for (const filePath of actionOrientedFiles) {
+      const source = readFileSync(resolve(process.cwd(), "..", "..", "..", filePath), "utf8");
+
+      expect(source).toContain("useCurrentDefaultTick");
+      expect(source).not.toContain("useCoarseCurrentDefaultTick");
+    }
+  });
+});

--- a/client/apps/game/src/hooks/helpers/use-block-timestamp.test.ts
+++ b/client/apps/game/src/hooks/helpers/use-block-timestamp.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { selectCoarseCurrentDefaultTick, selectCurrentDefaultTick, useCurrentDefaultTick } from "./use-block-timestamp";
+
+const buildTimestampState = (currentDefaultTick: number) => ({
+  currentBlockTimestamp: currentDefaultTick,
+  currentDefaultTick,
+  currentArmiesTick: 0,
+  armiesTickTimeRemaining: 0,
+  tick: () => undefined,
+});
+
+describe("use-block-timestamp selectors", () => {
+  it("returns the live current default tick without bucketing", () => {
+    expect(selectCurrentDefaultTick(buildTimestampState(109))).toBe(109);
+  });
+
+  it("buckets the coarse current default tick to the configured window", () => {
+    expect(selectCoarseCurrentDefaultTick(buildTimestampState(109), 10)).toBe(100);
+    expect(selectCoarseCurrentDefaultTick(buildTimestampState(110), 10)).toBe(110);
+  });
+
+  it("exports a live default tick hook for action-oriented consumers", () => {
+    expect(useCurrentDefaultTick).toBeTypeOf("function");
+  });
+});

--- a/client/apps/game/src/hooks/helpers/use-block-timestamp.ts
+++ b/client/apps/game/src/hooks/helpers/use-block-timestamp.ts
@@ -1,9 +1,31 @@
 import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
 import { useShallow } from "zustand/react/shallow";
 
+const normalizeCoarseTickWindow = (windowSeconds: number) => {
+  if (!Number.isFinite(windowSeconds) || windowSeconds <= 1) {
+    return 1;
+  }
+
+  return Math.floor(windowSeconds);
+};
+
+export const selectCurrentDefaultTick = (state: { currentDefaultTick: number }) => state.currentDefaultTick;
+
+export const selectCoarseCurrentDefaultTick = (state: { currentDefaultTick: number }, windowSeconds: number = 10) => {
+  const normalizedWindow = normalizeCoarseTickWindow(windowSeconds);
+  if (normalizedWindow === 1) {
+    return state.currentDefaultTick;
+  }
+
+  return Math.floor(state.currentDefaultTick / normalizedWindow) * normalizedWindow;
+};
+
 export const useCurrentBlockTimestamp = () => useBlockTimestampStore((state) => state.currentBlockTimestamp);
 
-export const useCurrentDefaultTick = () => useBlockTimestampStore((state) => state.currentDefaultTick);
+export const useCurrentDefaultTick = () => useBlockTimestampStore(selectCurrentDefaultTick);
+
+export const useCoarseCurrentDefaultTick = (windowSeconds: number = 10) =>
+  useBlockTimestampStore((state) => selectCoarseCurrentDefaultTick(state, windowSeconds));
 
 export const useCurrentArmiesTick = () => useBlockTimestampStore((state) => state.currentArmiesTick);
 

--- a/client/apps/game/src/ui/features/economy/trading/market-resource-row.tsx
+++ b/client/apps/game/src/ui/features/economy/trading/market-resource-row.tsx
@@ -1,6 +1,6 @@
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { currencyFormat, formatNumber } from "@/ui/utils/utils";
-import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
+import { useCoarseCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useResourceManager } from "@bibliothecadao/react";
 import { findResourceById, ResourcesIds, ID } from "@bibliothecadao/types";
 import { memo, useMemo } from "react";
@@ -18,7 +18,7 @@ interface MarketResourceRowProps {
 
 export const MarketResourceRow = memo(
   ({ entityId, resourceId, active, onClick, askPrice, bidPrice, ammPrice }: MarketResourceRowProps) => {
-    const currentDefaultTick = useCurrentDefaultTick();
+    const currentDefaultTick = useCoarseCurrentDefaultTick();
     const resourceManager = useResourceManager(entityId);
 
     const balance = useMemo(() => {

--- a/client/apps/game/src/ui/features/settlement/production/buildings-list.tsx
+++ b/client/apps/game/src/ui/features/settlement/production/buildings-list.tsx
@@ -1,6 +1,6 @@
 import { BUILDING_IMAGES_PATH } from "@/ui/config";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
-import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useCoarseCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { ResourceChip } from "@/ui/features/economy/resources";
 
 import {
@@ -28,7 +28,7 @@ export const BuildingsList = ({
   producedResources: ResourcesIds[];
   productionBuildings: Building[];
 }) => {
-  const { currentDefaultTick, currentArmiesTick, armiesTickTimeRemaining } = useBlockTimestamp();
+  const currentDefaultTick = useCoarseCurrentDefaultTick();
   // Guard against invalid realm data to prevent crashes
   if (!realm || !realm.position || !realm.entityId) {
     return (
@@ -83,13 +83,11 @@ export const BuildingsList = ({
           (building) => building.produced.resource === resourceId,
         );
 
-        const balance = resourceManager.balanceWithProduction(currentDefaultTick, resourceId);
         if (!resource) return null;
         const production = ResourceManager.balanceAndProduction(resource, resourceId).production;
 
         return {
           resource: resourceId,
-          balance,
           production,
           buildings: buildingsForResource,
           isLabor: resourceId === ResourcesIds.Labor,
@@ -210,9 +208,6 @@ export const BuildingsList = ({
                     activeRelicEffects={activeRelicEffects}
                     canOpenProduction={production.buildings.length > 0}
                     onManageProduction={(resource) => onSelectProduction(resource)}
-                    currentDefaultTick={currentDefaultTick}
-                    currentArmiesTick={currentArmiesTick}
-                    armiesTickTimeRemaining={armiesTickTimeRemaining}
                   />
                 </div>
               </div>

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-10",
+    title: "Resource Action Tick Fix",
+    description:
+      "Trading, transfers, bridge checks, and realm upgrade requirements now use the live default tick again, so newly produced resources stop waiting on a coarse UI refresh window before they count toward actions.",
+    type: "fix",
+  },
+  {
+    date: "2026-04-10",
     title: "Army Stamina Alignment",
     description:
       "World map army labels and selected-army stamina bars now stay aligned more reliably, including passive regen and live troop-state updates that previously drifted apart.",

--- a/docs/prd-coarse-default-tick-regression.md
+++ b/docs/prd-coarse-default-tick-regression.md
@@ -1,0 +1,46 @@
+# PRD: Coarse Default Tick Must Not Gate Resource Actions
+
+## Problem
+
+The recent coarse default-tick hook buckets `currentDefaultTick` into 10-second windows before passing it into several
+economy and upgrade flows.
+
+That reduces re-renders, but it also changes the effective tick used for production-aware balance math. Resource
+availability, donkey capacity, bridge-out validation, and realm-upgrade requirements can all lag behind the real
+per-second default tick by up to 9 seconds.
+
+## Goal
+
+Keep the coarse tick available for display-oriented rendering, but restore live default-tick behavior anywhere the UI
+uses tick-derived balances to decide whether a player can act.
+
+## Non-Goals
+
+- Reworking the block timestamp store
+- Re-optimizing every resource display panel
+- Changing action semantics on-chain
+
+## Desired Behavior
+
+1. The client still exposes a coarse default-tick hook for render-throttled views.
+2. The client also exposes a live default-tick hook that returns the unbucketed store value.
+3. Action-oriented flows use the live default tick for production-aware balance math.
+4. Display-only panels may continue using the coarse tick when stale values are acceptable.
+
+## Acceptance Criteria
+
+- Resource action flows no longer bucket `currentDefaultTick` into 10-second windows before validation.
+- Realm transfer, market order execution/creation, unified trade execution, transfer automation, bridge-out validation,
+  realm upgrade requirements, and interactive resource-table balances use the live default tick.
+- The game client latest-features feed includes an entry describing the fix.
+
+## TDD Plan
+
+1. Add a selector-level test that expects the hook module to expose both a live default-tick selector and a coarse
+   default-tick selector.
+2. Add a source-level regression test that asserts the action-oriented client files import `useCurrentDefaultTick`
+   instead of `useCoarseCurrentDefaultTick`.
+3. Verify the new tests fail against the current code because the live hook is missing and the action files still use
+   the coarse hook.
+4. Implement the live hook and switch only the action-oriented consumers back to it.
+5. Re-run the targeted tests and update the latest-features feed.


### PR DESCRIPTION
This restores a live default-tick path for action-oriented resource flows while keeping coarse tick usage where stale display is acceptable.
The branch now adds explicit live/coarse default-tick selectors, keeps the market row and production buildings list on coarse refreshes, and switches the action-facing resource math back to the live tick so newly produced resources count immediately.
It also adds targeted regression tests plus a short PRD/TDD note for the tick-bucketing bug.
Verification: `pnpm --dir client/apps/game test -- src/hooks/helpers/use-block-timestamp.test.ts src/hooks/helpers/use-block-timestamp.source.test.ts`, `pnpm run format`, `pnpm run knip`, and `pnpm --dir client/apps/game typecheck`.
