### PR TITLE
Stabilize and trace army movement sync handoff

### DIFF
--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -4,7 +4,12 @@ import { type SetupResult } from "@bibliothecadao/dojo";
 
 import { useConnectionStore } from "@/hooks/store/use-connection-store";
 import { sqlApi } from "@/services/api";
-import { MAP_DATA_REFRESH_INTERVAL, MapDataStore } from "@bibliothecadao/eternum";
+import {
+  MAP_DATA_REFRESH_INTERVAL,
+  MapDataStore,
+  recordArmyMovementLatencyPhase,
+  tileOptToTile,
+} from "@bibliothecadao/eternum";
 import type { Component, Entity, Metadata, Schema } from "@dojoengine/recs";
 import { setEntities } from "@dojoengine/state";
 import type { Clause, ToriiClient, Entity as ToriiEntity } from "@dojoengine/torii-wasm/types";
@@ -42,6 +47,66 @@ export const cancelEntityStreamSubscription = () => {
     entityStreamSubscription = null;
   }
 };
+
+function toTraceBigInt(value: unknown): bigint | null {
+  if (typeof value === "bigint") {
+    return value;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return BigInt(Math.trunc(value));
+  }
+
+  if (typeof value === "string" && value.trim().length > 0) {
+    try {
+      return BigInt(value);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function recordTileOptStreamTrace(data: ToriiEntity): void {
+  const tileOptModel = (data.models as Record<string, unknown>)["s1_eternum-TileOpt"];
+  if (!tileOptModel || typeof tileOptModel !== "object") {
+    return;
+  }
+
+  const tileOptRecord = tileOptModel as Record<string, unknown>;
+  const tileData = toTraceBigInt(tileOptRecord.data);
+  if (tileData === null) {
+    return;
+  }
+
+  try {
+    const tile = tileOptToTile({
+      alt: Boolean(tileOptRecord.alt),
+      col: Number(tileOptRecord.col ?? 0),
+      row: Number(tileOptRecord.row ?? 0),
+      data: tileData,
+    });
+
+    recordArmyMovementLatencyPhase({
+      phase: "tileopt_stream_received",
+      source: "torii_sync",
+      entityId: typeof tile.occupier_id === "number" ? tile.occupier_id : undefined,
+      tileEntityKey: data.hashed_keys,
+      details: {
+        col: tile.col,
+        row: tile.row,
+        occupierType: tile.occupier_type,
+      },
+    });
+  } catch {
+    recordArmyMovementLatencyPhase({
+      phase: "tileopt_stream_received",
+      source: "torii_sync",
+      tileEntityKey: data.hashed_keys,
+    });
+  }
+}
 
 const GLOBAL_NON_SPATIAL_MODELS: string[] = [
   // Events
@@ -278,6 +343,7 @@ export const syncEntitiesDebounced = async (
       createEntitySubscription: () =>
         client.onEntityUpdated(entityKeyClause, (data: ToriiEntity) => {
           if (logging) console.log("Entity updated", data);
+          recordTileOptStreamTrace(data);
           queueUpdate(data, "entity");
         }),
       createEventSubscription: () =>

--- a/client/apps/game/src/three/WORLDMAP_ARMY_MOVEMENT_HANDOFF_PRD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_ARMY_MOVEMENT_HANDOFF_PRD_TDD.md
@@ -1,0 +1,239 @@
+# Worldmap Army Movement Handoff PRD / TDD
+
+## Status
+
+- Status: Proposed for implementation
+- Scope: `client/apps/game/src/three/scenes/worldmap.tsx`
+- Scope: `client/apps/game/src/three/managers/army-manager.ts`
+- Scope: movement timing, arrival ghost timing, and travel FX lifecycle
+
+## Problem Statement
+
+The local army move flow currently mixes three separate clocks:
+
+1. transaction submission
+2. authoritative world tile sync
+3. visual movement start and completion
+
+Those clocks are currently wired together incorrectly.
+
+Today the worldmap clears pending movement as soon as it sees the authoritative tile update, but the visual movement
+does not start until `ArmyManager` finishes applying the move and kicks off the renderer path.
+
+This creates a visible and gameplay gap:
+
+1. the move transaction succeeds
+2. the destination ghost and movement FX disappear
+3. the unit remains visible at the source tile
+4. the unit becomes reselectable even though its onchain state already changed
+5. a second action can fail because the render state is behind the chain state
+6. the movement animation finally starts later
+
+## Findings From The Trace
+
+### Stable facts
+
+1. Submit path
+   - `onArmyMovement(...)` creates movement FX, creates the arrival ghost, and marks the army pending.
+
+2. Tile sync path
+   - `updateArmyHexes(...)` updates the worldmap cache immediately when tile or explorer troop updates arrive.
+
+3. Render path
+   - `ArmyManager.onTileUpdate(...)` calls `moveArmy(...)`.
+   - `moveArmy(...)` can await worker pathfinding before it calls `armyModel.startMovement(...)`.
+
+4. Current mismatch
+   - pending movement clears from cache sync
+   - visual movement starts later from army-manager sync
+
+5. Explorer troop updates are especially risky
+   - they call `updateArmyHexes(...)`
+   - they do not call `moveArmy(...)`
+   - they must never clear local visual pending state
+
+### Most important implication
+
+Authoritative tile sync is not a safe proxy for visual movement start.
+
+Pending local movement must clear from a renderer-owned event, not from the first world cache update.
+
+## Goals
+
+### User goals
+
+- Local armies should stay blocked until the rendered move actually starts.
+- The source army should never sit reselectable in a stale pre-move pose after the chain state changed.
+- The destination ghost should remain until the rendered move actually completes.
+- Travel FX should still end when the rendered move completes.
+
+### Engineering goals
+
+- Separate cache sync from movement presentation state.
+- Give `WorldmapScene` a clean way to observe visual movement start.
+- Resolve arrival ghosts from movement completion, not from pending-cache heuristics.
+- Prevent explorer troop updates from clearing local pending movement.
+
+## Non-goals
+
+- Reworking remote army movement.
+- Changing onchain timing or Torii delivery order.
+- Changing travel path generation.
+- Redesigning source-visual suppression for unrelated army removal cases.
+
+## Proposed Behavior
+
+### Movement lifecycle
+
+For local moves the lifecycle should be:
+
+1. submit move
+2. mark local movement pending
+3. create travel FX and destination ghost
+4. accept authoritative tile sync without clearing pending
+5. `ArmyManager` starts the rendered move
+6. clear local pending movement
+7. keep travel FX alive during the rendered move
+8. `ArmyManager` completes the rendered move
+9. resolve the arrival ghost into the landed unit
+10. clean up travel FX
+
+### Source of truth
+
+- world cache sync owns authoritative position caches
+- `ArmyManager` owns visual movement lifecycle
+- `WorldmapScene` reacts to army-manager lifecycle events
+
+## Architecture
+
+## 1. Add a visual movement start seam to `ArmyManager`
+
+`ArmyManager` already exposes `onMovementComplete(...)`.
+
+Add a matching `onMovementStart(...)` seam that fires only when the renderer has actually accepted the move:
+
+- after `armyModel.startMovement(...)` for animated moves
+- after destination rendering is restored for the no-animation fallback path
+
+This keeps movement lifecycle ownership inside the army manager.
+
+## 2. Stop clearing pending movement from `updateArmyHexes(...)`
+
+`updateArmyHexes(...)` should remain a cache synchronizer only.
+
+It should:
+
+- update normalized position caches
+- update worker caches
+- invalidate affected render areas
+
+It should not:
+
+- clear local pending movement
+- resolve arrival ghosts
+- infer visual progress from authoritative state alone
+
+## 3. Resolve ghosts from movement completion
+
+The arrival ghost should no longer resolve from:
+
+- `!hasPendingMovement`
+- `isArmyRenderableInCurrentChunk`
+
+That condition is too weak because the stale source unit can still be renderable.
+
+Instead:
+
+- register a movement-complete callback when the local move is submitted
+- request ghost resolution only from that callback
+- let the ghost manager animate the absorb only when the destination chunk is visible
+
+## 4. Keep travel FX completion on movement completion
+
+Travel FX already use `onMovementComplete(...)`.
+
+That remains correct.
+
+The important change is that pending movement must no longer be assumed equivalent to travel-FX lifetime.
+
+## Implementation Plan
+
+### Step 1. Add the PRD/TDD and failing wiring tests
+
+Cover:
+
+- visual start listener registration
+- pending clear moving out of `updateArmyHexes(...)`
+- arrival ghost resolution moving to movement completion
+
+### Step 2. Add `ArmyManager` movement-start listeners
+
+Mirror the existing movement-complete listener structure.
+
+### Step 3. Move local pending clear to the visual-start listener
+
+Install the listener from the local submit path.
+
+### Step 4. Move arrival ghost resolution to the movement-complete listener
+
+Install the listener from the local submit path and remove the pending-based resolution path.
+
+### Step 5. Simplify worldmap per-frame ghost handling
+
+Keep chunk visibility syncing. Remove the per-frame “pending cleared and renderable” resolve heuristic.
+
+### Step 6. Add the user-facing changelog entry
+
+Describe the movement handoff fix in `latest-features.ts`.
+
+## TDD Plan
+
+## Red phase
+
+Add failing tests for:
+
+1. source wiring in the move submit path
+   - registers `onMovementStart(...)`
+   - registers `onMovementComplete(...)` for ghost resolution
+
+2. cache sync path
+   - `updateArmyHexes(...)` no longer clears pending movement
+
+3. ghost timing
+   - worldmap no longer resolves ghosts from `!hasPendingMovement && isArmyRenderableInCurrentChunk`
+
+4. army-manager seam
+   - source contains a public `onMovementStart(...)`
+   - source fires movement-start listeners from the renderer-owned move path
+
+## Green phase
+
+Implement the smallest clean changes that satisfy those tests.
+
+## Refactor phase
+
+- keep listener registration isolated in well-named helpers
+- keep `updateArmyHexes(...)` at one level of abstraction
+- keep worldmap update loop focused on per-frame orchestration, not movement state inference
+
+## Verification
+
+Targeted tests:
+
+- `worldmap-arrival-ghost.source.test.ts`
+- `worldmap-travel-effect-lifecycle.source.test.ts`
+- new movement-start source tests
+
+Broader checks:
+
+- `pnpm run format`
+- `pnpm run knip`
+
+## Expected Outcome
+
+After the fix:
+
+- the unit is not reselectable during the stale pre-animation gap
+- the destination ghost stays up until the rendered move completes
+- travel FX continue to match rendered movement completion
+- authoritative tile sync no longer pretends the visual move already happened

--- a/client/apps/game/src/three/fx/world-fx-backends.test.ts
+++ b/client/apps/game/src/three/fx/world-fx-backends.test.ts
@@ -267,6 +267,43 @@ describe.each([
 
     expect(scene.children).toHaveLength(0);
   });
+
+  it("disables depth testing for floating icon fx so terrain cannot occlude them", () => {
+    const scene = new THREE.Scene();
+    const backend = createWorldFxBackend({
+      capabilities: resolveRendererFxCapabilities({
+        activeMode,
+      }),
+      scene,
+    });
+
+    backend.spawnIconFx({
+      animate: (fx) => {
+        fx.setOpacity(1);
+        return true;
+      },
+      isInfinite: true,
+      size: 1.25,
+      texture: createTexture(),
+      type: "travel",
+      x: 4,
+      y: 5,
+      z: 6,
+    });
+
+    const mesh = findFirstMesh(scene);
+    if (mesh) {
+      const material = mesh.material as THREE.MeshBasicMaterial;
+      expect(material.depthTest).toBe(false);
+      expect(mesh.renderOrder).toBeGreaterThan(0);
+      return;
+    }
+
+    const sprite = findFirstSprite(scene);
+    expect(sprite).toBeDefined();
+    const material = sprite!.material as THREE.SpriteMaterial;
+    expect(material.depthTest).toBe(false);
+  });
 });
 
 describe("world fx promise teardown", () => {

--- a/client/apps/game/src/three/fx/world-fx-backends.ts
+++ b/client/apps/game/src/three/fx/world-fx-backends.ts
@@ -228,6 +228,7 @@ class LegacySpriteWorldFxEffect extends BaseIconWorldFxEffect {
     super(scene, spec, labelEnabled);
 
     this.material = new THREE.SpriteMaterial({
+      depthTest: false,
       depthWrite: false,
       map: spec.texture,
       opacity: 0,
@@ -268,6 +269,7 @@ class WebGpuBillboardWorldFxEffect extends BaseIconWorldFxEffect {
     super(scene, spec, labelEnabled);
 
     this.material = new THREE.MeshBasicMaterial({
+      depthTest: false,
       depthWrite: false,
       map: spec.texture,
       opacity: 0,
@@ -277,6 +279,7 @@ class WebGpuBillboardWorldFxEffect extends BaseIconWorldFxEffect {
 
     this.pivot = new THREE.Group();
     this.mesh = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), this.material);
+    this.mesh.renderOrder = WORLD_FX_RENDER_ORDER;
     this.mesh.onBeforeRender = (_renderer, _scene, camera) => {
       this.pivot.quaternion.copy(camera.quaternion);
       this.applyScale();

--- a/client/apps/game/src/three/managers/army-manager.movement-start-wiring.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.movement-start-wiring.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readSource(): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, "army-manager.ts"), "utf8");
+}
+
+describe("ArmyManager movement start wiring", () => {
+  it("exposes an onMovementStart listener seam alongside movement completion", () => {
+    const source = readSource();
+
+    expect(source).toContain("private movementStartListeners");
+    expect(source).toContain("public onMovementStart(entityId: ID, callback: () => void): () => void");
+  });
+
+  it("fires movement-start listeners from the renderer-owned move path", () => {
+    const source = readSource();
+
+    expect(source).toContain("this.runMovementStartListeners(numericEntityId)");
+    expect(source).toContain("this.armyModel.startMovement");
+  });
+});

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -167,6 +167,7 @@ export class ArmyManager {
   private hexagonScene?: HexagonScene;
   private fxManager: FXManager;
   private components?: ClientComponents;
+  private movementStartListeners: Map<number, Set<() => void>> = new Map();
   private movementCompleteListeners: Map<number, Set<() => void>> = new Map();
   private pointsRenderers?: {
     player: PointsLabelRenderer;
@@ -1808,8 +1809,9 @@ export class ArmyManager {
       this.armyModel.setMovementCompleteCallback(numericEntityId, undefined);
       // Clean up source bucket tracking since movement won't actually happen
       this.cleanupMovementSourceBucket(entityId);
-      this.runMovementCompleteListeners(numericEntityId);
       await this.renderArmyIntoCurrentChunkIfVisible(entityId);
+      this.runMovementStartListeners(numericEntityId);
+      this.runMovementCompleteListeners(numericEntityId);
       return;
     }
 
@@ -1829,6 +1831,7 @@ export class ArmyManager {
 
     // Start movement in ArmyModel with troop information
     this.armyModel.startMovement(numericEntityId, worldPath, matrixIndex, armyData.category, armyData.tier);
+    this.runMovementStartListeners(numericEntityId);
 
     // Create path visualization with player-specific color
     const colorProfile = this.getArmyColorProfile(armyData);
@@ -1991,14 +1994,6 @@ export class ArmyManager {
     };
   }
 
-  public isArmyRenderableInCurrentChunk(entityId: ID): boolean {
-    if (this.suppressedArmies.has(entityId)) {
-      return false;
-    }
-
-    return this.visibleArmyIndices.has(entityId);
-  }
-
   public syncAttachedArmiesOwnerForStructure(params: {
     structureId: ID;
     ownerAddress: bigint;
@@ -2078,6 +2073,28 @@ export class ArmyManager {
     return this.selectedArmyForPath;
   }
 
+  public onMovementStart(entityId: ID, callback: () => void): () => void {
+    const numericEntityId = this.toNumericId(entityId);
+    let listeners = this.movementStartListeners.get(numericEntityId);
+    if (!listeners) {
+      listeners = new Set();
+      this.movementStartListeners.set(numericEntityId, listeners);
+    }
+
+    listeners.add(callback);
+
+    return () => {
+      const active = this.movementStartListeners.get(numericEntityId);
+      if (!active) {
+        return;
+      }
+      active.delete(callback);
+      if (active.size === 0) {
+        this.movementStartListeners.delete(numericEntityId);
+      }
+    };
+  }
+
   public onMovementComplete(entityId: ID, callback: () => void): () => void {
     const numericEntityId = this.toNumericId(entityId);
     let listeners = this.movementCompleteListeners.get(numericEntityId);
@@ -2102,6 +2119,22 @@ export class ArmyManager {
 
   public hasMovingArmies(): boolean {
     return this.armyModel.hasMovingInstances();
+  }
+
+  private runMovementStartListeners(entityId: number): void {
+    const listeners = this.movementStartListeners.get(entityId);
+    if (!listeners || listeners.size === 0) {
+      return;
+    }
+
+    this.movementStartListeners.delete(entityId);
+    listeners.forEach((listener) => {
+      try {
+        listener();
+      } catch (error) {
+        console.error("[ArmyManager] Movement start listener failed", error);
+      }
+    });
   }
 
   private runMovementCompleteListeners(entityId: number): void {
@@ -2931,6 +2964,7 @@ ${
     this.movingArmySourceBuckets.clear();
     this.suppressedArmies.clear();
     this.chunkToArmies.clear();
+    this.movementStartListeners.clear();
     this.movementCompleteListeners.clear();
 
     destroyArmyManagerOwnedResources({

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1973,6 +1973,32 @@ export class ArmyManager {
     return this.armies.get(entityId);
   }
 
+  public getArrivalGhostSourceSnapshot(entityId: ID): { armyColor: string; sourceScene: Object3D } | null {
+    const army = this.armies.get(entityId);
+    if (!army) {
+      return null;
+    }
+
+    const numericEntityId = this.toNumericId(entityId);
+    const modelData = this.armyModel.getModelForEntity(numericEntityId);
+    if (!modelData) {
+      return null;
+    }
+
+    return {
+      armyColor: army.color,
+      sourceScene: modelData.sourceScene,
+    };
+  }
+
+  public isArmyRenderableInCurrentChunk(entityId: ID): boolean {
+    if (this.suppressedArmies.has(entityId)) {
+      return false;
+    }
+
+    return this.visibleArmyIndices.has(entityId);
+  }
+
   public syncAttachedArmiesOwnerForStructure(params: {
     structureId: ID;
     ownerAddress: bigint;

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -32,7 +32,7 @@ import { getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { shortString } from "starknet";
 import * as THREE from "three";
-import { Color, Euler, Group, Raycaster, Scene, Vector3 } from "three";
+import { Color, Euler, Group, Object3D, Raycaster, Scene, Vector3 } from "three";
 import { CSS2DObject } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 import { env } from "../../../env";
 import type { AttachmentTransform, CosmeticAttachmentTemplate } from "../cosmetics";

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -327,6 +327,7 @@ export class ArmyModel {
 
   private createModelData(gltf: any): ModelData {
     const group = new Group();
+    const sourceScene = this.createRenderableSourceScene(gltf.scene);
     const instancedMeshes: AnimatedInstancedMesh[] = [];
     const baseMeshes: Mesh[] = [];
 
@@ -350,6 +351,7 @@ export class ArmyModel {
 
     return {
       group,
+      sourceScene,
       instancedMeshes,
       contactShadowMesh,
       contactShadowScale,
@@ -366,6 +368,26 @@ export class ArmyModel {
       lastAnimationUpdate: 0,
       animationUpdateInterval: this.MODEL_ANIMATION_UPDATE_INTERVAL,
     };
+  }
+
+  private createRenderableSourceScene(scene: Object3D): Object3D {
+    const template = new Group();
+    scene.updateMatrixWorld(true);
+    this.dummyMatrix.copy(scene.matrixWorld).invert();
+
+    scene.traverse((child: Object3D) => {
+      if (!(child instanceof Mesh)) {
+        return;
+      }
+
+      const clone = child.clone();
+      clone.raycast = () => {};
+      this.contactShadowMatrix.copy(this.dummyMatrix).multiply(child.matrixWorld);
+      this.contactShadowMatrix.decompose(clone.position, clone.quaternion, clone.scale);
+      template.add(clone);
+    });
+
+    return template;
   }
 
   private computeContactShadowScale(gltf: any): number {

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
@@ -1,7 +1,8 @@
-import { Position } from "@bibliothecadao/eternum";
 import { describe, expect, it } from "vitest";
 import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Scene } from "three";
 import { ArrivalGhostManager } from "./arrival-ghost-manager";
+
+const hex = (col: number, row: number) => ({ col, row });
 
 function createTemplateScene(): Group {
   const group = new Group();
@@ -19,7 +20,7 @@ describe("ArrivalGhostManager", () => {
     manager.setCurrentChunk("0,0");
     manager.upsertLocalArrivalGhost({
       entityId: 1,
-      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
       visualStyle: {
         color: "#ffffff",
@@ -42,7 +43,7 @@ describe("ArrivalGhostManager", () => {
     manager.setCurrentChunk("0,0");
     manager.upsertLocalArrivalGhost({
       entityId: 1,
-      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
       visualStyle: {
         color: "#ffffff",
@@ -53,7 +54,7 @@ describe("ArrivalGhostManager", () => {
     });
     manager.upsertLocalArrivalGhost({
       entityId: 1,
-      hexCoords: new Position({ x: 2, y: 2 }).getNormalized(),
+      hexCoords: hex(2, 2),
       sourceScene: createTemplateScene(),
       visualStyle: {
         color: "#ffffff",
@@ -76,7 +77,7 @@ describe("ArrivalGhostManager", () => {
     manager.setCurrentChunk("0,0");
     manager.upsertLocalArrivalGhost({
       entityId: 1,
-      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
       visualStyle: {
         color: "#ffffff",
@@ -102,7 +103,7 @@ describe("ArrivalGhostManager", () => {
     manager.setCurrentChunk("0,0");
     manager.upsertLocalArrivalGhost({
       entityId: 1,
-      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
       visualStyle: {
         color: "#ffffff",
@@ -117,7 +118,7 @@ describe("ArrivalGhostManager", () => {
 
     manager.upsertLocalArrivalGhost({
       entityId: 2,
-      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
       visualStyle: {
         color: "#ffffff",

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
@@ -10,6 +10,15 @@ function createTemplateScene(): Group {
   return group;
 }
 
+function createVisualStyle() {
+  return {
+    color: "#b8ffb0",
+    opacity: 0.52,
+    scaleMultiplier: 1,
+    yOffset: 0.05,
+  };
+}
+
 describe("ArrivalGhostManager", () => {
   it("upserts a decorative ghost and tracks it by entity id", () => {
     const manager = new ArrivalGhostManager(new Scene(), {
@@ -22,12 +31,7 @@ describe("ArrivalGhostManager", () => {
       entityId: 1,
       hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
-      visualStyle: {
-        color: "#ffffff",
-        opacity: 0.38,
-        scaleMultiplier: 0.97,
-        yOffset: 0.05,
-      },
+      visualStyle: createVisualStyle(),
     });
 
     expect(manager.hasArrivalGhost(1)).toBe(true);
@@ -45,23 +49,13 @@ describe("ArrivalGhostManager", () => {
       entityId: 1,
       hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
-      visualStyle: {
-        color: "#ffffff",
-        opacity: 0.38,
-        scaleMultiplier: 0.97,
-        yOffset: 0.05,
-      },
+      visualStyle: createVisualStyle(),
     });
     manager.upsertLocalArrivalGhost({
       entityId: 1,
       hexCoords: hex(2, 2),
       sourceScene: createTemplateScene(),
-      visualStyle: {
-        color: "#ffffff",
-        opacity: 0.38,
-        scaleMultiplier: 0.97,
-        yOffset: 0.05,
-      },
+      visualStyle: createVisualStyle(),
     });
 
     expect(manager.getTrackedEntityIds()).toEqual([1]);
@@ -79,19 +73,72 @@ describe("ArrivalGhostManager", () => {
       entityId: 1,
       hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
-      visualStyle: {
-        color: "#ffffff",
-        opacity: 0.38,
-        scaleMultiplier: 0.97,
-        yOffset: 0.05,
-      },
+      visualStyle: createVisualStyle(),
     });
 
     const ghostContainer = scene.children.at(-1) as Group;
-    const ghostMesh = ghostContainer.children[0].children[0] as Mesh;
+    const ghostMesh = ghostContainer.getObjectByName("arrival-ghost-body") as Group;
+    const destinationRing = ghostContainer.getObjectByName("arrival-ghost-ring") as Mesh;
 
     expect(ghostContainer.position.y).toBeCloseTo(0.2);
-    expect(ghostMesh.renderOrder).toBe(10);
+    expect(ghostMesh).toBeDefined();
+    expect(destinationRing).toBeDefined();
+    expect(destinationRing.rotation.x).toBeCloseTo(-Math.PI / 2);
+  });
+
+  it("animates an idle pulse while the ghost waits for arrival", () => {
+    const scene = new Scene();
+    const manager = new ArrivalGhostManager(scene, {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: hex(0, 0),
+      sourceScene: createTemplateScene(),
+      visualStyle: createVisualStyle(),
+    });
+
+    const ghostContainer = scene.children.at(-1) as Group;
+    const ghostBody = ghostContainer.getObjectByName("arrival-ghost-body") as Group;
+    const destinationRing = ghostContainer.getObjectByName("arrival-ghost-ring") as Mesh;
+    const initialBodyY = ghostBody.position.y;
+    const initialRingScale = destinationRing.scale.x;
+
+    manager.update(0.25);
+
+    expect(ghostBody.position.y).not.toBe(initialBodyY);
+    expect(destinationRing.scale.x).not.toBe(initialRingScale);
+  });
+
+  it("plays an absorb burst before clearing the ghost on arrival", () => {
+    const scene = new Scene();
+    const manager = new ArrivalGhostManager(scene, {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: hex(0, 0),
+      sourceScene: createTemplateScene(),
+      visualStyle: createVisualStyle(),
+    });
+
+    const ghostContainer = scene.children.at(-1) as Group;
+    const burstRing = ghostContainer.getObjectByName("arrival-ghost-burst-ring") as Mesh;
+
+    manager.resolveArrivalGhost(1);
+    manager.update(0.05);
+
+    expect(burstRing.visible).toBe(true);
+    expect(burstRing.scale.x).toBeGreaterThan(1);
+
+    manager.update(0.3);
+    expect(manager.hasArrivalGhost(1)).toBe(false);
   });
 
   it("clears ghosts by reason and destroys all tracked ghosts", () => {
@@ -105,12 +152,7 @@ describe("ArrivalGhostManager", () => {
       entityId: 1,
       hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
-      visualStyle: {
-        color: "#ffffff",
-        opacity: 0.38,
-        scaleMultiplier: 0.97,
-        yOffset: 0.05,
-      },
+      visualStyle: createVisualStyle(),
     });
 
     manager.clearArrivalGhost(1, "tx_failed");
@@ -120,12 +162,7 @@ describe("ArrivalGhostManager", () => {
       entityId: 2,
       hexCoords: hex(0, 0),
       sourceScene: createTemplateScene(),
-      visualStyle: {
-        color: "#ffffff",
-        opacity: 0.38,
-        scaleMultiplier: 0.97,
-        yOffset: 0.05,
-      },
+      visualStyle: createVisualStyle(),
     });
     manager.destroy();
     expect(manager.getTrackedEntityIds()).toEqual([]);

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
@@ -1,0 +1,132 @@
+import { Position } from "@bibliothecadao/eternum";
+import { describe, expect, it } from "vitest";
+import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Scene } from "three";
+import { ArrivalGhostManager } from "./arrival-ghost-manager";
+
+function createTemplateScene(): Group {
+  const group = new Group();
+  group.add(new Mesh(new BoxGeometry(1, 1, 1), new MeshStandardMaterial({ color: "#6699ff" })));
+  return group;
+}
+
+describe("ArrivalGhostManager", () => {
+  it("upserts a decorative ghost and tracks it by entity id", () => {
+    const manager = new ArrivalGhostManager(new Scene(), {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      sourceScene: createTemplateScene(),
+      visualStyle: {
+        color: "#ffffff",
+        opacity: 0.38,
+        scaleMultiplier: 0.97,
+        yOffset: 0.05,
+      },
+    });
+
+    expect(manager.hasArrivalGhost(1)).toBe(true);
+    expect(manager.getTrackedEntityIds()).toEqual([1]);
+  });
+
+  it("replaces an existing ghost for the same entity", () => {
+    const manager = new ArrivalGhostManager(new Scene(), {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      sourceScene: createTemplateScene(),
+      visualStyle: {
+        color: "#ffffff",
+        opacity: 0.38,
+        scaleMultiplier: 0.97,
+        yOffset: 0.05,
+      },
+    });
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: new Position({ x: 2, y: 2 }).getNormalized(),
+      sourceScene: createTemplateScene(),
+      visualStyle: {
+        color: "#ffffff",
+        opacity: 0.38,
+        scaleMultiplier: 0.97,
+        yOffset: 0.05,
+      },
+    });
+
+    expect(manager.getTrackedEntityIds()).toEqual([1]);
+  });
+
+  it("lifts ghost meshes above the terrain surface and assigns the unit render order", () => {
+    const scene = new Scene();
+    const manager = new ArrivalGhostManager(scene, {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      sourceScene: createTemplateScene(),
+      visualStyle: {
+        color: "#ffffff",
+        opacity: 0.38,
+        scaleMultiplier: 0.97,
+        yOffset: 0.05,
+      },
+    });
+
+    const ghostContainer = scene.children.at(-1) as Group;
+    const ghostMesh = ghostContainer.children[0].children[0] as Mesh;
+
+    expect(ghostContainer.position.y).toBeCloseTo(0.2);
+    expect(ghostMesh.renderOrder).toBe(10);
+  });
+
+  it("clears ghosts by reason and destroys all tracked ghosts", () => {
+    const manager = new ArrivalGhostManager(new Scene(), {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      sourceScene: createTemplateScene(),
+      visualStyle: {
+        color: "#ffffff",
+        opacity: 0.38,
+        scaleMultiplier: 0.97,
+        yOffset: 0.05,
+      },
+    });
+
+    manager.clearArrivalGhost(1, "tx_failed");
+    expect(manager.hasArrivalGhost(1)).toBe(false);
+
+    manager.upsertLocalArrivalGhost({
+      entityId: 2,
+      hexCoords: new Position({ x: 0, y: 0 }).getNormalized(),
+      sourceScene: createTemplateScene(),
+      visualStyle: {
+        color: "#ffffff",
+        opacity: 0.38,
+        scaleMultiplier: 0.97,
+        yOffset: 0.05,
+      },
+    });
+    manager.destroy();
+    expect(manager.getTrackedEntityIds()).toEqual([]);
+  });
+});

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.ts
@@ -1,0 +1,226 @@
+import { HexPosition, ID } from "@bibliothecadao/types";
+import { Color, Group, Material, Mesh, MeshBasicMaterial, MeshStandardMaterial, Object3D, Scene, Vector3 } from "three";
+import { getRenderBounds } from "../utils/chunk-geometry";
+import { getWorldPositionForHex, hashCoordinates } from "../utils";
+import { MANAGER_UNCOMMITTED_CHUNK, isCommittedManagerChunk } from "./manager-update-convergence";
+import type { ArrivalGhostClearReason, ArrivalGhostVisualStyle } from "./arrival-ghost-policy";
+
+const ARRIVAL_GHOST_ABSORB_DURATION_S = 0.18;
+const ARRIVAL_GHOST_ABSORB_SCALE_REDUCTION = 0.45;
+const ARRIVAL_GHOST_SURFACE_Y_OFFSET = 0.15;
+const ARRIVAL_GHOST_RENDER_ORDER = 10;
+
+export interface ArrivalGhostSpec {
+  entityId: ID;
+  hexCoords: HexPosition;
+  sourceScene: Object3D;
+  visualStyle: ArrivalGhostVisualStyle;
+}
+
+interface ArrivalGhostState extends ArrivalGhostSpec {
+  baseScale: Vector3;
+  container: Group;
+  resolveElapsedS: number;
+  resolveRequested: boolean;
+}
+
+interface ArrivalGhostManagerOptions {
+  chunkStride: number;
+  renderChunkSize: { width: number; height: number };
+}
+
+export class ArrivalGhostManager {
+  private readonly ghosts = new Map<ID, ArrivalGhostState>();
+  private currentChunkKey: string | null = MANAGER_UNCOMMITTED_CHUNK;
+
+  constructor(
+    private readonly scene: Scene,
+    private readonly options: ArrivalGhostManagerOptions,
+  ) {}
+
+  public upsertLocalArrivalGhost(input: ArrivalGhostSpec): void {
+    this.clearArrivalGhost(input.entityId, "superseded");
+
+    const container = this.buildGhostContainer(input);
+    const state: ArrivalGhostState = {
+      ...input,
+      baseScale: container.scale.clone(),
+      container,
+      resolveElapsedS: 0,
+      resolveRequested: false,
+    };
+
+    this.ghosts.set(input.entityId, state);
+    this.syncGhostVisibility(state);
+  }
+
+  public resolveArrivalGhost(entityId: ID): void {
+    const ghost = this.ghosts.get(entityId);
+    if (!ghost) {
+      return;
+    }
+
+    ghost.resolveRequested = true;
+  }
+
+  public clearArrivalGhost(entityId: ID, _reason: ArrivalGhostClearReason): void {
+    const ghost = this.ghosts.get(entityId);
+    if (!ghost) {
+      return;
+    }
+
+    this.scene.remove(ghost.container);
+    this.disposeGhostContainer(ghost.container);
+    this.ghosts.delete(entityId);
+  }
+
+  public hasArrivalGhost(entityId: ID): boolean {
+    return this.ghosts.has(entityId);
+  }
+
+  public getTrackedEntityIds(): ID[] {
+    return Array.from(this.ghosts.keys());
+  }
+
+  public update(deltaTime: number): void {
+    for (const ghost of this.ghosts.values()) {
+      this.syncGhostVisibility(ghost);
+      if (!ghost.resolveRequested || !ghost.container.visible) {
+        continue;
+      }
+
+      ghost.resolveElapsedS += deltaTime;
+      const resolveProgress = Math.min(1, ghost.resolveElapsedS / ARRIVAL_GHOST_ABSORB_DURATION_S);
+      this.applyResolvePresentation(ghost, resolveProgress);
+
+      if (resolveProgress >= 1) {
+        this.clearArrivalGhost(ghost.entityId, "arrived");
+      }
+    }
+  }
+
+  public setCurrentChunk(chunkKey: string | null): void {
+    this.currentChunkKey = chunkKey;
+    for (const ghost of this.ghosts.values()) {
+      this.syncGhostVisibility(ghost);
+    }
+  }
+
+  public destroy(): void {
+    Array.from(this.ghosts.keys()).forEach((entityId) => this.clearArrivalGhost(entityId, "scene_destroyed"));
+  }
+
+  private buildGhostContainer(input: ArrivalGhostSpec): Group {
+    const container = new Group();
+    const worldPosition = getWorldPositionForHex(input.hexCoords);
+    const rotationSeed = hashCoordinates(input.hexCoords.col, input.hexCoords.row);
+    const rotationIndex = Math.floor(rotationSeed * 6);
+    const rotationY = (rotationIndex * Math.PI) / 3;
+    const ghostRoot = input.sourceScene.clone(true);
+
+    this.applyGhostPresentation(ghostRoot, input.visualStyle);
+
+    container.position.set(
+      worldPosition.x,
+      worldPosition.y + ARRIVAL_GHOST_SURFACE_Y_OFFSET + input.visualStyle.yOffset,
+      worldPosition.z,
+    );
+    container.rotation.y = rotationY;
+    container.scale.multiplyScalar(input.visualStyle.scaleMultiplier);
+    container.visible = false;
+    container.add(ghostRoot);
+    this.scene.add(container);
+
+    return container;
+  }
+
+  private applyGhostPresentation(root: Object3D, visualStyle: ArrivalGhostVisualStyle): void {
+    const ghostTint = new Color(visualStyle.color);
+
+    root.traverse((child) => {
+      if (!(child instanceof Mesh)) {
+        return;
+      }
+
+      child.raycast = () => {};
+      child.castShadow = false;
+      child.receiveShadow = false;
+      child.renderOrder = ARRIVAL_GHOST_RENDER_ORDER;
+      child.material = this.cloneGhostMaterial(child.material, ghostTint, visualStyle.opacity);
+    });
+  }
+
+  private cloneGhostMaterial(
+    material: Material | Material[],
+    ghostTint: Color,
+    opacity: number,
+  ): Material | Material[] {
+    if (Array.isArray(material)) {
+      return material.map((entry) => this.cloneGhostMaterial(entry, ghostTint, opacity) as Material);
+    }
+
+    const cloned = material.clone();
+    if (cloned instanceof MeshStandardMaterial || cloned instanceof MeshBasicMaterial) {
+      cloned.transparent = true;
+      cloned.opacity = opacity;
+      cloned.depthWrite = false;
+      cloned.color.lerp(ghostTint, 0.6);
+    }
+
+    cloned.userData.arrivalGhostMaterial = true;
+    return cloned;
+  }
+
+  private syncGhostVisibility(ghost: ArrivalGhostState): void {
+    ghost.container.visible = this.isGhostVisibleInCurrentChunk(ghost.hexCoords);
+  }
+
+  private isGhostVisibleInCurrentChunk(hexCoords: HexPosition): boolean {
+    if (!isCommittedManagerChunk(this.currentChunkKey)) {
+      return false;
+    }
+
+    const [startRow, startCol] = this.currentChunkKey.split(",").map(Number);
+    const bounds = getRenderBounds(startRow, startCol, this.options.renderChunkSize, this.options.chunkStride);
+
+    return (
+      hexCoords.col >= bounds.minCol &&
+      hexCoords.col <= bounds.maxCol &&
+      hexCoords.row >= bounds.minRow &&
+      hexCoords.row <= bounds.maxRow
+    );
+  }
+
+  private applyResolvePresentation(ghost: ArrivalGhostState, resolveProgress: number): void {
+    const resolveScale = 1 - ARRIVAL_GHOST_ABSORB_SCALE_REDUCTION * resolveProgress;
+    ghost.container.scale.copy(ghost.baseScale).multiplyScalar(resolveScale);
+
+    ghost.container.traverse((child) => {
+      if (!(child instanceof Mesh)) {
+        return;
+      }
+
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((material) => {
+        if (material instanceof MeshStandardMaterial || material instanceof MeshBasicMaterial) {
+          material.opacity = ghost.visualStyle.opacity * (1 - resolveProgress);
+        }
+      });
+    });
+  }
+
+  private disposeGhostContainer(container: Object3D): void {
+    container.traverse((child) => {
+      if (!(child instanceof Mesh)) {
+        return;
+      }
+
+      const materials = Array.isArray(child.material) ? child.material : [child.material];
+      materials.forEach((material) => {
+        if (material.userData.arrivalGhostMaterial) {
+          material.dispose();
+        }
+      });
+    });
+  }
+}

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.ts
@@ -1,5 +1,17 @@
 import { HexPosition, ID } from "@bibliothecadao/types";
-import { Color, Group, Material, Mesh, MeshBasicMaterial, MeshStandardMaterial, Object3D, Scene, Vector3 } from "three";
+import {
+  Color,
+  DoubleSide,
+  Group,
+  Material,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  Object3D,
+  RingGeometry,
+  Scene,
+  Vector3,
+} from "three";
 import { getRenderBounds } from "../utils/chunk-geometry";
 import { getWorldPositionForHex, hashCoordinates } from "../utils";
 import { MANAGER_UNCOMMITTED_CHUNK, isCommittedManagerChunk } from "./manager-update-convergence";
@@ -9,6 +21,18 @@ const ARRIVAL_GHOST_ABSORB_DURATION_S = 0.18;
 const ARRIVAL_GHOST_ABSORB_SCALE_REDUCTION = 0.45;
 const ARRIVAL_GHOST_SURFACE_Y_OFFSET = 0.15;
 const ARRIVAL_GHOST_RENDER_ORDER = 10;
+const ARRIVAL_GHOST_IDLE_BOB_AMPLITUDE = 0.035;
+const ARRIVAL_GHOST_IDLE_BOB_SPEED = 2.8;
+const ARRIVAL_GHOST_IDLE_BREATHE_AMPLITUDE = 0.035;
+const ARRIVAL_GHOST_IDLE_BREATHE_SPEED = 2.2;
+const ARRIVAL_GHOST_RING_INNER_RADIUS = 0.52;
+const ARRIVAL_GHOST_RING_OUTER_RADIUS = 0.82;
+const ARRIVAL_GHOST_RING_Y_OFFSET = 0.02;
+const ARRIVAL_GHOST_RING_OPACITY = 0.34;
+const ARRIVAL_GHOST_RING_PULSE_AMPLITUDE = 0.22;
+const ARRIVAL_GHOST_RING_PULSE_SPEED = 2.4;
+const ARRIVAL_GHOST_BURST_RING_OPACITY = 0.52;
+const ARRIVAL_GHOST_BURST_RING_EXPANSION = 0.95;
 
 export interface ArrivalGhostSpec {
   entityId: ID;
@@ -19,7 +43,11 @@ export interface ArrivalGhostSpec {
 
 interface ArrivalGhostState extends ArrivalGhostSpec {
   baseScale: Vector3;
+  burstRing: Mesh<RingGeometry, MeshBasicMaterial>;
   container: Group;
+  ghostBody: Group;
+  idleElapsedS: number;
+  ring: Mesh<RingGeometry, MeshBasicMaterial>;
   resolveElapsedS: number;
   resolveRequested: boolean;
 }
@@ -44,8 +72,12 @@ export class ArrivalGhostManager {
     const container = this.buildGhostContainer(input);
     const state: ArrivalGhostState = {
       ...input,
+      burstRing: container.getObjectByName("arrival-ghost-burst-ring") as Mesh<RingGeometry, MeshBasicMaterial>,
       baseScale: container.scale.clone(),
       container,
+      ghostBody: container.getObjectByName("arrival-ghost-body") as Group,
+      idleElapsedS: 0,
+      ring: container.getObjectByName("arrival-ghost-ring") as Mesh<RingGeometry, MeshBasicMaterial>,
       resolveElapsedS: 0,
       resolveRequested: false,
     };
@@ -85,7 +117,13 @@ export class ArrivalGhostManager {
   public update(deltaTime: number): void {
     for (const ghost of this.ghosts.values()) {
       this.syncGhostVisibility(ghost);
-      if (!ghost.resolveRequested || !ghost.container.visible) {
+      if (!ghost.container.visible) {
+        continue;
+      }
+
+      if (!ghost.resolveRequested) {
+        ghost.idleElapsedS += deltaTime;
+        this.applyIdlePresentation(ghost);
         continue;
       }
 
@@ -117,6 +155,9 @@ export class ArrivalGhostManager {
     const rotationIndex = Math.floor(rotationSeed * 6);
     const rotationY = (rotationIndex * Math.PI) / 3;
     const ghostRoot = input.sourceScene.clone(true);
+    ghostRoot.name = "arrival-ghost-body";
+    const destinationRing = this.createDestinationRing(input.visualStyle);
+    const burstRing = this.createBurstRing(input.visualStyle);
 
     this.applyGhostPresentation(ghostRoot, input.visualStyle);
 
@@ -128,6 +169,8 @@ export class ArrivalGhostManager {
     container.rotation.y = rotationY;
     container.scale.multiplyScalar(input.visualStyle.scaleMultiplier);
     container.visible = false;
+    container.add(destinationRing);
+    container.add(burstRing);
     container.add(ghostRoot);
     this.scene.add(container);
 
@@ -150,6 +193,53 @@ export class ArrivalGhostManager {
     });
   }
 
+  private createDestinationRing(visualStyle: ArrivalGhostVisualStyle): Mesh<RingGeometry, MeshBasicMaterial> {
+    const material = new MeshBasicMaterial({
+      color: new Color(visualStyle.color).lerp(new Color("#b8ffb0"), 0.4),
+      depthTest: false,
+      depthWrite: false,
+      opacity: ARRIVAL_GHOST_RING_OPACITY,
+      side: DoubleSide,
+      transparent: true,
+    });
+    material.userData.arrivalGhostMaterial = true;
+
+    const mesh = new Mesh(
+      new RingGeometry(ARRIVAL_GHOST_RING_INNER_RADIUS, ARRIVAL_GHOST_RING_OUTER_RADIUS, 48),
+      material,
+    );
+    mesh.name = "arrival-ghost-ring";
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.position.y = -(ARRIVAL_GHOST_SURFACE_Y_OFFSET + visualStyle.yOffset) + ARRIVAL_GHOST_RING_Y_OFFSET;
+    mesh.renderOrder = ARRIVAL_GHOST_RENDER_ORDER - 1;
+    mesh.raycast = () => {};
+    return mesh;
+  }
+
+  private createBurstRing(visualStyle: ArrivalGhostVisualStyle): Mesh<RingGeometry, MeshBasicMaterial> {
+    const material = new MeshBasicMaterial({
+      color: new Color(visualStyle.color).lerp(new Color("#f5ffcf"), 0.45),
+      depthTest: false,
+      depthWrite: false,
+      opacity: 0,
+      side: DoubleSide,
+      transparent: true,
+    });
+    material.userData.arrivalGhostMaterial = true;
+
+    const mesh = new Mesh(
+      new RingGeometry(ARRIVAL_GHOST_RING_INNER_RADIUS * 0.7, ARRIVAL_GHOST_RING_OUTER_RADIUS * 0.92, 48),
+      material,
+    );
+    mesh.name = "arrival-ghost-burst-ring";
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.position.y = -(ARRIVAL_GHOST_SURFACE_Y_OFFSET + visualStyle.yOffset) + ARRIVAL_GHOST_RING_Y_OFFSET * 1.5;
+    mesh.renderOrder = ARRIVAL_GHOST_RENDER_ORDER;
+    mesh.raycast = () => {};
+    mesh.visible = false;
+    return mesh;
+  }
+
   private cloneGhostMaterial(
     material: Material | Material[],
     ghostTint: Color,
@@ -169,6 +259,22 @@ export class ArrivalGhostManager {
 
     cloned.userData.arrivalGhostMaterial = true;
     return cloned;
+  }
+
+  private applyIdlePresentation(ghost: ArrivalGhostState): void {
+    const bob = Math.sin(ghost.idleElapsedS * ARRIVAL_GHOST_IDLE_BOB_SPEED) * ARRIVAL_GHOST_IDLE_BOB_AMPLITUDE;
+    const breathe =
+      1 + Math.sin(ghost.idleElapsedS * ARRIVAL_GHOST_IDLE_BREATHE_SPEED) * ARRIVAL_GHOST_IDLE_BREATHE_AMPLITUDE;
+    const ringPulse =
+      1 + Math.sin(ghost.idleElapsedS * ARRIVAL_GHOST_RING_PULSE_SPEED) * ARRIVAL_GHOST_RING_PULSE_AMPLITUDE;
+
+    ghost.ghostBody.position.y = bob;
+    ghost.container.scale.copy(ghost.baseScale).multiplyScalar(breathe);
+    ghost.ring.scale.setScalar(ringPulse);
+    ghost.ring.material.opacity = ARRIVAL_GHOST_RING_OPACITY + (ringPulse - 1) * 0.18;
+    ghost.burstRing.visible = false;
+    ghost.burstRing.material.opacity = 0;
+    ghost.burstRing.scale.setScalar(1);
   }
 
   private syncGhostVisibility(ghost: ArrivalGhostState): void {
@@ -194,6 +300,12 @@ export class ArrivalGhostManager {
   private applyResolvePresentation(ghost: ArrivalGhostState, resolveProgress: number): void {
     const resolveScale = 1 - ARRIVAL_GHOST_ABSORB_SCALE_REDUCTION * resolveProgress;
     ghost.container.scale.copy(ghost.baseScale).multiplyScalar(resolveScale);
+    ghost.ghostBody.position.y = resolveProgress * 0.08;
+    ghost.ring.scale.setScalar(1 + resolveProgress * 0.5);
+    ghost.ring.material.opacity = ARRIVAL_GHOST_RING_OPACITY * (1 - resolveProgress);
+    ghost.burstRing.visible = true;
+    ghost.burstRing.scale.setScalar(1 + resolveProgress * ARRIVAL_GHOST_BURST_RING_EXPANSION);
+    ghost.burstRing.material.opacity = ARRIVAL_GHOST_BURST_RING_OPACITY * (1 - resolveProgress);
 
     ghost.container.traverse((child) => {
       if (!(child instanceof Mesh)) {

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.test.ts
@@ -3,7 +3,6 @@ import {
   resolveArrivalGhostVisualStyle,
   shouldCreatePredictiveArrivalGhost,
   shouldHideSourceArmyOnTileRemoval,
-  shouldResolveArrivalGhost,
 } from "./arrival-ghost-policy";
 
 describe("arrival-ghost-policy", () => {
@@ -39,24 +38,6 @@ describe("arrival-ghost-policy", () => {
         reason: "tile",
       }),
     ).toBe(true);
-  });
-
-  it("resolves a ghost only after pending movement clears and the live army is renderable", () => {
-    expect(
-      shouldResolveArrivalGhost({
-        hasGhost: true,
-        hasPendingMovement: false,
-        isArmyRenderableInCurrentChunk: true,
-      }),
-    ).toBe(true);
-
-    expect(
-      shouldResolveArrivalGhost({
-        hasGhost: true,
-        hasPendingMovement: true,
-        isArmyRenderableInCurrentChunk: true,
-      }),
-    ).toBe(false);
   });
 
   it("returns the configured ghost visuals", () => {

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveArrivalGhostVisualStyle,
+  shouldCreatePredictiveArrivalGhost,
+  shouldHideSourceArmyOnTileRemoval,
+  shouldResolveArrivalGhost,
+} from "./arrival-ghost-policy";
+
+describe("arrival-ghost-policy", () => {
+  it("creates predictive ghosts only for local travel moves with a target hex", () => {
+    expect(
+      shouldCreatePredictiveArrivalGhost({
+        hasTargetHex: true,
+        isLocalArmy: true,
+        isTravelAction: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldCreatePredictiveArrivalGhost({
+        hasTargetHex: true,
+        isLocalArmy: false,
+        isTravelAction: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the source army visible for pending tile removals", () => {
+    expect(
+      shouldHideSourceArmyOnTileRemoval({
+        hasPendingMovement: true,
+        reason: "tile",
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldHideSourceArmyOnTileRemoval({
+        hasPendingMovement: false,
+        reason: "tile",
+      }),
+    ).toBe(true);
+  });
+
+  it("resolves a ghost only after pending movement clears and the live army is renderable", () => {
+    expect(
+      shouldResolveArrivalGhost({
+        hasGhost: true,
+        hasPendingMovement: false,
+        isArmyRenderableInCurrentChunk: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldResolveArrivalGhost({
+        hasGhost: true,
+        hasPendingMovement: true,
+        isArmyRenderableInCurrentChunk: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns the configured ghost visuals", () => {
+    const style = resolveArrivalGhostVisualStyle({ armyColor: "#3366ff" });
+
+    expect(style.opacity).toBe(0.52);
+    expect(style.scaleMultiplier).toBe(1);
+    expect(style.yOffset).toBe(0.05);
+    expect(style.color).toMatch(/^#/);
+  });
+});

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.ts
@@ -1,0 +1,54 @@
+import { Color } from "three";
+
+export type ArrivalGhostClearReason =
+  | "arrived"
+  | "tx_failed"
+  | "stale_timeout"
+  | "army_removed"
+  | "scene_destroyed"
+  | "superseded";
+
+export interface ArrivalGhostVisualStyle {
+  color: string;
+  opacity: number;
+  scaleMultiplier: number;
+  yOffset: number;
+}
+
+export function shouldCreatePredictiveArrivalGhost(input: {
+  hasTargetHex: boolean;
+  isLocalArmy: boolean;
+  isTravelAction: boolean;
+}): boolean {
+  return input.isLocalArmy && input.isTravelAction && input.hasTargetHex;
+}
+
+export function shouldHideSourceArmyOnTileRemoval(input: {
+  hasPendingMovement: boolean;
+  reason: "tile" | "zero";
+}): boolean {
+  return input.reason !== "tile" || !input.hasPendingMovement;
+}
+
+export function shouldResolveArrivalGhost(input: {
+  hasGhost: boolean;
+  hasPendingMovement: boolean;
+  isArmyRenderableInCurrentChunk: boolean;
+}): boolean {
+  return input.hasGhost && !input.hasPendingMovement && input.isArmyRenderableInCurrentChunk;
+}
+
+export function resolveArrivalGhostVisualStyle(input: { armyColor: string }): ArrivalGhostVisualStyle {
+  const ghostColor = new Color(input.armyColor);
+  const ghostHsl = { h: 0, s: 0, l: 0 };
+  ghostColor.getHSL(ghostHsl);
+  ghostColor.setHSL(ghostHsl.h, ghostHsl.s * 0.28, Math.min(0.88, ghostHsl.l * 0.62 + 0.24));
+  ghostColor.lerp(new Color("#b8ffb0"), 0.62);
+
+  return {
+    color: `#${ghostColor.getHexString()}`,
+    opacity: 0.52,
+    scaleMultiplier: 1,
+    yOffset: 0.05,
+  };
+}

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.ts
@@ -30,14 +30,6 @@ export function shouldHideSourceArmyOnTileRemoval(input: {
   return input.reason !== "tile" || !input.hasPendingMovement;
 }
 
-export function shouldResolveArrivalGhost(input: {
-  hasGhost: boolean;
-  hasPendingMovement: boolean;
-  isArmyRenderableInCurrentChunk: boolean;
-}): boolean {
-  return input.hasGhost && !input.hasPendingMovement && input.isArmyRenderableInCurrentChunk;
-}
-
 export function resolveArrivalGhostVisualStyle(input: { armyColor: string }): ArrivalGhostVisualStyle {
   const ghostColor = new Color(input.armyColor);
   const ghostHsl = { h: 0, s: 0, l: 0 };

--- a/client/apps/game/src/three/managers/fx-manager.asset-paths.source.test.ts
+++ b/client/apps/game/src/three/managers/fx-manager.asset-paths.source.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("FXManager built-in asset paths", () => {
+  it("registers shared world fx textures with absolute public paths", () => {
+    const source = readSource("src/three/managers/fx-manager.ts");
+
+    expect(source).toContain("const buildSharedFxTexturePath = (fileName: string): string => `/textures/${fileName}`;");
+    expect(source).toContain('textureUrl: buildSharedFxTexturePath("skull.png")');
+    expect(source).toContain('textureUrl: buildSharedFxTexturePath("compass.png")');
+    expect(source).toContain('textureUrl: buildSharedFxTexturePath("travel.png")');
+    expect(source).toContain('textureUrl: buildSharedFxTexturePath("attack.png")');
+    expect(source).toContain('textureUrl: buildSharedFxTexturePath("defense.png")');
+  });
+});

--- a/client/apps/game/src/three/managers/fx-manager.ts
+++ b/client/apps/game/src/three/managers/fx-manager.ts
@@ -23,6 +23,8 @@ interface FXManagerOptions {
   capabilities?: RendererFxCapabilities;
 }
 
+const buildSharedFxTexturePath = (fileName: string): string => `/textures/${fileName}`;
+
 export class FXManager {
   private readonly backend: WorldFxBackend;
   private readonly defaultSize: number;
@@ -171,7 +173,7 @@ export class FXManager {
 
         return true;
       },
-      textureUrl: "textures/skull.png",
+      textureUrl: buildSharedFxTexturePath("skull.png"),
     });
 
     this.registerFX("compass", {
@@ -180,7 +182,7 @@ export class FXManager {
         fx.setRotation(t * 2);
         return true;
       },
-      textureUrl: "textures/compass.png",
+      textureUrl: buildSharedFxTexturePath("compass.png"),
     });
 
     this.registerFX("travel", {
@@ -196,11 +198,11 @@ export class FXManager {
         return true;
       },
       isInfinite: true,
-      textureUrl: "textures/travel.png",
+      textureUrl: buildSharedFxTexturePath("travel.png"),
     });
 
     this.registerFX("attack", {
-      textureUrl: "textures/attack.png",
+      textureUrl: buildSharedFxTexturePath("attack.png"),
       animate: (fx, t) => {
         const fadeIn = Math.min(t / 0.25, 1);
         fx.setOpacity(0.78 * fadeIn);
@@ -213,7 +215,7 @@ export class FXManager {
     });
 
     this.registerFX("defense", {
-      textureUrl: "textures/defense.png",
+      textureUrl: buildSharedFxTexturePath("defense.png"),
       animate: (fx, t) => {
         const fadeIn = Math.min(t / 0.25, 1);
         fx.setOpacity(0.72 * fadeIn);

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.visual-hide.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.visual-hide.test.ts
@@ -9,7 +9,7 @@ function readSource(relativePath: string): string {
 }
 
 describe("Stage 5: removal visual hide", () => {
-  it("scheduleArmyRemoval calls hideArmyVisual before scheduling timeout", () => {
+  it("scheduleArmyRemoval only hides armies immediately when no pending move is keeping the source visual alive", () => {
     const src = readSource("worldmap.tsx");
 
     // Find the method definition (private scheduleArmyRemoval)
@@ -18,17 +18,11 @@ describe("Stage 5: removal visual hide", () => {
 
     const methodBody = src.slice(methodStart, methodStart + 2000);
 
-    const metaSetPos = methodBody.indexOf("pendingArmyRemovalMeta.set(");
-    const hideVisualPos = methodBody.indexOf("hideArmyVisual(");
-    const schedulePos = methodBody.indexOf("const schedule =");
-
-    expect(metaSetPos).toBeGreaterThan(-1);
-    expect(hideVisualPos).toBeGreaterThan(-1);
-    expect(schedulePos).toBeGreaterThan(-1);
-
-    // hideArmyVisual must appear after pendingArmyRemovalMeta.set and before const schedule
-    expect(hideVisualPos).toBeGreaterThan(metaSetPos);
-    expect(hideVisualPos).toBeLessThan(schedulePos);
+    expect(methodBody).toContain(
+      'const hasPendingMovement = reason === "tile" && this.pendingArmyMovements.has(entityId);',
+    );
+    expect(methodBody).toContain("if (!hasPendingMovement) {");
+    expect(methodBody).toContain("this.armyManager.hideArmyVisual(entityId);");
   });
 
   it("hideArmyVisual is a public method on ArmyManager", () => {

--- a/client/apps/game/src/three/scenes/worldmap-arrival-ghost.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-arrival-ghost.source.test.ts
@@ -14,10 +14,11 @@ describe("Worldmap arrival ghost wiring", () => {
     expect(source).toContain("this.arrivalGhostManager.upsertLocalArrivalGhost");
   });
 
-  it("resolves tracked ghosts only after pending movement clears and the live army is renderable", () => {
+  it("resolves tracked ghosts from movement completion instead of pending-clear heuristics", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
 
-    expect(source).toContain("shouldResolveArrivalGhost");
-    expect(source).toContain("this.arrivalGhostManager.resolveArrivalGhost(entityId)");
+    expect(source).toContain("this.armyManager.onMovementComplete");
+    expect(source).toContain("this.arrivalGhostManager.resolveArrivalGhost");
+    expect(source).not.toContain("shouldResolveArrivalGhost");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-arrival-ghost.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-arrival-ghost.source.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Worldmap arrival ghost wiring", () => {
+  it("creates a local arrival ghost from the movement submit path", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("shouldCreatePredictiveArrivalGhost");
+    expect(source).toContain("this.arrivalGhostManager.upsertLocalArrivalGhost");
+  });
+
+  it("resolves tracked ghosts only after pending movement clears and the live army is renderable", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("shouldResolveArrivalGhost");
+    expect(source).toContain("this.arrivalGhostManager.resolveArrivalGhost(entityId)");
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-debug-hooks.ts
+++ b/client/apps/game/src/three/scenes/worldmap-debug-hooks.ts
@@ -1,6 +1,14 @@
+import {
+  clearArmyMovementLatencyTrace,
+  snapshotArmyMovementLatencyTrace,
+  type ArmyMovementLatencyTraceEntry,
+} from "@bibliothecadao/eternum";
+
 export interface WorldmapDebugWindow {
   testMaterialSharing?: () => void;
   testTroopDiffFx?: (diff?: number) => void;
+  getArmyMovementLatencyTrace?: () => ArmyMovementLatencyTraceEntry[];
+  clearArmyMovementLatencyTrace?: () => void;
 }
 
 interface WorldmapDebugHooks {
@@ -14,9 +22,13 @@ export function installWorldmapDebugHooks<T extends object>(
 ): void {
   debugWindow.testMaterialSharing = hooks.testMaterialSharing;
   debugWindow.testTroopDiffFx = hooks.testTroopDiffFx;
+  debugWindow.getArmyMovementLatencyTrace = () => snapshotArmyMovementLatencyTrace();
+  debugWindow.clearArmyMovementLatencyTrace = () => clearArmyMovementLatencyTrace();
 }
 
 export function uninstallWorldmapDebugHooks<T extends object>(debugWindow: T & WorldmapDebugWindow): void {
   delete debugWindow.testMaterialSharing;
   delete debugWindow.testTroopDiffFx;
+  delete debugWindow.getArmyMovementLatencyTrace;
+  delete debugWindow.clearArmyMovementLatencyTrace;
 }

--- a/client/apps/game/src/three/scenes/worldmap-movement-latency-tracing.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-movement-latency-tracing.source.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+const readRepoSource = (relativePath: string) =>
+  readFileSync(resolve(process.cwd(), "..", "..", "..", relativePath), "utf8");
+
+describe("Worldmap movement latency tracing wiring", () => {
+  it("records tx, visual movement, and completion phases from worldmap", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain('"move_requested"');
+    expect(source).toContain('"tx_response_received"');
+    expect(source).toContain('"tx_confirmed"');
+    expect(source).toContain('"movement_started"');
+    expect(source).toContain('"movement_completed"');
+  });
+
+  it("uses an authoritative world-sync timeout longer than the old 10 second stale cutoff", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("authoritativePendingArmyMovementMs = 30_000");
+  });
+
+  it("records raw TileOpt stream delivery from the torii sync layer", () => {
+    const source = readSource("src/dojo/sync.ts");
+
+    expect(source).toContain('"tileopt_stream_received"');
+  });
+
+  it("records TileOpt processing phases in the world update listener", () => {
+    const source = readRepoSource("packages/core/src/systems/world-update-listener.ts");
+
+    expect(source).toContain('"tileopt_component_received"');
+    expect(source).toContain('"tileopt_component_ready"');
+  });
+
+  it("exposes debug hooks for reading and clearing movement latency traces", () => {
+    const source = readSource("src/three/scenes/worldmap-debug-hooks.ts");
+
+    expect(source).toContain("getArmyMovementLatencyTrace");
+    expect(source).toContain("clearArmyMovementLatencyTrace");
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-ownership-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/worldmap-ownership-lifecycle.ts
@@ -4,6 +4,7 @@ interface Destroyable {
 
 interface WorldmapOwnedManagers {
   armyManager?: Destroyable | null;
+  arrivalGhostManager?: Destroyable | null;
   structureManager?: Destroyable | null;
   chestManager?: Destroyable | null;
   fxManager?: Destroyable | null;
@@ -12,6 +13,7 @@ interface WorldmapOwnedManagers {
 
 export function destroyWorldmapOwnedManagers(managers: WorldmapOwnedManagers): void {
   managers.armyManager?.destroy();
+  managers.arrivalGhostManager?.destroy();
   managers.structureManager?.destroy();
   managers.chestManager?.destroy();
   managers.fxManager?.destroy();

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Worldmap pending movement visual handoff wiring", () => {
+  it("keeps updateArmyHexes focused on cache sync instead of clearing pending movement", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const methodStart = source.indexOf("public updateArmyHexes(");
+
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const methodBody = source.slice(methodStart, methodStart + 2600);
+    expect(methodBody).not.toContain('this.clearPendingArmyMovement(entityId, "movement_started")');
+    expect(methodBody).not.toContain("this.clearPendingArmyMovement(entityId)");
+  });
+
+  it("wires local pending clear to ArmyManager movement-start notifications", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("this.armyManager.onMovementStart");
+    expect(source).toContain('this.clearPendingArmyMovement(entityId, "movement_started")');
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-lifecycle.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-lifecycle.source.test.ts
@@ -8,11 +8,11 @@ import { describe, expect, it } from "vitest";
 const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
 
 describe("Worldmap travel effect lifecycle wiring", () => {
-  it("cleans up travel effects on movement completion and preserves them when movement starts", () => {
+  it("clears pending movement on renderer-owned movement start and cleans up travel effects on completion", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
 
+    expect(source).toContain("this.armyManager.onMovementStart");
     expect(source).toContain('if (effectType === "travel") {');
     expect(source).toContain("this.armyManager.onMovementComplete(selectedEntityId, cleanup)");
-    expect(source).toContain('this.clearPendingArmyMovement(entityId, "movement_started");');
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-lifecycle.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-lifecycle.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Worldmap travel effect lifecycle wiring", () => {
+  it("cleans up travel effects on movement completion and preserves them when movement starts", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain('if (effectType === "travel") {');
+    expect(source).toContain("this.armyManager.onMovementComplete(selectedEntityId, cleanup)");
+    expect(source).toContain('this.clearPendingArmyMovement(entityId, "movement_started");');
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveExploreCompletionPendingClearPlan } from "./worldmap-travel-effect-policy";
+import {
+  resolveExploreCompletionPendingClearPlan,
+  shouldCleanupTrackedTravelEffectOnPendingClear,
+} from "./worldmap-travel-effect-policy";
 
 describe("resolveExploreCompletionPendingClearPlan", () => {
   it("returns pending compass effect entities for the explored tile", () => {
@@ -37,5 +40,32 @@ describe("resolveExploreCompletionPendingClearPlan", () => {
     });
 
     expect(plan).toEqual([]);
+  });
+
+  it("preserves travel effects when pending movement clears because movement started", () => {
+    expect(
+      shouldCleanupTrackedTravelEffectOnPendingClear({
+        trackedEffect: { key: "7,8", effectType: "travel" },
+        reason: "movement_started",
+      }),
+    ).toBe(false);
+  });
+
+  it("cleans up compass effects when pending movement clears because exploration resolved", () => {
+    expect(
+      shouldCleanupTrackedTravelEffectOnPendingClear({
+        trackedEffect: { key: "7,8", effectType: "compass" },
+        reason: "movement_started",
+      }),
+    ).toBe(true);
+  });
+
+  it("cleans up tracked effects when pending movement is force-cleared", () => {
+    expect(
+      shouldCleanupTrackedTravelEffectOnPendingClear({
+        trackedEffect: { key: "7,8", effectType: "travel" },
+        reason: "cleanup_requested",
+      }),
+    ).toBe(true);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
@@ -1,8 +1,9 @@
-import { ID } from "@bibliothecadao/types";
+import type { ID } from "@bibliothecadao/types";
 
 export type TravelEffectType = "travel" | "compass";
+export type PendingArmyMovementEffectClearReason = "movement_started" | "cleanup_requested";
 
-interface TrackedTravelEffect {
+export interface TrackedTravelEffect {
   key: string;
   effectType: TravelEffectType;
 }
@@ -37,4 +38,19 @@ export function resolveExploreCompletionPendingClearPlan(input: ResolveExploreCo
   }
 
   return pendingEntityIdsToClear;
+}
+
+export function shouldCleanupTrackedTravelEffectOnPendingClear(input: {
+  trackedEffect?: TrackedTravelEffect;
+  reason: PendingArmyMovementEffectClearReason;
+}): boolean {
+  if (!input.trackedEffect) {
+    return false;
+  }
+
+  if (input.reason === "cleanup_requested") {
+    return true;
+  }
+
+  return input.trackedEffect.effectType !== "travel";
 }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -186,7 +186,6 @@ import {
   resolveArrivalGhostVisualStyle,
   shouldCreatePredictiveArrivalGhost,
   shouldHideSourceArmyOnTileRemoval,
-  shouldResolveArrivalGhost,
 } from "../managers/arrival-ghost-policy";
 import {
   resolveExploreCompletionPendingClearPlan,
@@ -573,6 +572,7 @@ export default class WorldmapScene extends WarpTravel {
   private pendingArmyMovementStartedAt: Map<ID, number> = new Map();
   private pendingArmyMovementFallbackTimeouts: Map<ID, ReturnType<typeof setTimeout>> = new Map();
   private pendingArmyMovementTxMap: Map<string, ID> = new Map();
+  private pendingArmyMovementVisualLifecycleDisposers: Map<ID, () => void> = new Map();
 
   private get hydratedChunkRefreshes(): Set<string> {
     return this.hydratedRefreshQueueState.queuedChunkKeys;
@@ -1006,6 +1006,7 @@ export default class WorldmapScene extends WarpTravel {
       });
       if (plan.shouldClearPendingMovement && plan.entityId !== undefined) {
         this.clearPendingArmyMovement(plan.entityId);
+        this.disposePendingMovementVisualLifecycle(plan.entityId);
         this.arrivalGhostManager?.clearArrivalGhost(plan.entityId, "tx_failed");
       }
       this.pendingArmyMovementTxMap.delete(txHash);
@@ -2357,13 +2358,13 @@ export default class WorldmapScene extends WarpTravel {
         maxLifetimeTimeout = setTimeout(cleanup, MAX_TRAVEL_EFFECT_LIFETIME_MS);
       }
 
-      if (
-        shouldCreatePredictiveArrivalGhost({
-          hasTargetHex: true,
-          isLocalArmy: selectedArmy?.isMine ?? false,
-          isTravelAction,
-        })
-      ) {
+      const shouldTrackArrivalGhost = shouldCreatePredictiveArrivalGhost({
+        hasTargetHex: true,
+        isLocalArmy: selectedArmy?.isMine ?? false,
+        isTravelAction,
+      });
+
+      if (shouldTrackArrivalGhost) {
         const ghostSource = this.armyManager.getArrivalGhostSourceSnapshot(selectedEntityId);
         if (ghostSource) {
           this.arrivalGhostManager.upsertLocalArrivalGhost({
@@ -2379,6 +2380,11 @@ export default class WorldmapScene extends WarpTravel {
           });
         }
       }
+
+      this.installPendingMovementVisualLifecycle({
+        entityId: selectedEntityId,
+        shouldAnimateArrivalGhostOnCompletion: shouldTrackArrivalGhost,
+      });
 
       // Mark army as having pending movement transaction
       this.markPendingArmyMovement(selectedEntityId);
@@ -2400,6 +2406,7 @@ export default class WorldmapScene extends WarpTravel {
         .catch((e) => {
           // Transaction failed at submission, remove from pending and cleanup
           this.clearPendingArmyMovement(selectedEntityId);
+          this.disposePendingMovementVisualLifecycle(selectedEntityId);
           this.arrivalGhostManager.clearArrivalGhost(selectedEntityId, "tx_failed");
           cleanup();
           console.error("Army movement failed:", e);
@@ -2592,6 +2599,40 @@ export default class WorldmapScene extends WarpTravel {
     if (shouldCleanupTrackedTravelEffectOnPendingClear({ trackedEffect, reason })) {
       trackedEffect.cleanup();
     }
+  }
+
+  private installPendingMovementVisualLifecycle(input: {
+    entityId: ID;
+    shouldAnimateArrivalGhostOnCompletion: boolean;
+  }): void {
+    const { entityId, shouldAnimateArrivalGhostOnCompletion } = input;
+
+    this.disposePendingMovementVisualLifecycle(entityId);
+
+    const disposeMovementStart = this.armyManager.onMovementStart(entityId, () => {
+      this.clearPendingArmyMovement(entityId, "movement_started");
+    });
+    const disposeMovementComplete = this.armyManager.onMovementComplete(entityId, () => {
+      if (shouldAnimateArrivalGhostOnCompletion) {
+        this.arrivalGhostManager.resolveArrivalGhost(entityId);
+      }
+      this.disposePendingMovementVisualLifecycle(entityId);
+    });
+
+    this.pendingArmyMovementVisualLifecycleDisposers.set(entityId, () => {
+      disposeMovementStart();
+      disposeMovementComplete();
+      this.pendingArmyMovementVisualLifecycleDisposers.delete(entityId);
+    });
+  }
+
+  private disposePendingMovementVisualLifecycle(entityId: ID): void {
+    const dispose = this.pendingArmyMovementVisualLifecycleDisposers.get(entityId);
+    if (!dispose) {
+      return;
+    }
+
+    dispose();
   }
 
   private markPendingArmyMovement(entityId: ID): void {
@@ -2808,6 +2849,7 @@ export default class WorldmapScene extends WarpTravel {
       }
 
       this.clearPendingArmyMovement(entityId);
+      this.disposePendingMovementVisualLifecycle(entityId);
       this.arrivalGhostManager.clearArrivalGhost(entityId, "stale_timeout");
       if (fallbackPlan.shouldRequestChunkRefresh) {
         this.requestChunkRefresh(true);
@@ -2838,6 +2880,7 @@ export default class WorldmapScene extends WarpTravel {
 
     if (selectionPlan.shouldClearPendingMovement) {
       this.clearPendingArmyMovement(selectedEntityId);
+      this.disposePendingMovementVisualLifecycle(selectedEntityId);
       this.arrivalGhostManager.clearArrivalGhost(selectedEntityId, "stale_timeout");
     }
 
@@ -3487,6 +3530,7 @@ export default class WorldmapScene extends WarpTravel {
   public deleteArmy(entityId: ID, options: { playDefeatFx?: boolean } = {}) {
     const { playDefeatFx = true } = options;
     this.cancelPendingArmyRemoval(entityId);
+    this.disposePendingMovementVisualLifecycle(entityId);
     this.arrivalGhostManager.clearArrivalGhost(entityId, "army_removed");
     this.armyManager.removeArmy(entityId, { playDefeatFx });
     const oldPos = this.armiesPositions.get(entityId);
@@ -3617,6 +3661,7 @@ export default class WorldmapScene extends WarpTravel {
             }
 
             this.clearPendingArmyMovement(entityId);
+            this.disposePendingMovementVisualLifecycle(entityId);
           }
         }
 
@@ -3797,13 +3842,6 @@ export default class WorldmapScene extends WarpTravel {
     this.armyHexes.get(newPos.col)?.set(newPos.row, armyHexData);
     gameWorkerManager.updateArmyHex(newPos.col, newPos.row, armyHexData);
     this.invalidateAllChunkCachesContainingHex(newPos.col, newPos.row);
-
-    const movedToDifferentHex = !!oldPos && (oldPos.col !== newPos.col || oldPos.row !== newPos.row);
-
-    // Remove from pending movements only after onchain position change.
-    if (movedToDifferentHex && this.pendingArmyMovements.has(entityId)) {
-      this.clearPendingArmyMovement(entityId, "movement_started");
-    }
   }
 
   public updateStructureHexes(update: {
@@ -3940,6 +3978,7 @@ export default class WorldmapScene extends WarpTravel {
     });
     for (const entityId of pendingExploreEntities) {
       this.clearPendingArmyMovement(entityId);
+      this.disposePendingMovementVisualLifecycle(entityId);
     }
 
     const endCompass = this.travelEffects.get(key);
@@ -7044,20 +7083,8 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
-  private resolveRenderableArrivalGhosts(): void {
+  private syncArrivalGhostChunkVisibility(): void {
     this.arrivalGhostManager.setCurrentChunk(this.currentChunk);
-
-    this.arrivalGhostManager.getTrackedEntityIds().forEach((entityId) => {
-      if (
-        shouldResolveArrivalGhost({
-          hasGhost: this.arrivalGhostManager.hasArrivalGhost(entityId),
-          hasPendingMovement: this.pendingArmyMovements.has(entityId),
-          isArmyRenderableInCurrentChunk: this.armyManager.isArmyRenderableInCurrentChunk(entityId),
-        })
-      ) {
-        this.arrivalGhostManager.resolveArrivalGhost(entityId);
-      }
-    });
   }
 
   update(deltaTime: number) {
@@ -7065,7 +7092,7 @@ export default class WorldmapScene extends WarpTravel {
     this.syncWorldmapZoomSnapshot(deltaTime);
     super.update(deltaTime);
     this.armyManager.update(deltaTime, animationContext);
-    this.resolveRenderableArrivalGhosts();
+    this.syncArrivalGhostChunkVisibility();
     this.arrivalGhostManager.update(deltaTime);
     this.fxManager.update(deltaTime);
     this.resourceFXManager.update(deltaTime);
@@ -7550,6 +7577,8 @@ export default class WorldmapScene extends WarpTravel {
     this.disposeStoreSubscriptions();
     this.disposeWorldUpdateSubscriptions();
     this.pendingArmyMovements.forEach((entityId) => this.clearPendingArmyMovement(entityId));
+    this.pendingArmyMovementVisualLifecycleDisposers.forEach((dispose) => dispose());
+    this.pendingArmyMovementVisualLifecycleDisposers.clear();
     this.pendingArmyMovements.clear();
     if (this.handleTransactionFailed) {
       this.dojo.network?.provider?.off("transactionFailed", this.handleTransactionFailed);

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -2658,7 +2658,7 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     const trackedEffect = this.travelEffectsByEntity.get(entityId);
-    if (shouldCleanupTrackedTravelEffectOnPendingClear({ trackedEffect, reason })) {
+    if (trackedEffect && shouldCleanupTrackedTravelEffectOnPendingClear({ trackedEffect, reason })) {
       trackedEffect.cleanup();
     }
   }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -96,6 +96,7 @@ import { playerCosmeticsStore, preloadAllCosmeticAssets } from "../cosmetics";
 import { FXManager } from "../managers/fx-manager";
 import { HoverLabelManager } from "../managers/hover-label-manager";
 import { ResourceFXManager } from "../managers/resource-fx-manager";
+import { ArrivalGhostManager } from "../managers/arrival-ghost-manager";
 import { resolveHoverVisualPalette, resolveSelectionPulsePalette } from "../managers/worldmap-interaction-palette";
 import { SceneName } from "../types/common";
 import { getWorldPositionForHex, isAddressEqualToAccount } from "../utils";
@@ -181,7 +182,18 @@ import {
   shouldClearPendingCreateArmyEffect,
 } from "./worldmap-pending-action-effect-policy";
 import { shouldPlayArmyMovementFx } from "./worldmap-movement-fx-policy";
-import { resolveExploreCompletionPendingClearPlan, type TravelEffectType } from "./worldmap-travel-effect-policy";
+import {
+  resolveArrivalGhostVisualStyle,
+  shouldCreatePredictiveArrivalGhost,
+  shouldHideSourceArmyOnTileRemoval,
+  shouldResolveArrivalGhost,
+} from "../managers/arrival-ghost-policy";
+import {
+  resolveExploreCompletionPendingClearPlan,
+  shouldCleanupTrackedTravelEffectOnPendingClear,
+  type PendingArmyMovementEffectClearReason,
+  type TravelEffectType,
+} from "./worldmap-travel-effect-policy";
 import { findSupersededArmyRemoval } from "./worldmap-army-removal";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
@@ -871,6 +883,7 @@ export default class WorldmapScene extends WarpTravel {
   private deferredChunkRemovals: Map<ID, { reason: "tile" | "zero"; scheduledAt: number }> = new Map();
 
   private fxManager!: FXManager;
+  private arrivalGhostManager!: ArrivalGhostManager;
   private resourceFXManager!: ResourceFXManager;
   private armyIndex: number = 0;
   private selectableArmies: SelectableArmy[] = [];
@@ -993,6 +1006,7 @@ export default class WorldmapScene extends WarpTravel {
       });
       if (plan.shouldClearPendingMovement && plan.entityId !== undefined) {
         this.clearPendingArmyMovement(plan.entityId);
+        this.arrivalGhostManager?.clearArrivalGhost(plan.entityId, "tx_failed");
       }
       this.pendingArmyMovementTxMap.delete(txHash);
     };
@@ -1018,6 +1032,10 @@ export default class WorldmapScene extends WarpTravel {
       this.visibilityManager,
       this.chunkSize,
     );
+    this.arrivalGhostManager = new ArrivalGhostManager(this.scene, {
+      chunkStride: this.chunkSize,
+      renderChunkSize: this.renderChunkSize,
+    });
 
     installWorldmapDebugHooks(window, {
       testMaterialSharing: () => this.armyManager.logMaterialSharingStats(),
@@ -2242,6 +2260,7 @@ export default class WorldmapScene extends WarpTravel {
     const isTravelAction = actionType === ActionType.Move || actionType === ActionType.SpireTravel;
     if (actionPath.length > 0) {
       const armyActionManager = new ArmyActionManager(this.dojo.components, this.dojo.systemCalls, selectedEntityId);
+      const selectedArmy = this.armyManager.getArmy(selectedEntityId);
       playUnitCommandSoundForWorldmapAction(actionType);
 
       // Get the target position for the effect
@@ -2283,6 +2302,7 @@ export default class WorldmapScene extends WarpTravel {
         );
 
         let cleaned = false;
+        let unsubscribeFromMovementComplete: (() => void) | undefined;
         const effectStartedAtMs = performance.now();
         let delayedCleanupTimeout: ReturnType<typeof setTimeout> | undefined;
         let maxLifetimeTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -2299,6 +2319,8 @@ export default class WorldmapScene extends WarpTravel {
           }
           end();
           this.travelEffects.delete(key);
+          unsubscribeFromMovementComplete?.();
+          unsubscribeFromMovementComplete = undefined;
 
           const tracked = this.travelEffectsByEntity.get(selectedEntityId);
           if (tracked?.key === key) {
@@ -2327,9 +2349,35 @@ export default class WorldmapScene extends WarpTravel {
 
         // Store the cleanup function with the hex coordinates as key
         this.travelEffects.set(key, cleanup);
+        if (effectType === "travel") {
+          unsubscribeFromMovementComplete = this.armyManager.onMovementComplete(selectedEntityId, cleanup);
+        }
 
         this.travelEffectsByEntity.set(selectedEntityId, { key, cleanup, effectType });
         maxLifetimeTimeout = setTimeout(cleanup, MAX_TRAVEL_EFFECT_LIFETIME_MS);
+      }
+
+      if (
+        shouldCreatePredictiveArrivalGhost({
+          hasTargetHex: true,
+          isLocalArmy: selectedArmy?.isMine ?? false,
+          isTravelAction,
+        })
+      ) {
+        const ghostSource = this.armyManager.getArrivalGhostSourceSnapshot(selectedEntityId);
+        if (ghostSource) {
+          this.arrivalGhostManager.upsertLocalArrivalGhost({
+            entityId: selectedEntityId,
+            hexCoords: {
+              col: targetHex.col - FELT_CENTER(),
+              row: targetHex.row - FELT_CENTER(),
+            },
+            sourceScene: ghostSource.sourceScene,
+            visualStyle: resolveArrivalGhostVisualStyle({
+              armyColor: ghostSource.armyColor,
+            }),
+          });
+        }
       }
 
       // Mark army as having pending movement transaction
@@ -2352,6 +2400,7 @@ export default class WorldmapScene extends WarpTravel {
         .catch((e) => {
           // Transaction failed at submission, remove from pending and cleanup
           this.clearPendingArmyMovement(selectedEntityId);
+          this.arrivalGhostManager.clearArrivalGhost(selectedEntityId, "tx_failed");
           cleanup();
           console.error("Army movement failed:", e);
         });
@@ -2519,7 +2568,10 @@ export default class WorldmapScene extends WarpTravel {
     this.updateStructureOwnershipPulses(selectedEntityId, extraHexes);
   }
 
-  private clearPendingArmyMovement(entityId: ID): void {
+  private clearPendingArmyMovement(
+    entityId: ID,
+    reason: PendingArmyMovementEffectClearReason = "cleanup_requested",
+  ): void {
     this.pendingArmyMovements.delete(entityId);
     this.pendingArmyMovementStartedAt.delete(entityId);
 
@@ -2536,9 +2588,10 @@ export default class WorldmapScene extends WarpTravel {
       }
     }
 
-    // Clear any lingering movement fx when pending state is cleared outside
-    // of normal movement-start handling (e.g., stale timeout).
-    this.travelEffectsByEntity.get(entityId)?.cleanup();
+    const trackedEffect = this.travelEffectsByEntity.get(entityId);
+    if (shouldCleanupTrackedTravelEffectOnPendingClear({ trackedEffect, reason })) {
+      trackedEffect.cleanup();
+    }
   }
 
   private markPendingArmyMovement(entityId: ID): void {
@@ -2755,6 +2808,7 @@ export default class WorldmapScene extends WarpTravel {
       }
 
       this.clearPendingArmyMovement(entityId);
+      this.arrivalGhostManager.clearArrivalGhost(entityId, "stale_timeout");
       if (fallbackPlan.shouldRequestChunkRefresh) {
         this.requestChunkRefresh(true);
       }
@@ -2784,6 +2838,7 @@ export default class WorldmapScene extends WarpTravel {
 
     if (selectionPlan.shouldClearPendingMovement) {
       this.clearPendingArmyMovement(selectedEntityId);
+      this.arrivalGhostManager.clearArrivalGhost(selectedEntityId, "stale_timeout");
     }
 
     if (selectionPlan.shouldRequestChunkRefresh) {
@@ -3432,6 +3487,7 @@ export default class WorldmapScene extends WarpTravel {
   public deleteArmy(entityId: ID, options: { playDefeatFx?: boolean } = {}) {
     const { playDefeatFx = true } = options;
     this.cancelPendingArmyRemoval(entityId);
+    this.arrivalGhostManager.clearArrivalGhost(entityId, "army_removed");
     this.armyManager.removeArmy(entityId, { playDefeatFx });
     const oldPos = this.armiesPositions.get(entityId);
     if (oldPos) {
@@ -3518,9 +3574,17 @@ export default class WorldmapScene extends WarpTravel {
       position: removalPosition,
     });
 
-    // Immediately hide the army visually so it doesn't render at a stale
-    // position during the deferred removal window
-    this.armyManager.hideArmyVisual(entityId);
+    // Preserve the source visual while a move is still pending. Torii can emit
+    // the old-tile removal before the destination tile update, and hiding here
+    // creates a dead zone where the army vanishes until the add catches up.
+    if (
+      shouldHideSourceArmyOnTileRemoval({
+        hasPendingMovement,
+        reason,
+      })
+    ) {
+      this.armyManager.hideArmyVisual(entityId);
+    }
 
     const schedule = (delay: number) => {
       const timeout = setTimeout(() => {
@@ -3736,14 +3800,9 @@ export default class WorldmapScene extends WarpTravel {
 
     const movedToDifferentHex = !!oldPos && (oldPos.col !== newPos.col || oldPos.row !== newPos.row);
 
-    // End travel/explore FX as soon as the army starts moving (first onchain position change).
-    if (movedToDifferentHex) {
-      this.travelEffectsByEntity.get(entityId)?.cleanup();
-    }
-
     // Remove from pending movements only after onchain position change.
     if (movedToDifferentHex && this.pendingArmyMovements.has(entityId)) {
-      this.clearPendingArmyMovement(entityId);
+      this.clearPendingArmyMovement(entityId, "movement_started");
     }
   }
 
@@ -6985,11 +7044,29 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
+  private resolveRenderableArrivalGhosts(): void {
+    this.arrivalGhostManager.setCurrentChunk(this.currentChunk);
+
+    this.arrivalGhostManager.getTrackedEntityIds().forEach((entityId) => {
+      if (
+        shouldResolveArrivalGhost({
+          hasGhost: this.arrivalGhostManager.hasArrivalGhost(entityId),
+          hasPendingMovement: this.pendingArmyMovements.has(entityId),
+          isArmyRenderableInCurrentChunk: this.armyManager.isArmyRenderableInCurrentChunk(entityId),
+        })
+      ) {
+        this.arrivalGhostManager.resolveArrivalGhost(entityId);
+      }
+    });
+  }
+
   update(deltaTime: number) {
     const animationContext = this.getAnimationVisibilityContext();
     this.syncWorldmapZoomSnapshot(deltaTime);
     super.update(deltaTime);
     this.armyManager.update(deltaTime, animationContext);
+    this.resolveRenderableArrivalGhosts();
+    this.arrivalGhostManager.update(deltaTime);
     this.fxManager.update(deltaTime);
     this.resourceFXManager.update(deltaTime);
     this.selectionPulseManager.update(deltaTime);
@@ -7487,6 +7564,7 @@ export default class WorldmapScene extends WarpTravel {
 
     destroyWorldmapOwnedManagers({
       armyManager: this.armyManager,
+      arrivalGhostManager: this.arrivalGhostManager,
       structureManager: this.structureManager,
       chestManager: this.chestManager,
       fxManager: this.fxManager,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -55,6 +55,7 @@ import {
   ExplorerTroopsTileSystemUpdate,
   getBlockTimestamp,
   getTileAt,
+  recordArmyMovementLatencyPhase,
   SelectableArmy,
   StructureActionManager,
   TileSystemUpdate,
@@ -676,8 +677,9 @@ export default class WorldmapScene extends WarpTravel {
   private set postCommitManagerCatchUpFrameHandle(value: number | null) {
     this.postCommitManagerCatchUpRuntimeState.frameHandle = value;
   }
+  private handleTransactionComplete?: (...args: any[]) => void;
   private handleTransactionFailed?: (...args: any[]) => void;
-  private readonly stalePendingArmyMovementMs = 10_000;
+  private readonly authoritativePendingArmyMovementMs = 30_000;
   private armySelectionRecoveryInFlight: Set<ID> = new Set();
   private structureManager!: StructureManager;
   private memoryMonitor?: MemoryMonitor;
@@ -992,6 +994,25 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private bindTransactionFailureLifecycle(dojoContext: SetupResult): void {
+    this.handleTransactionComplete = (payload: { details?: { transaction_hash?: string } }) => {
+      const txHash = payload?.details?.transaction_hash;
+      if (!txHash) {
+        return;
+      }
+
+      const entityId = this.pendingArmyMovementTxMap.get(txHash);
+      if (entityId === undefined) {
+        return;
+      }
+
+      recordArmyMovementLatencyPhase({
+        phase: "tx_confirmed",
+        source: "worldmap",
+        entityId,
+        txHash,
+      });
+    };
+
     this.handleTransactionFailed = (_error: any, meta?: any) => {
       const txHash =
         typeof _error === "object" && _error?.transactionHash ? _error.transactionHash : meta?.transactionHash;
@@ -1012,6 +1033,7 @@ export default class WorldmapScene extends WarpTravel {
       this.pendingArmyMovementTxMap.delete(txHash);
     };
 
+    dojoContext.network?.provider?.on("transactionComplete", this.handleTransactionComplete);
     dojoContext.network?.provider?.on("transactionFailed", this.handleTransactionFailed);
   }
 
@@ -1143,6 +1165,15 @@ export default class WorldmapScene extends WarpTravel {
     this.addWorldUpdateSubscription(
       this.worldUpdateListener.Army.onTileUpdate(async (update: ExplorerTroopsTileSystemUpdate) => {
         this.incrementToriiBoundsCounter("explorerTiles");
+        recordArmyMovementLatencyPhase({
+          phase: "worldmap_tile_update_received",
+          source: "worldmap",
+          entityId: update.entityId,
+          details: {
+            col: update.hexCoords.col,
+            row: update.hexCoords.row,
+          },
+        });
         const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId);
         const normalizedPos = new Position({ x: update.hexCoords.col, y: update.hexCoords.row }).getNormalized();
 
@@ -1186,6 +1217,15 @@ export default class WorldmapScene extends WarpTravel {
         }
 
         await this.armyManager.onTileUpdate(update);
+        recordArmyMovementLatencyPhase({
+          phase: "army_manager_tile_update_applied",
+          source: "worldmap",
+          entityId: update.entityId,
+          details: {
+            col: update.hexCoords.col,
+            row: update.hexCoords.row,
+          },
+        });
         this.armyLastTileSyncAt.set(update.entityId, Date.now());
         if (recoveredPendingRemoval) {
           void this.armyManager.restoreArmyVisualIfVisible(update.entityId);
@@ -2388,6 +2428,16 @@ export default class WorldmapScene extends WarpTravel {
 
       // Mark army as having pending movement transaction
       this.markPendingArmyMovement(selectedEntityId);
+      recordArmyMovementLatencyPhase({
+        phase: "move_requested",
+        source: "worldmap",
+        entityId: selectedEntityId,
+        details: {
+          actionType,
+          targetCol: targetHex.col,
+          targetRow: targetHex.row,
+        },
+      });
 
       // Monitor memory usage before army movement action
       this.memoryMonitor?.getCurrentStats(`worldmap-moveArmy-start-${selectedEntityId}`);
@@ -2397,8 +2447,20 @@ export default class WorldmapScene extends WarpTravel {
         .then((result: any) => {
           // Track txHash → entityId so provider transactionFailed events can clear pending state
           const txHash = result?.transaction_hash;
+          recordArmyMovementLatencyPhase({
+            phase: "tx_response_received",
+            source: "worldmap",
+            entityId: selectedEntityId,
+            txHash,
+          });
           if (txHash) {
             this.pendingArmyMovementTxMap.set(txHash, selectedEntityId);
+            recordArmyMovementLatencyPhase({
+              phase: "tx_submitted",
+              source: "worldmap",
+              entityId: selectedEntityId,
+              txHash,
+            });
           }
           // Monitor memory usage after army movement completion
           this.memoryMonitor?.getCurrentStats(`worldmap-moveArmy-complete-${selectedEntityId}`);
@@ -2610,9 +2672,19 @@ export default class WorldmapScene extends WarpTravel {
     this.disposePendingMovementVisualLifecycle(entityId);
 
     const disposeMovementStart = this.armyManager.onMovementStart(entityId, () => {
+      recordArmyMovementLatencyPhase({
+        phase: "movement_started",
+        source: "worldmap",
+        entityId,
+      });
       this.clearPendingArmyMovement(entityId, "movement_started");
     });
     const disposeMovementComplete = this.armyManager.onMovementComplete(entityId, () => {
+      recordArmyMovementLatencyPhase({
+        phase: "movement_completed",
+        source: "worldmap",
+        entityId,
+      });
       if (shouldAnimateArrivalGhostOnCompletion) {
         this.arrivalGhostManager.resolveArrivalGhost(entityId);
       }
@@ -2836,7 +2908,7 @@ export default class WorldmapScene extends WarpTravel {
         hasPendingMovement: this.pendingArmyMovements.has(entityId),
         pendingMovementStartedAtMs: this.pendingArmyMovementStartedAt.get(entityId),
         nowMs: Date.now(),
-        staleAfterMs: this.stalePendingArmyMovementMs,
+        staleAfterMs: this.authoritativePendingArmyMovementMs,
       });
 
       if (fallbackPlan.shouldDeleteFallbackTimeout) {
@@ -2858,7 +2930,7 @@ export default class WorldmapScene extends WarpTravel {
       if (import.meta.env.DEV) {
         console.warn(`[DEBUG] Cleared stale pending movement for army ${entityId} via fallback timeout`);
       }
-    }, this.stalePendingArmyMovementMs);
+    }, this.authoritativePendingArmyMovementMs);
 
     this.pendingArmyMovementFallbackTimeouts.set(entityId, fallbackTimeout);
   }
@@ -2875,7 +2947,7 @@ export default class WorldmapScene extends WarpTravel {
       hasPendingMovement: this.pendingArmyMovements.has(selectedEntityId),
       pendingMovementStartedAtMs: this.pendingArmyMovementStartedAt.get(selectedEntityId),
       nowMs: Date.now(),
-      staleAfterMs: this.stalePendingArmyMovementMs,
+      staleAfterMs: this.authoritativePendingArmyMovementMs,
     });
 
     if (selectionPlan.shouldClearPendingMovement) {
@@ -7580,6 +7652,9 @@ export default class WorldmapScene extends WarpTravel {
     this.pendingArmyMovementVisualLifecycleDisposers.forEach((dispose) => dispose());
     this.pendingArmyMovementVisualLifecycleDisposers.clear();
     this.pendingArmyMovements.clear();
+    if (this.handleTransactionComplete) {
+      this.dojo.network?.provider?.off("transactionComplete", this.handleTransactionComplete);
+    }
     if (this.handleTransactionFailed) {
       this.dojo.network?.provider?.off("transactionFailed", this.handleTransactionFailed);
     }

--- a/client/apps/game/src/three/types/army.ts
+++ b/client/apps/game/src/three/types/army.ts
@@ -7,6 +7,7 @@ import {
   InstancedMesh,
   Group,
   Mesh,
+  Object3D,
   AnimationMixer,
   AnimationClip,
   AnimationAction,

--- a/client/apps/game/src/three/types/army.ts
+++ b/client/apps/game/src/three/types/army.ts
@@ -82,6 +82,7 @@ export interface AnimatedInstancedMesh extends InstancedMesh {
 
 export interface ModelData {
   group: Group;
+  sourceScene: Object3D;
   instancedMeshes: AnimatedInstancedMesh[];
   contactShadowMesh?: InstancedMesh;
   contactShadowScale?: number;

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-12",
+    title: "Longer Movement Sync Bridge",
+    description:
+      "Army move ghosts and travel effects now stay visible through longer world-sync delays, so confirmed moves no longer drop into an empty dead gap before the real unit catches up.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-12",
     title: "Synchronized Army Move Handoff",
     description:
       "Local army moves now stay locked until the rendered movement actually begins, and destination ghosts wait for the real arrival before resolving, so move confirmations no longer leave units stranded in a stale pre-move state.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-12",
+    title: "Synchronized Army Move Handoff",
+    description:
+      "Local army moves now stay locked until the rendered movement actually begins, and destination ghosts wait for the real arrival before resolving, so move confirmations no longer leave units stranded in a stale pre-move state.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-12",
     title: "Arrival Ghost Moves",
     description:
       "Local army moves now leave a ghosted unit at the destination while the world update catches up, so moves stay readable and the real unit can absorb into place on arrival instead of disappearing into a dead gap.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-12",
+    title: "Juicier Move Ghosts",
+    description:
+      "Destination ghosts now breathe with a soft idle pulse, show a clearer ground ring, and burst into the arriving unit with a brighter handoff so delayed moves stay visible instead of feeling static.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-12",
     title: "Longer Movement Sync Bridge",
     description:
       "Army move ghosts and travel effects now stay visible through longer world-sync delays, so confirmed moves no longer drop into an empty dead gap before the real unit catches up.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,22 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-12",
+    title: "Arrival Ghost Moves",
+    description:
+      "Local army moves now leave a ghosted unit at the destination while the world update catches up, so moves stay readable and the real unit can absorb into place on arrival instead of disappearing into a dead gap.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-12",
+    title: "Smoother Army Move FX",
+    description:
+      "Army move effects now stay visible until the rendered unit actually starts and finishes its travel, so long chunk-sync updates no longer make movement look stalled or broken.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-12",
     title: "Faster Play Asset Warmup",
     description:
       "Shared play assets now start warming from the dashboard so common world models and textures are more likely to be ready before you enter a game.",

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -546,14 +546,16 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
               <Sword className="h-3 w-3 text-gold/50" />
               <span className="uppercase tracking-wide text-gold/60">Field</span>
               <span className="font-semibold text-gold">
-                {attackArmyCount}{maxAttackArmies !== null ? `/${maxAttackArmies}` : ""}
+                {attackArmyCount}
+                {maxAttackArmies !== null ? `/${maxAttackArmies}` : ""}
               </span>
             </div>
             <div className="flex items-center gap-1.5 rounded border border-gold/10 bg-[#1b140f]/80 px-2 py-1">
               <Shield className="h-3 w-3 text-gold/50" />
               <span className="uppercase tracking-wide text-gold/60">Guard</span>
               <span className="font-semibold text-gold">
-                {guardArmyCount}{maxGuardArmies !== null ? `/${maxGuardArmies}` : ""}
+                {guardArmyCount}
+                {maxGuardArmies !== null ? `/${maxGuardArmies}` : ""}
               </span>
             </div>
           </div>

--- a/packages/core/src/systems/army-movement-latency-trace.test.ts
+++ b/packages/core/src/systems/army-movement-latency-trace.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearArmyMovementLatencyTrace,
+  recordArmyMovementLatencyPhase,
+  snapshotArmyMovementLatencyTrace,
+} from "./army-movement-latency-trace";
+
+describe("army-movement-latency-trace", () => {
+  beforeEach(() => {
+    clearArmyMovementLatencyTrace();
+  });
+
+  it("records trace entries in order", () => {
+    recordArmyMovementLatencyPhase({
+      entityId: 7,
+      phase: "tx_submitted",
+      source: "worldmap",
+    });
+    recordArmyMovementLatencyPhase({
+      entityId: 7,
+      phase: "movement_started",
+      source: "worldmap",
+    });
+
+    const trace = snapshotArmyMovementLatencyTrace();
+
+    expect(trace).toHaveLength(2);
+    expect(trace[0]?.phase).toBe("tx_submitted");
+    expect(trace[1]?.phase).toBe("movement_started");
+    expect(trace[0]?.sequence).toBeLessThan(trace[1]?.sequence ?? 0);
+  });
+
+  it("clears recorded entries", () => {
+    recordArmyMovementLatencyPhase({
+      entityId: 9,
+      phase: "tx_confirmed",
+      source: "worldmap",
+    });
+
+    clearArmyMovementLatencyTrace();
+
+    expect(snapshotArmyMovementLatencyTrace()).toEqual([]);
+  });
+});

--- a/packages/core/src/systems/army-movement-latency-trace.ts
+++ b/packages/core/src/systems/army-movement-latency-trace.ts
@@ -1,0 +1,93 @@
+import type { ID } from "@bibliothecadao/types";
+
+export type ArmyMovementLatencyPhase =
+  | "move_requested"
+  | "tx_submitted"
+  | "tx_response_received"
+  | "tx_confirmed"
+  | "tileopt_stream_received"
+  | "tileopt_component_received"
+  | "tileopt_component_ready"
+  | "worldmap_tile_update_received"
+  | "army_manager_tile_update_applied"
+  | "movement_started"
+  | "movement_completed";
+
+export type ArmyMovementLatencySource = "worldmap" | "torii_sync" | "world_update_listener";
+
+export interface ArmyMovementLatencyTraceEntry {
+  sequence: number;
+  phase: ArmyMovementLatencyPhase;
+  source: ArmyMovementLatencySource;
+  entityId?: ID;
+  txHash?: string;
+  tileEntityKey?: string;
+  timestampMs: number;
+  wallTimeMs: number;
+  details?: Record<string, unknown>;
+}
+
+interface ArmyMovementLatencyTraceTarget {
+  __armyMovementLatencyTraceEntries?: ArmyMovementLatencyTraceEntry[];
+}
+
+const MAX_TRACE_ENTRIES = 400;
+
+let sequence = 0;
+let traceEntries: ArmyMovementLatencyTraceEntry[] = [];
+
+function getTraceTarget(): ArmyMovementLatencyTraceTarget | null {
+  if (typeof globalThis === "undefined") {
+    return null;
+  }
+
+  return globalThis as ArmyMovementLatencyTraceTarget;
+}
+
+function publishTraceEntries(): void {
+  const target = getTraceTarget();
+  if (!target) {
+    return;
+  }
+
+  target.__armyMovementLatencyTraceEntries = traceEntries;
+}
+
+export function recordArmyMovementLatencyPhase(input: {
+  phase: ArmyMovementLatencyPhase;
+  source: ArmyMovementLatencySource;
+  entityId?: ID;
+  txHash?: string;
+  tileEntityKey?: string;
+  timestampMs?: number;
+  wallTimeMs?: number;
+  details?: Record<string, unknown>;
+}): void {
+  sequence += 1;
+
+  traceEntries = [
+    ...traceEntries,
+    {
+      sequence,
+      phase: input.phase,
+      source: input.source,
+      entityId: input.entityId,
+      txHash: input.txHash,
+      tileEntityKey: input.tileEntityKey,
+      timestampMs: input.timestampMs ?? Date.now(),
+      wallTimeMs: input.wallTimeMs ?? performance.now(),
+      details: input.details,
+    },
+  ].slice(-MAX_TRACE_ENTRIES);
+
+  publishTraceEntries();
+}
+
+export function snapshotArmyMovementLatencyTrace(): ArmyMovementLatencyTraceEntry[] {
+  return [...traceEntries];
+}
+
+export function clearArmyMovementLatencyTrace(): void {
+  traceEntries = [];
+  publishTraceEntries();
+}

--- a/packages/core/src/systems/index.ts
+++ b/packages/core/src/systems/index.ts
@@ -1,3 +1,4 @@
+export * from "./army-movement-latency-trace";
 export * from "./data-enhancer";
 export * from "./position";
 export * from "./story-event-formatter";

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -33,6 +33,7 @@ import { MAP_DATA_REFRESH_INTERVAL } from "../utils/constants";
 import { getStructureName } from "../utils/entities";
 import { getBlockTimestamp } from "../utils/timestamp";
 import { DataEnhancer } from "./data-enhancer";
+import { recordArmyMovementLatencyPhase } from "./army-movement-latency-trace";
 import {
   type BattleEventSystemUpdate,
   type BuildingSystemUpdate,
@@ -331,6 +332,16 @@ export class WorldUpdateListener {
                 return;
               }
 
+              recordArmyMovementLatencyPhase({
+                phase: "tileopt_component_received",
+                source: "world_update_listener",
+                entityId: rawOccupierId,
+                details: {
+                  col: currentState.col,
+                  row: currentState.row,
+                },
+              });
+
               const { currentArmiesTick } = getBlockTimestamp();
 
               // Use sequential update processing to prevent race conditions
@@ -386,6 +397,17 @@ export class WorldUpdateListener {
               });
 
               // Return undefined if update was cancelled due to being outdated
+              if (result) {
+                recordArmyMovementLatencyPhase({
+                  phase: "tileopt_component_ready",
+                  source: "world_update_listener",
+                  entityId: rawOccupierId,
+                  details: {
+                    col: result.hexCoords.col,
+                    row: result.hexCoords.row,
+                  },
+                });
+              }
               return result || undefined;
             }
           },


### PR DESCRIPTION
This keeps local army movement visuals alive until authoritative world state catches up, instead of dropping them as soon as the old fallback expires. It adds arrival ghost and travel-effect handoff handling across the worldmap and army managers, plus the supporting FX wiring and regression coverage for that visual lifecycle. It also adds cross-layer movement latency tracing from tx submit and confirmation through Torii TileOpt delivery and world-update application, with debug hooks and source tests to inspect the trace in development. Verification: `pnpm run format`, `pnpm run knip`, `pnpm --dir client/apps/game exec vitest run src/three/scenes/worldmap-movement-latency-tracing.source.test.ts`, `pnpm exec vitest run packages/core/src/systems/army-movement-latency-trace.test.ts`.
