### PR TITLE
fix: recover armies after stale tile removals

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.moving-bounds-refresh.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.moving-bounds-refresh.test.ts
@@ -9,7 +9,7 @@ function readSource(relativePath: string): string {
 }
 
 describe("ArmyManager moving-bounds refresh", () => {
-  it("update calls refreshMovingArmyBoundsIfNeeded after batched visible-army updates", () => {
+  it("update calls syncArmyBoundsForMovementState after batched visible-army updates", () => {
     const source = readSource("./army-manager.ts");
 
     const methodStart = source.indexOf("update(deltaTime: number, animationContext?: AnimationVisibilityContext)");
@@ -17,7 +17,7 @@ describe("ArmyManager moving-bounds refresh", () => {
 
     const methodBody = source.slice(methodStart, methodStart + 1200);
     const batchedUpdatePos = methodBody.indexOf("this.updateVisibleArmiesBatched()");
-    const refreshPos = methodBody.indexOf("this.refreshMovingArmyBoundsIfNeeded()");
+    const refreshPos = methodBody.indexOf("this.syncArmyBoundsForMovementState()");
 
     expect(batchedUpdatePos).toBeGreaterThan(-1);
     expect(refreshPos).toBeGreaterThan(-1);
@@ -31,6 +31,32 @@ describe("ArmyManager moving-bounds refresh", () => {
     expect(methodStart).toBeGreaterThan(-1);
 
     const methodBody = source.slice(methodStart, methodStart + 800);
+    expect(methodBody).toContain("this.armyModel.requestBoundsUpdate()");
+    expect(methodBody).toContain("this.armyModel.applyPendingBounds()");
+    expect(methodBody).toContain("this.playerIndicatorManager.computeBoundingSphere()");
+  });
+
+  it("syncArmyBoundsForMovementState performs one final bounds refresh when movement settles", () => {
+    const source = readSource("./army-manager.ts");
+
+    const methodStart = source.indexOf("private syncArmyBoundsForMovementState()");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const methodBody = source.slice(methodStart, methodStart + 900);
+    expect(methodBody).toContain("const hasMovingArmies = this.hasMovingArmies()");
+    expect(methodBody).toContain("this.refreshMovingArmyBoundsIfNeeded()");
+    expect(methodBody).toContain("if (this.hadMovingArmiesLastFrame)");
+    expect(methodBody).toContain("this.refreshSettledArmyBounds()");
+  });
+
+  it("refreshSettledArmyBounds resets moving-bounds cadence and recomputes bounds", () => {
+    const source = readSource("./army-manager.ts");
+
+    const methodStart = source.indexOf("private refreshSettledArmyBounds()");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const methodBody = source.slice(methodStart, methodStart + 500);
+    expect(methodBody).toContain("this.lastMovingBoundsRefreshAt = Number.NEGATIVE_INFINITY");
     expect(methodBody).toContain("this.armyModel.requestBoundsUpdate()");
     expect(methodBody).toContain("this.armyModel.applyPendingBounds()");
     expect(methodBody).toContain("this.playerIndicatorManager.computeBoundingSphere()");

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -182,6 +182,7 @@ export class ArmyManager {
   // Keep moving-army culling bounds fresh without paying a full recompute every frame.
   private lastMovingBoundsRefreshAt = Number.NEGATIVE_INFINITY;
   private readonly movingBoundsRefreshIntervalMs = 1000 / 20;
+  private hadMovingArmiesLastFrame = false;
   private unsubscribeFrustum?: () => void;
   private visibilityManager?: CentralizedVisibilityManager;
   private unsubscribeVisibility?: () => void;
@@ -2121,6 +2122,10 @@ export class ArmyManager {
     return this.armyModel.hasMovingInstances();
   }
 
+  public isArmyMoving(entityId: ID): boolean {
+    return this.armyModel.isEntityMoving(this.toNumericId(entityId));
+  }
+
   private runMovementStartListeners(entityId: number): void {
     const listeners = this.movementStartListeners.get(entityId);
     if (!listeners || listeners.size === 0) {
@@ -2176,7 +2181,7 @@ export class ArmyManager {
     // Batch update: single pass over visible armies for all per-frame operations
     // This consolidates point icons, attachment transforms, and indicators
     this.updateVisibleArmiesBatched();
-    this.refreshMovingArmyBoundsIfNeeded();
+    this.syncArmyBoundsForMovementState();
 
     if (this.frustumVisibilityDirty) {
       const now = performance.now();
@@ -2189,6 +2194,22 @@ export class ArmyManager {
 
     // Flush batched label pool operations to minimize layout thrashing
     this.labelPool.flushBatch();
+  }
+
+  private syncArmyBoundsForMovementState() {
+    const hasMovingArmies = this.hasMovingArmies();
+
+    if (hasMovingArmies) {
+      this.refreshMovingArmyBoundsIfNeeded();
+      this.hadMovingArmiesLastFrame = true;
+      return;
+    }
+
+    if (this.hadMovingArmiesLastFrame) {
+      this.refreshSettledArmyBounds();
+    }
+
+    this.hadMovingArmiesLastFrame = false;
   }
 
   private refreshMovingArmyBoundsIfNeeded() {
@@ -2205,6 +2226,15 @@ export class ArmyManager {
     this.armyModel.requestBoundsUpdate();
     this.armyModel.applyPendingBounds();
     this.playerIndicatorManager.computeBoundingSphere();
+    this.frustumVisibilityDirty = true;
+  }
+
+  private refreshSettledArmyBounds() {
+    this.lastMovingBoundsRefreshAt = Number.NEGATIVE_INFINITY;
+    this.armyModel.requestBoundsUpdate();
+    this.armyModel.applyPendingBounds();
+    this.playerIndicatorManager.computeBoundingSphere();
+    this.frustumVisibilityDirty = true;
   }
 
   /**

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.test.ts
@@ -24,17 +24,17 @@ describe("arrival-ghost-policy", () => {
     ).toBe(false);
   });
 
-  it("keeps the source army visible for pending tile removals", () => {
+  it("keeps the source army visible while movement is still in flight", () => {
     expect(
       shouldHideSourceArmyOnTileRemoval({
-        hasPendingMovement: true,
+        hasMovementInFlight: true,
         reason: "tile",
       }),
     ).toBe(false);
 
     expect(
       shouldHideSourceArmyOnTileRemoval({
-        hasPendingMovement: false,
+        hasMovementInFlight: false,
         reason: "tile",
       }),
     ).toBe(true);

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.ts
@@ -24,10 +24,10 @@ export function shouldCreatePredictiveArrivalGhost(input: {
 }
 
 export function shouldHideSourceArmyOnTileRemoval(input: {
-  hasPendingMovement: boolean;
+  hasMovementInFlight: boolean;
   reason: "tile" | "zero";
 }): boolean {
-  return input.reason !== "tile" || !input.hasPendingMovement;
+  return input.reason !== "tile" || !input.hasMovementInFlight;
 }
 
 export function resolveArrivalGhostVisualStyle(input: { armyColor: string }): ArrivalGhostVisualStyle {

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.test.ts
@@ -1,5 +1,45 @@
 import { describe, expect, it } from "vitest";
-import { findSupersededArmyRemoval } from "./worldmap-army-removal";
+import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
+
+describe("isStaleTrackedArmyTileRemoval", () => {
+  it("treats a tile removal as stale when the tracked army already moved elsewhere", () => {
+    expect(
+      isStaleTrackedArmyTileRemoval({
+        reason: "tile",
+        trackedPosition: { col: 12, row: 15 },
+        removalPosition: { col: 10, row: 10 },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps matching tracked tile removals eligible for normal processing", () => {
+    expect(
+      isStaleTrackedArmyTileRemoval({
+        reason: "tile",
+        trackedPosition: { col: 10, row: 10 },
+        removalPosition: { col: 10, row: 10 },
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores non-tile removals and missing positions", () => {
+    expect(
+      isStaleTrackedArmyTileRemoval({
+        reason: "zero",
+        trackedPosition: { col: 10, row: 10 },
+        removalPosition: { col: 12, row: 15 },
+      }),
+    ).toBe(false);
+
+    expect(
+      isStaleTrackedArmyTileRemoval({
+        reason: "tile",
+        trackedPosition: undefined,
+        removalPosition: { col: 10, row: 10 },
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("findSupersededArmyRemoval", () => {
   it("returns undefined when incoming owner is missing", () => {

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.ts
@@ -3,6 +3,12 @@ interface ArmyHexPosition {
   row: number;
 }
 
+interface StaleTrackedArmyTileRemovalInput {
+  reason: "tile" | "zero";
+  trackedPosition?: ArmyHexPosition;
+  removalPosition?: ArmyHexPosition;
+}
+
 interface PendingArmyRemovalCandidate<TArmyId> {
   entityId: TArmyId;
   scheduledAt: number;
@@ -33,6 +39,16 @@ function hasUsableStructureId(structureId: unknown): boolean {
 
 function isExactPosition(a: ArmyHexPosition, b: ArmyHexPosition): boolean {
   return a.col === b.col && a.row === b.row;
+}
+
+export function isStaleTrackedArmyTileRemoval(input: StaleTrackedArmyTileRemovalInput): boolean {
+  const { reason, trackedPosition, removalPosition } = input;
+
+  if (reason !== "tile" || !trackedPosition || !removalPosition) {
+    return false;
+  }
+
+  return !isExactPosition(trackedPosition, removalPosition);
 }
 
 /**

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.visual-hide.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.visual-hide.test.ts
@@ -9,19 +9,36 @@ function readSource(relativePath: string): string {
 }
 
 describe("Stage 5: removal visual hide", () => {
-  it("scheduleArmyRemoval only hides armies immediately when no pending move is keeping the source visual alive", () => {
+  it("scheduleArmyRemoval keeps source visuals alive while movement is still in flight", () => {
     const src = readSource("worldmap.tsx");
 
     // Find the method definition (private scheduleArmyRemoval)
     const methodStart = src.indexOf("private scheduleArmyRemoval(");
     expect(methodStart).toBeGreaterThan(-1);
 
-    const methodBody = src.slice(methodStart, methodStart + 2000);
+    const methodBody = src.slice(methodStart, methodStart + 2600);
 
     expect(methodBody).toContain(
       'const hasPendingMovement = reason === "tile" && this.pendingArmyMovements.has(entityId);',
     );
-    expect(methodBody).toContain("if (!hasPendingMovement) {");
+    expect(methodBody).toContain("this.armyManager.isArmyMoving(entityId)");
+    expect(methodBody).toContain("hasMovementInFlight");
+    expect(methodBody).toContain("shouldHideSourceArmyOnTileRemoval({");
+    expect(methodBody).toContain("hasMovementInFlight");
+    expect(methodBody).not.toContain("if (!hasPendingMovement) {");
+    expect(methodBody).toContain("this.armyManager.hideArmyVisual(entityId);");
+  });
+
+  it("scheduleArmyRemoval ignores stale tile removals after the tracked army already moved", () => {
+    const src = readSource("worldmap.tsx");
+
+    const methodStart = src.indexOf("private scheduleArmyRemoval(");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const methodBody = src.slice(methodStart, methodStart + 2600);
+    expect(methodBody).toContain("isStaleTrackedArmyTileRemoval({");
+    expect(methodBody).toContain("this.armyManager.unsuppressArmy(entityId)");
+    expect(methodBody).toContain("restoreArmyVisualIfVisible(entityId)");
     expect(methodBody).toContain("this.armyManager.hideArmyVisual(entityId);");
   });
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -194,7 +194,7 @@ import {
   type PendingArmyMovementEffectClearReason,
   type TravelEffectType,
 } from "./worldmap-travel-effect-policy";
-import { findSupersededArmyRemoval } from "./worldmap-army-removal";
+import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
 import { resolveOwnershipPulseHexes } from "./worldmap-ownership-pulse-policy";
@@ -3668,19 +3668,35 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     const hasPendingMovement = reason === "tile" && this.pendingArmyMovements.has(entityId);
+    const hasMovementInFlight = reason === "tile" && (hasPendingMovement || this.armyManager.isArmyMoving(entityId));
     // Tile removals wait longer (1500ms) to ensure movement updates arrive
     // Zero troop removals are immediate (0ms) since they're confirmed deaths
     const baseDelay = reason === "tile" ? 1500 : 0;
-    const initialDelay = hasPendingMovement ? 3000 : baseDelay;
+    const initialDelay = hasMovementInFlight ? 3000 : baseDelay;
     const retryDelay = 500;
     const maxPendingWaitMs = 10000;
 
     const scheduledAt = Date.now();
     const removalPosition = context?.position ?? this.armiesPositions.get(entityId);
+    const trackedPosition = this.armiesPositions.get(entityId);
     const removalOwnerAddress =
       context?.ownerAddress ??
       (removalPosition ? this.armyHexes.get(removalPosition.col)?.get(removalPosition.row)?.owner : undefined);
     const removalOwnerStructureId = context?.ownerStructureId ?? this.armyStructureOwners.get(entityId);
+
+    if (
+      isStaleTrackedArmyTileRemoval({
+        reason,
+        trackedPosition,
+        removalPosition,
+      })
+    ) {
+      this.pendingArmyRemovalMeta.delete(entityId);
+      this.armyManager.unsuppressArmy(entityId);
+      void this.armyManager.restoreArmyVisualIfVisible(entityId);
+      return;
+    }
+
     this.pendingArmyRemovalMeta.set(entityId, {
       scheduledAt,
       chunkKey: this.currentChunk,
@@ -3690,12 +3706,13 @@ export default class WorldmapScene extends WarpTravel {
       position: removalPosition,
     });
 
-    // Preserve the source visual while a move is still pending. Torii can emit
-    // the old-tile removal before the destination tile update, and hiding here
-    // creates a dead zone where the army vanishes until the add catches up.
+    // Preserve the source visual while the move is still pending or actively
+    // rendering. Torii can emit the old-tile removal before or during the
+    // destination handoff, and hiding here creates a dead zone where the army
+    // vanishes until the add catches up.
     if (
       shouldHideSourceArmyOnTileRemoval({
-        hasPendingMovement,
+        hasMovementInFlight,
         reason,
       })
     ) {
@@ -3725,7 +3742,7 @@ export default class WorldmapScene extends WarpTravel {
             return;
           }
 
-          if (this.pendingArmyMovements.has(entityId)) {
+          if (this.pendingArmyMovements.has(entityId) || this.armyManager.isArmyMoving(entityId)) {
             const elapsed = Date.now() - meta.scheduledAt;
             if (elapsed < maxPendingWaitMs) {
               schedule(retryDelay);

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-13",
+    title: "Settled Army Render Recovery",
+    description:
+      "Armies now refresh their world-map render bounds when movement fully settles, so multi-army moves no longer disappear at the destination until a chunk refresh happens.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-12",
     title: "Cleaner Game Entry Handoff",
     description:


### PR DESCRIPTION
This fixes intermittent world-map troop ghosting after multi-army moves by treating stale old-tile removals as stale once the tracked army has already moved, and by keeping source visuals alive while movement is still rendering.

It also adds a final army-bounds refresh when movement settles so landed units stay renderable without waiting for a chunk refresh.

The diff includes regression coverage for the stale-removal path, movement-in-flight hide policy, and settled-bounds refresh, plus the latest-features entry for the fix.

Verification: targeted vitest for arrival ghost policy, army-manager movement bounds, worldmap army removal, worldmap pending movement handoff, and army suppression; `pnpm run format`; `pnpm run knip`.