### PR TITLE
fix(game): require stamina for structure claims

### DIFF
--- a/client/apps/game/src/ui/features/military/battle/attack-stamina-state.test.ts
+++ b/client/apps/game/src/ui/features/military/battle/attack-stamina-state.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAttackStaminaRequirementLabel,
+  buildAttackStaminaWarning,
+  resolveAttackStaminaState,
+} from "./attack-stamina-state";
+
+describe("attack-stamina-state", () => {
+  it("blocks undefended structure claims when stamina is below the requirement", () => {
+    const state = resolveAttackStaminaState({
+      attackerStamina: 0n,
+      hasAttackerTroops: true,
+      hasDefenders: false,
+      requiredStamina: 50,
+    });
+
+    expect(state.actionLabel).toBe("Claim");
+    expect(state.isBlocked).toBe(true);
+    expect(buildAttackStaminaRequirementLabel(state)).toBe("Need 50 stamina to claim");
+  });
+
+  it("allows attacks when stamina meets the requirement", () => {
+    const state = resolveAttackStaminaState({
+      attackerStamina: 50n,
+      hasAttackerTroops: true,
+      hasDefenders: true,
+      requiredStamina: 50,
+    });
+
+    expect(state.actionLabel).toBe("Attack");
+    expect(state.isBlocked).toBe(false);
+    expect(state.hasRequiredStamina).toBe(true);
+  });
+
+  it("builds action-specific stamina warnings", () => {
+    const state = resolveAttackStaminaState({
+      attackerStamina: 10n,
+      hasAttackerTroops: true,
+      hasDefenders: true,
+      requiredStamina: 50,
+    });
+
+    expect(buildAttackStaminaWarning(state)).toBe("Insufficient stamina: 10 / 50 required to attack");
+  });
+});

--- a/client/apps/game/src/ui/features/military/battle/attack-stamina-state.ts
+++ b/client/apps/game/src/ui/features/military/battle/attack-stamina-state.ts
@@ -1,0 +1,41 @@
+type AttackActionLabel = "Attack" | "Claim";
+
+interface ResolveAttackStaminaStateInput {
+  attackerStamina: bigint | number;
+  hasAttackerTroops: boolean;
+  hasDefenders: boolean;
+  requiredStamina: number;
+}
+
+export interface AttackStaminaState {
+  actionLabel: AttackActionLabel;
+  currentStamina: number;
+  hasAttackerTroops: boolean;
+  hasRequiredStamina: boolean;
+  isBlocked: boolean;
+  requiredStamina: number;
+}
+
+export function resolveAttackStaminaState(input: ResolveAttackStaminaStateInput): AttackStaminaState {
+  const currentStamina = Number(input.attackerStamina);
+  const actionLabel: AttackActionLabel = input.hasDefenders ? "Attack" : "Claim";
+  const hasRequiredStamina = currentStamina >= input.requiredStamina;
+  const isBlocked = input.hasAttackerTroops && !hasRequiredStamina;
+
+  return {
+    actionLabel,
+    currentStamina,
+    hasAttackerTroops: input.hasAttackerTroops,
+    hasRequiredStamina,
+    isBlocked,
+    requiredStamina: input.requiredStamina,
+  };
+}
+
+export function buildAttackStaminaRequirementLabel(state: AttackStaminaState): string {
+  return `Need ${state.requiredStamina} stamina to ${state.actionLabel.toLowerCase()}`;
+}
+
+export function buildAttackStaminaWarning(state: AttackStaminaState): string {
+  return `Insufficient stamina: ${state.currentStamina} / ${state.requiredStamina} required to ${state.actionLabel.toLowerCase()}`;
+}

--- a/client/apps/game/src/ui/features/military/battle/combat-container.tsx
+++ b/client/apps/game/src/ui/features/military/battle/combat-container.tsx
@@ -50,6 +50,11 @@ import { useMemo, useState } from "react";
 import { ActiveRelicEffects } from "../../world/components/entities/active-relic-effects";
 import { GuardStaminaBar } from "../components/guard-stamina-bar";
 import { getGuardStaminaSnapshot } from "../utils/guard-stamina";
+import {
+  buildAttackStaminaRequirementLabel,
+  buildAttackStaminaWarning,
+  resolveAttackStaminaState,
+} from "./attack-stamina-state";
 import { BattleCooldownTimer } from "./battle-cooldown-timer";
 import { BattleStats, CombatLoading, ResourceStealing, TroopDisplay } from "./components";
 import { AttackTarget, TargetType } from "./types";
