### PR TITLE
fix: snap worldmap zoom to fixed bands

### DIFF
--- a/client/apps/game/src/three/WORLDMAP_FIXED_ZOOM_PTD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_FIXED_ZOOM_PTD_TDD.md
@@ -1,0 +1,302 @@
+# Worldmap Fixed Zoom PTD / TDD
+
+## Status
+
+- Status: Proposed for implementation
+- Scope: `client/apps/game/src/three/scenes/worldmap.tsx` and the worldmap zoom helper seams
+- Primary goal: replace continuous worldmap zoom with three fixed camera profiles that do not move the worldmap target
+
+## Problem Statement
+
+The current worldmap zoom path is more complex than the rest of the worldmap rendering model.
+
+Today:
+
+1. Wheel, minimap zoom, and keyboard shortcuts all feed a shared zoom coordinator.
+2. The coordinator owns target distance and an anchor world point.
+3. During zoom, the coordinator can move both `controls.object.position` and `controls.target`.
+4. Worldmap chunk authority is resolved from the camera ground intersection, which collapses to `controls.target`.
+5. Every controls change can schedule chunk refresh work once the refresh planner decides it is safe to do so.
+
+This creates two classes of problems:
+
+- UX instability
+  - zoom can feel slippery because the focus point shifts during wheel gestures
+  - minimap drag/tween movement and zoom can fight over camera ownership
+  - the worldmap uses three semantic camera bands, but runtime zoom still passes through many intermediate distances
+- worldmap safety risk
+  - zoom can move `controls.target`, which means zoom can indirectly affect chunk authority
+  - even when render bounds do not resize, a zoom gesture can still schedule same-chunk refresh or cross-area chunk work
+
+The user-reported direction is to use three fixed zoom levels and cycle between them.
+
+## Findings From The Trace
+
+### Stable facts
+
+1. Chunk geometry is fixed.
+   - `stride = 24`
+   - `renderSize = 48 x 48`
+   - zoom does not change those values at runtime
+
+2. The worldmap camera profiles are already discrete.
+   - `Close = distance 10, angle 42`
+   - `Medium = distance 20, angle 52`
+   - `Far = distance 40, angle 58`
+
+3. Initial worldmap entry applies the full profile.
+   - both the distance and the tilt are applied on first alignment
+
+4. Runtime zoom does not keep applying the full profile.
+   - the current zoom path continuously changes distance
+   - the scene mostly treats the camera profile as distance-only after initial setup
+
+5. Chunk authority is target-driven.
+   - worldmap chunk resolution is based on the camera ground intersection
+   - on this scene, that ground intersection resolves to `controls.target`
+
+### Most important implication
+
+If worldmap zoom stops moving `controls.target`, zoom stops participating in chunk selection.
+
+That does not remove all chunk work, but it removes the most direct path where zoom itself can cause chunk authority
+churn.
+
+## Goals
+
+### User goals
+
+- Wheel zoom should feel intentional instead of slippery.
+- Minimap zoom should match keyboard zoom and use the same three levels.
+- The worldmap should always settle on one of the three intended camera framings.
+- Zoom should stop creating chunk-selection surprises during the gesture.
+
+### Engineering goals
+
+- Zoom must not move `controls.target`.
+- Zoom entry points must all map to `Close`, `Medium`, or `Far`.
+- The three camera profiles must apply both distance and angle.
+- Existing refresh hardening should keep working while the interaction model becomes simpler.
+- The code should read as fixed-profile camera orchestration, not as a partially continuous zoom system.
+
+## Non-goals
+
+- Rebuilding non-worldmap scenes.
+- Redesigning worldmap chunk sizes or Torii fetch area sizes.
+- Removing the existing refresh hardening in this pass.
+- Reworking minimap drag behavior beyond making zoom consistent with the new model.
+
+## Proposed Behavior
+
+### Zoom model
+
+Worldmap zoom becomes band-stepped:
+
+- wheel up: step one band closer
+- wheel down: step one band farther
+- minimap zoom in/out: same one-band step
+- keyboard `1/2/3`: snap directly to `Close`, `Medium`, `Far`
+
+### Camera ownership
+
+Zoom changes only the camera pose around the current target.
+
+It does **not** move `controls.target`.
+
+This means:
+
+- panning and explicit camera movement still own `controls.target`
+- zoom only changes camera height and depth from the target according to the selected profile
+
+### Runtime state
+
+The worldmap keeps its local zoom publication layer so listeners still observe:
+
+- stable camera band
+- transition status
+
+But the actual movement comes from fixed-profile camera transitions rather than continuous dolly math.
+
+## Architecture
+
+## 1. Stepped worldmap wheel policy
+
+Introduce a focused helper that converts normalized wheel input into band steps.
+
+Responsibilities:
+
+- accumulate trackpad deltas until they cross a threshold
+- detect direction changes and reset accumulation cleanly
+- step to adjacent bands only
+- clamp at `Close` and `Far`
+
+This keeps wheel handling deterministic while still supporting both mouse wheel and trackpad input.
+
+## 2. Fixed-profile worldmap camera changes
+
+Worldmap camera changes should use the existing camera profiles as the source of truth:
+
+- `resolveWorldmapCameraViewProfile(CameraView.Close)`
+- `resolveWorldmapCameraViewProfile(CameraView.Medium)`
+- `resolveWorldmapCameraViewProfile(CameraView.Far)`
+
+Every zoom transition must apply:
+
+- profile distance
+- profile angle
+
+Every transition should animate the camera to:
+
+- same `controls.target`
+- new camera position computed from the selected profile
+
+## 3. Coordinator becomes publication, not movement ownership
+
+The existing `WorldmapZoomCoordinator` remains useful for:
+
+- stable band publication
+- transition status
+- zoom snapshot reporting to the rest of the worldmap
+
+But it should no longer be the system that physically moves the camera every frame.
+
+Instead:
+
+1. a fixed-profile transition starts
+2. the coordinator is told which band is now targeted
+3. the scene animation moves the camera around the existing target
+4. the coordinator samples the live camera distance and resolves stable band / idle status
+
+## 4. Refresh behavior
+
+The refresh planner stays in place, but the new model changes what it sees:
+
+- no arbitrary target drift from zoom
+- only three intended target distances
+- zoom work settles after one of three profile transitions instead of after continuous arbitrary distances
+
+Expected result:
+
+- fewer zoom-driven force refreshes
+- fewer chances for zoom to coincide with chunk authority changes
+- chunk refresh work becomes easier to reason about in tests
+
+## Implementation Plan
+
+### Step 1. Add the stepped zoom helper
+
+Create a worldmap-local helper for wheel accumulation and band stepping.
+
+### Step 2. Change worldmap wheel and minimap zoom entry points
+
+Replace continuous zoom intents with band-step requests.
+
+### Step 3. Make worldmap `changeCameraView()` use fixed profiles
+
+Use the full profile through the existing scene camera transition path.
+
+### Step 4. Stop worldmap per-frame zoom from mutating camera position
+
+Keep only state publication and settle detection.
+
+### Step 5. Tighten worldmap zoom bounds
+
+The worldmap max zoom distance should match the far profile instead of extending beyond it.
+
+### Step 6. Update UX changelog entry
+
+Add a new entry to `latest-features.ts` describing the simplified fixed-profile zoom behavior.
+
+## TDD Plan
+
+## Red phase
+
+Add failing tests for the intended behavior:
+
+1. stepped wheel policy
+   - one full wheel step from medium zooms to far
+   - repeated same-direction input clamps at far
+   - opposite direction resets accumulation and steps back toward medium / close
+   - sub-threshold trackpad deltas do not change the band
+
+2. worldmap wiring
+   - worldmap wheel path steps between camera bands instead of applying continuous delta intents
+   - minimap zoom uses the same directional step path
+   - worldmap no longer resolves wheel cursor anchors for zoom
+   - worldmap max zoom distance is the far profile distance, not a fourth implicit zoom level
+
+3. coordinator publication behavior
+   - `snap_to_band` still updates target distance and status
+   - live distance sampling settles to the selected band without moving camera ownership itself
+
+## Green phase
+
+Implement only enough production code to satisfy those tests:
+
+- stepped wheel helper
+- worldmap zoom entrypoint rewrite
+- fixed-profile `changeCameraView()` usage
+- state-only worldmap zoom sampling
+
+## Refactor phase
+
+Once green:
+
+- simplify now-unused anchor-specific wheel code
+- remove dead scratch objects and helper methods
+- rename helpers so the top-level worldmap flow reads like intent
+
+## Test Matrix
+
+### Unit tests
+
+- stepped zoom helper tests
+- worldmap zoom coordinator tests updated for publication-only behavior
+- worldmap source wiring tests
+
+### Focused integration tests
+
+- worldmap refresh planner tests stay green
+- worldmap chunk transition tests stay green
+
+### Manual verification
+
+1. Enter worldmap and confirm initial zoom is medium.
+2. Mouse wheel cycles `Medium -> Far -> Medium -> Close`.
+3. Minimap wheel does the same.
+4. Keyboard `1/2/3` still maps to the same profiles.
+5. Zooming does not move the viewed tile under the camera target.
+6. Rapid zooming near chunk boundaries does not change authority unless the player pans.
+
+## Risks
+
+### Risk: trackpad feels too coarse
+
+Mitigation:
+
+- keep wheel accumulation so small deltas still coalesce into one intentional step
+- tune threshold using the existing normalized wheel units
+
+### Risk: existing tests assume continuous zoom ownership
+
+Mitigation:
+
+- update tests to assert the intended fixed-profile model explicitly
+
+### Risk: refresh timing changes uncover old same-chunk bugs
+
+Mitigation:
+
+- keep latest-wins refresh hardening in place for this pass
+- do not combine this change with chunk-policy rewrites
+
+## Success Criteria
+
+The implementation is complete when:
+
+1. worldmap zoom always settles on `Close`, `Medium`, or `Far`
+2. zoom no longer moves `controls.target`
+3. wheel, minimap zoom, and keyboard shortcuts all use the same stepped model
+4. the targeted tests pass
+5. the repo-required checks pass
+6. the final code reads like fixed-profile camera orchestration rather than anchor-driven continuous zoom

