### PR TITLE
fix(game): compact realm list cards and taller scroll area

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -683,7 +683,7 @@ const StructureListItem = memo(
           isSelected ? "border-gold bg-black/60" : "border-gold/20 bg-black/20 hover:border-gold/40 hover:bg-black/30"
         }`}
       >
-        <div className="flex items-center gap-1.5">
+        <div className="flex items-center gap-1.5 overflow-hidden">
           <button
             type="button"
             onClick={(event) => {
@@ -701,11 +701,12 @@ const StructureListItem = memo(
             />
           )}
           <span
-            className={`truncate text-xs font-semibold ${
+            className={`min-w-0 max-w-[7rem] shrink truncate text-xs font-semibold ${
               structure.groupColor
                 ? (STRUCTURE_GROUP_CONFIG[structure.groupColor]?.textClass ?? "text-gold")
                 : "text-gold"
             }`}
+            title={structure.displayName}
           >
             {structure.displayName}
           </span>

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -575,7 +575,7 @@ const LeftPanelHeader = memo(
           </Tabs>
 
           {orderedStructures.length > 0 ? (
-            <div className="max-h-[9.5rem] space-y-2 overflow-y-auto pr-1">
+            <div className="max-h-[16rem] space-y-1 overflow-y-auto pr-1">
               {orderedStructures.map((structure) => (
                 <StructureListItem
                   key={structure.entityId}
@@ -679,51 +679,47 @@ const StructureListItem = memo(
         tabIndex={0}
         onClick={handleSelectStructure}
         onKeyDown={handleKeyDown}
-        className={`w-full rounded-lg border px-3 py-2 text-left transition ${
+        className={`w-full rounded-lg border px-2 py-1.5 text-left transition ${
           isSelected ? "border-gold bg-black/60" : "border-gold/20 bg-black/20 hover:border-gold/40 hover:bg-black/30"
         }`}
       >
-        <div className="flex items-start gap-2">
+        <div className="flex items-center gap-1.5">
           <button
             type="button"
             onClick={(event) => {
               event.stopPropagation();
               onToggleFavorite(structure.entityId);
             }}
-            className="rounded border border-transparent p-1 text-gold/60 hover:text-gold"
+            className="rounded border border-transparent p-0.5 text-gold/60 hover:text-gold shrink-0"
             title={structure.isFavorite ? "Remove from favorites" : "Favorite structure"}
           >
-            <Star className={`h-4 w-4 ${structure.isFavorite ? "fill-current text-gold" : "text-gold/60"}`} />
+            <Star className={`h-3.5 w-3.5 ${structure.isFavorite ? "fill-current text-gold" : "text-gold/60"}`} />
           </button>
-          <div className="flex flex-1 min-w-0 items-start gap-2">
-            {structure.groupColor && (
-              <span
-                className={`mt-1 h-2 w-2 shrink-0 rounded-full ${STRUCTURE_GROUP_CONFIG[structure.groupColor]?.dotClass ?? ""}`}
+          {structure.groupColor && (
+            <span
+              className={`h-2 w-2 shrink-0 rounded-full ${STRUCTURE_GROUP_CONFIG[structure.groupColor]?.dotClass ?? ""}`}
+            />
+          )}
+          <span
+            className={`truncate text-xs font-semibold ${
+              structure.groupColor
+                ? (STRUCTURE_GROUP_CONFIG[structure.groupColor]?.textClass ?? "text-gold")
+                : "text-gold"
+            }`}
+          >
+            {structure.displayName}
+          </span>
+          {showInfoLine && (
+            <>
+              <span className="shrink-0 whitespace-nowrap text-[10px] text-gold/50">{infoLineLabel}</span>
+              <StructureStatusStats
+                populationLabel={populationStatusLabel}
+                buildingTilesLabel={buildingTilesStatusLabel}
               />
-            )}
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <span
-                className={`truncate text-sm font-semibold ${
-                  structure.groupColor
-                    ? (STRUCTURE_GROUP_CONFIG[structure.groupColor]?.textClass ?? "text-gold")
-                    : "text-gold"
-                }`}
-              >
-                {structure.displayName}
-              </span>
-              {showInfoLine && (
-                <div className="flex flex-wrap items-center gap-2 text-xxs text-gold/70">
-                  <span className="shrink-0 whitespace-nowrap">{infoLineLabel}</span>
-                  <StructureStatusStats
-                    populationLabel={populationStatusLabel}
-                    buildingTilesLabel={buildingTilesStatusLabel}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
+            </>
+          )}
           {activeRelicEffects.length > 0 && (
-            <div className="flex items-center gap-0.5 shrink-0 pt-0.5">
+            <div className="flex items-center gap-0.5 shrink-0 ml-auto">
               {activeRelicEffects.map((effect) => {
                 const resourceId = Number(effect.id);
                 return (
@@ -735,7 +731,7 @@ const StructureListItem = memo(
             </div>
           )}
           {structure.category === StructureType.Realm && (
-            <StructureLevelUpButton structureEntityId={structure.entityId} className="ml-auto shrink-0 pt-0.5" />
+            <StructureLevelUpButton structureEntityId={structure.entityId} className="ml-auto shrink-0" />
           )}
         </div>
       </div>

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -334,7 +334,7 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   }
 
   return (
-    <div className={cn("flex h-full flex-col gap-3 p-3 text-gold", className)}>
+    <div className={cn("flex h-full flex-col gap-2 p-2 text-gold", className)}>
       {canShowProductionCard && (
         <div className="rounded border border-gold/20 bg-black/50 p-2">
           <div className="flex items-center justify-between gap-3">
@@ -541,20 +541,20 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
               </button>
             </div>
           </div>
-          <div className="mt-2 grid grid-cols-2 gap-2">
-            <div className="rounded border border-gold/10 bg-[#1b140f]/80 p-2">
-              <div className="text-xxs uppercase tracking-[0.12em] text-gold/60">Field Armies</div>
-              <div className="mt-1 text-sm font-semibold text-gold">
-                {attackArmyCount}
-                {maxAttackArmies !== null ? ` / ${maxAttackArmies}` : ""}
-              </div>
+          <div className="mt-1.5 flex items-center gap-3 text-xxs text-gold/80">
+            <div className="flex items-center gap-1.5 rounded border border-gold/10 bg-[#1b140f]/80 px-2 py-1">
+              <Sword className="h-3 w-3 text-gold/50" />
+              <span className="uppercase tracking-wide text-gold/60">Field</span>
+              <span className="font-semibold text-gold">
+                {attackArmyCount}{maxAttackArmies !== null ? `/${maxAttackArmies}` : ""}
+              </span>
             </div>
-            <div className="rounded border border-gold/10 bg-[#1b140f]/80 p-2">
-              <div className="text-xxs uppercase tracking-[0.12em] text-gold/60">Guard Armies</div>
-              <div className="mt-1 text-sm font-semibold text-gold">
-                {guardArmyCount}
-                {maxGuardArmies !== null ? ` / ${maxGuardArmies}` : ""}
-              </div>
+            <div className="flex items-center gap-1.5 rounded border border-gold/10 bg-[#1b140f]/80 px-2 py-1">
+              <Shield className="h-3 w-3 text-gold/50" />
+              <span className="uppercase tracking-wide text-gold/60">Guard</span>
+              <span className="font-semibold text-gold">
+                {guardArmyCount}{maxGuardArmies !== null ? `/${maxGuardArmies}` : ""}
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Makes the realm/structure list panel taller (`max-h` from 9.5rem to 16rem) so more items are visible without scrolling
- Flattens realm cards to a single-row inline layout: star, name, level label, population, and building tiles all on one line instead of stacked
- Reduces card padding and spacing between cards for denser list
- Compacts the armies section in the detail panel from a 2-column grid to an inline row with icons
- Tightens overall detail panel gaps and padding

## Test plan
- [ ] Verify realm list shows more items in the scrollable area
- [ ] Confirm card info (level, population, tiles) displays inline next to realm name
- [ ] Check armies section shows Field/Guard counts inline with icons
- [ ] Test on various screen heights to ensure scroll behavior works