### PR TITLE
fix(game): force settle before blitz auto-entry

### DIFF
--- a/client/apps/game/src/hooks/use-world-registration.ts
+++ b/client/apps/game/src/hooks/use-world-registration.ts
@@ -7,6 +7,7 @@ import { getFactorySqlBaseUrl } from "@/runtime/world";
 import { resolveWorldContracts } from "@/runtime/world/factory-resolver";
 import { normalizeSelector } from "@/runtime/world/normalize";
 import { getRpcUrlForChain } from "@/ui/features/admin/constants";
+import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
 import { ENTRY_TOKEN_LOCK_ID } from "@bibliothecadao/eternum";
 import type { Chain } from "@contracts";
 import { useAccount } from "@starknet-react/core";
@@ -159,6 +160,31 @@ const fetchAvailableEntryTokenId = async (
     console.error("Failed to fetch entry token:", error);
     return null;
   }
+};
+
+const waitForSubmittedRegistrationTransaction = async ({
+  result,
+  chain,
+  label,
+  account,
+}: {
+  result: unknown;
+  chain: Chain;
+  label: string;
+  account: Account;
+}) => {
+  const txHash = extractTransactionHash(result);
+  if (!txHash) {
+    throw new Error(`Missing transaction hash for ${label}`);
+  }
+
+  const provider = new RpcProvider({ nodeUrl: getRpcUrlForChain(chain) });
+  await waitForTransactionConfirmation({
+    txHash,
+    account: account as unknown as { waitForTransaction?: (txHash: string) => Promise<unknown> },
+    label,
+    provider: provider as unknown as { waitForTransactionWithCheck?: (txHash: string) => Promise<unknown> },
+  });
 };
 
 export const useWorldRegistration = ({
@@ -419,10 +445,16 @@ export const useWorldRegistration = ({
           const point = params?.point ?? 0;
 
           setRegistrationStage("registering");
-          await starknetAccount.execute({
+          const createResult = await starknetAccount.execute({
             contractAddress: realmSystemsAddress,
             entrypoint: "create",
             calldata: CallData.compile([owner, realmId, frontend, side, layer, point]),
+          });
+          await waitForSubmittedRegistrationTransaction({
+            result: createResult,
+            chain,
+            label: "realm_systems.create",
+            account: starknetAccount,
           });
           setRegistrationStage("done");
           return;
@@ -484,12 +516,24 @@ export const useWorldRegistration = ({
           // Step 3: Register with token
           setRegistrationStage("registering");
           const registerCalls = buildRegisterCalls(blitzSystemsAddress, tokenId);
-          await starknetAccount.execute(registerCalls);
+          const registerResult = await starknetAccount.execute(registerCalls);
+          await waitForSubmittedRegistrationTransaction({
+            result: registerResult,
+            chain,
+            label: "blitz_realm_systems.register",
+            account: starknetAccount,
+          });
         } else {
           // No entry token required - direct registration
           setRegistrationStage("registering");
           const registerCalls = buildRegisterCalls(blitzSystemsAddress, 0n);
-          await starknetAccount.execute(registerCalls);
+          const registerResult = await starknetAccount.execute(registerCalls);
+          await waitForSubmittedRegistrationTransaction({
+            result: registerResult,
+            chain,
+            label: "blitz_realm_systems.register",
+            account: starknetAccount,
+          });
         }
 
         setRegistrationStage("done");

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -53,6 +53,7 @@ import { Coord, Direction, DirectionName, ResourcesIds, StructureType } from "@b
 import { getGameManifest, getSeasonAddresses, type Chain } from "@contracts";
 import { Account, Call, CallData, RpcProvider, uint256 } from "starknet";
 import {
+  applyAutoSettleRegistrationHint,
   buildSettlementExecutionPlan,
   deriveSettlementStatus,
   type SettlementSnapshot,
@@ -2949,6 +2950,9 @@ export const GameEntryModal = ({
       walletAddress: account.address,
     });
   }, [account?.address, chain, worldName]);
+  const autoSettleEntry = useAutoSettleStore((state) =>
+    autoSettleEntryKey ? state.entries[autoSettleEntryKey] : undefined,
+  );
   const playerFeltAddress = useMemo(() => {
     if (!account?.address) return null;
     try {
@@ -3772,14 +3776,19 @@ export const GameEntryModal = ({
     const playerRegister = registerRows[0] ?? null;
     const settleFinish = settleFinishRows[0] ?? null;
 
-    return {
-      registered: playerRegister?.registered === true,
-      onceRegistered: playerRegister?.once_registered === true,
-      hasSettledStructure: playerStructures.length > 0,
-      coordsCount: parseSpanLength(settleFinish?.coords),
-      settledCount: parseSpanLength(settleFinish?.structure_ids),
-    };
-  }, [account, selectedWorldSqlApi, selectedWorldSqlBaseUrl]);
+    return applyAutoSettleRegistrationHint({
+      snapshot: {
+        registered: playerRegister?.registered === true,
+        onceRegistered: playerRegister?.once_registered === true,
+        hasSettledStructure: playerStructures.length > 0,
+        coordsCount: parseSpanLength(settleFinish?.coords),
+        settledCount: parseSpanLength(settleFinish?.structure_ids),
+      },
+      autoSettleEnabled,
+      entryIntent: eternumEntryIntent,
+      hasAutoSettleEntry: autoSettleEntry != null,
+    });
+  }, [account, autoSettleEnabled, autoSettleEntry, eternumEntryIntent, selectedWorldSqlApi, selectedWorldSqlBaseUrl]);
 
   const syncSettlementStateFromSnapshot = useCallback(
     (snapshot: SettlementSnapshot) => {

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyAutoSettleRegistrationHint,
   buildSettlementExecutionPlan,
   deriveSettlementStatus,
   getExpectedSettlementCount,
@@ -61,6 +62,58 @@ describe("deriveSettlementStatus", () => {
     expect(result.remainingToSettle).toBe(0);
     expect(result.canPlay).toBe(true);
     expect(result.needsSettlement).toBe(false);
+  });
+});
+
+describe("applyAutoSettleRegistrationHint", () => {
+  it("treats auto-settle entry handoffs as registered while the settlement index catches up", () => {
+    const hintedSnapshot = applyAutoSettleRegistrationHint({
+      snapshot: snapshot(),
+      autoSettleEnabled: true,
+      entryIntent: "settle",
+      hasAutoSettleEntry: true,
+    });
+
+    expect(hintedSnapshot.registered).toBe(true);
+    expect(deriveSettlementStatus(hintedSnapshot).needsSettlement).toBe(true);
+  });
+
+  it("does not invent registration outside the auto-settle settle flow", () => {
+    expect(
+      applyAutoSettleRegistrationHint({
+        snapshot: snapshot(),
+        autoSettleEnabled: false,
+        entryIntent: "settle",
+        hasAutoSettleEntry: true,
+      }).registered,
+    ).toBe(false);
+
+    expect(
+      applyAutoSettleRegistrationHint({
+        snapshot: snapshot(),
+        autoSettleEnabled: true,
+        entryIntent: "play",
+        hasAutoSettleEntry: true,
+      }).registered,
+    ).toBe(false);
+  });
+
+  it("keeps indexed settlement progress unchanged", () => {
+    const progressedSnapshot = snapshot({
+      registered: false,
+      onceRegistered: true,
+      coordsCount: 2,
+      settledCount: 1,
+    });
+
+    expect(
+      applyAutoSettleRegistrationHint({
+        snapshot: progressedSnapshot,
+        autoSettleEnabled: true,
+        entryIntent: "settle",
+        hasAutoSettleEntry: true,
+      }),
+    ).toEqual(progressedSnapshot);
   });
 });
 

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
@@ -6,6 +6,9 @@ export type SettlementSnapshot = {
   settledCount: number;
 };
 
+const hasIndexedSettlementProgress = (snapshot: SettlementSnapshot): boolean =>
+  snapshot.hasSettledStructure || snapshot.coordsCount > 0 || snapshot.settledCount > 0;
+
 type SettlementStatus = {
   assignedCount: number;
   settledCount: number;
@@ -31,6 +34,35 @@ export const deriveSettlementStatus = (snapshot: SettlementSnapshot): Settlement
     remainingToSettle,
     canPlay,
     needsSettlement,
+  };
+};
+
+export const applyAutoSettleRegistrationHint = ({
+  snapshot,
+  autoSettleEnabled,
+  entryIntent,
+  hasAutoSettleEntry,
+}: {
+  snapshot: SettlementSnapshot;
+  autoSettleEnabled: boolean;
+  entryIntent: "play" | "settle";
+  hasAutoSettleEntry: boolean;
+}): SettlementSnapshot => {
+  const shouldHintRegistration =
+    autoSettleEnabled &&
+    entryIntent === "settle" &&
+    hasAutoSettleEntry &&
+    !snapshot.registered &&
+    !snapshot.onceRegistered &&
+    !hasIndexedSettlementProgress(snapshot);
+
+  if (!shouldHintRegistration) {
+    return snapshot;
+  }
+
+  return {
+    ...snapshot,
+    registered: true,
   };
 };
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-14",
+    title: "Reliable Auto-Settle Entry",
+    description:
+      "Auto-settle now keeps freshly registered Blitz players on the settlement path until their realm setup is ready, so dashboard handoffs stop dropping new entrants into the game as spectators.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
     date: "2026-04-13",
     title: "Stable Reload Chunk Refresh",
     description:


### PR DESCRIPTION
## Summary
This fixes the Blitz auto-settle registration handoff so newly registered players no longer fall through to the map before settlement is enforced.
The modal now treats an armed auto-settle handoff as registration-ready while Torii catches up, and the registration hook waits for tx confirmation before surfacing `done`.
It also adds regression coverage for the stale-index snapshot case and records the landing fix in the latest-features feed.

## Test Coverage
Added regression coverage for the stale-index auto-settle snapshot path.

## Pre-Landing Review
No issues found in the 5-file diff.

## Design Review
No frontend design changes beyond entry-flow behavior.

## Eval Results
No prompt-related files changed.

## Plan Completion
No plan file detected.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] `game-entry-settlement.utils.test.ts`
- [x] `game-entry-modal.auto-settle.source.test.ts`
- [x] `client/apps/game typecheck`
- [x] `pnpm run format`
- [x] `pnpm run knip`