### PR TITLE
fix: add loading feedback for map zoom refresh

### DIFF
--- a/client/apps/game/src/three/WORLDMAP_ZOOM_REFRESH_LOADING_PRD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_ZOOM_REFRESH_LOADING_PRD_TDD.md
@@ -1,0 +1,138 @@
+# Worldmap Zoom Refresh Loading PRD / TDD
+
+## Status
+
+- Status: Proposed for implementation
+- Scope: `client/apps/game/src/three/scenes/worldmap.tsx`, a small worldmap loading helper seam, and the world loading
+  UI copy path
+- Primary goal: replace visible zoom-refresh jitter with an explicit loading state while the worldmap swaps or refreshes
+  chunks after zoom
+
+## Problem Statement
+
+Worldmap zoom already uses stepped camera bands, but chunk refresh work still happens after the zoom gesture settles.
+
+Today:
+
+1. A zoom gesture updates the camera band.
+2. Controls-change hardening can request a chunk refresh when the distance change is large enough.
+3. Chunk hydration and presentation then run asynchronously.
+4. During that window the map can visibly pop or stall while terrain catches up.
+
+The current UI does not clearly communicate that this is active loading work.
+
+The result is a jittery-feeling zoom transition even when the renderer is behaving correctly.
+
+## User Goal
+
+When zoom crosses into a chunk refresh, the player should see a short loading state instead of perceiving the renderer
+as stuttering.
+
+## Goals
+
+- Show a world loading state while a zoom-triggered chunk refresh or chunk switch is actively executing.
+- Keep the loading state scoped to zoom refresh work so normal world interaction is not constantly masked.
+- Preserve existing Torii fetch loading behavior.
+- Preserve timeout recovery so loading does not get stuck if a chunk phase times out.
+
+## Non-goals
+
+- Reworking the chunk hydration pipeline.
+- Removing the existing world loading banner or replacing it with a new overlay.
+- Showing loading for every pan, shortcut selection, or background prefetch.
+- Changing camera zoom behavior in this pass.
+
+## Proposed Behavior
+
+### Loading trigger
+
+The loading state should turn on when a zoom-requested chunk refresh begins execution.
+
+That includes both outcomes of `updateVisibleChunks(...)` when entered from zoom refresh execution:
+
+- `switch_chunk`
+- `refresh_current_chunk`
+
+### Loading lifetime
+
+The loading state should stay on for the duration of the active refresh execution and clear when the refresh settles,
+whether it:
+
+- commits successfully
+- no-ops after refresh bookkeeping
+- throws and is caught by the refresh execution wrapper
+
+### Loading presentation
+
+Reuse the existing map loading affordance so the user gets a clear, consistent signal instead of a second loading UI.
+
+The copy should explain that the map is refreshing for zoom rather than only implying initial map charting.
+
+## Architecture
+
+## 1. Separate zoom refresh loading from Torii fetch counting
+
+The existing `toriiLoadingCounter` is fetch-specific. A zoom refresh can feel jittery outside the fetch window, so the
+zoom refresh loading state needs its own ownership.
+
+Introduce a small helper that answers:
+
+- should map loading be visible?
+- how should zoom refresh loading start?
+- how should zoom refresh loading finish?
+
+This helper should compose with Torii fetch loading instead of replacing it.
+
+## 2. Scope the loading state at the refresh execution boundary
+
+The right orchestration layer is the zoom refresh execution path, not every lower-level hydration helper.
+
+At the top level this should read like:
+
+1. resolve whether this refresh should show zoom loading
+2. start zoom refresh loading if needed
+3. execute visible chunk update
+4. clear zoom refresh loading in `finally`
+
+## 3. Keep timeout recovery safe
+
+Chunk timeout recovery currently clears the map loading flag for fetch-related stalls.
+
+That recovery must be updated so it clears the combined loading state correctly when fetch loading is forced back to
+idle, without leaving zoom-refresh loading stuck on or accidentally hiding a still-active zoom refresh.
+
+## TDD Plan
+
+## Red phase
+
+Add failing tests for:
+
+1. loading visibility helper
+   - map loading stays visible when either Torii fetch loading or zoom refresh loading is active
+   - clearing fetch loading does not hide an active zoom refresh
+   - clearing zoom refresh loading does not hide an active fetch
+
+2. worldmap wiring
+   - zoom refresh execution starts map loading before `updateVisibleChunks(...)`
+   - zoom refresh execution clears map loading after the awaited refresh settles
+   - the worldmap source uses the loading helper instead of directly toggling `LoadingStateKey.Map` in the zoom refresh
+     path
+
+3. loading copy
+   - the world loading UI surfaces copy that reads correctly for the refreshed map state
+
+## Green phase
+
+Implement the minimum code to make those tests pass:
+
+- a focused worldmap loading helper
+- zoom refresh loading start/finish wiring in `worldmap.tsx`
+- combined loading visibility updates that still work with Torii fetch counting
+- updated world loading copy
+
+## Verification
+
+1. Zoom the world map across chunk boundaries and confirm the loading state appears during the refresh window.
+2. Wait for the refresh to settle and confirm the loading state clears.
+3. Trigger initial worldmap loading and confirm the existing loading behavior still works.
+4. Force a chunk timeout in development and confirm loading does not remain stuck.

