### PR TITLE
Fix game entry timing and first-load handoff

### DIFF
--- a/client/apps/game/src/hooks/context/world-controller-session.test.ts
+++ b/client/apps/game/src/hooks/context/world-controller-session.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const applyWorldSelection = vi.fn();
+const configureSelectedWorldDojoRuntime = vi.fn();
+const refreshSessionPolicies = vi.fn();
+
+vi.mock("@/runtime/world", () => ({
+  applyWorldSelection,
+}));
+
+vi.mock("@/runtime/world/dojo-runtime-config", () => ({
+  configureSelectedWorldDojoRuntime,
+}));
+
+vi.mock("./session-policy-refresh", () => ({
+  refreshSessionPolicies,
+}));
+
+import { prepareControllerSessionForWorld } from "./world-controller-session";
+
+describe("prepareControllerSessionForWorld", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies the selected world before refreshing controller session policies", async () => {
+    const connector = { id: "controller" };
+    const profile = {
+      name: "aurora-blitz",
+      chain: "slot",
+      rpcUrl: "https://rpc.example/aurora",
+      toriiBaseUrl: "https://torii.example/aurora",
+      worldAddress: "0x123",
+      contractsBySelector: { "0xabc": "0xdef" },
+    };
+
+    applyWorldSelection.mockResolvedValue({
+      profile,
+      currentChain: "slot",
+      targetChain: "slot",
+      chainChanged: false,
+    });
+
+    await prepareControllerSessionForWorld({
+      connector,
+      chain: "slot",
+      worldName: "aurora-blitz",
+    });
+
+    expect(applyWorldSelection).toHaveBeenCalledWith({ name: "aurora-blitz", chain: "slot" }, "slot");
+    expect(configureSelectedWorldDojoRuntime).toHaveBeenCalledWith({
+      chain: "slot",
+      profile,
+    });
+    expect(refreshSessionPolicies).toHaveBeenCalledWith(connector);
+    expect(applyWorldSelection.mock.invocationCallOrder[0]).toBeLessThan(
+      configureSelectedWorldDojoRuntime.mock.invocationCallOrder[0],
+    );
+    expect(configureSelectedWorldDojoRuntime.mock.invocationCallOrder[0]).toBeLessThan(
+      refreshSessionPolicies.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/client/apps/game/src/hooks/context/world-controller-session.ts
+++ b/client/apps/game/src/hooks/context/world-controller-session.ts
@@ -1,0 +1,26 @@
+import { applyWorldSelection } from "@/runtime/world";
+import { configureSelectedWorldDojoRuntime } from "@/runtime/world/dojo-runtime-config";
+import type { Chain } from "@contracts";
+
+import { refreshSessionPolicies } from "./session-policy-refresh";
+
+export const prepareControllerSessionForWorld = async ({
+  connector,
+  chain,
+  worldName,
+}: {
+  connector: unknown;
+  chain: Chain;
+  worldName: string;
+}) => {
+  if (!connector) {
+    throw new Error("Controller connector unavailable for world session preparation.");
+  }
+
+  const { profile } = await applyWorldSelection({ name: worldName, chain }, chain);
+
+  configureSelectedWorldDojoRuntime({ chain, profile });
+  await refreshSessionPolicies(connector);
+
+  return profile;
+};

--- a/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
@@ -13,7 +13,7 @@ const baseEntry: AutoSettleEntryRecord = {
   chain: "mainnet",
   worldName: "aurora-blitz",
   worldKey: "mainnet:aurora-blitz",
-  settleAtSec: 1_234,
+  triggerAtSec: 1_234,
   armedAtMs: 100,
   status: "armed",
   lastError: null,

--- a/client/apps/game/src/hooks/store/use-auto-settle-store.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.ts
@@ -10,7 +10,7 @@ export interface AutoSettleEntryRecord {
   chain: Chain;
   worldName: string;
   worldKey: string;
-  settleAtSec: number;
+  triggerAtSec: number;
   armedAtMs: number;
   status: AutoSettleStatus;
   lastError: string | null;
@@ -70,6 +70,58 @@ const updateEntry = (
     ...entries,
     [key]: updater(current),
   };
+};
+
+const migrateAutoSettleEntries = (persistedState: unknown): Record<string, AutoSettleEntryRecord> => {
+  if (
+    typeof persistedState !== "object" ||
+    persistedState === null ||
+    !("entries" in persistedState) ||
+    typeof (persistedState as { entries?: unknown }).entries !== "object" ||
+    (persistedState as { entries?: unknown }).entries === null
+  ) {
+    return {};
+  }
+
+  const entries = (persistedState as { entries: Record<string, unknown> }).entries;
+
+  return Object.fromEntries(
+    Object.entries(entries).flatMap(([key, entry]) => {
+      if (typeof entry !== "object" || entry === null) {
+        return [];
+      }
+
+      const currentEntry = entry as AutoSettleEntryRecord & { settleAtSec?: unknown };
+      const triggerAtSec =
+        typeof currentEntry.triggerAtSec === "number"
+          ? currentEntry.triggerAtSec
+          : typeof currentEntry.settleAtSec === "number"
+            ? currentEntry.settleAtSec
+            : null;
+
+      if (triggerAtSec == null) {
+        return [];
+      }
+
+      return [
+        [
+          key,
+          {
+            enabled: currentEntry.enabled,
+            walletAddress: currentEntry.walletAddress,
+            chain: currentEntry.chain,
+            worldName: currentEntry.worldName,
+            worldKey: currentEntry.worldKey,
+            triggerAtSec,
+            armedAtMs: currentEntry.armedAtMs,
+            status: currentEntry.status,
+            lastError: currentEntry.lastError,
+            lastAttemptAtMs: currentEntry.lastAttemptAtMs,
+          } satisfies AutoSettleEntryRecord,
+        ],
+      ];
+    }),
+  );
 };
 
 export const useAutoSettleStore = create<AutoSettleStoreState>()(
@@ -140,9 +192,12 @@ export const useAutoSettleStore = create<AutoSettleStoreState>()(
     }),
     {
       name: AUTO_SETTLE_STORAGE_KEY,
-      version: 1,
+      version: 2,
       storage: createJSONStorage(createLocalStorage),
       partialize: (state) => ({ entries: state.entries }),
+      migrate: (persistedState) => ({
+        entries: migrateAutoSettleEntries(persistedState),
+      }),
     },
   ),
 );

--- a/client/apps/game/src/init/bootstrap.tsx
+++ b/client/apps/game/src/init/bootstrap.tsx
@@ -10,16 +10,15 @@ import {
   getActiveWorld,
   isRpcUrlCompatibleForChain,
   normalizeRpcUrl,
-  patchManifestWithFactory,
   resolveChain,
   setActiveWorldName,
   setSelectedChain,
   type WorldProfile,
 } from "@/runtime/world";
+import { configureSelectedWorldDojoRuntime } from "@/runtime/world/dojo-runtime-config";
 import { parsePlayRoute } from "@/play/navigation/play-route";
 import { buildWorldProfile } from "@/runtime/world/profile-builder";
-import { setSqlApiBaseUrl } from "@/services/api";
-import { Chain, getGameManifest } from "@contracts";
+import { Chain } from "@contracts";
 import { dojoConfig } from "../../dojo-config";
 import { env, hasPublicNodeUrl } from "../../env";
 import { clearSubscriptionQueue } from "../dojo/debounced-queries";
@@ -39,12 +38,6 @@ export type SetupResult = Awaited<ReturnType<typeof setup>>;
 
 type BootstrapResult = SetupResult;
 const bootstrapSession = createBootstrapSession<BootstrapResult>();
-
-type MutableDojoConfig = typeof dojoConfig & {
-  toriiUrl?: string;
-  rpcUrl?: string;
-  manifest?: unknown;
-};
 
 /**
  * Get the cached setup result if bootstrap has already completed.
@@ -112,7 +105,10 @@ const runBootstrap = async (): Promise<BootstrapResult> => {
   console.log("[STARTING DOJO SETUP]");
   const stores = resolveBootstrapStores();
   const worldContext = await resolveBootstrapWorldContext();
-  configureDojoRuntime(worldContext);
+  configureSelectedWorldDojoRuntime({
+    chain: worldContext.chain,
+    profile: worldContext.profile,
+  });
   const setupResult = await runDojoSetup();
   await runInitialWorldSync(setupResult, stores);
   configureGameSystems(setupResult, worldContext.chain);
@@ -152,7 +148,6 @@ type BootstrapStores = {
 type BootstrapWorldContext = {
   chain: Chain;
   profile: WorldProfile;
-  toriiUrl: string;
 };
 
 const resolveBootstrapStores = (): BootstrapStores => ({
@@ -202,7 +197,6 @@ const resolveBootstrapWorldContext = async (): Promise<BootstrapWorldContext> =>
   return {
     chain,
     profile,
-    toriiUrl: resolveBootstrapToriiUrl(chain, profile),
   };
 };
 
@@ -293,32 +287,6 @@ const didWorldProfileRefreshChange = (previousProfile: WorldProfile, refreshedPr
     refreshedProfile.rpcUrl !== previousProfile.rpcUrl ||
     (previousProfile.chain !== undefined && refreshedProfile.chain !== previousProfile.chain)
   );
-};
-
-const configureDojoRuntime = ({ chain, profile, toriiUrl }: BootstrapWorldContext) => {
-  const mutableDojoConfig = dojoConfig as MutableDojoConfig;
-
-  mutableDojoConfig.toriiUrl = toriiUrl;
-  mutableDojoConfig.rpcUrl = resolveBootstrapRpcUrl(chain, profile);
-  mutableDojoConfig.manifest = patchManifestWithFactory(
-    getGameManifest(chain),
-    profile.worldAddress,
-    profile.contractsBySelector,
-  );
-
-  setSqlApiBaseUrl(`${toriiUrl}/sql`);
-};
-
-const resolveBootstrapToriiUrl = (chain: Chain, profile: WorldProfile): string => {
-  return chain === "local" ? env.VITE_PUBLIC_TORII : profile.toriiBaseUrl;
-};
-
-const resolveBootstrapRpcUrl = (chain: Chain, profile: WorldProfile): string => {
-  if (chain === "local") {
-    return env.VITE_PUBLIC_NODE_URL;
-  }
-
-  return profile.rpcUrl ?? env.VITE_PUBLIC_NODE_URL;
 };
 
 const runDojoSetup = async (): Promise<BootstrapResult> => {

--- a/client/apps/game/src/runtime/world/dojo-runtime-config.ts
+++ b/client/apps/game/src/runtime/world/dojo-runtime-config.ts
@@ -1,0 +1,41 @@
+import { setSqlApiBaseUrl } from "@/services/api";
+import type { Chain } from "@contracts";
+import { getGameManifest } from "@contracts";
+
+import { dojoConfig } from "../../../dojo-config";
+import { env } from "../../../env";
+import { patchManifestWithFactory } from "./manifest-patcher";
+import type { WorldProfile } from "./types";
+
+type MutableDojoConfig = typeof dojoConfig & {
+  toriiUrl?: string;
+  rpcUrl?: string;
+  manifest?: unknown;
+};
+
+export const configureSelectedWorldDojoRuntime = ({ chain, profile }: { chain: Chain; profile: WorldProfile }) => {
+  const mutableDojoConfig = dojoConfig as MutableDojoConfig;
+  const toriiUrl = resolveSelectedWorldToriiUrl({ chain, profile });
+
+  mutableDojoConfig.toriiUrl = toriiUrl;
+  mutableDojoConfig.rpcUrl = resolveSelectedWorldRpcUrl({ chain, profile });
+  mutableDojoConfig.manifest = patchManifestWithFactory(
+    getGameManifest(chain),
+    profile.worldAddress,
+    profile.contractsBySelector,
+  );
+
+  setSqlApiBaseUrl(`${toriiUrl}/sql`);
+};
+
+const resolveSelectedWorldToriiUrl = ({ chain, profile }: { chain: Chain; profile: WorldProfile }) => {
+  return chain === "local" ? env.VITE_PUBLIC_TORII : profile.toriiBaseUrl;
+};
+
+const resolveSelectedWorldRpcUrl = ({ chain, profile }: { chain: Chain; profile: WorldProfile }) => {
+  if (chain === "local") {
+    return env.VITE_PUBLIC_NODE_URL;
+  }
+
+  return profile.rpcUrl ?? env.VITE_PUBLIC_NODE_URL;
+};

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts
@@ -13,7 +13,8 @@ describe("Game entry modal auto-settle", () => {
     );
 
     expect(source).toContain("autoSettleEnabled?: boolean");
-    expect(source).toContain('if (!autoSettleEnabled || phase !== "settlement"');
+    expect(source).toContain("hasReachedBlitzAutoSettleStart");
+    expect(source).toContain("!hasReachedBlitzAutoSettleStart");
     expect(source).toContain("void handleSettle();");
     expect(source).toContain("markCompleted(autoSettleEntryKey)");
     expect(source).toContain("markFailed(autoSettleEntryKey");

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.forge-session.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.forge-session.source.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("game-entry-modal forge session source", () => {
+  it("prepares the selected world's controller session before forging", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/landing/components/game-entry-modal.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      'import { prepareControllerSessionForWorld } from "@/hooks/context/world-controller-session";',
+    );
+    expect(source).toContain("await prepareControllerSessionForWorld({");
+
+    const prepareIndex = source.indexOf("await prepareControllerSessionForWorld({");
+    const executeIndex = source.indexOf("await signer.execute(calls);");
+
+    expect(prepareIndex).toBeGreaterThan(-1);
+    expect(executeIndex).toBeGreaterThan(prepareIndex);
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -27,6 +27,7 @@ import { useNavigate } from "react-router-dom";
 
 import { ReactComponent as TreasureChest } from "@/assets/icons/treasure-chest.svg";
 import { refreshSessionPolicies } from "@/hooks/context/session-policy-refresh";
+import { prepareControllerSessionForWorld } from "@/hooks/context/world-controller-session";
 import type { BootstrapTask } from "@/hooks/context/use-eager-bootstrap";
 import { createAutoSettleEntryKey, useAutoSettleStore } from "@/hooks/store/use-auto-settle-store";
 import { useAccountStore } from "@/hooks/store/use-account-store";
@@ -3384,6 +3385,8 @@ export const GameEntryModal = ({
   const seasonHasStarted = seasonStartAt != null && seasonStartAt <= nowSeconds;
   const seasonNotEnded = worldMeta?.endAt == null || worldMeta.endAt === 0 || nowSeconds <= worldMeta.endAt;
   const seasonTimingValid = seasonHasStarted && seasonNotEnded;
+  const hasReachedBlitzAutoSettleStart =
+    !isBlitzMode || !autoSettleEnabled || (worldMeta?.startMainAt != null && nowSeconds >= worldMeta.startMainAt);
   const spiresSettledCount = worldMeta?.spiresSettledCount ?? null;
   const spiresMaxCount = worldMeta?.spiresMaxCount ?? null;
   const spiresSettled =
@@ -4962,13 +4965,19 @@ export const GameEntryModal = ({
   }, [autoSettleEnabled, autoSettleEntryKey, isOpen, markOpening]);
 
   useEffect(() => {
-    if (!autoSettleEnabled || phase !== "settlement" || isSettling || autoSettleAttemptedRef.current) {
+    if (
+      !autoSettleEnabled ||
+      !hasReachedBlitzAutoSettleStart ||
+      phase !== "settlement" ||
+      isSettling ||
+      autoSettleAttemptedRef.current
+    ) {
       return;
     }
 
     autoSettleAttemptedRef.current = true;
     void handleSettle();
-  }, [autoSettleEnabled, handleSettle, isSettling, phase]);
+  }, [autoSettleEnabled, handleSettle, hasReachedBlitzAutoSettleStart, isSettling, phase]);
 
   // Forge hyperstructures handler - creates new hyperstructures during registration period
   const handleForgeHyperstructures = useCallback(async () => {
@@ -4997,6 +5006,13 @@ export const GameEntryModal = ({
       const batchSize = chain === "mainnet" ? 1 : 4;
       const hyperstructureCount = numHyperstructuresLeft > 0 ? Math.min(numHyperstructuresLeft, batchSize) : batchSize;
       const signer = account as unknown as Account;
+      const connector = useAccountStore.getState().connector;
+
+      await prepareControllerSessionForWorld({
+        connector,
+        chain,
+        worldName,
+      });
 
       const { env } = await import("../../../../../env");
       const vrfProviderAddress = env.VITE_PUBLIC_VRF_PROVIDER_ADDRESS;
@@ -5114,12 +5130,24 @@ export const GameEntryModal = ({
   // Auto-enter game when ready (spectate mode or already settled players)
   useEffect(() => {
     debugLog(worldName, "Auto-enter check - phase:", phase, "isSpectateMode:", isSpectateMode);
+    if (autoSettleEnabled && !hasReachedBlitzAutoSettleStart) {
+      return;
+    }
     const shouldAutoEnter = phase === "ready" && (!isEternumMode || eternumEntryIntent === "play");
     if (shouldAutoEnter) {
       debugLog(worldName, "Auto-entering game...");
       handleEnterGame();
     }
-  }, [phase, handleEnterGame, worldName, isSpectateMode, isEternumMode, eternumEntryIntent]);
+  }, [
+    autoSettleEnabled,
+    eternumEntryIntent,
+    handleEnterGame,
+    hasReachedBlitzAutoSettleStart,
+    isEternumMode,
+    isSpectateMode,
+    phase,
+    worldName,
+  ]);
 
   debugLog(worldName, "Render - isOpen:", isOpen, "phase:", phase, "bootstrapStatus:", bootstrapStatus);
 

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
@@ -1,15 +1,39 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveAutoSettleRuntimeState, type AutoSettleRuntimeInput } from "./auto-settle-runtime";
+import {
+  resolveAutoSettleRuntimeState,
+  resolveAutoSettleTriggerAtSec,
+  type AutoSettleRuntimeInput,
+} from "./auto-settle-runtime";
 
 const createInput = (overrides: Partial<AutoSettleRuntimeInput> = {}): AutoSettleRuntimeInput => ({
   enabled: true,
   persistedStatus: "armed",
-  settleAtSec: 130,
+  triggerAtSec: 130,
   nowSec: 100,
   hasConnectedWallet: true,
   hasCompatibleNetwork: true,
   ...overrides,
+});
+
+describe("resolveAutoSettleTriggerAtSec", () => {
+  it("uses the main game start as the auto-open boundary when it is available", () => {
+    expect(
+      resolveAutoSettleTriggerAtSec({
+        startSettlingAt: 130,
+        startMainAt: 160,
+      }),
+    ).toBe(160);
+  });
+
+  it("falls back to settlement start when main start is unavailable", () => {
+    expect(
+      resolveAutoSettleTriggerAtSec({
+        startSettlingAt: 130,
+        startMainAt: null,
+      }),
+    ).toBe(130);
+  });
 });
 
 describe("resolveAutoSettleRuntimeState", () => {
@@ -49,7 +73,7 @@ describe("resolveAutoSettleRuntimeState", () => {
     });
   });
 
-  it("opens the entry route exactly when the countdown reaches settlement time", () => {
+  it("opens the entry route exactly when the main game start is reached", () => {
     expect(resolveAutoSettleRuntimeState(createInput({ nowSec: 130 }))).toMatchObject({
       phase: "opening",
       shouldOpenEntry: true,

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
@@ -14,7 +14,7 @@ type AutoSettleRuntimePhase =
 export interface AutoSettleRuntimeInput {
   enabled: boolean;
   persistedStatus: AutoSettleStatus;
-  settleAtSec: number;
+  triggerAtSec: number;
   nowSec: number;
   hasConnectedWallet: boolean;
   hasCompatibleNetwork: boolean;
@@ -30,10 +30,18 @@ interface AutoSettleRuntimeState {
 const PREWARM_WINDOW_SECONDS = 30;
 const REFRESH_WINDOW_SECONDS = 5;
 
+export const resolveAutoSettleTriggerAtSec = ({
+  startSettlingAt,
+  startMainAt,
+}: {
+  startSettlingAt: number | null;
+  startMainAt: number | null;
+}): number | null => startMainAt ?? startSettlingAt;
+
 export const resolveAutoSettleRuntimeState = ({
   enabled,
   persistedStatus,
-  settleAtSec,
+  triggerAtSec,
   nowSec,
   hasConnectedWallet,
   hasCompatibleNetwork,
@@ -83,9 +91,9 @@ export const resolveAutoSettleRuntimeState = ({
     };
   }
 
-  const isDue = nowSec >= settleAtSec;
-  const inPrewarmWindow = nowSec >= settleAtSec - PREWARM_WINDOW_SECONDS;
-  const inRefreshWindow = nowSec >= settleAtSec - REFRESH_WINDOW_SECONDS;
+  const isDue = nowSec >= triggerAtSec;
+  const inPrewarmWindow = nowSec >= triggerAtSec - PREWARM_WINDOW_SECONDS;
+  const inRefreshWindow = nowSec >= triggerAtSec - REFRESH_WINDOW_SECONDS;
 
   if (!hasConnectedWallet) {
     return {
@@ -147,11 +155,11 @@ const formatCountdown = (secondsLeft: number): string => {
 export const describeAutoSettleRuntimePhase = ({
   phase,
   nowSec,
-  settleAtSec,
+  triggerAtSec,
 }: {
   phase: AutoSettleRuntimePhase;
   nowSec: number;
-  settleAtSec: number;
+  triggerAtSec: number;
 }) => {
   switch (phase) {
     case "off":
@@ -162,12 +170,12 @@ export const describeAutoSettleRuntimePhase = ({
     case "armed":
       return {
         title: "Auto-settle on",
-        detail: `Settles in ${formatCountdown(settleAtSec - nowSec)}`,
+        detail: `Starts in ${formatCountdown(triggerAtSec - nowSec)}`,
       };
     case "prewarming":
       return {
         title: "Prewarming entry",
-        detail: `Settles in ${formatCountdown(settleAtSec - nowSec)}`,
+        detail: `Starts in ${formatCountdown(triggerAtSec - nowSec)}`,
       };
     case "paused-wallet":
       return {

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.auto-settle.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.auto-settle.source.test.ts
@@ -12,6 +12,7 @@ describe("Game card auto-settle wiring", () => {
 
     expect(source).toContain("useAutoSettleStore");
     expect(source).toContain("resolveAutoSettleRuntimeState");
+    expect(source).toContain("resolveAutoSettleTriggerAtSec");
     expect(source).toContain("Auto-settle");
     expect(source).toContain("setEnabled(autoSettleEntryKey, true");
     expect(source).toContain("markOpening(autoSettleEntryKey");

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -33,7 +33,11 @@ import { CheckCircle2, Eye, Loader2, Play, RefreshCw, Sparkles, Trophy, UserPlus
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { primePlayEntryAssets, primePlayEntryRoute } from "@/game-entry-preload";
-import { describeAutoSettleRuntimePhase, resolveAutoSettleRuntimeState } from "./auto-settle-runtime";
+import {
+  describeAutoSettleRuntimePhase,
+  resolveAutoSettleRuntimeState,
+  resolveAutoSettleTriggerAtSec,
+} from "./auto-settle-runtime";
 import {
   createPendingNetworkAction,
   resolvePendingNetworkSwitchOutcome,
@@ -377,13 +381,16 @@ const GameCard = ({
   const upsertAutoSettleEntry = useAutoSettleStore((state) => state.upsertEntry);
   const setEnabled = useAutoSettleStore((state) => state.setEnabled);
   const showRegistered = game.isRegistered || registrationStage === "done";
-  const startSettlingAt = game.config?.startSettlingAt ?? null;
+  const autoSettleTriggerAt = resolveAutoSettleTriggerAtSec({
+    startSettlingAt: game.config?.startSettlingAt ?? null,
+    startMainAt: game.startMainAt,
+  });
   const canShowAutoSettleControl =
-    isBlitzMode && showRegistered && playerAddress !== null && startSettlingAt !== null && !isEnded;
+    isBlitzMode && showRegistered && playerAddress !== null && autoSettleTriggerAt !== null && !isEnded;
   const autoSettleRuntimeState = resolveAutoSettleRuntimeState({
     enabled: autoSettleEntry?.enabled ?? false,
     persistedStatus: autoSettleEntry?.status ?? "idle",
-    settleAtSec: startSettlingAt ?? 0,
+    triggerAtSec: autoSettleTriggerAt ?? 0,
     nowSec,
     hasConnectedWallet,
     hasCompatibleNetwork: canInteractOnChain(game.chain),
@@ -392,7 +399,7 @@ const GameCard = ({
     ? describeAutoSettleRuntimePhase({
         phase: autoSettleRuntimeState.phase,
         nowSec,
-        settleAtSec: startSettlingAt ?? 0,
+        triggerAtSec: autoSettleTriggerAt ?? 0,
       })
     : null;
   const autoSettleToggleDisabled =
@@ -468,7 +475,7 @@ const GameCard = ({
   );
 
   const handleAutoSettleToggle = useCallback(() => {
-    if (!autoSettleEntryKey || !startSettlingAt || !playerAddress) return;
+    if (!autoSettleEntryKey || !autoSettleTriggerAt || !playerAddress) return;
 
     if (!autoSettleEntry) {
       upsertAutoSettleEntry(autoSettleEntryKey, {
@@ -477,7 +484,7 @@ const GameCard = ({
         chain: game.chain,
         worldName: game.name,
         worldKey: game.worldKey,
-        settleAtSec: startSettlingAt,
+        triggerAtSec: autoSettleTriggerAt,
         armedAtMs: Date.now(),
         status: "armed",
         lastError: null,
@@ -495,7 +502,7 @@ const GameCard = ({
     game.worldKey,
     playerAddress,
     setEnabled,
-    startSettlingAt,
+    autoSettleTriggerAt,
     upsertAutoSettleEntry,
   ]);
 
@@ -511,14 +518,14 @@ const GameCard = ({
 
     if (autoSettleEntryKey && autoSettleEntry) {
       setEnabled(autoSettleEntryKey, true);
-    } else if (autoSettleEntryKey && startSettlingAt) {
+    } else if (autoSettleEntryKey && autoSettleTriggerAt) {
       upsertAutoSettleEntry(autoSettleEntryKey, {
         enabled: true,
         walletAddress: playerAddress!,
         chain: game.chain,
         worldName: game.name,
         worldKey: game.worldKey,
-        settleAtSec: startSettlingAt,
+        triggerAtSec: autoSettleTriggerAt,
         armedAtMs: Date.now(),
         status: "armed",
         lastError: null,
@@ -540,7 +547,7 @@ const GameCard = ({
     playerAddress,
     registrationStage,
     setEnabled,
-    startSettlingAt,
+    autoSettleTriggerAt,
     upsertAutoSettleEntry,
   ]);
 
@@ -1385,8 +1392,11 @@ export const UnifiedGameGrid = ({
     resolvedGames.forEach((game) => {
       if (game.config?.mode !== "blitz" || game.isRegistered !== true) return;
 
-      const settleAtSec = game.config?.startSettlingAt;
-      if (!settleAtSec) return;
+      const triggerAtSec = resolveAutoSettleTriggerAtSec({
+        startSettlingAt: game.config?.startSettlingAt ?? null,
+        startMainAt: game.startMainAt,
+      });
+      if (!triggerAtSec) return;
 
       const autoSettleEntryKey = createAutoSettleEntryKey({
         chain: game.chain,
@@ -1399,7 +1409,7 @@ export const UnifiedGameGrid = ({
       const runtimeState = resolveAutoSettleRuntimeState({
         enabled: autoSettleEntry.enabled,
         persistedStatus: autoSettleEntry.status,
-        settleAtSec,
+        triggerAtSec,
         nowSec,
         hasConnectedWallet: landingNetworkState.hasConnectedWallet,
         hasCompatibleNetwork: canInteractWithLandingChain(

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,30 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-12",
+    title: "First Entry Handoff Fix",
+    description:
+      "First-time game entry now clears the world handoff overlay as soon as the world map is ready and idle, so the loading screen no longer waits forever after missing an early map-loading pulse.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-12",
+    title: "Forge Session Preflight",
+    description:
+      "Forging Blitz hyperstructures now prepares the correct Cartridge session for the selected world before sending the transaction, so first-click forging opens session approval instead of stalling on a timeout.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-12",
+    title: "Auto-Settle Start Guard",
+    description:
+      "Blitz auto-settle now waits for the actual game start before opening the entry flow, so registering on a dashboard card no longer drops you into onboarding before the match is ready.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-12",
     title: "Expanded Play Music Loop",
     description:
       "The in-game music rotation now includes Monophonic Mixtape 14, giving standard matches and Blitz one more track in the active background loop.",

--- a/client/apps/game/src/ui/layouts/game-loading-overlay.test.tsx
+++ b/client/apps/game/src/ui/layouts/game-loading-overlay.test.tsx
@@ -2,6 +2,8 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { LoadingStateKey } from "@/hooks/store/use-world-loading";
+
 const navigateMock = vi.fn();
 const setShowBlankOverlayMock = vi.fn();
 const setStructureEntityIdMock = vi.fn();
@@ -60,6 +62,7 @@ describe("GameLoadingOverlay", () => {
 
   beforeEach(() => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -78,6 +81,7 @@ describe("GameLoadingOverlay", () => {
       root.unmount();
     });
     container.remove();
+    vi.useRealTimers();
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
   });
 
@@ -129,5 +133,34 @@ describe("GameLoadingOverlay", () => {
     });
 
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("dismisses once the world map scene is ready even if the overlay missed the initial loading edge", async () => {
+    useLocationMock.mockReturnValue({
+      pathname: "/play/sepolia/aurora-blitz/map",
+      search: "?col=12&row=34",
+      hash: "",
+      state: null,
+      key: "test",
+    });
+    uiStoreState.loadingStates = { [LoadingStateKey.Map]: false };
+    usePlayerStructuresMock.mockReturnValue([
+      {
+        entityId: 77,
+        position: { x: 4, y: 9 },
+      },
+    ]);
+
+    await act(async () => {
+      root.render(<GameLoadingOverlay />);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("worldmap:scene-ready"));
+      await Promise.resolve();
+      vi.runAllTimers();
+    });
+
+    expect(setShowBlankOverlayMock).toHaveBeenCalledWith(false);
   });
 });

--- a/client/apps/game/src/ui/layouts/game-loading-overlay.tsx
+++ b/client/apps/game/src/ui/layouts/game-loading-overlay.tsx
@@ -198,7 +198,7 @@ export const GameLoadingOverlay = () => {
       }
       setDidSafetyTimeout(false);
 
-      if (hasSeenMapLoading.current && !mapLoading) {
+      if (!mapLoading) {
         markWorldMapReady(0);
       }
     })();
@@ -226,7 +226,7 @@ export const GameLoadingOverlay = () => {
       hasSeenMapLoading.current = true;
     }
 
-    if (hasSeenMapLoading.current && !mapLoading && hasSeenWorldmapReady.current) {
+    if (hasSeenWorldmapReady.current && !mapLoading) {
       markGameEntryMilestone("worldmap-fetch-completed");
       markWorldMapReady(0);
     }


### PR DESCRIPTION
This hardens the game entry path in three places: it aligns Blitz auto-settle with the actual game start, prepares the selected world's controller session before forge transactions, and fixes the first-entry world handoff overlay so it no longer sticks after missing an early map-loading pulse.
It also pulls the selected-world Dojo runtime configuration into a dedicated helper and adds source/tests around the new entry-session and loading behavior.
Verification: `pnpm run format`, `pnpm run knip`.
The targeted Vitest overlay regression is included in the branch, but local execution is still blocked here by a jsdom `ERR_REQUIRE_ESM` environment issue before tests are collected.
