### PR TITLE
Show structure capacity stats in sidebar

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -31,6 +31,12 @@ import {
   StructureGroupsMap,
   useStructureGroups,
 } from "@/ui/features/world/containers/top-header/structure-groups";
+import {
+  countOccupiedBuildingTilesByStructure,
+  formatAvailableBuildingTilesLabel,
+  formatPopulationStatusLabel,
+  resolveAvailableBuildingTiles,
+} from "@/ui/features/world/containers/structure-status";
 import { useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
 import { BaseContainer } from "@/ui/shared/containers/base-container";
 import type { getEntityInfo } from "@bibliothecadao/eternum";
@@ -52,8 +58,8 @@ import {
   Structure,
   StructureType,
 } from "@bibliothecadao/types";
-import { useComponentValue } from "@dojoengine/react";
-import { ComponentValue, getComponentValue } from "@dojoengine/recs";
+import { useComponentValue, useEntityQuery } from "@dojoengine/react";
+import { ComponentValue, getComponentValue, Has } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import clsx from "clsx";
 import type { LucideIcon } from "lucide-react";
@@ -61,6 +67,7 @@ import Castle from "lucide-react/dist/esm/icons/castle";
 import ChevronUp from "lucide-react/dist/esm/icons/chevron-up";
 import ChevronsUp from "lucide-react/dist/esm/icons/chevrons-up";
 import Crown from "lucide-react/dist/esm/icons/crown";
+import Hexagon from "lucide-react/dist/esm/icons/hexagon";
 import Info from "lucide-react/dist/esm/icons/info";
 import Loader2 from "lucide-react/dist/esm/icons/loader-2";
 import MessageCircle from "lucide-react/dist/esm/icons/message-circle";
@@ -70,6 +77,7 @@ import ShieldCheck from "lucide-react/dist/esm/icons/shield-check";
 import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import Star from "lucide-react/dist/esm/icons/star";
 import Tent from "lucide-react/dist/esm/icons/tent";
+import Users from "lucide-react/dist/esm/icons/users";
 import type { ComponentProps, KeyboardEvent, MouseEvent, ReactNode } from "react";
 import { lazy, memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -99,6 +107,8 @@ type StructureWithMetadata = Structure & {
   realmLevelLabel: string | null;
   population: number;
   populationCapacity: number;
+  buildingTilesAvailable: number | null;
+  buildingTilesTotal: number | null;
   groupColor: StructureGroupColor | null;
   isFavorite: boolean;
   canUpgrade: boolean;
@@ -196,6 +206,39 @@ const useRealtimeChatConfig = () => {
 
 const DEFAULT_BUTTON_SIZE: CircleButtonProps["size"] = "lg";
 
+const StructureInfoStat = ({
+  icon: Icon,
+  label,
+  title,
+}: {
+  icon: LucideIcon;
+  label: string;
+  title: string;
+}) => (
+  <span
+    className="inline-flex items-center gap-1 rounded border border-gold/15 bg-black/25 px-1.5 py-0.5 text-xxs text-gold/75"
+    title={title}
+  >
+    <Icon className="h-3 w-3 text-gold/60" />
+    <span>{label}</span>
+  </span>
+);
+
+const StructureStatusStats = ({
+  populationLabel,
+  buildingTilesLabel,
+}: {
+  populationLabel: string;
+  buildingTilesLabel: string | null;
+}) => (
+  <div className="flex flex-wrap items-center gap-1.5">
+    <StructureInfoStat icon={Users} label={populationLabel} title="Population used / capacity" />
+    {buildingTilesLabel ? (
+      <StructureInfoStat icon={Hexagon} label={buildingTilesLabel} title="Available / total building tiles" />
+    ) : null}
+  </div>
+);
+
 const getResponsiveButtonSize = (itemCount: number): CircleButtonProps["size"] => {
   // Panel width is 420px, padding is 24px (px-3 on each side), available ~396px
   // lg buttons: 48px + 8px gap = fits ~7 buttons
@@ -227,6 +270,39 @@ const LeftPanelHeader = memo(
     const mode = useGameModeConfig();
 
     const favoritesSet = useMemo(() => new Set(favorites), [favorites]);
+    const structureTileStatIds = useMemo(
+      () =>
+        structures
+          .filter((structure) => resolveStructureUiCapabilities(structure.structure).hasPopulationDetails)
+          .map((structure) => Number(structure.entityId))
+          .filter((entityId) => Number.isFinite(entityId))
+          .toSorted((left, right) => left - right),
+      [structures],
+    );
+    const trackedStructureIds = useMemo(() => new Set(structureTileStatIds), [structureTileStatIds]);
+    const buildingEntities = useEntityQuery([Has(components.Building)]);
+    const buildingTileCountsByStructure = useMemo(
+      () =>
+        countOccupiedBuildingTilesByStructure({
+          trackedStructureIds,
+          buildings: Array.from(buildingEntities)
+            .map((entity) => getComponentValue(components.Building, entity))
+            .flatMap((building) => {
+              if (!building) {
+                return [];
+              }
+
+              return [
+                {
+                  outerEntityId: Number(building.outer_entity_id ?? 0),
+                  innerCol: Number(building.inner_col ?? 0),
+                  innerRow: Number(building.inner_row ?? 0),
+                },
+              ];
+            }),
+        }),
+      [buildingEntities, components.Building, trackedStructureIds],
+    );
 
     const structureEntityKey = useMemo(() => {
       try {
@@ -287,6 +363,14 @@ const LeftPanelHeader = memo(
           ? Math.max(Number(basePopulationCapacityValue ?? 0), 6)
           : 0;
         const populationCapacity = Number(structureBuildings?.population.max ?? 0) + normalizedBasePopulationCapacity;
+        const occupiedBuildingTiles = buildingTileCountsByStructure[structure.entityId];
+        const buildingTileSummary =
+          structureCapabilities.hasPopulationDetails && occupiedBuildingTiles !== undefined
+            ? resolveAvailableBuildingTiles({
+                level: normalizedLevel,
+                occupiedBuildingTiles,
+              })
+            : null;
         const groupColor = structureGroups[structure.entityId] ?? null;
 
         const isFavorite = favoritesSet.has(structure.entityId);
@@ -299,12 +383,22 @@ const LeftPanelHeader = memo(
           realmLevelLabel,
           population,
           populationCapacity,
+          buildingTilesAvailable: buildingTileSummary?.available ?? null,
+          buildingTilesTotal: buildingTileSummary?.total ?? null,
           groupColor,
           isFavorite,
           canUpgrade: structure.category === StructureType.Realm && normalizedLevel < maxRealmLevel,
         };
       });
-    }, [structures, components.StructureBuildings, structureGroups, nameUpdateVersion, favoritesSet, mode]);
+    }, [
+      structures,
+      components.StructureBuildings,
+      structureGroups,
+      nameUpdateVersion,
+      favoritesSet,
+      mode,
+      buildingTileCountsByStructure,
+    ]);
 
     const orderedStructures = useMemo(() => {
       const currentTab = structureTabs[activeTab] ?? structureTabs[0];
@@ -362,7 +456,17 @@ const LeftPanelHeader = memo(
     const livePopulationCapacity =
       Number(liveStructureBuildings?.population.max ?? selectedStructureMetadata?.populationCapacity ?? 0) +
       normalizedBasePopulationCapacity;
-    const populationCapacityLabel = selectedStructureMetadata ? `${livePopulation}/${livePopulationCapacity}` : null;
+    const populationStatusLabel = selectedStructureMetadata
+      ? formatPopulationStatusLabel(livePopulation, livePopulationCapacity)
+      : null;
+    const buildingTilesStatusLabel =
+      selectedStructureMetadata?.buildingTilesAvailable !== null &&
+      selectedStructureMetadata?.buildingTilesTotal !== null
+        ? formatAvailableBuildingTilesLabel(
+            selectedStructureMetadata.buildingTilesAvailable,
+            selectedStructureMetadata.buildingTilesTotal,
+          )
+        : null;
     const showDetailedStats = Boolean(selectedStructureMetadata && selectedStructureCapabilities.hasPopulationDetails);
     const headerTitle =
       selectedStructureMetadata?.displayName ??
@@ -399,12 +503,15 @@ const LeftPanelHeader = memo(
               >
                 {headerTitle}
               </p>
-              {showDetailedStats && populationCapacityLabel && (
+              {showDetailedStats && populationStatusLabel && (
                 <div className="flex items-center gap-2 flex-shrink-0 text-xs text-gold/70">
                   <span className="text-gold/40">•</span>
                   <span>{levelLabel}</span>
                   <span className="text-gold/40">•</span>
-                  <span>{populationCapacityLabel}</span>
+                  <StructureStatusStats
+                    populationLabel={populationStatusLabel}
+                    buildingTilesLabel={buildingTilesStatusLabel}
+                  />
                 </div>
               )}
             </div>
@@ -551,7 +658,11 @@ const StructureListItem = memo(
       normalizedBasePopulationCapacity;
 
     const showInfoLine = structureCapabilities.hasPopulationDetails;
-    const capacityDisplay = `${population}/${populationCapacity}`;
+    const populationStatusLabel = formatPopulationStatusLabel(population, populationCapacity);
+    const buildingTilesStatusLabel =
+      structure.buildingTilesAvailable !== null && structure.buildingTilesTotal !== null
+        ? formatAvailableBuildingTilesLabel(structure.buildingTilesAvailable, structure.buildingTilesTotal)
+        : null;
     const infoLineLabel = levelLabel ?? `Level ${normalizedLevel}`;
 
     const handleSelectStructure = useCallback(
@@ -579,7 +690,7 @@ const StructureListItem = memo(
           isSelected ? "border-gold bg-black/60" : "border-gold/20 bg-black/20 hover:border-gold/40 hover:bg-black/30"
         }`}
       >
-        <div className="flex items-center gap-2">
+        <div className="flex items-start gap-2">
           <button
             type="button"
             onClick={(event) => {
@@ -591,29 +702,35 @@ const StructureListItem = memo(
           >
             <Star className={`h-4 w-4 ${structure.isFavorite ? "fill-current text-gold" : "text-gold/60"}`} />
           </button>
-          <div className="flex flex-1 min-w-0 items-center gap-2">
+          <div className="flex flex-1 min-w-0 items-start gap-2">
             {structure.groupColor && (
               <span
-                className={`h-2 w-2 shrink-0 rounded-full ${STRUCTURE_GROUP_CONFIG[structure.groupColor]?.dotClass ?? ""}`}
+                className={`mt-1 h-2 w-2 shrink-0 rounded-full ${STRUCTURE_GROUP_CONFIG[structure.groupColor]?.dotClass ?? ""}`}
               />
             )}
-            <span
-              className={`truncate text-sm font-semibold ${
-                structure.groupColor
-                  ? (STRUCTURE_GROUP_CONFIG[structure.groupColor]?.textClass ?? "text-gold")
-                  : "text-gold"
-              }`}
-            >
-              {structure.displayName}
-            </span>
-            {showInfoLine && (
-              <span className="shrink-0 whitespace-nowrap text-xxs text-gold/70">
-                {infoLineLabel} • {capacityDisplay}
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <span
+                className={`truncate text-sm font-semibold ${
+                  structure.groupColor
+                    ? (STRUCTURE_GROUP_CONFIG[structure.groupColor]?.textClass ?? "text-gold")
+                    : "text-gold"
+                }`}
+              >
+                {structure.displayName}
               </span>
-            )}
+              {showInfoLine && (
+                <div className="flex flex-wrap items-center gap-2 text-xxs text-gold/70">
+                  <span className="shrink-0 whitespace-nowrap">{infoLineLabel}</span>
+                  <StructureStatusStats
+                    populationLabel={populationStatusLabel}
+                    buildingTilesLabel={buildingTilesStatusLabel}
+                  />
+                </div>
+              )}
+            </div>
           </div>
           {activeRelicEffects.length > 0 && (
-            <div className="flex items-center gap-0.5 shrink-0">
+            <div className="flex items-center gap-0.5 shrink-0 pt-0.5">
               {activeRelicEffects.map((effect) => {
                 const resourceId = Number(effect.id);
                 return (
@@ -625,7 +742,7 @@ const StructureListItem = memo(
             </div>
           )}
           {structure.category === StructureType.Realm && (
-            <StructureLevelUpButton structureEntityId={structure.entityId} className="ml-auto shrink-0" />
+            <StructureLevelUpButton structureEntityId={structure.entityId} className="ml-auto shrink-0 pt-0.5" />
           )}
         </div>
       </div>

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -460,8 +460,9 @@ const LeftPanelHeader = memo(
       ? formatPopulationStatusLabel(livePopulation, livePopulationCapacity)
       : null;
     const buildingTilesStatusLabel =
-      selectedStructureMetadata?.buildingTilesAvailable !== null &&
-      selectedStructureMetadata?.buildingTilesTotal !== null
+      selectedStructureMetadata &&
+      selectedStructureMetadata.buildingTilesAvailable !== null &&
+      selectedStructureMetadata.buildingTilesTotal !== null
         ? formatAvailableBuildingTilesLabel(
             selectedStructureMetadata.buildingTilesAvailable,
             selectedStructureMetadata.buildingTilesTotal,

--- a/client/apps/game/src/ui/features/world/containers/structure-status.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/structure-status.test.ts
@@ -1,0 +1,67 @@
+import { RealmLevels } from "@bibliothecadao/types";
+import { describe, expect, it } from "vitest";
+import {
+  countOccupiedBuildingTilesByStructure,
+  formatAvailableBuildingTilesLabel,
+  formatPopulationStatusLabel,
+  resolveAvailableBuildingTiles,
+} from "./structure-status";
+
+describe("structure-status", () => {
+  it("formats population labels explicitly", () => {
+    expect(formatPopulationStatusLabel(7, 12)).toBe("7/12");
+  });
+
+  it("formats available building tile labels explicitly", () => {
+    expect(formatAvailableBuildingTilesLabel(53, 60)).toBe("53/60");
+  });
+
+  it("counts occupied building tiles from RECS rows and skips the center keep tile", () => {
+    expect(
+      countOccupiedBuildingTilesByStructure({
+        trackedStructureIds: new Set([7, 8]),
+        buildings: [
+          { outerEntityId: 7, innerCol: 0, innerRow: 0 },
+          { outerEntityId: 7, innerCol: 1, innerRow: 0 },
+          { outerEntityId: 7, innerCol: 1, innerRow: 1 },
+          { outerEntityId: 8, innerCol: 0, innerRow: -1 },
+          { outerEntityId: 99, innerCol: 2, innerRow: 0 },
+        ],
+      }),
+    ).toEqual({
+      7: 2,
+      8: 1,
+    });
+  });
+
+  it("resolves realm buildable tile totals from level progression", () => {
+    expect(resolveAvailableBuildingTiles({ level: RealmLevels.Settlement, occupiedBuildingTiles: 0 })).toEqual({
+      available: 6,
+      occupied: 0,
+      total: 6,
+    });
+    expect(resolveAvailableBuildingTiles({ level: RealmLevels.City, occupiedBuildingTiles: 0 })).toEqual({
+      available: 18,
+      occupied: 0,
+      total: 18,
+    });
+    expect(resolveAvailableBuildingTiles({ level: RealmLevels.Kingdom, occupiedBuildingTiles: 0 })).toEqual({
+      available: 36,
+      occupied: 0,
+      total: 36,
+    });
+    expect(resolveAvailableBuildingTiles({ level: RealmLevels.Empire, occupiedBuildingTiles: 0 })).toEqual({
+      available: 60,
+      occupied: 0,
+      total: 60,
+    });
+  });
+
+  it("clamps occupied tiles to the available buildable capacity", () => {
+    expect(resolveAvailableBuildingTiles({ level: RealmLevels.Settlement, occupiedBuildingTiles: 9 })).toEqual({
+      available: 0,
+      occupied: 6,
+      total: 6,
+    });
+  });
+});

--- a/client/apps/game/src/ui/features/world/containers/structure-status.ts
+++ b/client/apps/game/src/ui/features/world/containers/structure-status.ts
@@ -1,0 +1,57 @@
+import { BUILDINGS_CENTER } from "@bibliothecadao/types";
+
+const normalizeNonNegativeInteger = (value: number) => {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+};
+
+const resolveBuildRadius = (level: number) => normalizeNonNegativeInteger(level) + 1;
+
+export const formatPopulationStatusLabel = (population: number, populationCapacity: number) =>
+  `${normalizeNonNegativeInteger(population)}/${normalizeNonNegativeInteger(populationCapacity)}`;
+
+export const formatAvailableBuildingTilesLabel = (available: number, total: number) =>
+  `${normalizeNonNegativeInteger(available)}/${normalizeNonNegativeInteger(total)}`;
+
+export const countOccupiedBuildingTilesByStructure = ({
+  buildings,
+  trackedStructureIds,
+}: {
+  buildings: Array<{ outerEntityId: number; innerCol: number; innerRow: number }>;
+  trackedStructureIds: ReadonlySet<number>;
+}) =>
+  buildings.reduce<Record<number, number>>((counts, building) => {
+    const outerEntityId = normalizeNonNegativeInteger(building.outerEntityId);
+    if (!trackedStructureIds.has(outerEntityId)) {
+      return counts;
+    }
+
+    const innerCol = normalizeNonNegativeInteger(building.innerCol);
+    const innerRow = normalizeNonNegativeInteger(building.innerRow);
+    const isCenterKeepTile = innerCol === BUILDINGS_CENTER[0] && innerRow === BUILDINGS_CENTER[1];
+
+    if (isCenterKeepTile) {
+      return counts;
+    }
+
+    counts[outerEntityId] = (counts[outerEntityId] ?? 0) + 1;
+    return counts;
+  }, {});
+
+export const resolveAvailableBuildingTiles = ({
+  level,
+  occupiedBuildingTiles,
+}: {
+  level: number;
+  occupiedBuildingTiles: number;
+}) => {
+  const radius = resolveBuildRadius(level);
+  const total = 3 * radius * (radius + 1);
+  const occupied = Math.min(normalizeNonNegativeInteger(occupiedBuildingTiles), total);
+
+  return {
+    available: total - occupied,
+    occupied,
+    total,
+  };
+};

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-10",
+    title: "Structure Capacity Icons",
+    description:
+      "Realm and village entries in the left sidebar now show compact population and free building-tile stats with small icons, making it clearer how much capacity and construction room each structure still has.",
+    type: "fix",
+  },
+  {
+    date: "2026-04-10",
     title: "Army Stamina Alignment",
     description:
       "World map army labels and selected-army stamina bars now stay aligned more reliably, including passive regen and live troop-state updates that previously drifted apart.",


### PR DESCRIPTION
This updates the left command sidebar to show clearer structure capacity state instead of an ambiguous raw count.

It adds compact population and free building-tile stats with small icons, and derives occupied tiles from RECS Building entities so the sidebar stays in sync without a SQL fetch.
The tile math now lives in a small shared helper with focused coverage for buildable-capacity and center-tile exclusion behavior.
Verification was limited in this workspace because node_modules is missing and the repo requires Node >=20.19.0 while the environment is on 20.9.0, so format, knip, and vitest were not runnable.