### PR TITLE
fix: remove duplicate landing hero images

### DIFF
--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -598,12 +598,6 @@ const ModeCoexistenceHero = ({
               transitionDelay: mounted ? "0ms" : `${index * 150}ms`,
             }}
           >
-            <img
-              src={config.posterSrc}
-              alt=""
-              aria-hidden="true"
-              className="absolute inset-0 h-full w-full object-cover scale-105"
-            />
             <video
               autoPlay
               muted
@@ -611,10 +605,7 @@ const ModeCoexistenceHero = ({
               playsInline
               preload="metadata"
               poster={config.posterSrc}
-              className={cn(
-                "absolute inset-0 h-full w-full object-cover transition-opacity duration-300",
-                hoveredMode === mode ? "opacity-100" : "opacity-75",
-              )}
+              className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.02]"
             >
               <source src={config.videoSrc} type="video/mp4" />
             </video>

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-12",
+    title: "Cleaner Hero Cards",
+    description:
+      "The Play dashboard hero cards now show a single artwork layer per mode, so hovering between Seasons and Blitz no longer creates a ghosted double-image effect.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
     date: "2026-04-10",
     title: "Smoother Map Zoom Steps",
     description:


### PR DESCRIPTION
This keeps the Play dashboard hero cards to a single media layer per mode.

The poster image underneath each autoplaying video is removed so hovering between Seasons and Blitz no longer shows a ghosted double image, and the landing latest-features feed now records the fix.

Verification: `pnpm run format`, `pnpm run knip`.