--- a/client/apps/game/src/three/scenes/worldmap-timeout-loading-recovery.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-timeout-loading-recovery.test.ts
@@ -10,6 +10,7 @@ describe("worldmap timeout loading recovery", () => {
 
     const nextCounter = recoverWorldmapMapLoadingStateFromChunkTimeout({
       phase: "tile_fetch",
+      keepMapLoadingVisible: false,
       toriiLoadingCounter: 2,
       clearMapLoading,
     });
@@ -23,11 +24,26 @@ describe("worldmap timeout loading recovery", () => {
 
     const nextCounter = recoverWorldmapMapLoadingStateFromChunkTimeout({
       phase: "structure_hydration",
+      keepMapLoadingVisible: false,
       toriiLoadingCounter: 2,
       clearMapLoading,
     });
 
     expect(nextCounter).toBe(2);
+    expect(clearMapLoading).not.toHaveBeenCalled();
+  });
+
+  it("does not hide map loading when zoom refresh loading is still active", () => {
+    const clearMapLoading = vi.fn();
+
+    const nextCounter = recoverWorldmapMapLoadingStateFromChunkTimeout({
+      phase: "tile_fetch",
+      keepMapLoadingVisible: true,
+      toriiLoadingCounter: 2,
+      clearMapLoading,
+    });
+
+    expect(nextCounter).toBe(0);
     expect(clearMapLoading).not.toHaveBeenCalled();
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-timeout-loading-recovery.ts
+++ b/client/apps/game/src/three/scenes/worldmap-timeout-loading-recovery.ts
@@ -2,12 +2,14 @@ import type { WorldmapChunkPresentationPhase } from "./worldmap-chunk-presentati
 
 interface RecoverWorldmapMapLoadingStateFromChunkTimeoutInput {
   phase: WorldmapChunkPresentationPhase;
+  keepMapLoadingVisible: boolean;
   toriiLoadingCounter: number;
   clearMapLoading: () => void;
 }
 
 export const recoverWorldmapMapLoadingStateFromChunkTimeout = ({
   phase,
+  keepMapLoadingVisible,
   toriiLoadingCounter,
   clearMapLoading,
 }: RecoverWorldmapMapLoadingStateFromChunkTimeoutInput): number => {
@@ -19,6 +21,8 @@ export const recoverWorldmapMapLoadingStateFromChunkTimeout = ({
     return toriiLoadingCounter;
   }
 
-  clearMapLoading();
+  if (!keepMapLoadingVisible) {
+    clearMapLoading();
+  }
   return 0;
 };

--- a/client/apps/game/src/three/scenes/worldmap-zoom-refresh-loading.wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-zoom-refresh-loading.wiring.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readWorldmapSource(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, "worldmap.tsx"), "utf8");
+}
+
+function extractMethod(source: string, signature: string, nextSignature: string): string {
+  const start = source.indexOf(signature);
+  const end = source.indexOf(nextSignature, start);
+  return source.slice(start, end);
+}
+
+describe("worldmap zoom refresh loading wiring", () => {
+  it("marks zoom-driven chunk refresh requests to show map loading", () => {
+    const source = readWorldmapSource();
+    const controlsChangeSource = extractMethod(
+      source,
+      "  private handleWorldmapControlsChange = () => {",
+      "  private isUrlChangedListenerAttached = false;",
+    );
+
+    expect(controlsChangeSource).toMatch(
+      /this\.requestChunkRefresh\(refreshPlan\.immediateLevel === "forced",\s*"default",\s*\{\s*showMapLoading:\s*true\s*,?\s*\}\)/,
+    );
+  });
+
+  it("runs both refresh execution paths through the shared map loading wrapper", () => {
+    const source = readWorldmapSource();
+    const legacyRefreshSource = extractMethod(
+      source,
+      "  private scheduleLegacyChunkRefresh(",
+      "  private scheduleChunkRefreshExecution(",
+    );
+    const flushRefreshSource = extractMethod(
+      source,
+      "  private async flushChunkRefresh(",
+      "  async updateVisibleChunks(",
+    );
+
+    expect(source).toMatch(/private async runChunkRefreshWithMapLoading\(/);
+    expect(legacyRefreshSource).toMatch(/this\.runChunkRefreshWithMapLoading\(/);
+    expect(flushRefreshSource).toMatch(/await this\.runChunkRefreshWithMapLoading\(/);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -525,6 +525,7 @@ export default class WorldmapScene extends WarpTravel {
   private chunkTransitionRuntimeState = createWorldmapChunkTransitionRuntimeState<Promise<void>>();
   private chunkRefreshRuntimeState = createWorldmapChunkRefreshRuntimeState();
   private pendingChunkRefreshForce = false;
+  private pendingChunkRefreshShowsMapLoading = false;
   private pendingChunkRefreshUiReason: "default" | "shortcut" = "default";
   private isShortcutArmySelectionInFlight = false;
   private lastControlsCameraDistance: number | null = null;
@@ -546,6 +547,7 @@ export default class WorldmapScene extends WarpTravel {
   private readonly minCachedExploredRetentionFraction = 0.6;
   private readonly minExpectedExploredForCacheValidation = 48;
   private toriiLoadingCounter = 0;
+  private zoomRefreshLoadingCounter = 0;
   private readonly chunkRowsAhead = WORLDMAP_CHUNK_POLICY.pin.rowsAhead;
   private readonly chunkRowsBehind = WORLDMAP_CHUNK_POLICY.pin.rowsBehind;
   private readonly chunkColsEachSide = WORLDMAP_CHUNK_POLICY.pin.colsEachSide;
@@ -757,7 +759,7 @@ export default class WorldmapScene extends WarpTravel {
     this.lastControlsCameraDistance = nextCameraDistance;
 
     if (refreshPlan.immediateLevel !== "none") {
-      this.requestChunkRefresh(refreshPlan.immediateLevel === "forced");
+      this.requestChunkRefresh(refreshPlan.immediateLevel === "forced", "default", { showMapLoading: true });
     }
   };
   private isUrlChangedListenerAttached = false;
@@ -3307,6 +3309,7 @@ export default class WorldmapScene extends WarpTravel {
     this.chunkRefreshRunning = resetState.chunkRefreshRunning;
     this.chunkRefreshRerunRequested = resetState.chunkRefreshRerunRequested;
     this.pendingChunkRefreshForce = resetState.pendingChunkRefreshForce;
+    this.pendingChunkRefreshShowsMapLoading = false;
     this.pendingChunkRefreshUiReason = "default";
     this.zeroTerrainFrames = resetState.zeroTerrainFrames;
     this.terrainRecoveryInFlight = resetState.terrainRecoveryInFlight;
@@ -3349,9 +3352,11 @@ export default class WorldmapScene extends WarpTravel {
       this.chunkRecoveryTimeout = null;
     }
 
-    // Clear map loading state so "Charting Territories" doesn't persist
-    // when switching away while fetches are still in-flight.
+    // Clear map loading so the shared world-loading banner cannot persist
+    // when switching away while fetches or zoom refreshes are still in-flight.
     this.toriiLoadingCounter = 0;
+    this.zoomRefreshLoadingCounter = 0;
+    this.pendingChunkRefreshShowsMapLoading = false;
     this.state.setLoading(LoadingStateKey.Map, false);
   }
 
@@ -5373,6 +5378,7 @@ export default class WorldmapScene extends WarpTravel {
     const areaKey = this.clearStalledChunkAreaState(info.chunkKey);
     this.toriiLoadingCounter = recoverWorldmapMapLoadingStateFromChunkTimeout({
       phase: info.phase,
+      keepMapLoadingVisible: this.zoomRefreshLoadingCounter > 0,
       toriiLoadingCounter: this.toriiLoadingCounter,
       clearMapLoading: () => this.state.setLoading(LoadingStateKey.Map, false),
     });
@@ -5484,6 +5490,10 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
+  private syncMapLoadingVisibility(): void {
+    this.state.setLoading(LoadingStateKey.Map, this.toriiLoadingCounter > 0 || this.zoomRefreshLoadingCounter > 0);
+  }
+
   private disposeWorldUpdateSubscriptions() {
     this.worldUpdateUnsubscribes.forEach((unsub) => {
       try {
@@ -5497,10 +5507,8 @@ export default class WorldmapScene extends WarpTravel {
 
   private beginToriiFetch() {
     if (this.isSwitchedOff) return;
-    if (this.toriiLoadingCounter === 0) {
-      this.state.setLoading(LoadingStateKey.Map, true);
-    }
     this.toriiLoadingCounter += 1;
+    this.syncMapLoadingVisibility();
   }
 
   private endToriiFetch() {
@@ -5509,9 +5517,21 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     this.toriiLoadingCounter -= 1;
-    if (this.toriiLoadingCounter === 0) {
-      this.state.setLoading(LoadingStateKey.Map, false);
+    this.syncMapLoadingVisibility();
+  }
+
+  private beginZoomRefreshLoading(): void {
+    this.zoomRefreshLoadingCounter += 1;
+    this.syncMapLoadingVisibility();
+  }
+
+  private endZoomRefreshLoading(): void {
+    if (this.zoomRefreshLoadingCounter === 0) {
+      return;
     }
+
+    this.zoomRefreshLoadingCounter -= 1;
+    this.syncMapLoadingVisibility();
   }
 
   private async computeTileEntities(chunkKey: string): Promise<boolean> {
@@ -6332,7 +6352,11 @@ export default class WorldmapScene extends WarpTravel {
     return this.cameraGroundIntersectionScratch;
   }
 
-  public requestChunkRefresh(force: boolean = false, reason: WorldmapForceRefreshReason = "default"): number {
+  public requestChunkRefresh(
+    force: boolean = false,
+    reason: WorldmapForceRefreshReason = "default",
+    options?: { showMapLoading?: boolean },
+  ): number {
     if (this.isSwitchedOff) {
       return this.chunkRefreshRequestToken;
     }
@@ -6340,6 +6364,8 @@ export default class WorldmapScene extends WarpTravel {
     incrementWorldmapRenderCounter("chunkRefreshRequests");
     recordChunkDiagnosticsEvent(this.chunkDiagnostics, "refresh_requested");
     requestWorldmapChunkRefreshToken(this.chunkRefreshRuntimeState);
+    this.pendingChunkRefreshShowsMapLoading =
+      this.pendingChunkRefreshShowsMapLoading || options?.showMapLoading === true;
     this.pendingChunkRefreshUiReason = resolvePendingChunkRefreshUiReason({
       currentReason: this.pendingChunkRefreshUiReason,
       isShortcutArmySelectionInFlight: this.isShortcutArmySelectionInFlight,
@@ -6379,16 +6405,37 @@ export default class WorldmapScene extends WarpTravel {
     });
   }
 
+  private async runChunkRefreshWithMapLoading(
+    showMapLoading: boolean,
+    executeRefresh: () => Promise<void>,
+  ): Promise<void> {
+    if (!showMapLoading) {
+      await executeRefresh();
+      return;
+    }
+
+    this.beginZoomRefreshLoading();
+    try {
+      await executeRefresh();
+    } finally {
+      this.endZoomRefreshLoading();
+    }
+  }
+
   private scheduleLegacyChunkRefresh(requestedDelayMs: number): void {
     scheduleWorldmapChunkRefreshTimer({
       clearTimeoutFn: (timeoutId) => window.clearTimeout(timeoutId),
       nowMs: performance.now(),
       onTimer: () => {
         const shouldForce = this.pendingChunkRefreshForce;
+        const showMapLoading = this.pendingChunkRefreshShowsMapLoading;
         const refreshReason = this.pendingChunkRefreshUiReason;
         this.pendingChunkRefreshForce = false;
+        this.pendingChunkRefreshShowsMapLoading = false;
         this.pendingChunkRefreshUiReason = "default";
-        void this.updateVisibleChunks(shouldForce, { reason: refreshReason }).catch((error) => {
+        void this.runChunkRefreshWithMapLoading(showMapLoading, async () => {
+          await this.updateVisibleChunks(shouldForce, { reason: refreshReason });
+        }).catch((error) => {
           console.error("[WorldMap] Legacy chunk refresh failed:", error);
         });
       },
@@ -6414,14 +6461,18 @@ export default class WorldmapScene extends WarpTravel {
 
   private async flushChunkRefresh(scheduledToken: number): Promise<void> {
     const shouldForce = this.pendingChunkRefreshForce;
+    const showMapLoading = this.pendingChunkRefreshShowsMapLoading;
     const refreshReason = this.pendingChunkRefreshUiReason;
     this.pendingChunkRefreshForce = false;
+    this.pendingChunkRefreshShowsMapLoading = false;
     this.pendingChunkRefreshUiReason = "default";
 
     await runWorldmapChunkRefreshExecution({
       executeRefresh: async () => {
         recordChunkDiagnosticsEvent(this.chunkDiagnostics, "refresh_executed");
-        await this.updateVisibleChunks(shouldForce, { reason: refreshReason });
+        await this.runChunkRefreshWithMapLoading(showMapLoading, async () => {
+          await this.updateVisibleChunks(shouldForce, { reason: refreshReason });
+        });
       },
       onError: (error) => {
         console.error("[WorldMap] Chunk refresh failed:", error);

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-12",
+    title: "Map Refresh Feedback",
+    description:
+      "World map zoom now shows a refresh loading state while chunk swaps catch up, so stepping between map bands reads as active loading instead of a jittery terrain hitch.",
+    type: "fix",
+  },
+  {
+    date: "2026-04-12",
     title: "Cleaner Hero Cards",
     description:
       "The Play dashboard hero cards now show a single artwork layer per mode, so hovering between Seasons and Blitz no longer creates a ghosted double-image effect.",

--- a/client/apps/game/src/ui/shared/components/world-loading.test.tsx
+++ b/client/apps/game/src/ui/shared/components/world-loading.test.tsx
@@ -1,0 +1,49 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LoadingStateKey } from "@/hooks/store/use-world-loading";
+
+const uiStoreState = {
+  loadingStates: {
+    [LoadingStateKey.Map]: false,
+  },
+};
+
+vi.mock("@/hooks/store/use-ui-store", () => ({
+  useUIStore: (selector: (state: typeof uiStoreState) => unknown) => selector(uiStoreState),
+}));
+
+const { WorldLoading } = await import("./world-loading");
+
+describe("WorldLoading", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    uiStoreState.loadingStates[LoadingStateKey.Map] = false;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("describes map loading as a refresh so chunk swaps do not read like first-load charting", async () => {
+    uiStoreState.loadingStates[LoadingStateKey.Map] = true;
+
+    await act(async () => {
+      root.render(<WorldLoading />);
+    });
+
+    expect(container.textContent).toContain("Refreshing Territories");
+    expect(container.textContent).not.toContain("Charting Territories");
+  });
+});

--- a/client/apps/game/src/ui/shared/components/world-loading.tsx
+++ b/client/apps/game/src/ui/shared/components/world-loading.tsx
@@ -10,7 +10,7 @@ export const WorldLoading = () => {
     const items = [];
     if (loadingStates[LoadingStateKey.Market]) items.push("Gathering Merchants"); // Market
     if (loadingStates[LoadingStateKey.AllPlayerStructures]) items.push("Constructing Settlements"); // Player Structures
-    if (loadingStates[LoadingStateKey.Map]) items.push("Charting Territories"); // Map
+    if (loadingStates[LoadingStateKey.Map]) items.push("Refreshing Territories"); // Map
     if (loadingStates[LoadingStateKey.Hyperstructure]) items.push("Awakening Ancient Powers"); // Hyperstructure
     if (loadingStates[LoadingStateKey.MarketHistory]) items.push("Counting Gold"); // Market History
     if (loadingStates[LoadingStateKey.Leaderboard]) items.push("Ranking Players"); // Leaderboard


### PR DESCRIPTION
## Summary
Adds a small worldmap loading layer for zoom-triggered chunk refreshes so stepping between map bands shows explicit feedback instead of jitter.
Keeps the map loading banner correct when Torii fetches and zoom refresh overlap, including timeout recovery.
Updates the loading copy to `Refreshing Territories`, adds wiring and UI tests for the new behavior, and includes a short PRD plus latest-features entry.
Verified with `pnpm --dir client/apps/game test src/three/scenes/worldmap-zoom-refresh-loading.wiring.test.ts src/three/scenes/worldmap-timeout-loading-recovery.test.ts src/ui/shared/components/world-loading.test.tsx src/three/scenes/worldmap-zoom-wiring.test.ts`, `pnpm run format`, and `pnpm run knip`.