@@ -422,7 +427,7 @@ export const CombatContainer = ({
   }, [attackerArmyData, target, accountName, account.address, targetArmyData, components]);
 
   const onAttack = async () => {
-    if (!selectedHex) return;
+    if (!selectedHex || isAttackerOnCooldown || attackStaminaState.isBlocked) return;
 
     let pendingFxKey: string | null = null;
     try {
@@ -609,13 +614,23 @@ export const CombatContainer = ({
     return attackerArmyData.troops.battle_cooldown_end > currentTime;
   }, [attackerArmyData]);
 
+  const attackStaminaState = useMemo(
+    () =>
+      resolveAttackStaminaState({
+        attackerStamina,
+        hasAttackerTroops: Boolean(attackerArmyData),
+        hasDefenders: Boolean(targetArmyData),
+        requiredStamina: Number(combatConfig.stamina_attack_req),
+      }),
+    [attackerArmyData, attackerStamina, combatConfig, targetArmyData],
+  );
+
   const buttonMessage = useMemo(() => {
     if (isAttackerOnCooldown) return "On Battle Cooldown";
-    if (attackerStamina < combatConfig.stamina_attack_req)
-      return `Not Enough Stamina (${combatConfig.stamina_attack_req} Required)`;
+    if (attackStaminaState.isBlocked) return buildAttackStaminaRequirementLabel(attackStaminaState);
     if (!attackerArmyData) return "No Troops Present";
-    return "Attack!";
-  }, [isAttackerOnCooldown, attackerStamina, attackerArmyData, combatConfig]);
+    return attackStaminaState.actionLabel;
+  }, [attackStaminaState, attackerArmyData, isAttackerOnCooldown]);
 
   const trueAttackDamage = useMemo(() => {
     if (!battleSimulation || !targetArmyData) return 0;
@@ -800,18 +815,18 @@ export const CombatContainer = ({
           variant="primary"
           className="px-4 sm:px-6 py-2 sm:py-3 rounded-lg font-bold text-base sm:text-lg transition-colors w-full sm:w-auto min-w-[200px]"
           isLoading={loading}
-          disabled={attackerStamina < combatConfig.stamina_attack_req || !attackerArmyData || isAttackerOnCooldown}
+          disabled={attackStaminaState.isBlocked || !attackerArmyData || isAttackerOnCooldown}
           onClick={onAttack}
           aria-label={`Attack button: ${buttonMessage}`}
-          aria-describedby={attackerStamina < combatConfig.stamina_attack_req ? "stamina-warning" : undefined}
+          aria-describedby={attackStaminaState.isBlocked ? "stamina-warning" : undefined}
         >
           {buttonMessage}
         </Button>
 
         {/* Stamina Warning */}
-        {attackerStamina < combatConfig.stamina_attack_req && (
+        {attackStaminaState.isBlocked && (
           <div id="stamina-warning" className="text-sm text-red-400 text-center" role="alert">
-            Insufficient stamina: {Number(attackerStamina)} / {combatConfig.stamina_attack_req} required
+            {buildAttackStaminaWarning(attackStaminaState)}
           </div>
         )}
 

--- a/client/apps/game/src/ui/features/military/battle/hooks/use-attack-target.test.tsx
+++ b/client/apps/game/src/ui/features/military/battle/hooks/use-attack-target.test.tsx
@@ -10,6 +10,7 @@ const {
   componentsMock,
   getBlockTimestampMock,
   getExplorerFromToriiClientMock,
+  getResourceBalancesWithProductionMock,
   getTileAtMock,
   toriiClientMock,
   getStructureFromToriiClientMock,
@@ -49,6 +50,7 @@ const {
     },
     resources: undefined,
   })),
+  getResourceBalancesWithProductionMock: vi.fn(() => []),
   getTileAtMock: vi.fn(() => ({
     occupier_id: 321,
     occupier_is_structure: false,
@@ -105,7 +107,7 @@ vi.mock("@bibliothecadao/eternum", () => ({
   },
   ResourceManager: {
     getResourceBalances: vi.fn(() => []),
-    getResourceBalancesWithProduction: vi.fn(() => []),
+    getResourceBalancesWithProduction: getResourceBalancesWithProductionMock,
   },
   StaminaManager: {
     getStamina: vi.fn((_troops: unknown, currentArmiesTick: number) => ({
@@ -149,7 +151,7 @@ describe("useAttackTargetData", () => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
   });
 
-  it("derives target stamina from the live armies tick instead of freezing the fetch-time value", async () => {
+  it("derives target stamina from the live armies tick without refetching the target", async () => {
     await act(async () => {
       root.render(<HookHarness />);
     });
@@ -159,9 +161,11 @@ describe("useAttackTargetData", () => {
     });
 
     expect(latestResult?.target?.info[0]?.stamina.amount).toBe(10n);
+    expect(getExplorerFromToriiClientMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       useBlockTimestampStore.setState({
+        currentBlockTimestamp: 60,
         currentArmiesTick: 2,
       });
     });
@@ -171,5 +175,6 @@ describe("useAttackTargetData", () => {
     });
 
     expect(latestResult?.target?.info[0]?.stamina.amount).toBe(20n);
+    expect(getExplorerFromToriiClientMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/apps/game/src/ui/features/military/battle/hooks/use-attack-target.ts
+++ b/client/apps/game/src/ui/features/military/battle/hooks/use-attack-target.ts
@@ -13,7 +13,6 @@ import {
 } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@bibliothecadao/torii";
-import { useComponentValue } from "@dojoengine/react";
 import { getComponentValue } from "@dojoengine/recs";
 import { useEffect, useMemo, useState } from "react";
 
@@ -38,6 +37,27 @@ interface UseAttackTargetResult {
   isLoading: boolean;
 }
 
+type StructureTargetFetchResult = Awaited<ReturnType<typeof getStructureFromToriiClient>>;
+type ExplorerTargetFetchResult = Awaited<ReturnType<typeof getExplorerFromToriiClient>>;
+
+type FetchedAttackTarget =
+  | {
+      targetType: TargetType.Structure;
+      id: ID;
+      hex: { x: number; y: number };
+      structure: NonNullable<StructureTargetFetchResult["structure"]>;
+      resources: StructureTargetFetchResult["resources"];
+      productionBoostBonus: StructureTargetFetchResult["productionBoostBonus"];
+    }
+  | {
+      targetType: TargetType.Army;
+      id: ID;
+      hex: { x: number; y: number };
+      explorer: NonNullable<ExplorerTargetFetchResult["explorer"]>;
+      resources: ExplorerTargetFetchResult["resources"];
+      addressOwner: Awaited<ReturnType<typeof sqlApi.fetchExplorerAddressOwner>>;
+    };
+
 export const useAttackTargetData = (
   attackerEntityId: ID,
   targetHex: { x: number; y: number },
@@ -56,14 +76,11 @@ export const useAttackTargetData = (
     [components, targetAlt, targetHex.x, targetHex.y],
   );
 
-  const [target, setTarget] = useState<AttackTarget | null>(null);
-  const [targetResources, setTargetResources] = useState<Array<{ resourceId: number; amount: number }>>([]);
+  const [fetchedTarget, setFetchedTarget] = useState<FetchedAttackTarget | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [attackerRelicEffects, setAttackerRelicEffects] = useState<RelicEffectWithEndTick[]>([]);
-  const [targetRelicEffects, setTargetRelicEffects] = useState<RelicEffectWithEndTick[]>([]);
   const { currentArmiesTick, currentBlockTimestamp } = useBlockTimestamp();
 
-  useEffect(() => {
+  const attackerRelicEffects = useMemo(() => {
     const structure = getComponentValue(Structure, getEntityIdFromKeys([BigInt(attackerEntityId)]));
 
     if (structure) {
@@ -77,16 +94,15 @@ export const useAttackTargetData = (
         : [];
       const structureArmyRelicEffects = getStructureArmyRelicEffects(structure, currentArmiesTick);
 
-      setAttackerRelicEffects([...structureRelicEffects, ...structureArmyRelicEffects]);
-      return;
+      return [...structureRelicEffects, ...structureArmyRelicEffects];
     }
 
     const explorer = getComponentValue(ExplorerTroops, getEntityIdFromKeys([BigInt(attackerEntityId)]));
     if (explorer) {
-      setAttackerRelicEffects(getArmyRelicEffects(explorer.troops, currentArmiesTick));
-    } else {
-      setAttackerRelicEffects([]);
+      return getArmyRelicEffects(explorer.troops, currentArmiesTick);
     }
+
+    return [];
   }, [attackerEntityId, Structure, ExplorerTroops, ProductionBoostBonus, currentArmiesTick]);
 
   useEffect(() => {
@@ -95,9 +111,7 @@ export const useAttackTargetData = (
     const loadTarget = async () => {
       if (!targetTile?.occupier_id) {
         if (isActive) {
-          setTarget(null);
-          setTargetResources([]);
-          setTargetRelicEffects([]);
+          setFetchedTarget(null);
           setIsLoading(false);
         }
         return;
@@ -117,77 +131,36 @@ export const useAttackTargetData = (
           if (!isActive) return;
 
           if (structure) {
-            const relicEffects = getStructureArmyRelicEffects(structure, currentArmiesTick);
-            const guards = getGuardsByStructure(structure)
-              .filter((guard) => guard.troops.count > 0n)
-              .toSorted((a, b) => a.slot - b.slot);
-
-            setTarget({
-              info: guards.map((guard) => ({
-                ...guard.troops,
-                stamina: StaminaManager.getStamina(guard.troops, currentArmiesTick),
-              })),
-              id: targetTile.occupier_id,
+            setFetchedTarget({
               targetType: TargetType.Structure,
-              structureCategory: structure.category,
+              id: targetTile.occupier_id,
               hex: { x: targetTile.col, y: targetTile.row },
-              addressOwner: structure.owner,
+              structure,
+              resources,
+              productionBoostBonus,
             });
-
-            if (productionBoostBonus) {
-              setTargetRelicEffects([
-                ...relicEffects,
-                ...getStructureRelicEffects(productionBoostBonus, currentArmiesTick),
-              ]);
-            } else {
-              setTargetRelicEffects(relicEffects);
-            }
           } else {
-            setTarget(null);
-          }
-
-          if (resources) {
-            const oneMinuteAgo = currentBlockTimestamp - 60;
-            setTargetResources(
-              orderResourcesByPriority(ResourceManager.getResourceBalancesWithProduction(resources, oneMinuteAgo)),
-            );
-          } else {
-            setTargetResources([]);
+            setFetchedTarget(null);
           }
         } else {
           const { explorer, resources } = await getExplorerFromToriiClient(toriiClient, targetTile.occupier_id);
 
           if (!isActive) return;
 
-          if (resources) {
-            setTargetResources(orderResourcesByPriority(ResourceManager.getResourceBalances(resources)));
-          } else {
-            setTargetResources([]);
-          }
-
           if (explorer) {
-            const relicEffects = getArmyRelicEffects(explorer.troops, currentArmiesTick);
-            setTargetRelicEffects(relicEffects);
-
             const addressOwner = await sqlApi.fetchExplorerAddressOwner(targetTile.occupier_id);
             if (!isActive) return;
 
-            setTarget({
-              info: [
-                {
-                  ...explorer.troops,
-                  stamina: StaminaManager.getStamina(explorer.troops, currentArmiesTick),
-                },
-              ],
-              id: targetTile.occupier_id,
+            setFetchedTarget({
               targetType: TargetType.Army,
-              structureCategory: null,
+              id: targetTile.occupier_id,
               hex: { x: targetTile.col, y: targetTile.row },
               addressOwner,
+              explorer,
+              resources,
             });
           } else {
-            setTarget(null);
-            setTargetRelicEffects([]);
+            setFetchedTarget(null);
           }
         }
       } finally {
@@ -202,7 +175,74 @@ export const useAttackTargetData = (
     return () => {
       isActive = false;
     };
-  }, [targetTile, toriiClient, currentArmiesTick, currentBlockTimestamp]);
+  }, [targetTile, toriiClient]);
+
+  const target = useMemo<AttackTarget | null>(() => {
+    if (!fetchedTarget) return null;
+
+    if (fetchedTarget.targetType === TargetType.Structure) {
+      const guards = getGuardsByStructure(fetchedTarget.structure)
+        .filter((guard) => guard.troops.count > 0n)
+        .toSorted((a, b) => a.slot - b.slot);
+
+      return {
+        info: guards.map((guard) => ({
+          ...guard.troops,
+          stamina: StaminaManager.getStamina(guard.troops, currentArmiesTick),
+        })),
+        id: fetchedTarget.id,
+        targetType: TargetType.Structure,
+        structureCategory: fetchedTarget.structure.category,
+        hex: fetchedTarget.hex,
+        addressOwner: fetchedTarget.structure.owner,
+      };
+    }
+
+    return {
+      info: [
+        {
+          ...fetchedTarget.explorer.troops,
+          stamina: StaminaManager.getStamina(fetchedTarget.explorer.troops, currentArmiesTick),
+        },
+      ],
+      id: fetchedTarget.id,
+      targetType: TargetType.Army,
+      structureCategory: null,
+      hex: fetchedTarget.hex,
+      addressOwner: fetchedTarget.addressOwner,
+    };
+  }, [currentArmiesTick, fetchedTarget]);
+
+  const targetRelicEffects = useMemo<RelicEffectWithEndTick[]>(() => {
+    if (!fetchedTarget) return [];
+
+    if (fetchedTarget.targetType === TargetType.Structure) {
+      const structureRelicEffects = getStructureArmyRelicEffects(fetchedTarget.structure, currentArmiesTick);
+      if (!fetchedTarget.productionBoostBonus) {
+        return structureRelicEffects;
+      }
+
+      return [
+        ...structureRelicEffects,
+        ...getStructureRelicEffects(fetchedTarget.productionBoostBonus, currentArmiesTick),
+      ];
+    }
+
+    return getArmyRelicEffects(fetchedTarget.explorer.troops, currentArmiesTick);
+  }, [currentArmiesTick, fetchedTarget]);
+
+  const targetResources = useMemo<Array<{ resourceId: number; amount: number }>>(() => {
+    if (!fetchedTarget?.resources) return [];
+
+    if (fetchedTarget.targetType === TargetType.Structure) {
+      const oneMinuteAgo = currentBlockTimestamp - 60;
+      return orderResourcesByPriority(
+        ResourceManager.getResourceBalancesWithProduction(fetchedTarget.resources, oneMinuteAgo),
+      );
+    }
+
+    return orderResourcesByPriority(ResourceManager.getResourceBalances(fetchedTarget.resources));
+  }, [currentBlockTimestamp, fetchedTarget]);
 
   return {
     attackerRelicEffects,

--- a/client/apps/game/src/ui/features/military/battle/quick-attack-preview.test.tsx
+++ b/client/apps/game/src/ui/features/military/battle/quick-attack-preview.test.tsx
@@ -1,0 +1,309 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QuickAttackPreview } from "./quick-attack-preview";
+
+const mocks = vi.hoisted(() => ({
+  account: { address: "0x123", name: "Tester" },
+  attackExplorerVsExplorer: vi.fn(async () => undefined),
+  attackExplorerVsGuard: vi.fn(async () => undefined),
+  attackGuardVsExplorer: vi.fn(async () => undefined),
+  playUnitCommandSound: vi.fn(),
+  toggleModal: vi.fn(),
+  updateSelectedEntityId: vi.fn(),
+  dispatchPendingWorldmapFxStart: vi.fn(),
+  dispatchPendingWorldmapFxStop: vi.fn(),
+  components: {
+    Structure: Symbol("Structure"),
+    ExplorerTroops: Symbol("ExplorerTroops"),
+  },
+  attackerTroops: {
+    count: 1000n,
+    category: 1,
+    tier: 1,
+    stamina: {
+      amount: 0n,
+      updated_tick: 0n,
+    },
+    boosts: {
+      incr_damage_dealt_percent_num: 0,
+      incr_damage_dealt_end_tick: 0,
+      decr_damage_gotten_percent_num: 0,
+      decr_damage_gotten_end_tick: 0,
+      incr_stamina_regen_percent_num: 0,
+      incr_stamina_regen_tick_count: 0,
+      incr_explore_reward_percent_num: 0,
+      incr_explore_reward_end_tick: 0,
+    },
+    battle_cooldown_end: 0,
+  },
+  attackerStamina: {
+    amount: 0n,
+    updated_tick: 0n,
+  },
+  quickAttackTargetData: {
+    attackerRelicEffects: [],
+    targetRelicEffects: [],
+    target: {
+      info: [],
+      id: 2,
+      targetType: 0,
+      structureCategory: null,
+      hex: { x: 11, y: 10 },
+      addressOwner: null,
+    },
+    targetResources: [],
+    isLoading: false,
+  },
+}));
+
+vi.mock("@/audio/unit-command-audio", () => ({
+  playUnitCommandSound: mocks.playUnitCommandSound,
+}));
+
+vi.mock("@/hooks/helpers/use-block-timestamp", () => ({
+  useBlockTimestamp: () => ({
+    currentArmiesTick: 1,
+    armiesTickTimeRemaining: 0,
+  }),
+}));
+
+vi.mock("@/hooks/store/use-account-store", () => ({
+  useAccountStore: (selector: (state: { accountName: string }) => unknown) =>
+    selector({ accountName: "Test Commander" }),
+}));
+
+vi.mock("@/hooks/store/use-ui-store", () => ({
+  useUIStore: (
+    selector: (state: {
+      selectedHex: { col: number; row: number };
+      toggleModal: typeof mocks.toggleModal;
+      updateEntityActionSelectedEntityId: typeof mocks.updateSelectedEntityId;
+    }) => unknown,
+  ) =>
+    selector({
+      selectedHex: { col: 10, row: 10 },
+      toggleModal: mocks.toggleModal,
+      updateEntityActionSelectedEntityId: mocks.updateSelectedEntityId,
+    }),
+}));
+
+vi.mock("@/utils/pending-worldmap-fx", () => ({
+  createPendingWorldmapFxKey: () => "attack-preview-fx",
+  dispatchPendingWorldmapFxStart: mocks.dispatchPendingWorldmapFxStart,
+  dispatchPendingWorldmapFxStop: mocks.dispatchPendingWorldmapFxStop,
+}));
+
+vi.mock("@/ui/design-system/atoms/button", () => ({
+  default: ({
+    children,
+    forceUppercase: _forceUppercase,
+    isLoading,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { forceUppercase?: boolean; isLoading?: boolean }) => (
+    <button type="button" {...props}>
+      {isLoading ? "Loading" : children}
+    </button>
+  ),
+}));
+
+vi.mock("@bibliothecadao/react", () => ({
+  useDojo: () => ({
+    account: {
+      account: mocks.account,
+    },
+    setup: {
+      systemCalls: {
+        attack_explorer_vs_explorer: mocks.attackExplorerVsExplorer,
+        attack_explorer_vs_guard: mocks.attackExplorerVsGuard,
+        attack_guard_vs_explorer: mocks.attackGuardVsExplorer,
+      },
+      components: mocks.components,
+    },
+  }),
+}));
+
+vi.mock("@dojoengine/recs", () => ({
+  getComponentValue: (component: symbol) => {
+    if (component === mocks.components.Structure) {
+      return undefined;
+    }
+
+    if (component === mocks.components.ExplorerTroops) {
+      return {
+        troops: mocks.attackerTroops,
+      };
+    }
+
+    return undefined;
+  },
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  Biome: {
+    getBiome: () => "forest",
+  },
+  CombatSimulator: class CombatSimulator {
+    simulateBattleWithParams() {
+      return {
+        attackerDamage: 0,
+        defenderDamage: 0,
+      };
+    }
+  },
+  configManager: {
+    getCombatConfig: () => ({
+      stamina_attack_req: 50,
+    }),
+    getRefillPerTick: () => 20,
+    getTick: () => 60,
+  },
+  DEFAULT_COORD_ALT: false,
+  formatTime: (seconds: number) => `${seconds}s`,
+  getEntityIdFromKeys: () => "entity",
+  getGuardsByStructure: () => [],
+  StaminaManager: class StaminaManager {
+    constructor(_components: unknown, _entityId: number) {}
+
+    getStamina() {
+      return mocks.attackerStamina;
+    }
+  },
+}));
+
+vi.mock("@bibliothecadao/types", () => ({
+  ActorType: {
+    Explorer: "explorer",
+    Structure: "structure",
+  },
+  getDirectionBetweenAdjacentHexes: () => 0,
+  RESOURCE_PRECISION: 1,
+  TickIds: {
+    Armies: "armies",
+  },
+}));
+
+vi.mock("./hooks/use-attack-target", () => ({
+  useAttackTargetData: () => mocks.quickAttackTargetData,
+}));
+
+vi.mock("./combat-modal", () => ({
+  CombatModal: () => <div data-testid="combat-modal">Combat Modal</div>,
+}));
+
+const waitForAsyncWork = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const findPrimaryActionButton = (container: HTMLElement) => {
+  return Array.from(container.querySelectorAll("button")).find((button) =>
+    /(attack|claim|need .* stamina|on cooldown|no troops selected)/i.test(button.textContent ?? ""),
+  ) as HTMLButtonElement | undefined;
+};
+
+describe("QuickAttackPreview", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    mocks.attackerStamina = {
+      amount: 0n,
+      updated_tick: 0n,
+    };
+    mocks.quickAttackTargetData = {
+      attackerRelicEffects: [],
+      targetRelicEffects: [],
+      target: {
+        info: [],
+        id: 2,
+        targetType: 0,
+        structureCategory: null,
+        hex: { x: 11, y: 10 },
+        addressOwner: null,
+      },
+      targetResources: [],
+      isLoading: false,
+    };
+
+    mocks.attackExplorerVsExplorer.mockClear();
+    mocks.attackExplorerVsGuard.mockClear();
+    mocks.attackGuardVsExplorer.mockClear();
+    mocks.playUnitCommandSound.mockClear();
+    mocks.toggleModal.mockClear();
+    mocks.updateSelectedEntityId.mockClear();
+    mocks.dispatchPendingWorldmapFxStart.mockClear();
+    mocks.dispatchPendingWorldmapFxStop.mockClear();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await waitForAsyncWork();
+    });
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("disables unguarded structure claims when stamina is below the required threshold", async () => {
+    await act(async () => {
+      root.render(
+        <QuickAttackPreview
+          attacker={{ type: "explorer" as never, id: 1 as never, hex: { x: 10, y: 10 } }}
+          target={{ type: "structure" as never, id: 2 as never, hex: { x: 11, y: 10 } }}
+        />,
+      );
+      await waitForAsyncWork();
+    });
+
+    const actionButton = findPrimaryActionButton(container);
+
+    expect(actionButton).toBeDefined();
+    expect(actionButton?.disabled).toBe(true);
+
+    await act(async () => {
+      actionButton?.click();
+      await waitForAsyncWork();
+    });
+
+    expect(mocks.attackExplorerVsGuard).not.toHaveBeenCalled();
+  });
+
+  it("still allows structure claims once stamina reaches the required threshold", async () => {
+    mocks.attackerStamina = {
+      amount: 50n,
+      updated_tick: 1n,
+    };
+
+    await act(async () => {
+      root.render(
+        <QuickAttackPreview
+          attacker={{ type: "explorer" as never, id: 1 as never, hex: { x: 10, y: 10 } }}
+          target={{ type: "structure" as never, id: 2 as never, hex: { x: 11, y: 10 } }}
+        />,
+      );
+      await waitForAsyncWork();
+    });
+
+    const actionButton = findPrimaryActionButton(container);
+
+    expect(actionButton).toBeDefined();
+    expect(actionButton?.disabled).toBe(false);
+
+    await act(async () => {
+      actionButton?.click();
+      await waitForAsyncWork();
+    });
+
+    expect(mocks.attackExplorerVsGuard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
+++ b/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
@@ -24,6 +24,7 @@ import { useDojo } from "@bibliothecadao/react";
 import { getComponentValue } from "@dojoengine/recs";
 
 import X from "lucide-react/dist/esm/icons/x";
+import { buildAttackStaminaRequirementLabel, resolveAttackStaminaState } from "./attack-stamina-state";
 import { CombatModal } from "./combat-modal";
 import { useAttackTargetData } from "./hooks/use-attack-target";
 import { TargetType } from "./types";
@@ -267,17 +268,27 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
   const attackerOnCooldown = attackerCooldownRemaining > 0;
 
   const hasDefenders = !!targetArmyData;
-  const attackDisabled =
-    (hasDefenders && (attackerOnCooldown || attackerStamina < combatConfig.stamina_attack_req)) || !attackerArmyData;
+  const attackStaminaState = useMemo(
+    () =>
+      resolveAttackStaminaState({
+        attackerStamina,
+        hasAttackerTroops: Boolean(attackerArmyData),
+        hasDefenders,
+        requiredStamina: requiredAttackStamina,
+      }),
+    [attackerArmyData, attackerStamina, hasDefenders, requiredAttackStamina],
+  );
+  const cooldownBlocksAttack = hasDefenders && attackerOnCooldown;
+  const attackDisabled = cooldownBlocksAttack || attackStaminaState.isBlocked || !attackerArmyData;
 
-  const isLowStamina = hasDefenders && !attackerOnCooldown && attackerStamina < combatConfig.stamina_attack_req;
+  const isLowStamina = attackStaminaState.isBlocked;
 
   const attackButtonLabel = (() => {
     if (!attackerArmyData) return "No troops selected";
+    if (cooldownBlocksAttack) return "On cooldown";
+    if (attackStaminaState.isBlocked) return buildAttackStaminaRequirementLabel(attackStaminaState);
     if (!hasDefenders) return "Claim";
-    if (attackerOnCooldown) return "On cooldown";
-    if (attackerStamina < combatConfig.stamina_attack_req) return `Need ${combatConfig.stamina_attack_req} stamina`;
-    return "Attack";
+    return attackStaminaState.actionLabel;
   })();
 
   const outcomeLabel = (() => {
@@ -307,7 +318,7 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
   })();
 
   const handleAttack = async () => {
-    if (!selectedHex || !targetData) return;
+    if (!selectedHex || !targetData || attackDisabled) return;
 
     let pendingFxKey: string | null = null;
     try {
@@ -477,7 +488,7 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
           {attackDisabled && (
             <div className="rounded-md border border-red-400/30 bg-red-900/20 px-3 py-2 text-xs text-red-200">
               <span>{attackButtonLabel}</span>
-              {attackerOnCooldown && attackerCooldownRemaining > 0 && (
+              {cooldownBlocksAttack && attackerCooldownRemaining > 0 && (
                 <div className="mt-1 text-[11px] text-gold/70">{formatTime(attackerCooldownRemaining)} remaining</div>
               )}
               {isLowStamina && (
@@ -503,7 +514,7 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
           forceUppercase={false}
           className="px-3 py-1 text-xs tracking-wide"
         >
-          Attack
+          {hasDefenders ? "Attack" : "Claim"}
         </Button>
         <Button
           variant="outline"

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-10",
+    title: "Structure Claim Stamina Guard",
+    description:
+      "Taking an undefended enemy structure now respects the same stamina requirement as other attacks, so the world map no longer invites claims your army cannot legally complete yet.",
+    type: "fix",
+  },
+  {
+    date: "2026-04-10",
     title: "World Map Ready Guard",
     description:
       "Fresh game entry now keeps the loading shell up until the first world map refresh actually succeeds, so players no longer drop into a visible map that cannot yet be clicked.",

--- a/packages/core/src/managers/army-action-manager.test.ts
+++ b/packages/core/src/managers/army-action-manager.test.ts
@@ -118,6 +118,9 @@ describe("ArmyActionManager.findActionPaths origin precedence", () => {
     vi.spyOn(configManager, "getMinTravelStaminaCost").mockReturnValue(1);
     vi.spyOn(configManager, "getTravelStaminaCost").mockReturnValue(1);
     vi.spyOn(configManager, "getExploreStaminaCost").mockReturnValue(1);
+    vi.spyOn(configManager, "getCombatConfig").mockReturnValue({
+      stamina_attack_req: 5,
+    } as any);
     vi.spyOn(configManager, "getTravelFoodCostConfig").mockReturnValue({
       travelWheatBurnAmount: 0,
       travelFishBurnAmount: 0,
@@ -203,6 +206,56 @@ describe("ArmyActionManager.findActionPaths origin precedence", () => {
     const spireActionPath = actionPaths.get(ActionPaths.posKey(spireHex));
     expect(spireActionPath).toBeDefined();
     expect(ActionPaths.getActionType(spireActionPath ?? [])).toBe(ActionType.SpireTravel);
+  });
+
+  it("omits adjacent enemy structure attack paths when attack stamina is below the required threshold", () => {
+    const { manager, structureHexes, armyHexes, exploredHexes, chestHexes, oldFeltStart } = createTestSetup();
+    const targetHex = getNeighborHexes(oldFeltStart.col, oldFeltStart.row)[0];
+
+    setNestedMapValue(structureHexes, targetHex.col - TEST_FELT_CENTER, targetHex.row - TEST_FELT_CENTER, {
+      owner: 0x999n,
+    } as HexEntityInfo);
+    vi.mocked(StaminaManager.prototype.getStamina).mockReturnValue({
+      amount: 4n,
+      updated_tick: 0n,
+    } as any);
+
+    const actionPaths = manager.findActionPaths(
+      structureHexes,
+      armyHexes,
+      exploredHexes,
+      chestHexes,
+      0,
+      0,
+      0x123n as any,
+    );
+
+    expect(actionPaths.get(ActionPaths.posKey(targetHex))).toBeUndefined();
+  });
+
+  it("keeps adjacent enemy structure attack paths when attack stamina meets the required threshold", () => {
+    const { manager, structureHexes, armyHexes, exploredHexes, chestHexes, oldFeltStart } = createTestSetup();
+    const targetHex = getNeighborHexes(oldFeltStart.col, oldFeltStart.row)[0];
+
+    setNestedMapValue(structureHexes, targetHex.col - TEST_FELT_CENTER, targetHex.row - TEST_FELT_CENTER, {
+      owner: 0x999n,
+    } as HexEntityInfo);
+    vi.mocked(StaminaManager.prototype.getStamina).mockReturnValue({
+      amount: 5n,
+      updated_tick: 0n,
+    } as any);
+
+    const actionPaths = manager.findActionPaths(
+      structureHexes,
+      armyHexes,
+      exploredHexes,
+      chestHexes,
+      0,
+      0,
+      0x123n as any,
+    );
+
+    expect(ActionPaths.getActionType(actionPaths.get(ActionPaths.posKey(targetHex)) ?? [])).toBe(ActionType.Attack);
   });
 });
 

--- a/packages/core/src/managers/army-action-manager.ts
+++ b/packages/core/src/managers/army-action-manager.ts
@@ -142,6 +142,10 @@ export class ArmyActionManager {
     return tile?.occupier_type === TileOccupier.Spire;
   }
 
+  private getAttackStaminaRequirement(): number {
+    return configManager.getCombatConfig().stamina_attack_req;
+  }
+
   public findActionPaths(
     structureHexes: Map<number, Map<number, HexEntityInfo>>,
     armyHexes: Map<number, Map<number, HexEntityInfo>>,
@@ -199,6 +203,7 @@ export class ArmyActionManager {
         actionType = ActionType.Help;
       } else if (canAttack) {
         actionType = ActionType.Attack;
+        staminaCost = this.getAttackStaminaRequirement();
       } else if (hasChest) {
         actionType = ActionType.Chest;
       } else if (biome) {


### PR DESCRIPTION
Require attack stamina before armies can claim undefended structures from the quick attack preview.\n\nThis moves claim and attack readiness into shared battle logic, applies the same stamina rule in the full combat modal, and stops low-stamina attack highlights from appearing on the world map.\n\nIt also adds regression coverage for the quick preview and action-path gating, and records the fix in latest features.\n\nVerification: PATH="/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.asdf/shims:/Users/os/.asdf/shims:/Users/os/.codex/tmp/arg0/codex-arg0EHljSM:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/usr/local/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/.local/share/solana/install/active_release/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/os/.asdf/shims:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/Library/pnpm:/Users/os/.starkli/bin:/Users/os/.cargo/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/./bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin" pnpm --dir packages/core exec vitest run src/managers/army-action-manager.test.ts; PATH="/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.asdf/shims:/Users/os/.asdf/shims:/Users/os/.codex/tmp/arg0/codex-arg0EHljSM:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/usr/local/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/.local/share/solana/install/active_release/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/os/.asdf/shims:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/Library/pnpm:/Users/os/.starkli/bin:/Users/os/.cargo/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/./bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin" pnpm --dir client/apps/game exec vitest run src/ui/features/military/battle/quick-attack-preview.test.tsx src/ui/features/military/battle/attack-stamina-state.test.ts; PATH="/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.asdf/shims:/Users/os/.asdf/shims:/Users/os/.codex/tmp/arg0/codex-arg0EHljSM:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/usr/local/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/.local/share/solana/install/active_release/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/os/.asdf/shims:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/Library/pnpm:/Users/os/.starkli/bin:/Users/os/.cargo/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/./bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin" pnpm run format; PATH="/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.asdf/shims:/Users/os/.asdf/shims:/Users/os/.codex/tmp/arg0/codex-arg0EHljSM:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/usr/local/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/.local/share/solana/install/active_release/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/os/.asdf/shims:/Users/os/.antigravity/antigravity/bin:/Users/os/.qlty/bin:/Users/os/.local/share/solana/install/active_release/bin:/Users/os/.opencode/bin:/Users/os/.codeium/windsurf/bin:/opt/miniconda3/bin:/opt/miniconda3/condabin:/Users/os/.nvm/versions/node/v22.22.1/bin:/Users/os/.bun/bin:/Users/os/Library/pnpm:/Users/os/.starkli/bin:/Users/os/.cargo/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/Library/Application Support/com.conductor.app/bin:/Users/os/.local/bin:/Users/os/Library/Application Support/com.conductor.app/./bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.slot/bin:/Users/os/.foundry/bin:/Users/os/.haiku/bin:/Users/os/.local/bin:/Users/os/.local/bin:/Users/os/.local/bin" pnpm run knip