### PR TITLE
Fix direct worldmap reload chunk refresh

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap-route-owned-refresh.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-route-owned-refresh.source.test.ts
@@ -8,14 +8,17 @@ import { describe, expect, it } from "vitest";
 const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
 
 describe("Worldmap route-owned refresh", () => {
-  it("reasserts canonical map routes after the blank overlay dismisses", () => {
+  it("reasserts canonical map routes with an immediate chunk reconciliation after the blank overlay dismisses", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
 
     expect(source).toContain("private bindRouteOwnedRefreshLifecycle(): void {");
+    expect(source).toContain("private refreshRouteOwnedChunkState(): void {");
     expect(source).toContain("(state) => state.showBlankOverlay");
     expect(source).toContain("const playRoute = parsePlayRoute(window.location);");
     expect(source).toContain('if (playRoute?.scene !== "map" || playRoute.col === null || playRoute.row === null) {');
     expect(source).toContain("this.moveCameraToURLLocation();");
-    expect(source).toContain('this.requestChunkRefresh(true, "default");');
+    expect(source).toContain("this.refreshRouteOwnedChunkState();");
+    expect(source).toContain('void this.updateVisibleChunks(true, { reason: "default" }).catch((error) => {');
+    expect(source).toContain('console.error("[WorldMap] Route-owned refresh failed:", error);');
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -8041,10 +8041,16 @@ export default class WorldmapScene extends WarpTravel {
           }
 
           this.moveCameraToURLLocation();
-          this.requestChunkRefresh(true, "default");
+          this.refreshRouteOwnedChunkState();
         },
       ),
     );
+  }
+
+  private refreshRouteOwnedChunkState(): void {
+    void this.updateVisibleChunks(true, { reason: "default" }).catch((error) => {
+      console.error("[WorldMap] Route-owned refresh failed:", error);
+    });
   }
 
   private disposeStoreSubscriptions() {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-13",
+    title: "Stable Reload Chunk Refresh",
+    description:
+      "Direct world-map reloads now force their route-owned chunk refresh immediately after the entry overlay clears, so crossing into nearby map chunks no longer drops terrain out from under the camera.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-13",
     title: "Settled Army Render Recovery",
     description:
       "Armies now refresh their world-map render bounds when movement fully settles, so multi-army moves no longer disappear at the destination until a chunk refresh happens.",


### PR DESCRIPTION
This forces the route-owned worldmap refresh to reconcile chunks immediately after the entry overlay clears. The goal is to keep direct `/play/.../map` reloads from carrying stale chunk state that can blank terrain when you cross into nearby chunks, while leaving the existing dashboard path unchanged. It also tightens the source regression for the route-owned refresh path and documents the fix in the latest-features feed. Verification is currently limited to source-level checks and `git diff --check` because `pnpm run format`, `pnpm run knip`, and `pnpm install --frozen-lockfile` are blocked by missing installs plus a duplicate-workspace-name conflict between `contracts/season_pass/ext/scripts/deployment` and `contracts/season_resources/ext/scripts/deployment`.