--- a/client/apps/game/src/three/scenes/hexagon-scene.ts
+++ b/client/apps/game/src/three/scenes/hexagon-scene.ts
@@ -1409,7 +1409,7 @@ export abstract class HexagonScene {
     }
   }
 
-  private syncResolvedCameraViewFromDistance(distance: number): void {
+  protected syncResolvedCameraViewFromDistance(distance: number): void {
     const nextView = resolveWorldmapZoomBand({
       currentBand: this.currentCameraView,
       distance,

--- a/client/apps/game/src/three/scenes/hexagon-scene.ts
+++ b/client/apps/game/src/three/scenes/hexagon-scene.ts
@@ -779,7 +779,13 @@ export abstract class HexagonScene {
     return { col, row, x, z };
   }
 
-  cameraAnimate(newPosition: Vector3, newTarget: Vector3, transitionDuration: number, onFinish?: () => void) {
+  cameraAnimate(
+    newPosition: Vector3,
+    newTarget: Vector3,
+    transitionDuration: number,
+    onFinish?: () => void,
+    options?: { ease?: string },
+  ) {
     const camera = this.controls.object;
     const target = this.controls.target;
     const transitionStart = resolveCameraTransitionStart(this.cameraTransitionState);
@@ -797,6 +803,7 @@ export abstract class HexagonScene {
     if (transitionToken === null) {
       return;
     }
+    const ease = options?.ease ?? "power3.inOut";
     this.setCameraTransitionStatus("transitioning");
 
     this.cameraTransitionTimeline = gsap.timeline({
@@ -819,7 +826,7 @@ export abstract class HexagonScene {
         x: newPosition.x,
         y: newPosition.y,
         z: newPosition.z,
-        ease: "power3.inOut",
+        ease,
       },
       0,
     );
@@ -832,7 +839,7 @@ export abstract class HexagonScene {
         x: newTarget.x,
         y: newTarget.y,
         z: newTarget.z,
-        ease: "power3.inOut",
+        ease,
       },
       0,
     );

--- a/client/apps/game/src/three/scenes/worldmap-view-resolution-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-view-resolution-policy.test.ts
@@ -15,4 +15,10 @@ describe("worldmap view resolution policy wiring", () => {
     expect(source).toMatch(/resolveWorldmapZoomBand\(/);
     expect(source).not.toMatch(/this\.currentCameraView = position;/);
   });
+
+  it("keeps distance-based view resync available to subclasses that own worldmap camera completion", () => {
+    const source = readHexagonSceneSource();
+
+    expect(source).toMatch(/protected syncResolvedCameraViewFromDistance\(distance: number\): void/);
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-zoom-controller.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-controller.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { CameraView } from "./camera-view";
+import {
+  applyWorldmapWheelIntent,
+  createWorldmapZoomControllerState,
+  resetWorldmapWheelIntent,
+  setWorldmapZoomTargetView,
+} from "./worldmap-zoom-controller";
+
+describe("applyWorldmapWheelIntent", () => {
+  it("does not step bands until the accumulated wheel gesture crosses the threshold", () => {
+    const state = createWorldmapZoomControllerState(CameraView.Medium);
+
+    const result = applyWorldmapWheelIntent(state, {
+      currentView: CameraView.Medium,
+      normalizedDelta: 40,
+      wheelThreshold: 120,
+    });
+
+    expect(result.didRequestViewChange).toBe(false);
+    expect(result.nextTargetView).toBe(CameraView.Medium);
+    expect(result.nextState.wheelAccumulator).toBe(40);
+  });
+
+  it("steps one band farther when a full wheel-out gesture crosses the threshold", () => {
+    const state = createWorldmapZoomControllerState(CameraView.Medium);
+
+    const result = applyWorldmapWheelIntent(state, {
+      currentView: CameraView.Medium,
+      normalizedDelta: 120,
+      wheelThreshold: 120,
+    });
+
+    expect(result.didRequestViewChange).toBe(true);
+    expect(result.nextTargetView).toBe(CameraView.Far);
+    expect(result.nextState.targetView).toBe(CameraView.Far);
+    expect(result.nextState.wheelAccumulator).toBe(0);
+  });
+
+  it("resets accumulation when the wheel direction reverses and steps back toward the current band", () => {
+    const state = setWorldmapZoomTargetView(createWorldmapZoomControllerState(CameraView.Medium), CameraView.Far);
+
+    const result = applyWorldmapWheelIntent(state, {
+      currentView: CameraView.Far,
+      normalizedDelta: -120,
+      wheelThreshold: 120,
+    });
+
+    expect(result.didRequestViewChange).toBe(true);
+    expect(result.nextTargetView).toBe(CameraView.Medium);
+    expect(result.nextState.targetView).toBe(CameraView.Medium);
+  });
+
+  it("clamps at the far band instead of inventing a fourth zoom level", () => {
+    const state = createWorldmapZoomControllerState(CameraView.Far);
+
+    const result = applyWorldmapWheelIntent(state, {
+      currentView: CameraView.Far,
+      normalizedDelta: 240,
+      wheelThreshold: 120,
+    });
+
+    expect(result.didRequestViewChange).toBe(false);
+    expect(result.nextTargetView).toBe(CameraView.Far);
+    expect(result.nextState.targetView).toBe(CameraView.Far);
+  });
+
+  it("resets the gesture accumulator without losing the current target band", () => {
+    const nextState = resetWorldmapWheelIntent({
+      targetView: CameraView.Close,
+      wheelAccumulator: 32,
+      wheelDirection: -1,
+    });
+
+    expect(nextState).toEqual({
+      targetView: CameraView.Close,
+      wheelAccumulator: 0,
+      wheelDirection: 0,
+    });
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-zoom-controller.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-controller.test.ts
@@ -5,6 +5,8 @@ import {
   applyWorldmapWheelIntent,
   createWorldmapZoomControllerState,
   resetWorldmapWheelIntent,
+  resolveWorldmapWheelGestureTimeoutMs,
+  resolveWorldmapWheelThreshold,
   setWorldmapZoomTargetView,
 } from "./worldmap-zoom-controller";
 
@@ -78,5 +80,19 @@ describe("applyWorldmapWheelIntent", () => {
       wheelAccumulator: 0,
       wheelDirection: 0,
     });
+  });
+});
+
+describe("worldmap zoom controller thresholds", () => {
+  it("uses a lower step threshold for trackpad gestures than for wheel gestures", () => {
+    expect(resolveWorldmapWheelThreshold("trackpad", 120)).toBeLessThan(resolveWorldmapWheelThreshold("wheel", 120));
+    expect(resolveWorldmapWheelThreshold("wheel", 120)).toBe(120);
+  });
+
+  it("keeps trackpad gesture accumulation alive longer than wheel accumulation", () => {
+    expect(resolveWorldmapWheelGestureTimeoutMs("trackpad", 50)).toBeGreaterThan(
+      resolveWorldmapWheelGestureTimeoutMs("wheel", 50),
+    );
+    expect(resolveWorldmapWheelGestureTimeoutMs("wheel", 50)).toBe(50);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-zoom-controller.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-controller.ts
@@ -6,6 +6,8 @@ export interface WorldmapZoomControllerState {
   wheelDirection: -1 | 0 | 1;
 }
 
+export type WorldmapZoomInputKind = "trackpad" | "wheel";
+
 interface ApplyWorldmapWheelIntentInput {
   currentView: CameraView;
   normalizedDelta: number;
@@ -53,6 +55,27 @@ export function resetWorldmapWheelIntent(state: WorldmapZoomControllerState): Wo
     wheelAccumulator: 0,
     wheelDirection: 0,
   };
+}
+
+export function resolveWorldmapWheelThreshold(inputKind: WorldmapZoomInputKind, baseThreshold: number = 120): number {
+  const normalizedBaseThreshold = Math.max(1, baseThreshold);
+  if (inputKind === "trackpad") {
+    return Math.max(48, Math.round(normalizedBaseThreshold * 0.6));
+  }
+
+  return normalizedBaseThreshold;
+}
+
+export function resolveWorldmapWheelGestureTimeoutMs(
+  inputKind: WorldmapZoomInputKind,
+  baseTimeoutMs: number = 50,
+): number {
+  const normalizedBaseTimeoutMs = Math.max(0, baseTimeoutMs);
+  if (inputKind === "trackpad") {
+    return Math.max(normalizedBaseTimeoutMs, 90);
+  }
+
+  return normalizedBaseTimeoutMs;
 }
 
 export function applyWorldmapWheelIntent(

--- a/client/apps/game/src/three/scenes/worldmap-zoom-controller.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-controller.ts
@@ -1,0 +1,106 @@
+import { CameraView } from "./camera-view";
+
+export interface WorldmapZoomControllerState {
+  targetView: CameraView;
+  wheelAccumulator: number;
+  wheelDirection: -1 | 0 | 1;
+}
+
+interface ApplyWorldmapWheelIntentInput {
+  currentView: CameraView;
+  normalizedDelta: number;
+  wheelThreshold: number;
+}
+
+export interface ApplyWorldmapWheelIntentResult {
+  didRequestViewChange: boolean;
+  nextTargetView: CameraView;
+  nextState: WorldmapZoomControllerState;
+}
+
+function stepWorldmapCameraView(view: CameraView, zoomOut: boolean): CameraView {
+  if (zoomOut) {
+    return Math.min(CameraView.Far, view + 1) as CameraView;
+  }
+
+  return Math.max(CameraView.Close, view - 1) as CameraView;
+}
+
+export function createWorldmapZoomControllerState(
+  targetView: CameraView = CameraView.Medium,
+): WorldmapZoomControllerState {
+  return {
+    targetView,
+    wheelAccumulator: 0,
+    wheelDirection: 0,
+  };
+}
+
+export function setWorldmapZoomTargetView(
+  state: WorldmapZoomControllerState,
+  targetView: CameraView,
+): WorldmapZoomControllerState {
+  return {
+    targetView,
+    wheelAccumulator: 0,
+    wheelDirection: 0,
+  };
+}
+
+export function resetWorldmapWheelIntent(state: WorldmapZoomControllerState): WorldmapZoomControllerState {
+  return {
+    targetView: state.targetView,
+    wheelAccumulator: 0,
+    wheelDirection: 0,
+  };
+}
+
+export function applyWorldmapWheelIntent(
+  state: WorldmapZoomControllerState,
+  input: ApplyWorldmapWheelIntentInput,
+): ApplyWorldmapWheelIntentResult {
+  const direction = Math.sign(input.normalizedDelta) as -1 | 0 | 1;
+  if (direction === 0) {
+    return {
+      didRequestViewChange: false,
+      nextTargetView: state.targetView,
+      nextState: state,
+    };
+  }
+
+  const isDirectionChange = state.wheelDirection !== 0 && state.wheelDirection !== direction;
+  const baselineView = isDirectionChange ? input.currentView : state.targetView;
+  const nextAccumulator = (isDirectionChange ? 0 : state.wheelAccumulator) + input.normalizedDelta;
+  const threshold = Math.max(1, input.wheelThreshold);
+  const steps = Math.floor(Math.abs(nextAccumulator) / threshold);
+
+  if (steps === 0) {
+    return {
+      didRequestViewChange: false,
+      nextTargetView: state.targetView,
+      nextState: {
+        targetView: state.targetView,
+        wheelAccumulator: nextAccumulator,
+        wheelDirection: direction,
+      },
+    };
+  }
+
+  let nextTargetView = baselineView;
+  for (let step = 0; step < steps; step += 1) {
+    nextTargetView = stepWorldmapCameraView(nextTargetView, direction > 0);
+  }
+
+  const consumed = steps * threshold * direction;
+  const remainder = nextAccumulator - consumed;
+
+  return {
+    didRequestViewChange: nextTargetView !== state.targetView,
+    nextTargetView,
+    nextState: {
+      targetView: nextTargetView,
+      wheelAccumulator: remainder,
+      wheelDirection: direction,
+    },
+  };
+}

--- a/client/apps/game/src/three/scenes/worldmap-zoom-wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-wiring.test.ts
@@ -14,6 +14,8 @@ describe("worldmap zoom wiring", () => {
 
     expect(source).toMatch(/WorldmapZoomCoordinator/);
     expect(source).toMatch(/applyWorldmapWheelIntent\(/);
+    expect(source).toMatch(/resolveWorldmapWheelThreshold\(/);
+    expect(source).toMatch(/resolveWorldmapWheelGestureTimeoutMs\(/);
     expect(source).toMatch(/setWorldmapZoomTargetView\(/);
     expect(source).not.toMatch(/type:\s*"continuous_delta"/);
   });
@@ -65,5 +67,12 @@ describe("worldmap zoom wiring", () => {
 
     expect(source).toMatch(/if \(!this\.hasInitialized\) \{\s*this\.alignInitialWorldmapCameraView\(\);\s*\}/);
     expect(source).toMatch(/this\.zoomCoordinator\.syncToBand\(CameraView\.Medium/);
+  });
+
+  it("uses a worldmap-specific camera transition curve for fixed zoom band changes", () => {
+    const source = readSceneSource("worldmap.tsx");
+
+    expect(source).toMatch(/resolveCameraViewTransitionDuration\(/);
+    expect(source).toMatch(/resolveCameraTransitionEase\(/);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-zoom-wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-wiring.test.ts
@@ -9,13 +9,13 @@ function readSceneSource(fileName: string): string {
 }
 
 describe("worldmap zoom wiring", () => {
-  it("routes worldmap zoom through the dedicated coordinator instead of stepped view intents", () => {
+  it("routes worldmap wheel zoom through the stepped zoom controller instead of continuous delta intents", () => {
     const source = readSceneSource("worldmap.tsx");
 
     expect(source).toMatch(/WorldmapZoomCoordinator/);
-    expect(source).toMatch(/this\.zoomCoordinator\.applyIntent\(/);
-    expect(source).not.toMatch(/applyWorldmapWheelIntent\(/);
-    expect(source).not.toMatch(/setWorldmapZoomTargetView\(/);
+    expect(source).toMatch(/applyWorldmapWheelIntent\(/);
+    expect(source).toMatch(/setWorldmapZoomTargetView\(/);
+    expect(source).not.toMatch(/type:\s*"continuous_delta"/);
   });
 
   it("keeps MapControls zoom disabled for worldmap", () => {
@@ -25,10 +25,10 @@ describe("worldmap zoom wiring", () => {
     expect(source).not.toMatch(/this\.controls\.enableZoom = useUIStore\.getState\(\)\.enableMapZoom/);
   });
 
-  it("extends the worldmap-only max zoom distance beyond the far presentation band", () => {
+  it("caps worldmap max zoom distance at the far presentation band", () => {
     const source = readSceneSource("worldmap.tsx");
 
-    expect(source).toMatch(/worldmapMaxZoomDistance = 60/);
+    expect(source).toMatch(/worldmapMaxZoomDistance = 40/);
     expect(source).toMatch(/maxDistance: this\.worldmapMaxZoomDistance/);
     expect(source).toMatch(/this\.controls\.maxDistance = this\.worldmapMaxZoomDistance/);
   });
@@ -47,10 +47,11 @@ describe("worldmap zoom wiring", () => {
     expect(source).toMatch(/interactiveHexManager\.setHoverVisualMode\("outline"\)/);
   });
 
-  it("guards the worldmap wheel anchor resolver when controls domElement is unavailable", () => {
+  it("does not use cursor-anchor wheel resolution for fixed worldmap zoom stepping", () => {
     const source = readSceneSource("worldmap.tsx");
 
-    expect(source).toMatch(/if \(!canvas\) \{\s*return null;\s*\}/);
+    expect(source).not.toMatch(/resolveWorldmapWheelAnchor\(/);
+    expect(source).not.toMatch(/resolveWorldmapGroundIntersection\(/);
   });
 
   it("removes direct worldmap refresh requests from GameRenderer control changes", () => {

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -85,7 +85,6 @@ import {
   InstancedBufferAttribute,
   Matrix4,
   Object3D,
-  Plane,
   Raycaster,
   Sphere,
   Vector2,
@@ -211,6 +210,12 @@ import {
   evaluateTerrainVisibilityAnomaly,
   resetWorldmapZoomHardeningRuntimeState,
 } from "./worldmap-zoom-hardening";
+import {
+  applyWorldmapWheelIntent,
+  createWorldmapZoomControllerState,
+  resetWorldmapWheelIntent,
+  setWorldmapZoomTargetView,
+} from "./worldmap-zoom-controller";
 import { WorldmapZoomCoordinator } from "./worldmap-zoom/worldmap-zoom-coordinator";
 import {
   WORLDMAP_STEP_WHEEL_DELTA,
@@ -221,7 +226,7 @@ import {
   createWorldmapZoomRefreshPlannerState,
   planWorldmapZoomRefresh,
 } from "./worldmap-zoom/worldmap-zoom-refresh-planner";
-import type { WorldmapCameraSnapshot, WorldmapZoomAnchor } from "./worldmap-zoom/worldmap-zoom-types";
+import type { WorldmapCameraSnapshot } from "./worldmap-zoom/worldmap-zoom-types";
 import { resolveStructureTileUpdateActions } from "./worldmap-structure-update-policy";
 import {
   resolveWorldmapChunkRefreshDebounceMs,
@@ -493,9 +498,13 @@ export default class WorldmapScene extends WarpTravel {
   private activePrefetches = 0;
   private readonly maxConcurrentPrefetches = WORLDMAP_CHUNK_POLICY.prefetch.maxConcurrent;
   private readonly worldmapMinZoomDistance = 10;
-  private readonly worldmapMaxZoomDistance = 60;
+  private readonly worldmapMaxZoomDistance = 40;
   private wheelHandler: ((event: WheelEvent) => void) | null = null;
   private wheelEventTarget: HTMLElement | null = null;
+  private zoomControllerState = createWorldmapZoomControllerState(CameraView.Medium);
+  private wheelResetTimeout: ReturnType<typeof setTimeout> | null = null;
+  private readonly wheelThreshold = WORLDMAP_STEP_WHEEL_DELTA;
+  private readonly wheelGestureTimeoutMs = 50;
   private readonly zoomCoordinator = new WorldmapZoomCoordinator({
     initialDistance: this.getCurrentCameraDistance(),
     minDistance: this.worldmapMinZoomDistance,
@@ -506,7 +515,6 @@ export default class WorldmapScene extends WarpTravel {
   private readonly worldmapCameraTransitionListeners: Set<(status: WorldmapCameraTransitionStatus) => void> = new Set();
   private lastPublishedStableCameraView = this.zoomCoordinator.getSnapshot().stableBand;
   private lastPublishedZoomStatus: WorldmapCameraTransitionStatus = "idle";
-  private readonly zoomGroundPlane = new Plane(new Vector3(0, 1, 0), 0);
   private renderChunkSize = this.chunkGeometry.renderSize;
 
   private totalStructures: number = 0;
@@ -544,9 +552,6 @@ export default class WorldmapScene extends WarpTravel {
   private cameraPositionScratch: Vector3 = new Vector3();
   private cameraDirectionScratch: Vector3 = new Vector3();
   private cameraGroundIntersectionScratch: Vector3 = new Vector3();
-  private wheelPointerScratch: Vector2 = new Vector2();
-  private wheelRaycasterScratch: Raycaster = new Raycaster();
-  private wheelGroundIntersectionScratch: Vector3 = new Vector3();
   private interactiveHexWindowKey: string | null = null;
 
   private armyManager!: ArmyManager;
@@ -717,12 +722,7 @@ export default class WorldmapScene extends WarpTravel {
     if (this.sceneManager.getCurrentScene() !== SceneName.WorldMap) return;
     const detail = (event as CustomEvent<{ zoomOut: boolean }>).detail;
     if (!detail) return;
-    this.zoomCoordinator.applyIntent({
-      type: "continuous_delta",
-      delta: detail.zoomOut ? WORLDMAP_STEP_WHEEL_DELTA : -WORLDMAP_STEP_WHEEL_DELTA,
-      anchor: this.resolveWorldmapMinimapZoomAnchor(),
-    });
-    this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
+    this.applyDirectionalZoomIntent(detail.zoomOut);
   };
   private pendingWorldmapFxStartHandler = (event: Event) => {
     if (this.sceneManager.getCurrentScene() !== SceneName.WorldMap) return;
@@ -1467,6 +1467,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private setupCameraZoomHandler() {
     this.detachWorldmapWheelHandler();
+    this.resetWheelState();
     this.wheelHandler = (event: WheelEvent) => {
       const normalizedWheelDelta = normalizeWorldmapWheelDelta({
         delta: event.deltaY,
@@ -1489,12 +1490,16 @@ export default class WorldmapScene extends WarpTravel {
       event.preventDefault();
       event.stopPropagation();
 
-      this.zoomCoordinator.applyIntent({
-        type: "continuous_delta",
-        delta: normalizedWheelDelta.normalizedDelta,
-        anchor: this.resolveWorldmapWheelAnchor(event),
+      const zoomIntent = applyWorldmapWheelIntent(this.zoomControllerState, {
+        currentView: this.zoomControllerState.targetView,
+        normalizedDelta: normalizedWheelDelta.normalizedDelta,
+        wheelThreshold: this.wheelThreshold,
       });
-      this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
+      this.zoomControllerState = zoomIntent.nextState;
+      if (zoomIntent.didRequestViewChange) {
+        this.changeCameraView(zoomIntent.nextTargetView);
+      }
+      this.scheduleWheelAccumulatorReset();
     };
 
     this.attachWorldmapWheelHandler();
@@ -1523,21 +1528,35 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private applyDirectionalZoomIntent(zoomOut: boolean) {
-    this.zoomCoordinator.applyIntent({
-      type: "continuous_delta",
-      delta: zoomOut ? WORLDMAP_STEP_WHEEL_DELTA : -WORLDMAP_STEP_WHEEL_DELTA,
-      anchor: this.resolveWorldmapMinimapZoomAnchor(),
+    const zoomIntent = applyWorldmapWheelIntent(this.zoomControllerState, {
+      currentView: this.zoomControllerState.targetView,
+      normalizedDelta: zoomOut ? this.wheelThreshold : -this.wheelThreshold,
+      wheelThreshold: this.wheelThreshold,
     });
-    this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
+    this.zoomControllerState = zoomIntent.nextState;
+
+    if (zoomIntent.didRequestViewChange) {
+      this.changeCameraView(zoomIntent.nextTargetView);
+      return;
+    }
+
+    if (this.isCameraDistanceOutOfSync(this.zoomControllerState.targetView)) {
+      this.changeCameraView(this.zoomControllerState.targetView);
+    }
   }
 
   public override changeCameraView(position: CameraView) {
+    this.zoomControllerState = setWorldmapZoomTargetView(this.zoomControllerState, position);
     this.zoomCoordinator.applyIntent({
       type: "snap_to_band",
       band: position,
-      anchor: this.resolveWorldmapKeyboardZoomAnchor(),
+      anchor: {
+        mode: "screen_center",
+        worldPoint: this.controls.target.clone(),
+      },
     });
     this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
+    super.changeCameraView(position);
   }
 
   public override getCurrentCameraView(): CameraView {
@@ -1585,51 +1604,34 @@ export default class WorldmapScene extends WarpTravel {
     return this.controls.object.position.distanceTo(this.controls.target);
   }
 
-  private resolveWorldmapWheelAnchor(event: WheelEvent): WorldmapZoomAnchor {
-    const worldPoint = this.resolveWorldmapGroundIntersection(event.clientX, event.clientY);
-
-    return {
-      mode: worldPoint ? "cursor" : "screen_center",
-      worldPoint: worldPoint ?? this.controls.target.clone(),
-    };
+  private getTargetDistanceForCameraView(view: CameraView): number {
+    return resolveWorldmapCameraViewProfile(view).distance;
   }
 
-  private resolveWorldmapKeyboardZoomAnchor(): WorldmapZoomAnchor {
-    return {
-      mode: "screen_center",
-      worldPoint: this.controls.target.clone(),
-    };
+  private isCameraDistanceOutOfSync(view: CameraView, tolerance: number = 1): boolean {
+    const currentDistance = this.getCurrentCameraDistance();
+    const targetDistance = this.getTargetDistanceForCameraView(view);
+    return Math.abs(currentDistance - targetDistance) > tolerance;
   }
 
-  private resolveWorldmapMinimapZoomAnchor(): WorldmapZoomAnchor {
-    return {
-      mode: "world_point",
-      worldPoint: this.controls.target.clone(),
-    };
-  }
-
-  private resolveWorldmapGroundIntersection(clientX: number, clientY: number): Vector3 | null {
-    const canvas = this.controls.domElement;
-    if (!canvas) {
-      return null;
-    }
-    const bounds = canvas.getBoundingClientRect();
-    if (bounds.width <= 0 || bounds.height <= 0) {
-      return null;
+  private scheduleWheelAccumulatorReset(): void {
+    if (this.wheelResetTimeout) {
+      clearTimeout(this.wheelResetTimeout);
     }
 
-    this.wheelPointerScratch.set(
-      ((clientX - bounds.left) / bounds.width) * 2 - 1,
-      -((clientY - bounds.top) / bounds.height) * 2 + 1,
-    );
-    this.wheelRaycasterScratch.setFromCamera(this.wheelPointerScratch, this.camera);
+    this.wheelResetTimeout = setTimeout(() => {
+      this.resetWheelState();
+    }, this.wheelGestureTimeoutMs);
+  }
 
-    const didIntersect = this.wheelRaycasterScratch.ray.intersectPlane(
-      this.zoomGroundPlane,
-      this.wheelGroundIntersectionScratch,
-    );
+  private resetWheelState(): void {
+    const timeoutId = this.wheelResetTimeout;
+    this.wheelResetTimeout = null;
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
 
-    return didIntersect ? this.wheelGroundIntersectionScratch : null;
+    this.zoomControllerState = resetWorldmapWheelIntent(this.zoomControllerState);
   }
 
   private publishWorldmapZoomSnapshot(snapshot: WorldmapCameraSnapshot): void {
@@ -1660,6 +1662,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private alignInitialWorldmapCameraView(): void {
     this.alignWorldmapCameraToBand(CameraView.Medium);
+    this.zoomControllerState = setWorldmapZoomTargetView(this.zoomControllerState, CameraView.Medium);
     this.zoomCoordinator.syncToBand(CameraView.Medium, performance.now());
     this.lastControlsCameraDistance = this.getCurrentCameraDistance();
     this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
@@ -6935,7 +6938,7 @@ export default class WorldmapScene extends WarpTravel {
 
   update(deltaTime: number) {
     const animationContext = this.getAnimationVisibilityContext();
-    this.updateWorldmapZoom(deltaTime);
+    this.syncWorldmapZoomSnapshot(deltaTime);
     super.update(deltaTime);
     this.armyManager.update(deltaTime, animationContext);
     this.fxManager.update(deltaTime);
@@ -6955,7 +6958,7 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
-  private updateWorldmapZoom(deltaTime: number): void {
+  private syncWorldmapZoomSnapshot(deltaTime: number): void {
     const zoomFrame = this.zoomCoordinator.tick({
       cameraPosition: this.controls.object.position,
       target: this.controls.target,
@@ -6963,15 +6966,6 @@ export default class WorldmapScene extends WarpTravel {
       nowMs: performance.now(),
     });
 
-    if (!zoomFrame.didMove) {
-      this.publishWorldmapZoomSnapshot(zoomFrame.snapshot);
-      return;
-    }
-
-    this.controls.object.position.copy(zoomFrame.cameraPosition);
-    this.controls.target.copy(zoomFrame.target);
-    this.notifyControlsChanged();
-    this.frustumManager?.forceUpdate();
     this.publishWorldmapZoomSnapshot(zoomFrame.snapshot);
   }
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -214,6 +214,8 @@ import {
   applyWorldmapWheelIntent,
   createWorldmapZoomControllerState,
   resetWorldmapWheelIntent,
+  resolveWorldmapWheelGestureTimeoutMs,
+  resolveWorldmapWheelThreshold,
   setWorldmapZoomTargetView,
 } from "./worldmap-zoom-controller";
 import { WorldmapZoomCoordinator } from "./worldmap-zoom/worldmap-zoom-coordinator";
@@ -1490,16 +1492,21 @@ export default class WorldmapScene extends WarpTravel {
       event.preventDefault();
       event.stopPropagation();
 
+      const wheelThreshold = resolveWorldmapWheelThreshold(normalizedWheelDelta.inputKind, this.wheelThreshold);
+      const wheelGestureTimeoutMs = resolveWorldmapWheelGestureTimeoutMs(
+        normalizedWheelDelta.inputKind,
+        this.wheelGestureTimeoutMs,
+      );
       const zoomIntent = applyWorldmapWheelIntent(this.zoomControllerState, {
         currentView: this.zoomControllerState.targetView,
         normalizedDelta: normalizedWheelDelta.normalizedDelta,
-        wheelThreshold: this.wheelThreshold,
+        wheelThreshold,
       });
       this.zoomControllerState = zoomIntent.nextState;
       if (zoomIntent.didRequestViewChange) {
         this.changeCameraView(zoomIntent.nextTargetView);
       }
-      this.scheduleWheelAccumulatorReset();
+      this.scheduleWheelAccumulatorReset(wheelGestureTimeoutMs);
     };
 
     this.attachWorldmapWheelHandler();
@@ -1556,7 +1563,36 @@ export default class WorldmapScene extends WarpTravel {
       },
     });
     this.publishWorldmapZoomSnapshot(this.zoomCoordinator.getSnapshot());
-    super.changeCameraView(position);
+
+    const previousView = this.targetCameraView;
+    const target = this.controls.target;
+    if (position !== previousView) {
+      incrementWorldmapRenderCounter("zoomTransitionsStarted");
+    }
+
+    this.targetCameraView = position;
+    const profile = resolveWorldmapCameraViewProfile(position);
+    this.cameraDistance = profile.distance;
+    this.cameraAngle = profile.angleRadians;
+
+    const cameraHeight = Math.sin(profile.angleRadians) * profile.distance;
+    const cameraDepth = Math.cos(profile.angleRadians) * profile.distance;
+    const newPosition = new Vector3(target.x, target.y + cameraHeight, target.z + cameraDepth);
+    const duration = this.resolveCameraViewTransitionDuration(Math.abs(position - previousView));
+    const ease = this.resolveCameraTransitionEase();
+
+    this.cameraAnimate(
+      newPosition,
+      target,
+      duration,
+      () => {
+        if (position !== previousView) {
+          incrementWorldmapRenderCounter("zoomTransitionsCompleted");
+        }
+        this.syncResolvedCameraViewFromDistance(this.controls.object.position.distanceTo(this.controls.target));
+      },
+      { ease },
+    );
   }
 
   public override getCurrentCameraView(): CameraView {
@@ -1614,14 +1650,14 @@ export default class WorldmapScene extends WarpTravel {
     return Math.abs(currentDistance - targetDistance) > tolerance;
   }
 
-  private scheduleWheelAccumulatorReset(): void {
+  private scheduleWheelAccumulatorReset(timeoutMs: number): void {
     if (this.wheelResetTimeout) {
       clearTimeout(this.wheelResetTimeout);
     }
 
     this.wheelResetTimeout = setTimeout(() => {
       this.resetWheelState();
-    }, this.wheelGestureTimeoutMs);
+    }, timeoutMs);
   }
 
   private resetWheelState(): void {
@@ -1632,6 +1668,18 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     this.zoomControllerState = resetWorldmapWheelIntent(this.zoomControllerState);
+  }
+
+  private resolveCameraViewTransitionDuration(viewDelta: number): number {
+    if (viewDelta <= 0) {
+      return 0.32;
+    }
+
+    return 0.3 + viewDelta * 0.12;
+  }
+
+  private resolveCameraTransitionEase(): string {
+    return "power2.out";
   }
 
   private publishWorldmapZoomSnapshot(snapshot: WorldmapCameraSnapshot): void {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-10",
+    title: "Smoother Map Zoom Steps",
+    description:
+      "World map zoom now responds more gently to trackpad gestures and settles into each tactical camera band faster, so stepping between map heights feels less chunky without bringing back unstable in-between zoom states.",
+    type: "improvement",
+  },
+  {
+    date: "2026-04-10",
     title: "Fixed World Map Zoom",
     description:
       "World map zoom now snaps between three intended tactical camera profiles instead of drifting through unstable in-between heights, so zooming feels steadier and no longer nudges chunk logic through extra camera-target movement.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-10",
+    title: "Fixed World Map Zoom",
+    description:
+      "World map zoom now snaps between three intended tactical camera profiles instead of drifting through unstable in-between heights, so zooming feels steadier and no longer nudges chunk logic through extra camera-target movement.",
+    type: "fix",
+  },
+  {
+    date: "2026-04-10",
     title: "Structure Claim Stamina Guard",
     description:
       "Taking an undefended enemy structure now respects the same stamina requirement as other attacks, so the world map no longer invites claims your army cannot legally complete yet.",


### PR DESCRIPTION
This pulls the world map back onto three fixed camera profiles instead of the continuous zoom path that was mutating camera distance through many intermediate states, then smooths the stepped interaction so the new model still feels responsive on trackpads and wheels.

The main goal is stability without giving up feel. Worldmap chunk authority is derived from the camera target, so allowing zoom gestures to move both camera and target created a direct path from zoom churn into chunk-selection and refresh churn. The first part of this PR keeps zoom transitions centered on the existing target. The second part lowers the step threshold for trackpads and uses a lighter worldmap-specific camera tween so the fixed-band model feels less chunky.

## What changed

- added a detailed worldmap fixed-zoom PTD/TDD at `client/apps/game/src/three/WORLDMAP_FIXED_ZOOM_PTD_TDD.md`
- added a stepped worldmap zoom controller that accumulates wheel deltas and only advances between `Close`, `Medium`, and `Far`
- rewired wheel and minimap zoom to use band stepping instead of continuous delta intents
- routed `changeCameraView()` back through the fixed camera profiles so band changes apply the intended distance and tilt together
- changed the worldmap zoom coordinator into snapshot publication for stable band / transition status instead of camera-target ownership
- capped the worldmap max zoom distance at the far profile and removed cursor-anchor wheel zoom resolution from the scene
- smoothed fixed-band zoom interaction by:
  - using a lower step threshold for trackpad gestures
  - keeping trackpad gesture accumulation alive slightly longer before reset
  - using a lighter worldmap-specific camera tween curve for band changes
- added latest-features entries for the fixed zoom behavior and the smoother stepping follow-up

## Why

The prior trace showed that zoom was not changing chunk geometry, but it was still able to influence chunk work indirectly by moving the worldmap target through anchor-driven camera updates. Stepping between the three existing camera profiles removes the unstable intermediate zoom states and keeps zoom out of the chunk-selection path. The follow-up smoothing pass keeps that safer model while making the input feel more natural on real hardware.

## Verification

- `pnpm run format`
- `pnpm run knip`
- Focused Vitest suite under Node `20.19.0`:
  - `src/three/scenes/hexagon-scene-camera-transition.test.ts`
  - `src/three/scenes/worldmap-zoom/worldmap-zoom-coordinator.test.ts`
  - `src/three/scenes/worldmap-zoom/worldmap-zoom-band-policy.test.ts`
  - `src/three/scenes/worldmap-zoom/worldmap-zoom-refresh-planner.test.ts`
  - `src/three/scenes/worldmap-zoom-hardening.test.ts`
  - `src/three/scenes/worldmap-chunk-transition.test.ts`
  - `src/three/scenes/worldmap-chunk-bounds.test.ts`
  - `src/three/scenes/worldmap-chunk-hysteresis-policy.test.ts`
  - `src/three/scenes/worldmap-zoom-controller.test.ts`
  - `src/three/scenes/worldmap-zoom-wiring.test.ts`
  - `src/ui/features/world/latest-features.test.ts`

## Notes

- I also ran a full game-client `tsc --noEmit`, but it still fails on the existing workspace/module resolution issues for `@bibliothecadao/*` packages and unrelated implicit-anys. I did not try to fold that unrelated cleanup into this PR.