### PR TITLE
fix(game): convert factory-v2 to dark theme

### DIFF
--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-content.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-content.tsx
@@ -249,14 +249,14 @@ const FactoryV2AdminSecretControl = ({
   return (
     <div
       className={cn(
-        "flex flex-col gap-3 rounded-[24px] border border-black/8 px-3 py-3 shadow-[0_12px_30px_rgba(23,15,8,0.06)] sm:flex-row sm:items-center sm:px-4",
+        "flex flex-col gap-3 rounded-[24px] border border-white/8 px-3 py-3 shadow-[0_12px_30px_rgba(0,0,0,0.14)] sm:flex-row sm:items-center sm:px-4",
         appearance.quietSurfaceClassName,
       )}
     >
       <div className="flex items-center gap-2 sm:min-w-[108px]">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-black/42">Admin</div>
+        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Admin</div>
         {hasSavedAdminSecret ? (
-          <span className="rounded-full border border-black/8 bg-white/80 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-black/56">
+          <span className="rounded-full border border-white/8 bg-white/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/56">
             Saved
           </span>
         ) : null}
@@ -269,7 +269,7 @@ const FactoryV2AdminSecretControl = ({
         value={adminSecret}
         onChange={(event) => onAdminSecretChange(event.target.value)}
         placeholder="Secret for admin actions"
-        className="h-11 min-w-0 flex-1 rounded-full border border-black/10 bg-white/84 px-4 text-sm text-black outline-none transition-colors focus:border-black/24"
+        className="h-11 min-w-0 flex-1 rounded-full border border-white/10 bg-white/8 px-4 text-sm text-[#fbf4ea] outline-none transition-colors focus:border-white/24"
       />
 
       <div className="grid grid-cols-2 gap-2 sm:flex sm:w-auto">
@@ -290,7 +290,7 @@ const FactoryV2AdminSecretControl = ({
           data-testid="factory-admin-clear"
           disabled={isBusy || !hasSavedAdminSecret}
           onClick={onClearAdminSecret}
-          className="inline-flex h-11 items-center justify-center rounded-full border border-black/10 bg-white px-4 text-sm font-semibold text-black/62 transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex h-11 items-center justify-center rounded-full border border-white/10 bg-white/8 px-4 text-sm font-semibold text-[#fbf4ea]/62 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Clear
         </button>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-content.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-content.tsx
@@ -249,14 +249,14 @@ const FactoryV2AdminSecretControl = ({
   return (
     <div
       className={cn(
-        "flex flex-col gap-3 rounded-[24px] border border-white/8 px-3 py-3 shadow-[0_12px_30px_rgba(0,0,0,0.14)] sm:flex-row sm:items-center sm:px-4",
+        "flex flex-col gap-3 rounded-[24px] border border-gold/10 px-3 py-3 shadow-[0_12px_30px_rgba(0,0,0,0.2)] sm:flex-row sm:items-center sm:px-4",
         appearance.quietSurfaceClassName,
       )}
     >
       <div className="flex items-center gap-2 sm:min-w-[108px]">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Admin</div>
+        <div className="text-[10px] font-semibold uppercase tracking-[0.22em] text-gold/42">Admin</div>
         {hasSavedAdminSecret ? (
-          <span className="rounded-full border border-white/8 bg-white/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/56">
+          <span className="rounded-full border border-gold/10 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-gold/56">
             Saved
           </span>
         ) : null}
@@ -269,7 +269,7 @@ const FactoryV2AdminSecretControl = ({
         value={adminSecret}
         onChange={(event) => onAdminSecretChange(event.target.value)}
         placeholder="Secret for admin actions"
-        className="h-11 min-w-0 flex-1 rounded-full border border-white/10 bg-white/8 px-4 text-sm text-[#fbf4ea] outline-none transition-colors focus:border-white/24"
+        className="h-11 min-w-0 flex-1 rounded-full border border-gold/15 bg-black/25 px-4 text-sm text-gold outline-none transition-colors focus:border-gold/30"
       />
 
       <div className="grid grid-cols-2 gap-2 sm:flex sm:w-auto">
@@ -290,7 +290,7 @@ const FactoryV2AdminSecretControl = ({
           data-testid="factory-admin-clear"
           disabled={isBusy || !hasSavedAdminSecret}
           onClick={onClearAdminSecret}
-          className="inline-flex h-11 items-center justify-center rounded-full border border-white/10 bg-white/8 px-4 text-sm font-semibold text-[#fbf4ea]/62 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex h-11 items-center justify-center rounded-full border border-gold/15 bg-black/25 px-4 text-sm font-semibold text-gold/62 transition-colors hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-50"
         >
           Clear
         </button>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-deployer-wallet-card.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-deployer-wallet-card.tsx
@@ -11,15 +11,15 @@ export const FactoryV2DeployerWalletCard = ({ chain, environmentLabel }: Factory
   const wallet = useFactoryV2DeployerWallet(chain);
 
   return (
-    <section className="rounded-[20px] border border-white/10 bg-black/8 px-3 py-3 backdrop-blur-xl md:px-4">
+    <section className="rounded-[20px] border border-gold/15 bg-black/8 px-3 py-3 backdrop-blur-xl md:px-4">
       <div className="space-y-3">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0 flex-1 space-y-1">
-            <p className="text-[0.58rem] font-semibold uppercase tracking-[0.28em] text-white/48">Deployer wallet</p>
-            <div className="text-[0.8rem] font-semibold text-white">
-              {environmentLabel} deployer <span className="text-white/55">· {displayAddress(wallet.address)}</span>
+            <p className="text-[0.58rem] font-semibold uppercase tracking-[0.28em] text-gold/48">Deployer wallet</p>
+            <div className="text-[0.8rem] font-semibold text-gold">
+              {environmentLabel} deployer <span className="text-gold/55">· {displayAddress(wallet.address)}</span>
             </div>
-            <p className="break-all font-mono text-[0.62rem] leading-4 text-white/56">{wallet.address}</p>
+            <p className="break-all font-mono text-[0.62rem] leading-4 text-gold/56">{wallet.address}</p>
           </div>
           <div className="flex items-center gap-1.5">
             <button
@@ -27,7 +27,7 @@ export const FactoryV2DeployerWalletCard = ({ chain, environmentLabel }: Factory
               onClick={() => {
                 void wallet.copyAddress();
               }}
-              className="rounded-full border border-white/12 bg-white/8 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-white/80 transition hover:bg-white/12"
+              className="rounded-full border border-gold/20 bg-black/25 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-gold/80 transition hover:bg-gold/10"
             >
               {resolveCopyActionLabel(wallet.copyState)}
             </button>
@@ -37,7 +37,7 @@ export const FactoryV2DeployerWalletCard = ({ chain, environmentLabel }: Factory
                 void wallet.refreshBalances();
               }}
               disabled={wallet.isRefreshing}
-              className="rounded-full border border-white/12 bg-white/8 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-white/80 transition hover:bg-white/12 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-full border border-gold/20 bg-black/25 px-2.5 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.12em] text-gold/80 transition hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {wallet.isRefreshing ? "Refreshing..." : "Refresh"}
             </button>
@@ -46,14 +46,14 @@ export const FactoryV2DeployerWalletCard = ({ chain, environmentLabel }: Factory
 
         <div className="grid gap-2 sm:grid-cols-2">
           {wallet.balances.map((balance) => (
-            <article key={balance.symbol} className="rounded-2xl border border-white/8 bg-black/14 px-2.5 py-2">
+            <article key={balance.symbol} className="rounded-2xl border border-gold/10 bg-black/14 px-2.5 py-2">
               <div className="flex items-center justify-between gap-3">
-                <p className="text-[0.58rem] font-semibold uppercase tracking-[0.22em] text-white/45">
+                <p className="text-[0.58rem] font-semibold uppercase tracking-[0.22em] text-gold/45">
                   {balance.symbol}
                 </p>
-                <p className="text-sm font-semibold text-white">{balance.isLoading ? "..." : balance.displayBalance}</p>
+                <p className="text-sm font-semibold text-gold">{balance.isLoading ? "..." : balance.displayBalance}</p>
               </div>
-              <p className="mt-1 text-[0.65rem] text-white/42">{balance.error ?? ``}</p>
+              <p className="mt-1 text-[0.65rem] text-gold/42">{balance.error ?? ``}</p>
             </article>
           ))}
         </div>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-config.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-config.tsx
@@ -54,17 +54,15 @@ export const FactoryV2DeveloperConfig = ({
         <div className="space-y-3">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
-                Factory config
-              </div>
-              <h3 className="mt-1 text-base font-semibold text-[#fbf4ea]/80">One multicall</h3>
-              <p className="mt-1 text-[13px] leading-5 text-[#fbf4ea]/48">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42">Factory config</div>
+              <h3 className="mt-1 text-base font-semibold text-gold/80">One multicall</h3>
+              <p className="mt-1 text-[13px] leading-5 text-gold/48">
                 Pick the factory setters and send one wallet call.
               </p>
             </div>
             <div
               className={cn(
-                "rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/56",
+                "rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/56",
                 appearance.quietSurfaceClassName,
               )}
             >
@@ -74,45 +72,39 @@ export const FactoryV2DeveloperConfig = ({
 
           <div className="grid gap-2 md:grid-cols-[minmax(0,1.4fr)_minmax(120px,150px)_minmax(120px,160px)]">
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
-                Factory
-              </span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-gold/42">Factory</span>
               <input
                 type="text"
                 value={developerConfig.draft.factoryAddress || "Not configured for this chain"}
                 readOnly
                 className={cn(
-                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/6 px-3 text-[12px] text-[#fbf4ea]/60 outline-none",
+                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-black/20 px-3 text-[12px] text-gold/60 outline-none",
                   appearance.listItemClassName,
                 )}
               />
             </label>
 
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
-                Version
-              </span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-gold/42">Version</span>
               <input
                 type="text"
                 value={developerConfig.draft.version}
                 onChange={(event) => developerConfig.setVersion(event.target.value)}
                 className={cn(
-                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/10 px-3 text-[12px] font-medium text-[#fbf4ea] outline-none transition-colors",
+                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-black/25 px-3 text-[12px] font-medium text-gold outline-none transition-colors",
                   appearance.listItemClassName,
                 )}
               />
             </label>
 
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
-                Namespace
-              </span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-gold/42">Namespace</span>
               <input
                 type="text"
                 value={developerConfig.draft.namespace}
                 readOnly
                 className={cn(
-                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/6 px-3 text-[12px] text-[#fbf4ea]/60 outline-none",
+                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-black/20 px-3 text-[12px] text-gold/60 outline-none",
                   appearance.listItemClassName,
                 )}
               />
@@ -130,8 +122,8 @@ export const FactoryV2DeveloperConfig = ({
           <div className="space-y-2">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">Setters</div>
-                <p className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/48">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-gold/42">Setters</div>
+                <p className="mt-1 text-[12px] leading-5 text-gold/48">
                   {developerConfig.selectedSections.length} selected · one wallet multicall
                 </p>
               </div>
@@ -174,25 +166,25 @@ export const FactoryV2DeveloperConfig = ({
                       "rounded-[18px] border px-3 py-3 text-left transition-all",
                       appearance.listItemClassName,
                       isSelected
-                        ? "border-white/35 bg-white/8 shadow-[0_10px_22px_rgba(0,0,0,0.18)]"
-                        : "border-white/10 bg-white/5 opacity-80",
+                        ? "border-gold/40 bg-black/25 shadow-[0_10px_22px_rgba(0,0,0,0.18)]"
+                        : "border-gold/15 bg-black/20 opacity-80",
                     )}
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div>
-                        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/40">
+                        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/40">
                           {section.label}
                         </div>
-                        <div className="mt-1 text-[11px] font-medium text-[#fbf4ea]/62">
+                        <div className="mt-1 text-[11px] font-medium text-gold/62">
                           {formatFactoryEntrypointLabel(section.entrypoint)}
                         </div>
                       </div>
-                      <div className="rounded-full border border-white/10 bg-white/6 px-2 py-0.5 text-[10px] font-medium text-[#fbf4ea]/58">
+                      <div className="rounded-full border border-gold/15 bg-black/20 px-2 py-0.5 text-[10px] font-medium text-gold/58">
                         {resolveSectionCountLabel(section.itemCount)}
                       </div>
                     </div>
 
-                    <p className="mt-2 text-[12px] leading-5 text-[#fbf4ea]/50">{section.description}</p>
+                    <p className="mt-2 text-[12px] leading-5 text-gold/50">{section.description}</p>
                   </button>
                 );
               })}
@@ -202,7 +194,7 @@ export const FactoryV2DeveloperConfig = ({
           {developerConfig.isManifestLoading ? (
             <div
               className={cn(
-                "rounded-[18px] border px-3 py-2.5 text-[12px] text-[#fbf4ea]/56",
+                "rounded-[18px] border px-3 py-2.5 text-[12px] text-gold/56",
                 appearance.quietSurfaceClassName,
               )}
             >
@@ -233,7 +225,7 @@ export const FactoryV2DeveloperConfig = ({
                 targetChainLabel: developerConfig.targetChainLabel,
               })}
             </button>
-            <span className="text-[11px] leading-5 text-[#fbf4ea]/42">
+            <span className="text-[11px] leading-5 text-gold/42">
               {!developerConfig.account
                 ? "Connect your wallet to send factory setters."
                 : developerConfig.canSubmitOnCurrentNetwork
@@ -246,15 +238,15 @@ export const FactoryV2DeveloperConfig = ({
             <div className={cn("rounded-[18px] border px-3 py-3", appearance.quietSurfaceClassName)}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/42">
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/42">
                     {submittedExecutionState.status === "confirmed" ? "Multicall confirmed" : "Multicall submitted"}
                   </div>
-                  <div className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/56">
+                  <div className="mt-1 text-[12px] leading-5 text-gold/56">
                     {submittedExecutionState.status === "confirmed"
                       ? "Factory setters confirmed onchain."
                       : "Awaiting confirmation. You can track the transaction below."}
                   </div>
-                  <div className="mt-2 break-all text-[12px] font-semibold text-[#fbf4ea]/82">
+                  <div className="mt-2 break-all text-[12px] font-semibold text-gold/82">
                     {submittedExecutionState.txHash}
                   </div>
                 </div>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-config.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-config.tsx
@@ -54,15 +54,15 @@ export const FactoryV2DeveloperConfig = ({
         <div className="space-y-3">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42">Factory config</div>
-              <h3 className="mt-1 text-base font-semibold text-black/80">One multicall</h3>
-              <p className="mt-1 text-[13px] leading-5 text-black/48">
+              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">Factory config</div>
+              <h3 className="mt-1 text-base font-semibold text-[#fbf4ea]/80">One multicall</h3>
+              <p className="mt-1 text-[13px] leading-5 text-[#fbf4ea]/48">
                 Pick the factory setters and send one wallet call.
               </p>
             </div>
             <div
               className={cn(
-                "rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-black/56",
+                "rounded-full border px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/56",
                 appearance.quietSurfaceClassName,
               )}
             >
@@ -72,33 +72,33 @@ export const FactoryV2DeveloperConfig = ({
 
           <div className="grid gap-2 md:grid-cols-[minmax(0,1.4fr)_minmax(120px,150px)_minmax(120px,160px)]">
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-black/42">Factory</span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">Factory</span>
               <input
                 type="text"
                 value={developerConfig.draft.factoryAddress || "Not configured for this chain"}
                 readOnly
                 className={cn(
-                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/60 px-3 text-[12px] text-black/60 outline-none",
+                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/6 px-3 text-[12px] text-[#fbf4ea]/60 outline-none",
                   appearance.listItemClassName,
                 )}
               />
             </label>
 
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-black/42">Version</span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">Version</span>
               <input
                 type="text"
                 value={developerConfig.draft.version}
                 onChange={(event) => developerConfig.setVersion(event.target.value)}
                 className={cn(
-                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/80 px-3 text-[12px] font-medium text-black outline-none transition-colors",
+                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/10 px-3 text-[12px] font-medium text-[#fbf4ea] outline-none transition-colors",
                   appearance.listItemClassName,
                 )}
               />
             </label>
 
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-black/42">
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
                 Namespace
               </span>
               <input
@@ -106,7 +106,7 @@ export const FactoryV2DeveloperConfig = ({
                 value={developerConfig.draft.namespace}
                 readOnly
                 className={cn(
-                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/60 px-3 text-[12px] text-black/60 outline-none",
+                  "mt-1.5 block h-10 w-full rounded-[16px] border bg-white/6 px-3 text-[12px] text-[#fbf4ea]/60 outline-none",
                   appearance.listItemClassName,
                 )}
               />
@@ -115,7 +115,7 @@ export const FactoryV2DeveloperConfig = ({
 
           {developerConfig.isVersionCustomized ? (
             <div className="rounded-[18px] border border-amber-500/24 bg-amber-500/8 px-3 py-2.5">
-              <p className="text-[12px] leading-5 text-amber-900/84">
+              <p className="text-[12px] leading-5 text-amber-400/84">
                 This version differs from the default for {mode}.
               </p>
             </div>
@@ -124,8 +124,8 @@ export const FactoryV2DeveloperConfig = ({
           <div className="space-y-2">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-black/42">Setters</div>
-                <p className="mt-1 text-[12px] leading-5 text-black/48">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">Setters</div>
+                <p className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/48">
                   {developerConfig.selectedSections.length} selected · one wallet multicall
                 </p>
               </div>
@@ -168,25 +168,25 @@ export const FactoryV2DeveloperConfig = ({
                       "rounded-[18px] border px-3 py-3 text-left transition-all",
                       appearance.listItemClassName,
                       isSelected
-                        ? "border-black/35 bg-white/78 shadow-[0_10px_22px_rgba(39,25,16,0.11)]"
-                        : "border-black/10 bg-white/38 opacity-80",
+                        ? "border-white/35 bg-white/8 shadow-[0_10px_22px_rgba(0,0,0,0.18)]"
+                        : "border-white/10 bg-white/5 opacity-80",
                     )}
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div>
-                        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-black/40">
+                        <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/40">
                           {section.label}
                         </div>
-                        <div className="mt-1 text-[11px] font-medium text-black/62">
+                        <div className="mt-1 text-[11px] font-medium text-[#fbf4ea]/62">
                           {formatFactoryEntrypointLabel(section.entrypoint)}
                         </div>
                       </div>
-                      <div className="rounded-full border border-black/10 bg-white/60 px-2 py-0.5 text-[10px] font-medium text-black/58">
+                      <div className="rounded-full border border-white/10 bg-white/6 px-2 py-0.5 text-[10px] font-medium text-[#fbf4ea]/58">
                         {resolveSectionCountLabel(section.itemCount)}
                       </div>
                     </div>
 
-                    <p className="mt-2 text-[12px] leading-5 text-black/50">{section.description}</p>
+                    <p className="mt-2 text-[12px] leading-5 text-[#fbf4ea]/50">{section.description}</p>
                   </button>
                 );
               })}
@@ -196,7 +196,7 @@ export const FactoryV2DeveloperConfig = ({
           {developerConfig.isManifestLoading ? (
             <div
               className={cn(
-                "rounded-[18px] border px-3 py-2.5 text-[12px] text-black/56",
+                "rounded-[18px] border px-3 py-2.5 text-[12px] text-[#fbf4ea]/56",
                 appearance.quietSurfaceClassName,
               )}
             >
@@ -205,8 +205,8 @@ export const FactoryV2DeveloperConfig = ({
           ) : null}
 
           {developerConfig.manifestErrorMessage ? (
-            <div className="rounded-[18px] border border-rose-500/18 bg-rose-500/6 px-3 py-2.5">
-              <p className="text-[12px] leading-5 text-rose-800">{developerConfig.manifestErrorMessage}</p>
+            <div className="rounded-[18px] border border-rose-500/18 bg-rose-500/10 px-3 py-2.5">
+              <p className="text-[12px] leading-5 text-rose-400">{developerConfig.manifestErrorMessage}</p>
             </div>
           ) : null}
 
@@ -227,7 +227,7 @@ export const FactoryV2DeveloperConfig = ({
                 targetChainLabel: developerConfig.targetChainLabel,
               })}
             </button>
-            <span className="text-[11px] leading-5 text-black/42">
+            <span className="text-[11px] leading-5 text-[#fbf4ea]/42">
               {!developerConfig.account
                 ? "Connect your wallet to send factory setters."
                 : developerConfig.canSubmitOnCurrentNetwork
@@ -240,15 +240,15 @@ export const FactoryV2DeveloperConfig = ({
             <div className={cn("rounded-[18px] border px-3 py-3", appearance.quietSurfaceClassName)}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-black/42">
+                  <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/42">
                     {submittedExecutionState.status === "confirmed" ? "Multicall confirmed" : "Multicall submitted"}
                   </div>
-                  <div className="mt-1 text-[12px] leading-5 text-black/56">
+                  <div className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/56">
                     {submittedExecutionState.status === "confirmed"
                       ? "Factory setters confirmed onchain."
                       : "Awaiting confirmation. You can track the transaction below."}
                   </div>
-                  <div className="mt-2 break-all text-[12px] font-semibold text-black/82">
+                  <div className="mt-2 break-all text-[12px] font-semibold text-[#fbf4ea]/82">
                     {submittedExecutionState.txHash}
                   </div>
                 </div>
@@ -270,8 +270,8 @@ export const FactoryV2DeveloperConfig = ({
           ) : null}
 
           {errorExecutionState ? (
-            <div className="rounded-[18px] border border-rose-500/18 bg-rose-500/6 px-3 py-2.5">
-              <p className="text-[12px] leading-5 text-rose-800">{errorExecutionState.message}</p>
+            <div className="rounded-[18px] border border-rose-500/18 bg-rose-500/10 px-3 py-2.5">
+              <p className="text-[12px] leading-5 text-rose-400">{errorExecutionState.message}</p>
               {errorExecutionState.txHash && developerConfig.txExplorerUrl ? (
                 <a
                   href={developerConfig.txExplorerUrl}

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-config.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-config.tsx
@@ -54,7 +54,9 @@ export const FactoryV2DeveloperConfig = ({
         <div className="space-y-3">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">Factory config</div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
+                Factory config
+              </div>
               <h3 className="mt-1 text-base font-semibold text-[#fbf4ea]/80">One multicall</h3>
               <p className="mt-1 text-[13px] leading-5 text-[#fbf4ea]/48">
                 Pick the factory setters and send one wallet call.
@@ -72,7 +74,9 @@ export const FactoryV2DeveloperConfig = ({
 
           <div className="grid gap-2 md:grid-cols-[minmax(0,1.4fr)_minmax(120px,150px)_minmax(120px,160px)]">
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">Factory</span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
+                Factory
+              </span>
               <input
                 type="text"
                 value={developerConfig.draft.factoryAddress || "Not configured for this chain"}
@@ -85,7 +89,9 @@ export const FactoryV2DeveloperConfig = ({
             </label>
 
             <label className="block">
-              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">Version</span>
+              <span className="block text-[10px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
+                Version
+              </span>
               <input
                 type="text"
                 value={developerConfig.draft.version}

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-contract-lookup.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-contract-lookup.tsx
@@ -31,16 +31,16 @@ export const FactoryV2DeveloperContractLookup = ({
       <div className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42">Contract lookup</div>
-            <h3 className="mt-2 text-lg font-semibold text-black/80">Resolve contract address</h3>
-            <p className="mt-1 text-sm leading-6 text-black/48">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">Contract lookup</div>
+            <h3 className="mt-2 text-lg font-semibold text-[#fbf4ea]/80">Resolve contract address</h3>
+            <p className="mt-1 text-sm leading-6 text-[#fbf4ea]/48">
               Look up a Factory-deployed contract address from the selected environment without touching the game
               indexer.
             </p>
           </div>
           <div
             className={cn(
-              "rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-black/56",
+              "rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/56",
               appearance.quietSurfaceClassName,
             )}
           >
@@ -50,21 +50,21 @@ export const FactoryV2DeveloperContractLookup = ({
 
         <div className="grid gap-3 md:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Game name</span>
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Game name</span>
             <input
               type="text"
               value={developerLookup.gameName}
               onChange={(event) => developerLookup.setGameName(event.target.value)}
               placeholder="etrn-sunrise-01"
               className={cn(
-                "mt-2 block h-11 w-full rounded-[18px] border bg-white/80 px-3 text-[13px] text-black outline-none transition-colors placeholder:text-black/25",
+                "mt-2 block h-11 w-full rounded-[18px] border bg-white/10 px-3 text-[13px] text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/25",
                 appearance.listItemClassName,
               )}
             />
           </label>
 
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
               Contract target
             </span>
             <select
@@ -73,7 +73,7 @@ export const FactoryV2DeveloperContractLookup = ({
                 developerLookup.setSelectedTargetId(event.target.value as typeof developerLookup.selectedTargetId)
               }
               className={cn(
-                "mt-2 block h-11 w-full rounded-[18px] border bg-white/80 px-3 text-[13px] font-medium text-black outline-none transition-colors",
+                "mt-2 block h-11 w-full rounded-[18px] border bg-white/10 px-3 text-[13px] font-medium text-[#fbf4ea] outline-none transition-colors",
                 appearance.listItemClassName,
               )}
             >
@@ -88,7 +88,7 @@ export const FactoryV2DeveloperContractLookup = ({
 
         {developerLookup.usesCustomContractInput ? (
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
               Manifest contract
             </span>
             <input
@@ -97,11 +97,11 @@ export const FactoryV2DeveloperContractLookup = ({
               onChange={(event) => developerLookup.setCustomContractName(event.target.value)}
               placeholder="prize_distribution_systems"
               className={cn(
-                "mt-2 block h-11 w-full rounded-[18px] border bg-white/80 px-3 text-[13px] text-black outline-none transition-colors placeholder:text-black/25",
+                "mt-2 block h-11 w-full rounded-[18px] border bg-white/10 px-3 text-[13px] text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/25",
                 appearance.listItemClassName,
               )}
             />
-            <p className="mt-2 text-[12px] leading-5 text-black/42">
+            <p className="mt-2 text-[12px] leading-5 text-[#fbf4ea]/42">
               Accepts raw names like <code>prize_distribution_systems</code>, wrapped values like{" "}
               <code>{"{prize_distribution_systems}"}</code>, or full manifest tags.
             </p>
@@ -122,18 +122,18 @@ export const FactoryV2DeveloperContractLookup = ({
           >
             {developerLookup.isSubmitting ? "Resolving..." : "Resolve address"}
           </button>
-          <span className="text-[12px] leading-5 text-black/42">
-            Default target: <span className="font-medium text-black/60">Prize address</span>
+          <span className="text-[12px] leading-5 text-[#fbf4ea]/42">
+            Default target: <span className="font-medium text-[#fbf4ea]/60">Prize address</span>
           </span>
         </div>
 
         {developerLookup.lookupFailure ? (
-          <div className="space-y-3 rounded-[20px] border border-rose-500/18 bg-rose-500/6 px-4 py-3">
-            <p className="text-sm leading-6 text-rose-800">{developerLookup.lookupFailure.message}</p>
+          <div className="space-y-3 rounded-[20px] border border-rose-500/18 bg-rose-500/10 px-4 py-3">
+            <p className="text-sm leading-6 text-rose-400">{developerLookup.lookupFailure.message}</p>
 
             {developerLookup.lookupFailure.worldSuggestions?.length ? (
               <div className="space-y-2">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-800/70">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-400/70">
                   World suggestions
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -144,7 +144,7 @@ export const FactoryV2DeveloperContractLookup = ({
                       onClick={() => {
                         void developerLookup.applyWorldSuggestion(worldSuggestion);
                       }}
-                      className="rounded-full border border-rose-600/18 bg-white/70 px-3 py-1.5 text-[12px] font-medium text-rose-900 transition-colors hover:bg-white"
+                      className="rounded-full border border-rose-600/18 bg-white/6 px-3 py-1.5 text-[12px] font-medium text-rose-400 transition-colors hover:bg-white/10"
                     >
                       {worldSuggestion}
                     </button>
@@ -155,7 +155,7 @@ export const FactoryV2DeveloperContractLookup = ({
 
             {developerLookup.lookupFailure.contractSuggestions?.length ? (
               <div className="space-y-2">
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-800/70">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-400/70">
                   Contract suggestions
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -166,7 +166,7 @@ export const FactoryV2DeveloperContractLookup = ({
                       onClick={() => {
                         void developerLookup.applyContractSuggestion(contractSuggestion);
                       }}
-                      className="rounded-full border border-rose-600/18 bg-white/70 px-3 py-1.5 text-[12px] font-medium text-rose-900 transition-colors hover:bg-white"
+                      className="rounded-full border border-rose-600/18 bg-white/6 px-3 py-1.5 text-[12px] font-medium text-rose-400 transition-colors hover:bg-white/10"
                     >
                       {resolveFactoryDeveloperContractSuggestionLabel(contractSuggestion)}
                     </button>
@@ -181,10 +181,10 @@ export const FactoryV2DeveloperContractLookup = ({
           <div className={cn("rounded-[20px] border px-4 py-4", appearance.quietSurfaceClassName)}>
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-black/42">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
                   {developerLookup.selectedTarget.label}
                 </div>
-                <div className="mt-2 text-lg font-semibold text-black/82">
+                <div className="mt-2 text-lg font-semibold text-[#fbf4ea]/82">
                   {developerLookup.lookupResult.contractAddress}
                 </div>
               </div>
@@ -206,18 +206,18 @@ export const FactoryV2DeveloperContractLookup = ({
               </button>
             </div>
 
-            <dl className="mt-4 grid gap-3 text-sm text-black/58 md:grid-cols-3">
+            <dl className="mt-4 grid gap-3 text-sm text-[#fbf4ea]/58 md:grid-cols-3">
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/38">World</dt>
-                <dd className="mt-1 font-medium text-black/72">{developerLookup.lookupResult.worldName}</dd>
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">World</dt>
+                <dd className="mt-1 font-medium text-[#fbf4ea]/72">{developerLookup.lookupResult.worldName}</dd>
               </div>
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/38">Tag</dt>
-                <dd className="mt-1 break-all font-medium text-black/72">{developerLookup.lookupResult.resolvedTag}</dd>
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">Tag</dt>
+                <dd className="mt-1 break-all font-medium text-[#fbf4ea]/72">{developerLookup.lookupResult.resolvedTag}</dd>
               </div>
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/38">World address</dt>
-                <dd className="mt-1 flex items-start gap-2 break-all font-medium text-black/72">
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">World address</dt>
+                <dd className="mt-1 flex items-start gap-2 break-all font-medium text-[#fbf4ea]/72">
                   <span className="min-w-0 flex-1">{developerLookup.lookupResult.worldAddress}</span>
                   <button
                     type="button"

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-contract-lookup.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-contract-lookup.tsx
@@ -31,18 +31,16 @@ export const FactoryV2DeveloperContractLookup = ({
       <div className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
-              Contract lookup
-            </div>
-            <h3 className="mt-2 text-lg font-semibold text-[#fbf4ea]/80">Resolve contract address</h3>
-            <p className="mt-1 text-sm leading-6 text-[#fbf4ea]/48">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42">Contract lookup</div>
+            <h3 className="mt-2 text-lg font-semibold text-gold/80">Resolve contract address</h3>
+            <p className="mt-1 text-sm leading-6 text-gold/48">
               Look up a Factory-deployed contract address from the selected environment without touching the game
               indexer.
             </p>
           </div>
           <div
             className={cn(
-              "rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/56",
+              "rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/56",
               appearance.quietSurfaceClassName,
             )}
           >
@@ -52,23 +50,21 @@ export const FactoryV2DeveloperContractLookup = ({
 
         <div className="grid gap-3 md:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
-              Game name
-            </span>
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Game name</span>
             <input
               type="text"
               value={developerLookup.gameName}
               onChange={(event) => developerLookup.setGameName(event.target.value)}
               placeholder="etrn-sunrise-01"
               className={cn(
-                "mt-2 block h-11 w-full rounded-[18px] border bg-white/10 px-3 text-[13px] text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/25",
+                "mt-2 block h-11 w-full rounded-[18px] border bg-black/25 px-3 text-[13px] text-gold outline-none transition-colors placeholder:text-gold/25",
                 appearance.listItemClassName,
               )}
             />
           </label>
 
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
               Contract target
             </span>
             <select
@@ -77,7 +73,7 @@ export const FactoryV2DeveloperContractLookup = ({
                 developerLookup.setSelectedTargetId(event.target.value as typeof developerLookup.selectedTargetId)
               }
               className={cn(
-                "mt-2 block h-11 w-full rounded-[18px] border bg-white/10 px-3 text-[13px] font-medium text-[#fbf4ea] outline-none transition-colors",
+                "mt-2 block h-11 w-full rounded-[18px] border bg-black/25 px-3 text-[13px] font-medium text-gold outline-none transition-colors",
                 appearance.listItemClassName,
               )}
             >
@@ -92,7 +88,7 @@ export const FactoryV2DeveloperContractLookup = ({
 
         {developerLookup.usesCustomContractInput ? (
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
               Manifest contract
             </span>
             <input
@@ -101,11 +97,11 @@ export const FactoryV2DeveloperContractLookup = ({
               onChange={(event) => developerLookup.setCustomContractName(event.target.value)}
               placeholder="prize_distribution_systems"
               className={cn(
-                "mt-2 block h-11 w-full rounded-[18px] border bg-white/10 px-3 text-[13px] text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/25",
+                "mt-2 block h-11 w-full rounded-[18px] border bg-black/25 px-3 text-[13px] text-gold outline-none transition-colors placeholder:text-gold/25",
                 appearance.listItemClassName,
               )}
             />
-            <p className="mt-2 text-[12px] leading-5 text-[#fbf4ea]/42">
+            <p className="mt-2 text-[12px] leading-5 text-gold/42">
               Accepts raw names like <code>prize_distribution_systems</code>, wrapped values like{" "}
               <code>{"{prize_distribution_systems}"}</code>, or full manifest tags.
             </p>
@@ -126,8 +122,8 @@ export const FactoryV2DeveloperContractLookup = ({
           >
             {developerLookup.isSubmitting ? "Resolving..." : "Resolve address"}
           </button>
-          <span className="text-[12px] leading-5 text-[#fbf4ea]/42">
-            Default target: <span className="font-medium text-[#fbf4ea]/60">Prize address</span>
+          <span className="text-[12px] leading-5 text-gold/42">
+            Default target: <span className="font-medium text-gold/60">Prize address</span>
           </span>
         </div>
 
@@ -148,7 +144,7 @@ export const FactoryV2DeveloperContractLookup = ({
                       onClick={() => {
                         void developerLookup.applyWorldSuggestion(worldSuggestion);
                       }}
-                      className="rounded-full border border-rose-600/18 bg-white/6 px-3 py-1.5 text-[12px] font-medium text-rose-400 transition-colors hover:bg-white/10"
+                      className="rounded-full border border-rose-600/18 bg-black/20 px-3 py-1.5 text-[12px] font-medium text-rose-400 transition-colors hover:bg-gold/10"
                     >
                       {worldSuggestion}
                     </button>
@@ -170,7 +166,7 @@ export const FactoryV2DeveloperContractLookup = ({
                       onClick={() => {
                         void developerLookup.applyContractSuggestion(contractSuggestion);
                       }}
-                      className="rounded-full border border-rose-600/18 bg-white/6 px-3 py-1.5 text-[12px] font-medium text-rose-400 transition-colors hover:bg-white/10"
+                      className="rounded-full border border-rose-600/18 bg-black/20 px-3 py-1.5 text-[12px] font-medium text-rose-400 transition-colors hover:bg-gold/10"
                     >
                       {resolveFactoryDeveloperContractSuggestionLabel(contractSuggestion)}
                     </button>
@@ -185,10 +181,10 @@ export const FactoryV2DeveloperContractLookup = ({
           <div className={cn("rounded-[20px] border px-4 py-4", appearance.quietSurfaceClassName)}>
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[#fbf4ea]/42">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.2em] text-gold/42">
                   {developerLookup.selectedTarget.label}
                 </div>
-                <div className="mt-2 text-lg font-semibold text-[#fbf4ea]/82">
+                <div className="mt-2 text-lg font-semibold text-gold/82">
                   {developerLookup.lookupResult.contractAddress}
                 </div>
               </div>
@@ -210,22 +206,18 @@ export const FactoryV2DeveloperContractLookup = ({
               </button>
             </div>
 
-            <dl className="mt-4 grid gap-3 text-sm text-[#fbf4ea]/58 md:grid-cols-3">
+            <dl className="mt-4 grid gap-3 text-sm text-gold/58 md:grid-cols-3">
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">World</dt>
-                <dd className="mt-1 font-medium text-[#fbf4ea]/72">{developerLookup.lookupResult.worldName}</dd>
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/38">World</dt>
+                <dd className="mt-1 font-medium text-gold/72">{developerLookup.lookupResult.worldName}</dd>
               </div>
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">Tag</dt>
-                <dd className="mt-1 break-all font-medium text-[#fbf4ea]/72">
-                  {developerLookup.lookupResult.resolvedTag}
-                </dd>
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/38">Tag</dt>
+                <dd className="mt-1 break-all font-medium text-gold/72">{developerLookup.lookupResult.resolvedTag}</dd>
               </div>
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">
-                  World address
-                </dt>
-                <dd className="mt-1 flex items-start gap-2 break-all font-medium text-[#fbf4ea]/72">
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/38">World address</dt>
+                <dd className="mt-1 flex items-start gap-2 break-all font-medium text-gold/72">
                   <span className="min-w-0 flex-1">{developerLookup.lookupResult.worldAddress}</span>
                   <button
                     type="button"

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-contract-lookup.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-contract-lookup.tsx
@@ -31,7 +31,9 @@ export const FactoryV2DeveloperContractLookup = ({
       <div className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">Contract lookup</div>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
+              Contract lookup
+            </div>
             <h3 className="mt-2 text-lg font-semibold text-[#fbf4ea]/80">Resolve contract address</h3>
             <p className="mt-1 text-sm leading-6 text-[#fbf4ea]/48">
               Look up a Factory-deployed contract address from the selected environment without touching the game
@@ -50,7 +52,9 @@ export const FactoryV2DeveloperContractLookup = ({
 
         <div className="grid gap-3 md:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <label className="block">
-            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Game name</span>
+            <span className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+              Game name
+            </span>
             <input
               type="text"
               value={developerLookup.gameName}
@@ -213,10 +217,14 @@ export const FactoryV2DeveloperContractLookup = ({
               </div>
               <div>
                 <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">Tag</dt>
-                <dd className="mt-1 break-all font-medium text-[#fbf4ea]/72">{developerLookup.lookupResult.resolvedTag}</dd>
+                <dd className="mt-1 break-all font-medium text-[#fbf4ea]/72">
+                  {developerLookup.lookupResult.resolvedTag}
+                </dd>
               </div>
               <div>
-                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">World address</dt>
+                <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">
+                  World address
+                </dt>
                 <dd className="mt-1 flex items-start gap-2 break-all font-medium text-[#fbf4ea]/72">
                   <span className="min-w-0 flex-1">{developerLookup.lookupResult.worldAddress}</span>
                   <button

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-tools.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-tools.tsx
@@ -24,7 +24,7 @@ export const FactoryV2DeveloperTools = ({
         <button
           type="button"
           onClick={developerPanel.registerRevealTap}
-          className="rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em] text-black/32 transition-colors hover:text-black/50"
+          className="rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em] text-[#fbf4ea]/32 transition-colors hover:text-[#fbf4ea]/50"
         >
           fv2/dev
         </button>
@@ -32,7 +32,7 @@ export const FactoryV2DeveloperTools = ({
 
       {developerPanel.isVisible ? (
         <div className="mt-3 space-y-4 md:mt-4">
-          <div className="px-1 text-center text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42">
+          <div className="px-1 text-center text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
             Developer tools
           </div>
 

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-tools.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-developer-tools.tsx
@@ -24,7 +24,7 @@ export const FactoryV2DeveloperTools = ({
         <button
           type="button"
           onClick={developerPanel.registerRevealTap}
-          className="rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em] text-[#fbf4ea]/32 transition-colors hover:text-[#fbf4ea]/50"
+          className="rounded-full px-3 py-1 text-[10px] font-medium uppercase tracking-[0.28em] text-gold/32 transition-colors hover:text-gold/50"
         >
           fv2/dev
         </button>
@@ -32,7 +32,7 @@ export const FactoryV2DeveloperTools = ({
 
       {developerPanel.isVisible ? (
         <div className="mt-3 space-y-4 md:mt-4">
-          <div className="px-1 text-center text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
+          <div className="px-1 text-center text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42">
             Developer tools
           </div>
 

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-header.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-header.tsx
@@ -4,15 +4,30 @@ import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left";
 export const FactoryV2Header = ({ onBack, onOpenLegacy }: { onBack: () => void; onOpenLegacy: () => void }) => {
   return (
     <section className="animate-fade-in-up px-4 pt-4 md:px-0 md:pt-0">
-      <div className="flex flex-col gap-4 text-center md:items-center">
+      <div className="flex flex-col gap-6 text-center md:items-center">
         <div className="mx-auto max-w-3xl">
-          <div className="text-xs font-semibold uppercase tracking-[0.32em] text-[#f4e6d0]/55">Factory V2</div>
-          <h1 className="mt-2 text-[1.9rem] font-semibold tracking-tight text-[#fbf4ea] sm:text-[2.15rem] md:mt-3 md:text-4xl">
-            Cleaner launch controls
+          <h1 className="text-[1.9rem] font-semibold tracking-tight text-[#fbf4ea] sm:text-[2.15rem] md:text-4xl">
+            Create a game
           </h1>
-          <p className="mx-auto mt-2 max-w-2xl text-[15px] leading-6 text-[#fbf4ea]/62 md:mt-3 md:text-sm">
-            This version keeps starting games, checking runs, and indexer upkeep in one calmer flow.
+          <p className="mx-auto mt-3 max-w-2xl text-[15px] leading-6 text-[#fbf4ea]/62 md:text-sm">
+            Launch a new Eternum or Blitz world in a few steps. Pick your network, choose a preset, set the timing, and
+            hit launch. You can also check on running games or manage indexers from here.
           </p>
+        </div>
+
+        <div className="mx-auto flex max-w-md flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[12px] text-[#fbf4ea]/40">
+          <div className="flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500/60" />
+            <span>Single game, series, or rotation</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-500/60" />
+            <span>Slot or mainnet</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="h-1.5 w-1.5 rounded-full bg-sky-500/60" />
+            <span>Live run monitoring</span>
+          </div>
         </div>
 
         <div className="grid w-full max-w-xl gap-2 sm:grid-cols-2">

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-header.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-header.tsx
@@ -6,16 +6,16 @@ export const FactoryV2Header = ({ onBack, onOpenLegacy }: { onBack: () => void; 
     <section className="animate-fade-in-up px-4 pt-4 md:px-0 md:pt-0">
       <div className="flex flex-col gap-6 text-center md:items-center">
         <div className="mx-auto max-w-3xl">
-          <h1 className="text-[1.9rem] font-semibold tracking-tight text-[#fbf4ea] sm:text-[2.15rem] md:text-4xl">
+          <h1 className="text-[1.9rem] font-semibold tracking-tight text-gold sm:text-[2.15rem] md:text-4xl">
             Create a game
           </h1>
-          <p className="mx-auto mt-3 max-w-2xl text-[15px] leading-6 text-[#fbf4ea]/62 md:text-sm">
+          <p className="mx-auto mt-3 max-w-2xl text-[15px] leading-6 text-gold/50 md:text-sm">
             Launch a new Eternum or Blitz world in a few steps. Pick your network, choose a preset, set the timing, and
             hit launch. You can also check on running games or manage indexers from here.
           </p>
         </div>
 
-        <div className="mx-auto flex max-w-md flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[12px] text-[#fbf4ea]/40">
+        <div className="mx-auto flex max-w-md flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[12px] text-gold/40">
           <div className="flex items-center gap-1.5">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500/60" />
             <span>Single game, series, or rotation</span>
@@ -34,7 +34,7 @@ export const FactoryV2Header = ({ onBack, onOpenLegacy }: { onBack: () => void; 
           <button
             type="button"
             onClick={onBack}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-[#fbf4ea]/78 transition-colors hover:bg-white/10 hover:text-[#fbf4ea]"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-gold/15 bg-black/20 px-4 py-2.5 text-sm font-medium text-gold/70 backdrop-blur-[6px] transition-colors hover:bg-gold/10 hover:text-gold hover:border-gold/30"
           >
             <ChevronLeft className="h-4 w-4" />
             Back to home
@@ -43,7 +43,7 @@ export const FactoryV2Header = ({ onBack, onOpenLegacy }: { onBack: () => void; 
           <button
             type="button"
             onClick={onOpenLegacy}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-[#fbf4ea]/78 transition-colors hover:bg-white/10 hover:text-[#fbf4ea]"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-gold/15 bg-black/20 px-4 py-2.5 text-sm font-medium text-gold/70 backdrop-blur-[6px] transition-colors hover:bg-gold/10 hover:text-gold hover:border-gold/30"
           >
             Open legacy factory
             <ArrowUpRight className="h-4 w-4" />

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-manage-indexers-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-manage-indexers-workspace.tsx
@@ -739,9 +739,7 @@ const FactoryV2IndexerRow = ({
       onClick={onToggle}
       className={cn(
         "w-full rounded-[22px] border px-4 py-4 text-left transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-55",
-        isSelected
-          ? "border-white/14 bg-white/12 shadow-[0_12px_28px_rgba(0,0,0,0.16)]"
-          : appearanceClassName,
+        isSelected ? "border-white/14 bg-white/12 shadow-[0_12px_28px_rgba(0,0,0,0.16)]" : appearanceClassName,
       )}
     >
       <div className="flex items-start gap-3">
@@ -798,7 +796,9 @@ const FactoryV2ManageIndexerWatcherCard = ({
       watcherStatus.tone === "warm" ? "border-[#dfaa54]/15 bg-[#dfaa54]/10" : "border-white/8 bg-white/8",
     )}
   >
-    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">{watcherStatus.eyebrow}</div>
+    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">
+      {watcherStatus.eyebrow}
+    </div>
     <div className="mt-1 text-sm font-semibold text-[#fbf4ea]/74">{watcherStatus.title}</div>
     <p className="mt-1 text-sm leading-6 text-[#fbf4ea]/58">{watcherStatus.detail}</p>
   </div>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-manage-indexers-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-manage-indexers-workspace.tsx
@@ -241,12 +241,12 @@ export const FactoryV2ManageIndexersWorkspace = ({
               <div className="space-y-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="space-y-1">
-                    <div className="text-sm font-semibold text-[#fbf4ea]/76">
+                    <div className="text-sm font-semibold text-gold/76">
                       {hasSelectedGames
                         ? `${selectedGameNames.length} selected`
                         : `${filteredLiveIndexers.length} shown`}
                     </div>
-                    <div className="text-xs font-medium text-[#fbf4ea]/52">
+                    <div className="text-xs font-medium text-gold/52">
                       {resolveLiveIndexerSnapshotStatusLine({ liveSummary, liveIndexersUpdatedAt })}
                     </div>
                   </div>
@@ -257,7 +257,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                     title="Check Slot"
                     disabled={!canLoadIndexers}
                     onClick={refreshLiveIndexerList}
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/10 text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-gold/15 bg-black/25 text-gold/64 transition-colors hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     <RotateCw className={cn("h-4 w-4", accessWatcherStatus ? "animate-spin" : "")} aria-hidden="true" />
                   </button>
@@ -266,7 +266,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 {accessWatcherStatus ? <FactoryV2ManageIndexerWatcherCard watcherStatus={accessWatcherStatus} /> : null}
 
                 {notice && notice !== deleteFeedback?.message ? (
-                  <div className="rounded-[18px] border border-white/8 bg-white/8 px-4 py-3 text-sm text-[#fbf4ea]/62">
+                  <div className="rounded-[18px] border border-gold/10 bg-black/25 px-4 py-3 text-sm text-gold/62">
                     {notice}
                   </div>
                 ) : null}
@@ -294,14 +294,14 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 ) : null}
 
                 {hasSelectedGames ? (
-                  <div className="flex flex-wrap items-center justify-between gap-2 rounded-[18px] border border-white/8 bg-white/6 px-3 py-2">
-                    <div className="text-sm font-semibold text-[#fbf4ea]/76">{selectedGameNames.length} selected</div>
+                  <div className="flex flex-wrap items-center justify-between gap-2 rounded-[18px] border border-gold/10 bg-black/20 px-3 py-2">
+                    <div className="text-sm font-semibold text-gold/76">{selectedGameNames.length} selected</div>
                     <button
                       type="button"
                       data-testid="factory-indexer-clear-selection"
                       disabled={isBusy}
                       onClick={() => setSelectedGameNames([])}
-                      className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center justify-center rounded-full border border-gold/15 bg-black/25 px-3 py-1.5 text-xs font-semibold text-gold/64 transition-colors hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Clear
                     </button>
@@ -313,7 +313,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                       data-testid="factory-indexer-select-all"
                       disabled={isBusy}
                       onClick={() => setSelectedGameNames(filteredGameNames)}
-                      className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center justify-center rounded-full border border-gold/15 bg-black/25 px-3 py-1.5 text-xs font-semibold text-gold/64 transition-colors hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Select visible
                     </button>
@@ -347,13 +347,13 @@ export const FactoryV2ManageIndexersWorkspace = ({
                   )}
                 </div>
 
-                <div className="border-t border-white/8 pt-2">
+                <div className="border-t border-gold/10 pt-2">
                   <button
                     type="button"
                     data-testid="factory-indexer-open-lookup"
                     disabled={isBusy}
                     onClick={() => setShowsLookupPanel((currentValue) => !currentValue)}
-                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex items-center gap-2 rounded-full border border-gold/15 bg-black/25 px-4 py-2 text-xs font-semibold text-gold/64 transition-colors hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Recreate by name
                     <ChevronDown
@@ -363,9 +363,9 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 </div>
 
                 {showsLookupPanel ? (
-                  <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 p-3">
+                  <div className="space-y-2 rounded-[20px] border border-gold/10 bg-black/20 p-3">
                     <label className="block">
-                      <span className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">
+                      <span className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/44">
                         Game names
                       </span>
                       <textarea
@@ -374,11 +374,11 @@ export const FactoryV2ManageIndexersWorkspace = ({
                         onChange={(event) => setLookupNamesText(event.target.value)}
                         placeholder={"bltz-franky-01\nbltz-franky-02"}
                         rows={3}
-                        className="mt-2 block min-h-[88px] w-full rounded-[18px] border border-white/10 bg-white/10 px-4 py-3 text-sm text-[#fbf4ea] outline-none transition-colors focus:border-white/22"
+                        className="mt-2 block min-h-[88px] w-full rounded-[18px] border border-gold/15 bg-black/25 px-4 py-3 text-sm text-gold outline-none transition-colors focus:border-gold/25"
                       />
                     </label>
                     {lookupGameNames.length > 0 ? (
-                      <div className="text-xs font-medium text-[#fbf4ea]/52">
+                      <div className="text-xs font-medium text-gold/52">
                         {lookupGameNames.length} {lookupGameNames.length === 1 ? "name" : "names"}
                       </div>
                     ) : null}
@@ -428,7 +428,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 )}
 
                 {notice && notice !== deleteFeedback?.message ? (
-                  <div className="rounded-[18px] border border-white/8 bg-white/8 px-4 py-3 text-sm text-[#fbf4ea]/62">
+                  <div className="rounded-[18px] border border-gold/10 bg-black/25 px-4 py-3 text-sm text-gold/62">
                     {notice}
                   </div>
                 ) : null}
@@ -481,13 +481,13 @@ const FactoryV2ManageIndexersSectionCard = ({
 }) => (
   <section
     className={cn(
-      "space-y-3 rounded-[24px] border border-white/8 px-4 py-4 text-left sm:px-5 sm:py-5",
+      "space-y-3 rounded-[24px] border border-gold/10 px-4 py-4 text-left sm:px-5 sm:py-5",
       appearanceClassName,
     )}
   >
     <div className="space-y-1">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">{title}</div>
-      {description ? <p className="text-sm leading-5 text-[#fbf4ea]/50">{description}</p> : null}
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">{title}</div>
+      {description ? <p className="text-sm leading-5 text-gold/50">{description}</p> : null}
     </div>
     {children}
   </section>
@@ -540,15 +540,15 @@ const FactoryV2ManageIndexersActionBar = ({
     <div
       data-testid="factory-indexer-action-panel"
       className={cn(
-        "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-white/10 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.22)] backdrop-blur-xl md:static md:rounded-[22px] md:border-white/8 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
+        "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-gold/15 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.22)] backdrop-blur-xl md:static md:rounded-[22px] md:border-gold/10 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
         appearance.quietSurfaceClassName,
       )}
     >
       {hasSelectedGames ? (
         <>
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Action</div>
-            <div className="text-sm font-semibold text-[#fbf4ea]/78">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Action</div>
+            <div className="text-sm font-semibold text-gold/78">
               {selectedGameNames.length} indexer{selectedGameNames.length === 1 ? "" : "s"} selected
             </div>
           </div>
@@ -589,8 +589,8 @@ const FactoryV2ManageIndexersActionBar = ({
                     className={cn(
                       "rounded-[18px] border px-3 py-3 text-sm font-semibold capitalize transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                       selectedTier === tier
-                        ? "border-white/16 bg-white/12 text-[#fbf4ea] shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
-                        : "border-white/10 bg-white/10 text-[#fbf4ea]/68 hover:bg-white/10",
+                        ? "border-gold/25 bg-black/30 text-gold shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
+                        : "border-gold/15 bg-black/25 text-gold/68 hover:bg-gold/10",
                     )}
                   >
                     {tier}
@@ -613,11 +613,11 @@ const FactoryV2ManageIndexersActionBar = ({
           ) : null}
 
           {actionTargets.deletableEntries.length > 0 ? (
-            <div className="rounded-[20px] border border-white/8 bg-white/6 p-3">
+            <div className="rounded-[20px] border border-gold/10 bg-black/20 p-3">
               <div className="space-y-3">
                 <div className="space-y-1">
-                  <div className="text-sm font-semibold text-[#fbf4ea]/78">Delete</div>
-                  <p className="text-sm leading-5 text-[#fbf4ea]/56">
+                  <div className="text-sm font-semibold text-gold/78">Delete</div>
+                  <p className="text-sm leading-5 text-gold/56">
                     {resolveSelectionPreviewText(actionTargets.deletableEntries)}
                   </p>
                 </div>
@@ -643,7 +643,7 @@ const FactoryV2ManageIndexersActionBar = ({
                         data-testid="factory-indexer-confirm-delete"
                         disabled={!canDelete}
                         onClick={onConfirmDelete}
-                        className="inline-flex w-full items-center justify-center rounded-full border border-[#a62f28]/20 bg-white/10 px-4 py-3 text-sm font-semibold text-[#8d2a23] transition-colors hover:bg-[#2a1512] disabled:cursor-not-allowed disabled:opacity-50"
+                        className="inline-flex w-full items-center justify-center rounded-full border border-[#a62f28]/20 bg-black/25 px-4 py-3 text-sm font-semibold text-[#8d2a23] transition-colors hover:bg-[#2a1512] disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         I understand, enable delete
                       </button>
@@ -654,7 +654,7 @@ const FactoryV2ManageIndexersActionBar = ({
                       data-testid="factory-indexer-cancel-delete"
                       disabled={isBusy}
                       onClick={onCancelDelete}
-                      className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/10 px-4 py-3 text-sm font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex w-full items-center justify-center rounded-full border border-gold/15 bg-black/25 px-4 py-3 text-sm font-semibold text-gold/64 transition-colors hover:bg-gold/10 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Keep these indexers
                     </button>
@@ -674,7 +674,7 @@ const FactoryV2ManageIndexersActionBar = ({
           data-testid="factory-indexer-action-delete"
           disabled={!canDelete}
           onClick={onDelete}
-          className="inline-flex w-full items-center justify-center rounded-full bg-[#a62f28] px-6 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-[#92261f] disabled:cursor-not-allowed disabled:bg-[#a62f28]/45"
+          className="inline-flex w-full items-center justify-center rounded-full bg-[#a62f28] px-6 py-3.5 text-sm font-semibold text-gold transition-colors hover:bg-[#92261f] disabled:cursor-not-allowed disabled:bg-[#a62f28]/45"
         >
           {resolveDeleteActionLabel(actionTargets.deletableGameNames.length)}
         </button>
@@ -707,10 +707,10 @@ const FactoryV2ManageIndexerActionCard = ({
   description: string;
   children: ReactNode;
 }) => (
-  <div className="space-y-3 rounded-[20px] border border-white/8 bg-white/6 p-3">
+  <div className="space-y-3 rounded-[20px] border border-gold/10 bg-black/20 p-3">
     <div className="space-y-1">
-      <div className="text-sm font-semibold text-[#fbf4ea]/78">{title}</div>
-      <p className="text-sm leading-5 text-[#fbf4ea]/56">{description}</p>
+      <div className="text-sm font-semibold text-gold/78">{title}</div>
+      <p className="text-sm leading-5 text-gold/56">{description}</p>
     </div>
     <div className="space-y-3">{children}</div>
   </div>
@@ -739,7 +739,7 @@ const FactoryV2IndexerRow = ({
       onClick={onToggle}
       className={cn(
         "w-full rounded-[22px] border px-4 py-4 text-left transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-55",
-        isSelected ? "border-white/14 bg-white/12 shadow-[0_12px_28px_rgba(0,0,0,0.16)]" : appearanceClassName,
+        isSelected ? "border-gold/20 bg-black/30 shadow-[0_12px_28px_rgba(0,0,0,0.16)]" : appearanceClassName,
       )}
     >
       <div className="flex items-start gap-3">
@@ -747,7 +747,7 @@ const FactoryV2IndexerRow = ({
           aria-hidden="true"
           className={cn(
             "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold transition-colors",
-            isSelected ? "border-[#fbf4ea] bg-[#fbf4ea] text-white" : "border-white/12 bg-white/10 text-transparent",
+            isSelected ? "border-gold bg-gold text-gold" : "border-gold/20 bg-black/25 text-transparent",
           )}
         >
           ✓
@@ -755,10 +755,10 @@ const FactoryV2IndexerRow = ({
 
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="truncate text-sm font-semibold text-[#fbf4ea]/82">{entry.gameName}</span>
+            <span className="truncate text-sm font-semibold text-gold/82">{entry.gameName}</span>
             <FactoryV2IndexerStateBadge label={resolveLiveIndexerPrimaryBadge(entry)} tone={tone} />
           </div>
-          <div className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/56">{resolveLiveIndexerStatusLabel(entry)}</div>
+          <div className="mt-1 text-[12px] leading-5 text-gold/56">{resolveLiveIndexerStatusLabel(entry)}</div>
         </div>
       </div>
     </button>
@@ -771,7 +771,7 @@ const FactoryV2IndexerStateBadge = ({ label, tone }: { label: string; tone: "neu
       "rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]",
       tone === "warm" && "border-[#dfaa54]/15 bg-[#dfaa54]/10 text-[#dfaa54]",
       tone === "danger" && "border-[#a62f28]/15 bg-[#a62f28]/10 text-[#a62f28]",
-      tone === "neutral" && "border-white/10 bg-white/10 text-[#fbf4ea]/52",
+      tone === "neutral" && "border-gold/15 bg-black/25 text-gold/52",
     )}
   >
     {label}
@@ -779,7 +779,7 @@ const FactoryV2IndexerStateBadge = ({ label, tone }: { label: string; tone: "neu
 );
 
 const FactoryV2IndexerEmptyState = ({ children }: { children: ReactNode }) => (
-  <div className="rounded-[22px] border border-dashed border-white/10 bg-white/8 px-4 py-8 text-center text-sm leading-6 text-[#fbf4ea]/54">
+  <div className="rounded-[22px] border border-dashed border-gold/15 bg-black/25 px-4 py-8 text-center text-sm leading-6 text-gold/54">
     {children}
   </div>
 );
@@ -793,14 +793,12 @@ const FactoryV2ManageIndexerWatcherCard = ({
     data-testid="factory-indexer-watcher"
     className={cn(
       "rounded-[18px] border px-4 py-3",
-      watcherStatus.tone === "warm" ? "border-[#dfaa54]/15 bg-[#dfaa54]/10" : "border-white/8 bg-white/8",
+      watcherStatus.tone === "warm" ? "border-[#dfaa54]/15 bg-[#dfaa54]/10" : "border-gold/10 bg-black/25",
     )}
   >
-    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">
-      {watcherStatus.eyebrow}
-    </div>
-    <div className="mt-1 text-sm font-semibold text-[#fbf4ea]/74">{watcherStatus.title}</div>
-    <p className="mt-1 text-sm leading-6 text-[#fbf4ea]/58">{watcherStatus.detail}</p>
+    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/44">{watcherStatus.eyebrow}</div>
+    <div className="mt-1 text-sm font-semibold text-gold/74">{watcherStatus.title}</div>
+    <p className="mt-1 text-sm leading-6 text-gold/58">{watcherStatus.detail}</p>
   </div>
 );
 

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-manage-indexers-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-manage-indexers-workspace.tsx
@@ -241,12 +241,12 @@ export const FactoryV2ManageIndexersWorkspace = ({
               <div className="space-y-3">
                 <div className="flex items-start justify-between gap-3">
                   <div className="space-y-1">
-                    <div className="text-sm font-semibold text-black/76">
+                    <div className="text-sm font-semibold text-[#fbf4ea]/76">
                       {hasSelectedGames
                         ? `${selectedGameNames.length} selected`
                         : `${filteredLiveIndexers.length} shown`}
                     </div>
-                    <div className="text-xs font-medium text-black/52">
+                    <div className="text-xs font-medium text-[#fbf4ea]/52">
                       {resolveLiveIndexerSnapshotStatusLine({ liveSummary, liveIndexersUpdatedAt })}
                     </div>
                   </div>
@@ -257,7 +257,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                     title="Check Slot"
                     disabled={!canLoadIndexers}
                     onClick={refreshLiveIndexerList}
-                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-black/10 bg-white text-black/64 transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/10 text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     <RotateCw className={cn("h-4 w-4", accessWatcherStatus ? "animate-spin" : "")} aria-hidden="true" />
                   </button>
@@ -266,7 +266,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 {accessWatcherStatus ? <FactoryV2ManageIndexerWatcherCard watcherStatus={accessWatcherStatus} /> : null}
 
                 {notice && notice !== deleteFeedback?.message ? (
-                  <div className="rounded-[18px] border border-black/8 bg-white/74 px-4 py-3 text-sm text-black/62">
+                  <div className="rounded-[18px] border border-white/8 bg-white/8 px-4 py-3 text-sm text-[#fbf4ea]/62">
                     {notice}
                   </div>
                 ) : null}
@@ -294,14 +294,14 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 ) : null}
 
                 {hasSelectedGames ? (
-                  <div className="flex flex-wrap items-center justify-between gap-2 rounded-[18px] border border-black/8 bg-white/64 px-3 py-2">
-                    <div className="text-sm font-semibold text-black/76">{selectedGameNames.length} selected</div>
+                  <div className="flex flex-wrap items-center justify-between gap-2 rounded-[18px] border border-white/8 bg-white/6 px-3 py-2">
+                    <div className="text-sm font-semibold text-[#fbf4ea]/76">{selectedGameNames.length} selected</div>
                     <button
                       type="button"
                       data-testid="factory-indexer-clear-selection"
                       disabled={isBusy}
                       onClick={() => setSelectedGameNames([])}
-                      className="inline-flex items-center justify-center rounded-full border border-black/10 bg-white px-3 py-1.5 text-xs font-semibold text-black/64 transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Clear
                     </button>
@@ -313,7 +313,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                       data-testid="factory-indexer-select-all"
                       disabled={isBusy}
                       onClick={() => setSelectedGameNames(filteredGameNames)}
-                      className="inline-flex items-center justify-center rounded-full border border-black/10 bg-white px-3 py-1.5 text-xs font-semibold text-black/64 transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/10 px-3 py-1.5 text-xs font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Select visible
                     </button>
@@ -347,13 +347,13 @@ export const FactoryV2ManageIndexersWorkspace = ({
                   )}
                 </div>
 
-                <div className="border-t border-black/8 pt-2">
+                <div className="border-t border-white/8 pt-2">
                   <button
                     type="button"
                     data-testid="factory-indexer-open-lookup"
                     disabled={isBusy}
                     onClick={() => setShowsLookupPanel((currentValue) => !currentValue)}
-                    className="inline-flex items-center gap-2 rounded-full border border-black/10 bg-white/80 px-4 py-2 text-xs font-semibold text-black/64 transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Recreate by name
                     <ChevronDown
@@ -363,9 +363,9 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 </div>
 
                 {showsLookupPanel ? (
-                  <div className="space-y-2 rounded-[20px] border border-black/8 bg-[#fff8f1] p-3">
+                  <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 p-3">
                     <label className="block">
-                      <span className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-black/44">
+                      <span className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">
                         Game names
                       </span>
                       <textarea
@@ -374,11 +374,11 @@ export const FactoryV2ManageIndexersWorkspace = ({
                         onChange={(event) => setLookupNamesText(event.target.value)}
                         placeholder={"bltz-franky-01\nbltz-franky-02"}
                         rows={3}
-                        className="mt-2 block min-h-[88px] w-full rounded-[18px] border border-black/10 bg-white px-4 py-3 text-sm text-black outline-none transition-colors focus:border-black/22"
+                        className="mt-2 block min-h-[88px] w-full rounded-[18px] border border-white/10 bg-white/10 px-4 py-3 text-sm text-[#fbf4ea] outline-none transition-colors focus:border-white/22"
                       />
                     </label>
                     {lookupGameNames.length > 0 ? (
-                      <div className="text-xs font-medium text-black/52">
+                      <div className="text-xs font-medium text-[#fbf4ea]/52">
                         {lookupGameNames.length} {lookupGameNames.length === 1 ? "name" : "names"}
                       </div>
                     ) : null}
@@ -428,7 +428,7 @@ export const FactoryV2ManageIndexersWorkspace = ({
                 )}
 
                 {notice && notice !== deleteFeedback?.message ? (
-                  <div className="rounded-[18px] border border-black/8 bg-white/74 px-4 py-3 text-sm text-black/62">
+                  <div className="rounded-[18px] border border-white/8 bg-white/8 px-4 py-3 text-sm text-[#fbf4ea]/62">
                     {notice}
                   </div>
                 ) : null}
@@ -481,13 +481,13 @@ const FactoryV2ManageIndexersSectionCard = ({
 }) => (
   <section
     className={cn(
-      "space-y-3 rounded-[24px] border border-black/8 px-4 py-4 text-left sm:px-5 sm:py-5",
+      "space-y-3 rounded-[24px] border border-white/8 px-4 py-4 text-left sm:px-5 sm:py-5",
       appearanceClassName,
     )}
   >
     <div className="space-y-1">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">{title}</div>
-      {description ? <p className="text-sm leading-5 text-black/50">{description}</p> : null}
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">{title}</div>
+      {description ? <p className="text-sm leading-5 text-[#fbf4ea]/50">{description}</p> : null}
     </div>
     {children}
   </section>
@@ -540,15 +540,15 @@ const FactoryV2ManageIndexersActionBar = ({
     <div
       data-testid="factory-indexer-action-panel"
       className={cn(
-        "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-black/10 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(23,15,8,0.16)] backdrop-blur-xl md:static md:rounded-[22px] md:border-black/8 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
+        "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-white/10 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.22)] backdrop-blur-xl md:static md:rounded-[22px] md:border-white/8 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
         appearance.quietSurfaceClassName,
       )}
     >
       {hasSelectedGames ? (
         <>
           <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Action</div>
-            <div className="text-sm font-semibold text-black/78">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Action</div>
+            <div className="text-sm font-semibold text-[#fbf4ea]/78">
               {selectedGameNames.length} indexer{selectedGameNames.length === 1 ? "" : "s"} selected
             </div>
           </div>
@@ -589,8 +589,8 @@ const FactoryV2ManageIndexersActionBar = ({
                     className={cn(
                       "rounded-[18px] border px-3 py-3 text-sm font-semibold capitalize transition-colors disabled:cursor-not-allowed disabled:opacity-50",
                       selectedTier === tier
-                        ? "border-black/16 bg-[rgba(255,252,247,0.82)] text-[#1b140f] shadow-[0_8px_20px_rgba(44,28,15,0.08)]"
-                        : "border-black/10 bg-white/82 text-black/68 hover:bg-white",
+                        ? "border-white/16 bg-white/12 text-[#fbf4ea] shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
+                        : "border-white/10 bg-white/10 text-[#fbf4ea]/68 hover:bg-white/10",
                     )}
                   >
                     {tier}
@@ -613,11 +613,11 @@ const FactoryV2ManageIndexersActionBar = ({
           ) : null}
 
           {actionTargets.deletableEntries.length > 0 ? (
-            <div className="rounded-[20px] border border-black/8 bg-white/64 p-3">
+            <div className="rounded-[20px] border border-white/8 bg-white/6 p-3">
               <div className="space-y-3">
                 <div className="space-y-1">
-                  <div className="text-sm font-semibold text-black/78">Delete</div>
-                  <p className="text-sm leading-5 text-black/56">
+                  <div className="text-sm font-semibold text-[#fbf4ea]/78">Delete</div>
+                  <p className="text-sm leading-5 text-[#fbf4ea]/56">
                     {resolveSelectionPreviewText(actionTargets.deletableEntries)}
                   </p>
                 </div>
@@ -627,14 +627,14 @@ const FactoryV2ManageIndexersActionBar = ({
                     disabled={isBusy}
                     data-testid="factory-indexer-open-delete"
                     onClick={onToggleDeletePanel}
-                    className="inline-flex w-full items-center justify-center rounded-full border border-[#a62f28]/20 bg-[#fff8f7] px-4 py-3 text-sm font-semibold text-[#8d2a23] transition-colors hover:bg-[#fff1ee] disabled:cursor-not-allowed disabled:opacity-50"
+                    className="inline-flex w-full items-center justify-center rounded-full border border-[#a62f28]/20 bg-[#2a1512] px-4 py-3 text-sm font-semibold text-[#8d2a23] transition-colors hover:bg-[#351a16] disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {resolveDeleteActionLabel(actionTargets.deletableGameNames.length)}
                   </button>
                 ) : (
                   <div className="space-y-3">
                     {deleteConfirmed ? (
-                      <div className="rounded-[18px] border border-[#a62f28]/18 bg-[#fff1ee] px-4 py-3 text-sm text-[#8d2a23]/82">
+                      <div className="rounded-[18px] border border-[#a62f28]/18 bg-[#2a1512] px-4 py-3 text-sm text-[#8d2a23]/82">
                         Delete is armed for the current live selection only.
                       </div>
                     ) : (
@@ -643,7 +643,7 @@ const FactoryV2ManageIndexersActionBar = ({
                         data-testid="factory-indexer-confirm-delete"
                         disabled={!canDelete}
                         onClick={onConfirmDelete}
-                        className="inline-flex w-full items-center justify-center rounded-full border border-[#a62f28]/20 bg-white px-4 py-3 text-sm font-semibold text-[#8d2a23] transition-colors hover:bg-[#fff8f7] disabled:cursor-not-allowed disabled:opacity-50"
+                        className="inline-flex w-full items-center justify-center rounded-full border border-[#a62f28]/20 bg-white/10 px-4 py-3 text-sm font-semibold text-[#8d2a23] transition-colors hover:bg-[#2a1512] disabled:cursor-not-allowed disabled:opacity-50"
                       >
                         I understand, enable delete
                       </button>
@@ -654,7 +654,7 @@ const FactoryV2ManageIndexersActionBar = ({
                       data-testid="factory-indexer-cancel-delete"
                       disabled={isBusy}
                       onClick={onCancelDelete}
-                      className="inline-flex w-full items-center justify-center rounded-full border border-black/10 bg-white px-4 py-3 text-sm font-semibold text-black/64 transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-50"
+                      className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/10 px-4 py-3 text-sm font-semibold text-[#fbf4ea]/64 transition-colors hover:bg-white/14 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       Keep these indexers
                     </button>
@@ -690,8 +690,8 @@ const FactoryV2ManageIndexerDeleteFeedback = ({ feedback }: { feedback: FactoryA
     className={cn(
       "rounded-[18px] border px-4 py-3 text-sm leading-6",
       feedback.ok
-        ? "border-emerald-700/15 bg-emerald-50/80 text-emerald-950"
-        : "border-[#a62f28]/18 bg-[#fff1ee] text-[#8d2a23]",
+        ? "border-emerald-700/15 bg-emerald-950/30 text-emerald-300"
+        : "border-[#a62f28]/18 bg-[#2a1512] text-[#8d2a23]",
     )}
   >
     {feedback.message}
@@ -707,10 +707,10 @@ const FactoryV2ManageIndexerActionCard = ({
   description: string;
   children: ReactNode;
 }) => (
-  <div className="space-y-3 rounded-[20px] border border-black/8 bg-white/64 p-3">
+  <div className="space-y-3 rounded-[20px] border border-white/8 bg-white/6 p-3">
     <div className="space-y-1">
-      <div className="text-sm font-semibold text-black/78">{title}</div>
-      <p className="text-sm leading-5 text-black/56">{description}</p>
+      <div className="text-sm font-semibold text-[#fbf4ea]/78">{title}</div>
+      <p className="text-sm leading-5 text-[#fbf4ea]/56">{description}</p>
     </div>
     <div className="space-y-3">{children}</div>
   </div>
@@ -740,7 +740,7 @@ const FactoryV2IndexerRow = ({
       className={cn(
         "w-full rounded-[22px] border px-4 py-4 text-left transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-55",
         isSelected
-          ? "border-black/14 bg-[rgba(255,252,247,0.82)] shadow-[0_12px_28px_rgba(44,28,15,0.08)]"
+          ? "border-white/14 bg-white/12 shadow-[0_12px_28px_rgba(0,0,0,0.16)]"
           : appearanceClassName,
       )}
     >
@@ -749,7 +749,7 @@ const FactoryV2IndexerRow = ({
           aria-hidden="true"
           className={cn(
             "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold transition-colors",
-            isSelected ? "border-[#1b140f] bg-[#1b140f] text-white" : "border-black/12 bg-white text-transparent",
+            isSelected ? "border-[#fbf4ea] bg-[#fbf4ea] text-white" : "border-white/12 bg-white/10 text-transparent",
           )}
         >
           ✓
@@ -757,10 +757,10 @@ const FactoryV2IndexerRow = ({
 
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="truncate text-sm font-semibold text-black/82">{entry.gameName}</span>
+            <span className="truncate text-sm font-semibold text-[#fbf4ea]/82">{entry.gameName}</span>
             <FactoryV2IndexerStateBadge label={resolveLiveIndexerPrimaryBadge(entry)} tone={tone} />
           </div>
-          <div className="mt-1 text-[12px] leading-5 text-black/56">{resolveLiveIndexerStatusLabel(entry)}</div>
+          <div className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/56">{resolveLiveIndexerStatusLabel(entry)}</div>
         </div>
       </div>
     </button>
@@ -771,9 +771,9 @@ const FactoryV2IndexerStateBadge = ({ label, tone }: { label: string; tone: "neu
   <span
     className={cn(
       "rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]",
-      tone === "warm" && "border-[#7a4b22]/15 bg-[#f7ecdf] text-[#7a4b22]",
-      tone === "danger" && "border-[#a62f28]/15 bg-[#f9ecea] text-[#a62f28]",
-      tone === "neutral" && "border-black/10 bg-white/80 text-black/52",
+      tone === "warm" && "border-[#dfaa54]/15 bg-[#dfaa54]/10 text-[#dfaa54]",
+      tone === "danger" && "border-[#a62f28]/15 bg-[#a62f28]/10 text-[#a62f28]",
+      tone === "neutral" && "border-white/10 bg-white/10 text-[#fbf4ea]/52",
     )}
   >
     {label}
@@ -781,7 +781,7 @@ const FactoryV2IndexerStateBadge = ({ label, tone }: { label: string; tone: "neu
 );
 
 const FactoryV2IndexerEmptyState = ({ children }: { children: ReactNode }) => (
-  <div className="rounded-[22px] border border-dashed border-black/10 bg-white/72 px-4 py-8 text-center text-sm leading-6 text-black/54">
+  <div className="rounded-[22px] border border-dashed border-white/10 bg-white/8 px-4 py-8 text-center text-sm leading-6 text-[#fbf4ea]/54">
     {children}
   </div>
 );
@@ -795,12 +795,12 @@ const FactoryV2ManageIndexerWatcherCard = ({
     data-testid="factory-indexer-watcher"
     className={cn(
       "rounded-[18px] border px-4 py-3",
-      watcherStatus.tone === "warm" ? "border-[#7a4b22]/15 bg-[#f7ecdf]" : "border-black/8 bg-white/72",
+      watcherStatus.tone === "warm" ? "border-[#dfaa54]/15 bg-[#dfaa54]/10" : "border-white/8 bg-white/8",
     )}
   >
-    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/44">{watcherStatus.eyebrow}</div>
-    <div className="mt-1 text-sm font-semibold text-black/74">{watcherStatus.title}</div>
-    <p className="mt-1 text-sm leading-6 text-black/58">{watcherStatus.detail}</p>
+    <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">{watcherStatus.eyebrow}</div>
+    <div className="mt-1 text-sm font-semibold text-[#fbf4ea]/74">{watcherStatus.title}</div>
+    <p className="mt-1 text-sm leading-6 text-[#fbf4ea]/58">{watcherStatus.detail}</p>
   </div>
 );
 

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-mode-switch.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-mode-switch.tsx
@@ -37,7 +37,7 @@ export const FactoryV2ModeSwitch = ({
         <FactoryV2ToggleGroup title="Network">
           <div
             data-testid="factory-network-switch"
-            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-white/8 bg-white/6 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.12)] md:max-w-[18rem]"
+            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-gold/10 bg-black/20 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.12)] md:max-w-[18rem]"
           >
             {environmentOptions.map((environment) => {
               const isSelected = environment.id === selectedEnvironmentId;
@@ -63,7 +63,7 @@ export const FactoryV2ModeSwitch = ({
         <FactoryV2ToggleGroup title="Game">
           <div
             data-testid="factory-game-switch"
-            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-white/8 bg-white/5 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[18rem]"
+            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-gold/10 bg-black/20 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[18rem]"
           >
             {modes.map((mode) => {
               const isSelected = mode.id === selectedMode;
@@ -92,7 +92,7 @@ export const FactoryV2ModeSwitch = ({
 
 const FactoryV2ToggleGroup = ({ title, children }: { title: string; children: ReactNode }) => (
   <div className="space-y-2 text-center">
-    <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[#fbf4ea]/42">{title}</div>
+    <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-gold/42">{title}</div>
     {children}
   </div>
 );

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-mode-switch.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-mode-switch.tsx
@@ -37,7 +37,7 @@ export const FactoryV2ModeSwitch = ({
         <FactoryV2ToggleGroup title="Network">
           <div
             data-testid="factory-network-switch"
-            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-black/8 bg-white/55 p-1.5 shadow-[0_10px_24px_rgba(34,24,14,0.06)] md:max-w-[18rem]"
+            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-white/8 bg-white/6 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.12)] md:max-w-[18rem]"
           >
             {environmentOptions.map((environment) => {
               const isSelected = environment.id === selectedEnvironmentId;
@@ -63,7 +63,7 @@ export const FactoryV2ModeSwitch = ({
         <FactoryV2ToggleGroup title="Game">
           <div
             data-testid="factory-game-switch"
-            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-black/8 bg-white/45 p-1.5 shadow-[0_10px_24px_rgba(34,24,14,0.05)] md:max-w-[18rem]"
+            className="mx-auto grid w-full grid-cols-2 gap-1.5 rounded-[22px] border border-white/8 bg-white/5 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[18rem]"
           >
             {modes.map((mode) => {
               const isSelected = mode.id === selectedMode;
@@ -92,7 +92,7 @@ export const FactoryV2ModeSwitch = ({
 
 const FactoryV2ToggleGroup = ({ title, children }: { title: string; children: ReactNode }) => (
   <div className="space-y-2 text-center">
-    <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-black/42">{title}</div>
+    <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[#fbf4ea]/42">{title}</div>
     {children}
   </div>
 );

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-more-options.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-more-options.tsx
@@ -113,7 +113,9 @@ export const FactoryV2MoreOptions = ({
                 className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-white/6"
               >
                 <div className="min-w-0">
-                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/58">{section.title}</div>
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/58">
+                    {section.title}
+                  </div>
                   <div className="mt-1 flex items-center gap-2 text-[11px] text-[#fbf4ea]/42">
                     <span>{section.description}</span>
                     <span>•</span>
@@ -152,7 +154,9 @@ export const FactoryV2MoreOptions = ({
                     <label key={field.id} className="block rounded-[16px] border border-white/8 bg-white/10 px-3 py-2">
                       <div className="flex items-center gap-3">
                         <div className="min-w-0 flex-1">
-                          <span className="block text-[13px] font-medium leading-5 text-[#fbf4ea]/74">{field.label}</span>
+                          <span className="block text-[13px] font-medium leading-5 text-[#fbf4ea]/74">
+                            {field.label}
+                          </span>
                           <span className="block text-[11px] leading-4 text-[#fbf4ea]/38">{field.helperText}</span>
                         </div>
                         {field.inputType === "number" ? (

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-more-options.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-more-options.tsx
@@ -74,49 +74,47 @@ export const FactoryV2MoreOptions = ({
         onClick={onToggle}
         aria-expanded={isOpen}
         className={cn(
-          "w-full rounded-[20px] border border-white/10 bg-white/6 px-4 py-3 text-left transition-colors hover:border-white/20",
-          mode === "blitz" ? "hover:bg-white/8" : "hover:bg-white/8",
+          "w-full rounded-[20px] border border-gold/15 bg-black/20 px-4 py-3 text-left transition-colors hover:border-gold/25",
+          mode === "blitz" ? "hover:bg-gold/10" : "hover:bg-gold/10",
         )}
       >
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold text-[#fbf4ea]">More options</span>
+              <span className="text-sm font-semibold text-gold">More options</span>
               {invalidReason ? (
                 <span className="rounded-full bg-rose-500/12 px-2 py-0.5 text-[10px] font-semibold text-rose-400">
                   Needs review
                 </span>
               ) : null}
             </div>
-            <p className="mt-1 text-[11px] text-[#fbf4ea]/45">
+            <p className="mt-1 text-[11px] text-gold/45">
               Chance fields use percentages. Time fields use minutes where shown. Prize amounts use human values.
             </p>
           </div>
           <ChevronDown
-            className={cn("h-4 w-4 flex-shrink-0 text-[#fbf4ea]/55 transition-transform", isOpen && "rotate-180")}
+            className={cn("h-4 w-4 flex-shrink-0 text-gold/55 transition-transform", isOpen && "rotate-180")}
           />
         </div>
       </button>
 
       {isOpen ? (
-        <div className="space-y-2 rounded-[20px] border border-white/10 bg-white/5 p-3 text-left">
-          <p className="text-[11px] uppercase tracking-[0.16em] text-[#fbf4ea]/40">
+        <div className="space-y-2 rounded-[20px] border border-gold/15 bg-black/20 p-3 text-left">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-gold/40">
             Compact overrides for this launch only.
           </p>
 
           {sections.map((section) => (
-            <div key={section.id} className="overflow-hidden rounded-[18px] border border-white/10 bg-white/6">
+            <div key={section.id} className="overflow-hidden rounded-[18px] border border-gold/15 bg-black/20">
               <button
                 type="button"
                 onClick={() => toggleSection(section.id)}
                 aria-expanded={expandedSectionIds.includes(section.id)}
-                className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-white/6"
+                className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-gold/10"
               >
                 <div className="min-w-0">
-                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/58">
-                    {section.title}
-                  </div>
-                  <div className="mt-1 flex items-center gap-2 text-[11px] text-[#fbf4ea]/42">
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-gold/58">{section.title}</div>
+                  <div className="mt-1 flex items-center gap-2 text-[11px] text-gold/42">
                     <span>{section.description}</span>
                     <span>•</span>
                     <span>{describeSectionContents(section)}</span>
@@ -130,40 +128,38 @@ export const FactoryV2MoreOptions = ({
                 </div>
                 <ChevronDown
                   className={cn(
-                    "h-4 w-4 flex-shrink-0 text-[#fbf4ea]/45 transition-transform",
+                    "h-4 w-4 flex-shrink-0 text-gold/45 transition-transform",
                     expandedSectionIds.includes(section.id) && "rotate-180",
                   )}
                 />
               </button>
 
               {expandedSectionIds.includes(section.id) ? (
-                <div className="space-y-2 border-t border-white/8 px-3 py-2.5">
+                <div className="space-y-2 border-t border-gold/10 px-3 py-2.5">
                   {section.previewRows?.map((row) => (
                     <div
                       key={row.id}
-                      className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/10 px-3 py-2"
+                      className="flex items-center justify-between gap-3 rounded-[16px] border border-gold/10 bg-black/25 px-3 py-2"
                     >
                       <div className="min-w-0">
-                        <div className="text-[13px] font-medium leading-5 text-[#fbf4ea]/74">{row.label}</div>
-                        <div className="text-[11px] leading-4 text-[#fbf4ea]/38">{row.probabilityLabel} chance</div>
+                        <div className="text-[13px] font-medium leading-5 text-gold/74">{row.label}</div>
+                        <div className="text-[11px] leading-4 text-gold/38">{row.probabilityLabel} chance</div>
                       </div>
-                      <div className="text-right text-[13px] font-semibold text-[#fbf4ea]/74">{row.amountLabel}</div>
+                      <div className="text-right text-[13px] font-semibold text-gold/74">{row.amountLabel}</div>
                     </div>
                   ))}
                   {section.fields.map((field) => (
-                    <label key={field.id} className="block rounded-[16px] border border-white/8 bg-white/10 px-3 py-2">
+                    <label key={field.id} className="block rounded-[16px] border border-gold/10 bg-black/25 px-3 py-2">
                       <div className="flex items-center gap-3">
                         <div className="min-w-0 flex-1">
-                          <span className="block text-[13px] font-medium leading-5 text-[#fbf4ea]/74">
-                            {field.label}
-                          </span>
-                          <span className="block text-[11px] leading-4 text-[#fbf4ea]/38">{field.helperText}</span>
+                          <span className="block text-[13px] font-medium leading-5 text-gold/74">{field.label}</span>
+                          <span className="block text-[11px] leading-4 text-gold/38">{field.helperText}</span>
                         </div>
                         {field.inputType === "number" ? (
                           <div
                             className={cn(
-                              "flex h-8 items-center gap-1 rounded-full border bg-white/10 px-2.5 shadow-[0_1px_0_rgba(255,255,255,0.06)]",
-                              errors[field.id] ? "border-rose-400/70" : "border-white/10",
+                              "flex h-8 items-center gap-1 rounded-full border bg-black/25 px-2.5 shadow-none",
+                              errors[field.id] ? "border-rose-400/70" : "border-gold/15",
                             )}
                           >
                             <input
@@ -175,12 +171,12 @@ export const FactoryV2MoreOptions = ({
                               value={draft[field.id]}
                               onChange={(event) => onValueChange(field.id, event.target.value)}
                               className={cn(
-                                "h-7 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-[#fbf4ea] outline-none",
+                                "h-7 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-gold outline-none",
                                 field.inputMode === "decimal" ? "w-16" : "w-20",
                               )}
                             />
                             {field.unitLabel ? (
-                              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[#fbf4ea]/42">
+                              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gold/42">
                                 {field.unitLabel}
                               </span>
                             ) : null}
@@ -195,8 +191,8 @@ export const FactoryV2MoreOptions = ({
                           placeholder={field.placeholder}
                           onChange={(event) => onValueChange(field.id, event.target.value)}
                           className={cn(
-                            "mt-2 block h-10 w-full rounded-[14px] border bg-white/10 px-3 text-[13px] text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/25",
-                            errors[field.id] ? "border-rose-400/70" : "border-white/10",
+                            "mt-2 block h-10 w-full rounded-[14px] border bg-black/25 px-3 text-[13px] text-gold outline-none transition-colors placeholder:text-gold/25",
+                            errors[field.id] ? "border-rose-400/70" : "border-gold/15",
                           )}
                         />
                       ) : null}

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-more-options.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-more-options.tsx
@@ -74,92 +74,92 @@ export const FactoryV2MoreOptions = ({
         onClick={onToggle}
         aria-expanded={isOpen}
         className={cn(
-          "w-full rounded-[20px] border border-black/10 bg-white/55 px-4 py-3 text-left transition-colors hover:border-black/20",
-          mode === "blitz" ? "hover:bg-white/75" : "hover:bg-white/70",
+          "w-full rounded-[20px] border border-white/10 bg-white/6 px-4 py-3 text-left transition-colors hover:border-white/20",
+          mode === "blitz" ? "hover:bg-white/8" : "hover:bg-white/8",
         )}
       >
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="text-sm font-semibold text-black">More options</span>
+              <span className="text-sm font-semibold text-[#fbf4ea]">More options</span>
               {invalidReason ? (
-                <span className="rounded-full bg-rose-500/10 px-2 py-0.5 text-[10px] font-semibold text-rose-700">
+                <span className="rounded-full bg-rose-500/12 px-2 py-0.5 text-[10px] font-semibold text-rose-400">
                   Needs review
                 </span>
               ) : null}
             </div>
-            <p className="mt-1 text-[11px] text-black/45">
+            <p className="mt-1 text-[11px] text-[#fbf4ea]/45">
               Chance fields use percentages. Time fields use minutes where shown. Prize amounts use human values.
             </p>
           </div>
           <ChevronDown
-            className={cn("h-4 w-4 flex-shrink-0 text-black/55 transition-transform", isOpen && "rotate-180")}
+            className={cn("h-4 w-4 flex-shrink-0 text-[#fbf4ea]/55 transition-transform", isOpen && "rotate-180")}
           />
         </div>
       </button>
 
       {isOpen ? (
-        <div className="space-y-2 rounded-[20px] border border-black/10 bg-white/45 p-3 text-left">
-          <p className="text-[11px] uppercase tracking-[0.16em] text-black/40">
+        <div className="space-y-2 rounded-[20px] border border-white/10 bg-white/5 p-3 text-left">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-[#fbf4ea]/40">
             Compact overrides for this launch only.
           </p>
 
           {sections.map((section) => (
-            <div key={section.id} className="overflow-hidden rounded-[18px] border border-black/10 bg-white/60">
+            <div key={section.id} className="overflow-hidden rounded-[18px] border border-white/10 bg-white/6">
               <button
                 type="button"
                 onClick={() => toggleSection(section.id)}
                 aria-expanded={expandedSectionIds.includes(section.id)}
-                className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-white/55"
+                className="flex w-full items-center justify-between gap-3 px-3 py-2.5 text-left transition-colors hover:bg-white/6"
               >
                 <div className="min-w-0">
-                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-black/58">{section.title}</div>
-                  <div className="mt-1 flex items-center gap-2 text-[11px] text-black/42">
+                  <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/58">{section.title}</div>
+                  <div className="mt-1 flex items-center gap-2 text-[11px] text-[#fbf4ea]/42">
                     <span>{section.description}</span>
                     <span>•</span>
                     <span>{describeSectionContents(section)}</span>
                     {section.fields.some((field) => Boolean(errors[field.id])) ? (
                       <>
                         <span>•</span>
-                        <span className="text-rose-700">Check values</span>
+                        <span className="text-rose-400">Check values</span>
                       </>
                     ) : null}
                   </div>
                 </div>
                 <ChevronDown
                   className={cn(
-                    "h-4 w-4 flex-shrink-0 text-black/45 transition-transform",
+                    "h-4 w-4 flex-shrink-0 text-[#fbf4ea]/45 transition-transform",
                     expandedSectionIds.includes(section.id) && "rotate-180",
                   )}
                 />
               </button>
 
               {expandedSectionIds.includes(section.id) ? (
-                <div className="space-y-2 border-t border-black/8 px-3 py-2.5">
+                <div className="space-y-2 border-t border-white/8 px-3 py-2.5">
                   {section.previewRows?.map((row) => (
                     <div
                       key={row.id}
-                      className="flex items-center justify-between gap-3 rounded-[16px] border border-black/8 bg-white/80 px-3 py-2"
+                      className="flex items-center justify-between gap-3 rounded-[16px] border border-white/8 bg-white/10 px-3 py-2"
                     >
                       <div className="min-w-0">
-                        <div className="text-[13px] font-medium leading-5 text-black/74">{row.label}</div>
-                        <div className="text-[11px] leading-4 text-black/38">{row.probabilityLabel} chance</div>
+                        <div className="text-[13px] font-medium leading-5 text-[#fbf4ea]/74">{row.label}</div>
+                        <div className="text-[11px] leading-4 text-[#fbf4ea]/38">{row.probabilityLabel} chance</div>
                       </div>
-                      <div className="text-right text-[13px] font-semibold text-black/74">{row.amountLabel}</div>
+                      <div className="text-right text-[13px] font-semibold text-[#fbf4ea]/74">{row.amountLabel}</div>
                     </div>
                   ))}
                   {section.fields.map((field) => (
-                    <label key={field.id} className="block rounded-[16px] border border-black/8 bg-white/80 px-3 py-2">
+                    <label key={field.id} className="block rounded-[16px] border border-white/8 bg-white/10 px-3 py-2">
                       <div className="flex items-center gap-3">
                         <div className="min-w-0 flex-1">
-                          <span className="block text-[13px] font-medium leading-5 text-black/74">{field.label}</span>
-                          <span className="block text-[11px] leading-4 text-black/38">{field.helperText}</span>
+                          <span className="block text-[13px] font-medium leading-5 text-[#fbf4ea]/74">{field.label}</span>
+                          <span className="block text-[11px] leading-4 text-[#fbf4ea]/38">{field.helperText}</span>
                         </div>
                         {field.inputType === "number" ? (
                           <div
                             className={cn(
-                              "flex h-8 items-center gap-1 rounded-full border bg-white px-2.5 shadow-[0_1px_0_rgba(255,255,255,0.55)]",
-                              errors[field.id] ? "border-rose-400/70" : "border-black/10",
+                              "flex h-8 items-center gap-1 rounded-full border bg-white/10 px-2.5 shadow-[0_1px_0_rgba(255,255,255,0.06)]",
+                              errors[field.id] ? "border-rose-400/70" : "border-white/10",
                             )}
                           >
                             <input
@@ -171,12 +171,12 @@ export const FactoryV2MoreOptions = ({
                               value={draft[field.id]}
                               onChange={(event) => onValueChange(field.id, event.target.value)}
                               className={cn(
-                                "h-7 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-black outline-none",
+                                "h-7 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-[#fbf4ea] outline-none",
                                 field.inputMode === "decimal" ? "w-16" : "w-20",
                               )}
                             />
                             {field.unitLabel ? (
-                              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-black/42">
+                              <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[#fbf4ea]/42">
                                 {field.unitLabel}
                               </span>
                             ) : null}
@@ -191,13 +191,13 @@ export const FactoryV2MoreOptions = ({
                           placeholder={field.placeholder}
                           onChange={(event) => onValueChange(field.id, event.target.value)}
                           className={cn(
-                            "mt-2 block h-10 w-full rounded-[14px] border bg-white px-3 text-[13px] text-black outline-none transition-colors placeholder:text-black/25",
-                            errors[field.id] ? "border-rose-400/70" : "border-black/10",
+                            "mt-2 block h-10 w-full rounded-[14px] border bg-white/10 px-3 text-[13px] text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/25",
+                            errors[field.id] ? "border-rose-400/70" : "border-white/10",
                           )}
                         />
                       ) : null}
                       {errors[field.id] ? (
-                        <span className="mt-1 block text-[11px] leading-5 text-rose-700">{errors[field.id]}</span>
+                        <span className="mt-1 block text-[11px] leading-5 text-rose-400">{errors[field.id]}</span>
                       ) : null}
                     </label>
                   ))}
@@ -207,7 +207,7 @@ export const FactoryV2MoreOptions = ({
           ))}
 
           {invalidReason && !sections.some((section) => section.fields.some((field) => Boolean(errors[field.id]))) ? (
-            <p className="text-[11px] leading-5 text-rose-700">{invalidReason}</p>
+            <p className="text-[11px] leading-5 text-rose-400">{invalidReason}</p>
           ) : null}
         </div>
       ) : null}

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-prize-funding-card.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-prize-funding-card.tsx
@@ -75,12 +75,10 @@ export const FactoryV2PrizeFundingCard = ({
   };
 
   return (
-    <div className="space-y-3 rounded-[24px] border border-white/8 bg-white/5 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
+    <div className="space-y-3 rounded-[24px] border border-gold/10 bg-black/20 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.2)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
-          Admin prize funding
-        </div>
-        <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Admin prize funding</div>
+        <p className="text-[13px] leading-5 text-gold/52">
           Send prizes to each game&apos;s trusted prize distribution address as soon as world setup is ready.
         </p>
       </div>
@@ -102,7 +100,7 @@ export const FactoryV2PrizeFundingCard = ({
 
       <div>
         <label className="space-y-1.5">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">Prize amount</span>
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/44">Prize amount</span>
           <input
             data-testid="factory-prize-amount"
             type="text"
@@ -110,7 +108,7 @@ export const FactoryV2PrizeFundingCard = ({
             value={amount}
             onChange={(event) => setAmount(event.target.value)}
             placeholder={isSeriesFunding ? "Per selected game" : "Token amount"}
-            className="w-full rounded-[18px] border border-white/10 bg-white/8 px-3 py-3 text-sm text-[#fbf4ea] shadow-[0_10px_24px_rgba(0,0,0,0.12)] outline-none transition-colors focus:border-[#dfaa54]/50"
+            className="w-full rounded-[18px] border border-gold/15 bg-black/25 px-3 py-3 text-sm text-gold shadow-[0_10px_24px_rgba(0,0,0,0.12)] outline-none transition-colors focus:border-[#dfaa54]/50"
           />
         </label>
       </div>
@@ -133,12 +131,12 @@ export const FactoryV2PrizeFundingCard = ({
 
       <div className="space-y-2 text-center">
         {isSeriesFunding ? (
-          <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
+          <p className="text-[13px] leading-5 text-gold/52">
             This sends one multicall with one transfer per selected game. Already funded games stay visible so you can
             explicitly resend them when needed, and games that are not ready stay visible until configuration finishes.
           </p>
         ) : (
-          <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
+          <p className="text-[13px] leading-5 text-gold/52">
             This sends one ERC20 transfer to the trusted prize distribution address for {run.name}.
           </p>
         )}
@@ -149,7 +147,7 @@ export const FactoryV2PrizeFundingCard = ({
           onClick={() => {
             void submitFundingRequest();
           }}
-          className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-[#dfaa54] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#c89540] disabled:cursor-not-allowed disabled:bg-[#dfaa54]/45"
+          className="inline-flex w-full items-center justify-center rounded-full border border-gold/15 bg-[#dfaa54] px-4 py-3 text-sm font-semibold text-gold transition-colors hover:bg-[#c89540] disabled:cursor-not-allowed disabled:bg-[#dfaa54]/45"
         >
           {isCoolingDown
             ? `Wait ${cooldownSecondsRemaining}s`
@@ -184,10 +182,10 @@ const FactoryV2PrizeFundingSeriesSelector = ({
   isBusy: boolean;
   onToggleGame: (gameName: string) => void;
 }) => (
-  <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 p-3">
+  <div className="space-y-2 rounded-[20px] border border-gold/10 bg-black/20 p-3">
     <div className="mx-auto max-w-sm space-y-1 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/42">{gameGroupLabel}</div>
-      <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/42">{gameGroupLabel}</div>
+      <p className="text-[13px] leading-5 text-gold/52">
         Eligible unfunded games are selected by default. Funded games stay reselectable and not-ready games stay
         visible.
       </p>
@@ -200,7 +198,7 @@ const FactoryV2PrizeFundingSeriesSelector = ({
         return (
           <label
             key={game.gameName}
-            className="flex items-center gap-3 rounded-[18px] border border-white/8 bg-white/8 px-3 py-3 text-left"
+            className="flex items-center gap-3 rounded-[18px] border border-gold/10 bg-black/25 px-3 py-3 text-left"
           >
             <input
               data-testid={`factory-prize-game-${game.gameName}`}
@@ -208,11 +206,11 @@ const FactoryV2PrizeFundingSeriesSelector = ({
               checked={isSelected}
               disabled={!isSelectable || isBusy}
               onChange={() => onToggleGame(game.gameName)}
-              className="h-4 w-4 rounded border-white/20 text-[#dfaa54] focus:ring-[#dfaa54]/40"
+              className="h-4 w-4 rounded border-gold/25 text-[#dfaa54] focus:ring-[#dfaa54]/40"
             />
             <div className="min-w-0 flex-1">
-              <div className="truncate text-sm font-semibold text-[#fbf4ea]">{game.gameName}</div>
-              <div className="text-[12px] text-[#fbf4ea]/48">{resolvePrizeFundingGameStatusLabel(game)}</div>
+              <div className="truncate text-sm font-semibold text-gold">{game.gameName}</div>
+              <div className="text-[12px] text-gold/48">{resolvePrizeFundingGameStatusLabel(game)}</div>
             </div>
           </label>
         );
@@ -222,9 +220,9 @@ const FactoryV2PrizeFundingSeriesSelector = ({
 );
 
 const FactoryV2PrizeFundingMetric = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-[18px] border border-white/8 bg-white/6 px-3 py-3 text-center">
-    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/40">{label}</div>
-    <div className="mt-1 text-[13px] font-semibold text-[#fbf4ea]">{value}</div>
+  <div className="rounded-[18px] border border-gold/10 bg-black/20 px-3 py-3 text-center">
+    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/40">{label}</div>
+    <div className="mt-1 text-[13px] font-semibold text-gold">{value}</div>
   </div>
 );
 

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-prize-funding-card.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-prize-funding-card.tsx
@@ -77,7 +77,9 @@ export const FactoryV2PrizeFundingCard = ({
   return (
     <div className="space-y-3 rounded-[24px] border border-white/8 bg-white/5 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Admin prize funding</div>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+          Admin prize funding
+        </div>
         <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
           Send prizes to each game&apos;s trusted prize distribution address as soon as world setup is ready.
         </p>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-prize-funding-card.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-prize-funding-card.tsx
@@ -75,10 +75,10 @@ export const FactoryV2PrizeFundingCard = ({
   };
 
   return (
-    <div className="space-y-3 rounded-[24px] border border-black/8 bg-white/40 p-4 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+    <div className="space-y-3 rounded-[24px] border border-white/8 bg-white/5 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Admin prize funding</div>
-        <p className="text-[13px] leading-5 text-black/52">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Admin prize funding</div>
+        <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
           Send prizes to each game&apos;s trusted prize distribution address as soon as world setup is ready.
         </p>
       </div>
@@ -100,7 +100,7 @@ export const FactoryV2PrizeFundingCard = ({
 
       <div>
         <label className="space-y-1.5">
-          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/44">Prize amount</span>
+          <span className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/44">Prize amount</span>
           <input
             data-testid="factory-prize-amount"
             type="text"
@@ -108,7 +108,7 @@ export const FactoryV2PrizeFundingCard = ({
             value={amount}
             onChange={(event) => setAmount(event.target.value)}
             placeholder={isSeriesFunding ? "Per selected game" : "Token amount"}
-            className="w-full rounded-[18px] border border-black/10 bg-white/72 px-3 py-3 text-sm text-black shadow-[0_10px_24px_rgba(15,23,42,0.04)] outline-none transition-colors focus:border-[#9d6c35]/50"
+            className="w-full rounded-[18px] border border-white/10 bg-white/8 px-3 py-3 text-sm text-[#fbf4ea] shadow-[0_10px_24px_rgba(0,0,0,0.12)] outline-none transition-colors focus:border-[#dfaa54]/50"
           />
         </label>
       </div>
@@ -131,12 +131,12 @@ export const FactoryV2PrizeFundingCard = ({
 
       <div className="space-y-2 text-center">
         {isSeriesFunding ? (
-          <p className="text-[13px] leading-5 text-black/52">
+          <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
             This sends one multicall with one transfer per selected game. Already funded games stay visible so you can
             explicitly resend them when needed, and games that are not ready stay visible until configuration finishes.
           </p>
         ) : (
-          <p className="text-[13px] leading-5 text-black/52">
+          <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
             This sends one ERC20 transfer to the trusted prize distribution address for {run.name}.
           </p>
         )}
@@ -147,7 +147,7 @@ export const FactoryV2PrizeFundingCard = ({
           onClick={() => {
             void submitFundingRequest();
           }}
-          className="inline-flex w-full items-center justify-center rounded-full border border-black/10 bg-[#7a4b22] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#6d411c] disabled:cursor-not-allowed disabled:bg-[#7a4b22]/45"
+          className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-[#dfaa54] px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-[#c89540] disabled:cursor-not-allowed disabled:bg-[#dfaa54]/45"
         >
           {isCoolingDown
             ? `Wait ${cooldownSecondsRemaining}s`
@@ -159,7 +159,7 @@ export const FactoryV2PrizeFundingCard = ({
           <div
             data-testid="factory-prize-success"
             aria-live="polite"
-            className="rounded-[18px] border border-emerald-700/15 bg-emerald-50/80 px-3 py-2 text-left text-[12px] leading-5 text-emerald-950"
+            className="rounded-[18px] border border-emerald-700/15 bg-emerald-950/30 px-3 py-2 text-left text-[12px] leading-5 text-emerald-300"
           >
             {successMessage}
           </div>
@@ -182,10 +182,10 @@ const FactoryV2PrizeFundingSeriesSelector = ({
   isBusy: boolean;
   onToggleGame: (gameName: string) => void;
 }) => (
-  <div className="space-y-2 rounded-[20px] border border-black/8 bg-white/52 p-3">
+  <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 p-3">
     <div className="mx-auto max-w-sm space-y-1 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/42">{gameGroupLabel}</div>
-      <p className="text-[13px] leading-5 text-black/52">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/42">{gameGroupLabel}</div>
+      <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
         Eligible unfunded games are selected by default. Funded games stay reselectable and not-ready games stay
         visible.
       </p>
@@ -198,7 +198,7 @@ const FactoryV2PrizeFundingSeriesSelector = ({
         return (
           <label
             key={game.gameName}
-            className="flex items-center gap-3 rounded-[18px] border border-black/8 bg-white/72 px-3 py-3 text-left"
+            className="flex items-center gap-3 rounded-[18px] border border-white/8 bg-white/8 px-3 py-3 text-left"
           >
             <input
               data-testid={`factory-prize-game-${game.gameName}`}
@@ -206,11 +206,11 @@ const FactoryV2PrizeFundingSeriesSelector = ({
               checked={isSelected}
               disabled={!isSelectable || isBusy}
               onChange={() => onToggleGame(game.gameName)}
-              className="h-4 w-4 rounded border-black/20 text-[#7a4b22] focus:ring-[#7a4b22]/40"
+              className="h-4 w-4 rounded border-white/20 text-[#dfaa54] focus:ring-[#dfaa54]/40"
             />
             <div className="min-w-0 flex-1">
-              <div className="truncate text-sm font-semibold text-black">{game.gameName}</div>
-              <div className="text-[12px] text-black/48">{resolvePrizeFundingGameStatusLabel(game)}</div>
+              <div className="truncate text-sm font-semibold text-[#fbf4ea]">{game.gameName}</div>
+              <div className="text-[12px] text-[#fbf4ea]/48">{resolvePrizeFundingGameStatusLabel(game)}</div>
             </div>
           </label>
         );
@@ -220,9 +220,9 @@ const FactoryV2PrizeFundingSeriesSelector = ({
 );
 
 const FactoryV2PrizeFundingMetric = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-[18px] border border-black/8 bg-white/62 px-3 py-3 text-center">
-    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-black/40">{label}</div>
-    <div className="mt-1 text-[13px] font-semibold text-black">{value}</div>
+  <div className="rounded-[18px] border border-white/8 bg-white/6 px-3 py-3 text-center">
+    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/40">{label}</div>
+    <div className="mt-1 text-[13px] font-semibold text-[#fbf4ea]">{value}</div>
   </div>
 );
 

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-shell.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-shell.tsx
@@ -2,11 +2,7 @@ import type { ReactNode } from "react";
 
 export const FactoryV2Shell = ({ children }: { children: ReactNode }) => {
   return (
-    <div className="relative h-screen overflow-y-auto bg-[#15110f] text-[#fbf4ea]">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(255,255,255,0.06),_transparent_30%),radial-gradient(circle_at_bottom_right,_rgba(245,158,11,0.08),_transparent_28%),linear-gradient(180deg,_rgba(21,17,15,0.98)_0%,_rgba(11,9,8,1)_100%)]" />
-      <div className="pointer-events-none absolute left-[-6rem] top-16 h-72 w-72 rounded-full bg-white/5 blur-3xl" />
-      <div className="pointer-events-none absolute bottom-8 right-[-5rem] h-80 w-80 rounded-full bg-amber-500/10 blur-3xl" />
-
+    <div className="relative h-screen overflow-y-auto text-gold/90">
       <main className="relative mx-auto flex min-h-screen max-w-[1600px] flex-col gap-4 px-0 pb-[calc(6.5rem+env(safe-area-inset-bottom))] pt-0 md:gap-6 md:px-6 md:pb-32 md:pt-6 xl:px-8">
         {children}
       </main>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-start-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-start-workspace.tsx
@@ -51,23 +51,23 @@ const getPresetFacts = (preset: FactoryLaunchPreset) =>
   ].filter(Boolean);
 
 const FACTORY_FIELD_CONTROL_CLASS_NAME =
-  "mt-2 block h-11 w-full min-w-0 max-w-full rounded-[18px] border border-black/10 bg-white/78 px-3 text-left text-[13px] text-black outline-none transition-colors focus:border-black/25 md:px-4 md:text-center md:text-sm";
+  "mt-2 block h-11 w-full min-w-0 max-w-full rounded-[18px] border border-white/10 bg-white/8 px-3 text-left text-[13px] text-[#fbf4ea] outline-none transition-colors focus:border-white/25 md:px-4 md:text-center md:text-sm";
 
 const FACTORY_SELECT_CONTROL_CLASS_NAME = `${FACTORY_FIELD_CONTROL_CLASS_NAME} appearance-none pr-11 font-medium`;
 
 const FACTORY_SCHEDULE_PANEL_CLASS_NAME =
-  "block min-w-0 overflow-hidden rounded-[20px] border border-black/8 bg-white/48 px-3 py-3 shadow-[0_8px_22px_rgba(15,23,42,0.04)] transition-colors focus-within:border-black/16";
+  "block min-w-0 overflow-hidden rounded-[20px] border border-white/8 bg-white/6 px-3 py-3 shadow-[0_8px_22px_rgba(0,0,0,0.10)] transition-colors focus-within:border-white/16";
 
 const FACTORY_MOBILE_PICKER_INPUT_CLASS_NAME =
   "absolute inset-0 h-full w-full min-w-0 max-w-full cursor-pointer opacity-0";
 
 const FACTORY_DESKTOP_PICKER_INPUT_CLASS_NAME =
-  "sm:static sm:mt-2 sm:block sm:h-11 sm:w-full sm:min-w-0 sm:max-w-full sm:rounded-[18px] sm:border sm:border-black/10 sm:bg-white/78 sm:px-4 sm:text-left sm:text-sm sm:font-medium sm:text-black sm:opacity-100 sm:outline-none sm:transition-colors sm:focus:border-black/25 sm:[color-scheme:light]";
+  "sm:static sm:mt-2 sm:block sm:h-11 sm:w-full sm:min-w-0 sm:max-w-full sm:rounded-[18px] sm:border sm:border-white/10 sm:bg-white/8 sm:px-4 sm:text-left sm:text-sm sm:font-medium sm:text-[#fbf4ea] sm:opacity-100 sm:outline-none sm:transition-colors sm:focus:border-white/25 sm:[color-scheme:dark]";
 
 const FACTORY_NATIVE_PICKER_INPUT_CLASS_NAME = `${FACTORY_MOBILE_PICKER_INPUT_CLASS_NAME} ${FACTORY_DESKTOP_PICKER_INPUT_CLASS_NAME}`;
 
 const FACTORY_SCHEDULE_VALUE_SURFACE_CLASS_NAME =
-  "pointer-events-none mt-2 flex h-11 items-center gap-3 rounded-[18px] border border-black/10 bg-white/78 px-4 text-left text-[13px] text-black shadow-[inset_0_1px_0_rgba(255,255,255,0.4)] sm:hidden";
+  "pointer-events-none mt-2 flex h-11 items-center gap-3 rounded-[18px] border border-white/10 bg-white/8 px-4 text-left text-[13px] text-[#fbf4ea] shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] sm:hidden";
 
 const FACTORY_SERIES_RETRY_OPTIONS: FactorySeriesRetryIntervalMinutes[] = [5, 15, 30, 60];
 const FACTORY_ROTATION_EVALUATION_OPTIONS: FactoryRotationEvaluationIntervalMinutes[] = [5, 15, 30, 60];
@@ -273,7 +273,7 @@ function resolveStartWorkspaceState(
 const FactoryV2StartWorkspaceEmptyState = ({ appearanceClassName }: { appearanceClassName: string }) => (
   <article className="w-full md:mx-auto md:max-w-xl">
     <div className={cn("px-4 py-5 md:rounded-[28px] md:border md:p-7", appearanceClassName)}>
-      <div className="text-sm leading-6 text-black/58">Pick a preset first.</div>
+      <div className="text-sm leading-6 text-[#fbf4ea]/58">Pick a preset first.</div>
     </div>
   </article>
 );
@@ -694,7 +694,7 @@ const FactoryV2PresetField = ({
   <div className="min-w-0">
     <label
       htmlFor="factory-preset"
-      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
     >
       Preset
     </label>
@@ -711,10 +711,10 @@ const FactoryV2PresetField = ({
           </option>
         ))}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-black/45" />
+      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
     </div>
-    <p className="mt-3 text-sm leading-6 text-black/48">{selectedPreset.description}</p>
-    {presetFacts ? <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-black/40">{presetFacts}</p> : null}
+    <p className="mt-3 text-sm leading-6 text-[#fbf4ea]/48">{selectedPreset.description}</p>
+    {presetFacts ? <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[#fbf4ea]/40">{presetFacts}</p> : null}
   </div>
 );
 
@@ -741,7 +741,7 @@ const FactoryV2SingleGameBasics = ({
     <div className="flex items-center justify-between gap-3">
       <label
         htmlFor="factory-game-name"
-        className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+        className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
       >
         Game name
       </label>
@@ -762,16 +762,16 @@ const FactoryV2SingleGameBasics = ({
       value={gameName}
       onChange={(event) => onGameNameChange(event.target.value)}
       placeholder={mode === "eternum" ? "etrn-sunrise-01" : "bltz-sprint-01"}
-      className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-black/30`}
+      className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-[#fbf4ea]/30`}
     />
     {existingRunName ? (
-      <p className="mt-2 text-sm leading-6 text-black/50">
+      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">
         That name is already in use. We will open that run instead.
       </p>
     ) : null}
-    {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-black/50">{notice}</p> : null}
+    {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{notice}</p> : null}
     {!existingRunName && launchDisabledReason ? (
-      <p className="mt-2 text-sm leading-6 text-black/50">{launchDisabledReason}</p>
+      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{launchDisabledReason}</p>
     ) : null}
   </div>
 );
@@ -861,8 +861,8 @@ const FactoryV2BlitzSetupSection = ({
     ) : null}
 
     <div className="space-y-1">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Play style</div>
-      <p className="text-sm leading-5 text-black/50">Choose how players and realms are arranged for this game.</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Play style</div>
+      <p className="text-sm leading-5 text-[#fbf4ea]/50">Choose how players and realms are arranged for this game.</p>
     </div>
     <div className="space-y-1.5">
       {blitzPlayStyleOptions.map((playStyle) => (
@@ -936,12 +936,12 @@ const FactoryV2LaunchTargetButton = ({
     className={cn(
       "rounded-[20px] border px-4 py-3 text-left transition-colors",
       isSelected
-        ? "border-black/14 bg-[rgba(255,252,247,0.82)] text-[#1b140f] shadow-[0_8px_20px_rgba(44,28,15,0.08)]"
+        ? "border-white/14 bg-white/12 text-[#fbf4ea] shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
         : appearanceClassName,
     )}
   >
     <div className="text-[13px] font-semibold leading-5">{label}</div>
-    <div className="mt-1 text-[11px] leading-5 text-black/48">{description}</div>
+    <div className="mt-1 text-[11px] leading-5 text-[#fbf4ea]/48">{description}</div>
   </button>
 );
 
@@ -1160,7 +1160,7 @@ const FactoryV2SeriesBasics = ({
     <div className="min-w-0">
       <label
         htmlFor="factory-series-name"
-        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
       >
         Series name
       </label>
@@ -1169,7 +1169,7 @@ const FactoryV2SeriesBasics = ({
         value={seriesName}
         onChange={(event) => onSeriesNameChange(event.target.value)}
         placeholder={mode === "eternum" ? "etrn-season-run" : "bltz-weekend-cup"}
-        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-black/30`}
+        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-[#fbf4ea]/30`}
       />
       {seriesSuggestions.length > 0 ? (
         <div className="mt-3 flex flex-wrap justify-center gap-2">
@@ -1178,31 +1178,31 @@ const FactoryV2SeriesBasics = ({
               key={series.name}
               type="button"
               onClick={() => onSelectSeriesSuggestion(series.name)}
-              className="rounded-full border border-black/10 bg-white/70 px-3 py-1 text-[11px] font-medium text-black/58 transition-colors hover:bg-white"
+              className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-medium text-[#fbf4ea]/58 transition-colors hover:bg-white/10"
             >
               {series.name} · next {series.nextGameNumber}
             </button>
           ))}
         </div>
       ) : null}
-      {isLoadingSeries ? <p className="mt-2 text-sm leading-6 text-black/50">Loading your series…</p> : null}
+      {isLoadingSeries ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">Loading your series…</p> : null}
       {!isLoadingSeries && seriesLookupError ? (
-        <p className="mt-2 text-sm leading-6 text-black/50">{seriesLookupError}</p>
+        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{seriesLookupError}</p>
       ) : null}
       {existingRunName ? (
-        <p className="mt-2 text-sm leading-6 text-black/50">
+        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">
           This series already has a parent run. Launching again will append any new games and resume that shared run.
         </p>
       ) : null}
-      {notice ? <p className="mt-2 text-sm leading-6 text-black/50">{notice}</p> : null}
-      {launchDisabledReason ? <p className="mt-2 text-sm leading-6 text-black/50">{launchDisabledReason}</p> : null}
+      {notice ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{notice}</p> : null}
+      {launchDisabledReason ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{launchDisabledReason}</p> : null}
     </div>
 
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="min-w-0">
         <label
           htmlFor="factory-series-count"
-          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
         >
           Game count
         </label>
@@ -1219,7 +1219,7 @@ const FactoryV2SeriesBasics = ({
       <div className="min-w-0">
         <label
           htmlFor="factory-series-retry-interval"
-          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
         >
           Retry interval
         </label>
@@ -1238,7 +1238,7 @@ const FactoryV2SeriesBasics = ({
               </option>
             ))}
           </select>
-          <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-black/45" />
+          <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
         </div>
       </div>
     </div>
@@ -1296,7 +1296,7 @@ const FactoryV2RotationBasics = ({
     <div className="min-w-0">
       <label
         htmlFor="factory-rotation-name"
-        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
       >
         Rotation name
       </label>
@@ -1305,16 +1305,16 @@ const FactoryV2RotationBasics = ({
         value={rotationName}
         onChange={(event) => onRotationNameChange(event.target.value)}
         placeholder={mode === "eternum" ? "etrn-hourly-rotation" : "bltz-ladder-loop"}
-        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-black/30`}
+        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-[#fbf4ea]/30`}
       />
       {existingRunName ? (
-        <p className="mt-2 text-sm leading-6 text-black/50">
+        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">
           This rotation already exists. Open it from Watch to continue it or run it now.
         </p>
       ) : null}
-      {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-black/50">{notice}</p> : null}
+      {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{notice}</p> : null}
       {!existingRunName && launchDisabledReason ? (
-        <p className="mt-2 text-sm leading-6 text-black/50">{launchDisabledReason}</p>
+        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{launchDisabledReason}</p>
       ) : null}
     </div>
 
@@ -1401,12 +1401,12 @@ const FactoryV2SeriesGameRow = ({
   const startTime = resolveFactoryStartTimePart(game.startAt);
 
   return (
-    <div className="rounded-[20px] border border-black/8 bg-white/65 p-3 shadow-[0_8px_20px_rgba(15,23,42,0.04)]">
+    <div className="rounded-[20px] border border-white/8 bg-white/6 p-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
           Game {game.seriesGameNumber}
         </div>
-        <div className="rounded-full border border-black/8 bg-white/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-black/46">
+        <div className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/46">
           Series
         </div>
       </div>
@@ -1414,7 +1414,7 @@ const FactoryV2SeriesGameRow = ({
         <div className="min-w-0">
           <label
             htmlFor={`factory-series-game-name-${game.id}`}
-            className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-black/38"
+            className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38"
           >
             Game name
           </label>
@@ -1422,7 +1422,7 @@ const FactoryV2SeriesGameRow = ({
             id={`factory-series-game-name-${game.id}`}
             value={game.gameName}
             onChange={(event) => onGameNameChange(game.id, event.target.value)}
-            className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} mt-2 placeholder:text-black/30`}
+            className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} mt-2 placeholder:text-[#fbf4ea]/30`}
           />
         </div>
         <div className="grid gap-2 sm:grid-cols-2">
@@ -1432,7 +1432,7 @@ const FactoryV2SeriesGameRow = ({
             type="date"
             value={startDate}
             displayValue={formatFactoryStartDateLabel(startDate)}
-            icon={<CalendarDays className="h-4 w-4 text-black/36" />}
+            icon={<CalendarDays className="h-4 w-4 text-[#fbf4ea]/36" />}
             displayTestId={`factory-series-start-date-display-${game.id}`}
             onChange={(value) => onStartAtChange(game.id, buildFactoryStartAtValue(value, startTime, game.startAt))}
           />
@@ -1442,7 +1442,7 @@ const FactoryV2SeriesGameRow = ({
             type="time"
             value={startTime}
             displayValue={formatFactoryStartTimeLabel(startTime)}
-            icon={<Clock3 className="h-4 w-4 text-black/36" />}
+            icon={<Clock3 className="h-4 w-4 text-[#fbf4ea]/36" />}
             displayTestId={`factory-series-start-time-display-${game.id}`}
             onChange={(value) => onStartAtChange(game.id, buildFactoryStartAtValue(startDate, value, game.startAt))}
           />
@@ -1457,20 +1457,20 @@ const FactoryV2RotationPreviewRow = ({ game }: { game: FactoryRotationPreviewGam
   const startTime = resolveFactoryStartTimePart(game.startAt);
 
   return (
-    <div className="rounded-[20px] border border-black/8 bg-white/65 p-3 shadow-[0_8px_20px_rgba(15,23,42,0.04)]">
+    <div className="rounded-[20px] border border-white/8 bg-white/6 p-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
           Game {game.seriesGameNumber}
         </div>
-        <div className="rounded-full border border-black/8 bg-white/70 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-black/46">
+        <div className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/46">
           Rotation
         </div>
       </div>
       <div className="space-y-2">
-        <div className="text-[13px] font-semibold text-black">{game.gameName}</div>
-        <div className="flex flex-wrap items-center gap-2 text-[12px] text-black/50">
+        <div className="text-[13px] font-semibold text-[#fbf4ea]">{game.gameName}</div>
+        <div className="flex flex-wrap items-center gap-2 text-[12px] text-[#fbf4ea]/50">
           <span>{formatFactoryStartDateLabel(startDate)}</span>
-          <span className="text-black/28">·</span>
+          <span className="text-[#fbf4ea]/28">·</span>
           <span>{formatFactoryStartTimeLabel(startTime)}</span>
         </div>
       </div>
@@ -1491,13 +1491,13 @@ const FactoryV2StartSectionCard = ({
 }) => (
   <section
     className={cn(
-      "space-y-4 rounded-[24px] border border-black/8 px-4 py-4 text-left sm:px-5 sm:py-5",
+      "space-y-4 rounded-[24px] border border-white/8 px-4 py-4 text-left sm:px-5 sm:py-5",
       appearanceClassName,
     )}
   >
     <div className="mx-auto max-w-sm space-y-1 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">{title}</div>
-      <p className="text-sm leading-5 text-black/50">{description}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">{title}</div>
+      <p className="text-sm leading-5 text-[#fbf4ea]/50">{description}</p>
     </div>
     {children}
   </section>
@@ -1520,11 +1520,11 @@ const FactoryV2StartTimeField = ({
       <div className="space-y-1 sm:flex sm:items-end sm:justify-between sm:gap-3 sm:space-y-0">
         <label
           htmlFor="factory-start-date"
-          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
         >
           Start time
         </label>
-        <span className="text-[11px] leading-5 text-black/38">Your local time</span>
+        <span className="text-[11px] leading-5 text-[#fbf4ea]/38">Your local time</span>
       </div>
       <div className="grid min-w-0 gap-2 sm:grid-cols-2">
         <FactoryV2NativePickerField
@@ -1533,7 +1533,7 @@ const FactoryV2StartTimeField = ({
           type="date"
           value={startDate}
           displayValue={formatFactoryStartDateLabel(startDate)}
-          icon={<CalendarDays className="h-4 w-4 text-black/36" />}
+          icon={<CalendarDays className="h-4 w-4 text-[#fbf4ea]/36" />}
           displayTestId="factory-start-date-display"
           onChange={(value) => onChange(buildFactoryStartAtValue(value, startTime, startAt))}
         />
@@ -1543,12 +1543,12 @@ const FactoryV2StartTimeField = ({
           type="time"
           value={startTime}
           displayValue={formatFactoryStartTimeLabel(startTime)}
-          icon={<Clock3 className="h-4 w-4 text-black/36" />}
+          icon={<Clock3 className="h-4 w-4 text-[#fbf4ea]/36" />}
           displayTestId="factory-start-time-display"
           onChange={(value) => onChange(buildFactoryStartAtValue(startDate, value, startAt))}
         />
       </div>
-      <p className="mt-2 text-sm leading-6 text-black/48">{helperText}</p>
+      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/48">{helperText}</p>
     </div>
   );
 };
@@ -1571,7 +1571,7 @@ const FactoryV2NumberField = ({
   onChange: (value: number) => void;
 }) => (
   <div className="min-w-0">
-    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
       {label}
     </label>
     <div className="relative mt-2">
@@ -1585,7 +1585,7 @@ const FactoryV2NumberField = ({
         className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} text-center font-medium`}
       />
       {suffix ? (
-        <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-[0.12em] text-black/36">
+        <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-[0.12em] text-[#fbf4ea]/36">
           {suffix}
         </span>
       ) : null}
@@ -1609,7 +1609,7 @@ const FactoryV2SelectField = ({
   onChange: (value: string) => void;
 }) => (
   <div className="min-w-0">
-    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
       {label}
     </label>
     <div className="relative mt-2">
@@ -1621,7 +1621,7 @@ const FactoryV2SelectField = ({
       >
         {children}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-black/45" />
+      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
     </div>
   </div>
 );
@@ -1634,7 +1634,7 @@ const FactoryV2ScheduleMeaningList = ({
     description: string;
   }>;
 }) => (
-  <div className="space-y-2 rounded-[20px] border border-black/8 bg-white/58 px-4 py-3">
+  <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 px-4 py-3">
     {items.map((item) => (
       <FactoryV2ScheduleMeaningItem key={item.label} label={item.label} description={item.description} />
     ))}
@@ -1643,12 +1643,12 @@ const FactoryV2ScheduleMeaningList = ({
 
 const FactoryV2ScheduleMeaningItem = ({ label, description }: { label: string; description: string }) => (
   <div className="flex items-start gap-3 text-left">
-    <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-black/10 bg-white/72 text-black/42">
+    <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/8 text-[#fbf4ea]/42">
       <Info className="h-3.5 w-3.5" />
     </span>
     <div className="min-w-0">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-black/42">{label}</div>
-      <p className="mt-1 text-[13px] leading-5 text-black/54">{description}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/42">{label}</div>
+      <p className="mt-1 text-[13px] leading-5 text-[#fbf4ea]/54">{description}</p>
     </div>
   </div>
 );
@@ -1673,11 +1673,11 @@ const FactoryV2NativePickerField = ({
   onChange: (value: string) => void;
 }) => (
   <label className={FACTORY_SCHEDULE_PANEL_CLASS_NAME}>
-    <span className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-black/38">{label}</span>
+    <span className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">{label}</span>
     <div className="relative min-w-0">
       <div data-testid={displayTestId} className={FACTORY_SCHEDULE_VALUE_SURFACE_CLASS_NAME}>
         {icon}
-        <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-black/72">{displayValue}</span>
+        <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-[#fbf4ea]/72">{displayValue}</span>
       </div>
       <input
         id={inputId}
@@ -1704,7 +1704,7 @@ const FactoryV2DurationField = ({
   <div className="min-w-0">
     <label
       htmlFor="factory-duration"
-      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42"
+      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
     >
       Duration
     </label>
@@ -1721,7 +1721,7 @@ const FactoryV2DurationField = ({
           </option>
         ))}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-black/45" />
+      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
     </div>
   </div>
 );
@@ -1737,16 +1737,16 @@ const FactoryV2InlineOptionField = ({
   error: string | null;
   onChange: (value: string) => void;
 }) => (
-  <label className="block rounded-[20px] border border-black/8 bg-white/72 px-4 py-3.5">
+  <label className="block rounded-[20px] border border-white/8 bg-white/8 px-4 py-3.5">
     <div className="flex items-center gap-3">
       <div className="min-w-0 flex-1">
-        <span className="block text-[13px] font-medium leading-5 text-black/74">{field.label}</span>
-        <span className="block text-[11px] leading-4 text-black/38">{field.helperText}</span>
+        <span className="block text-[13px] font-medium leading-5 text-[#fbf4ea]/74">{field.label}</span>
+        <span className="block text-[11px] leading-4 text-[#fbf4ea]/38">{field.helperText}</span>
       </div>
       <div
         className={cn(
-          "flex h-9 items-center gap-1 rounded-full border bg-white px-2.5 shadow-[0_1px_0_rgba(255,255,255,0.55)]",
-          error ? "border-rose-400/70" : "border-black/10",
+          "flex h-9 items-center gap-1 rounded-full border bg-white/10 px-2.5 shadow-[0_1px_0_rgba(255,255,255,0.06)]",
+          error ? "border-rose-400/70" : "border-white/10",
         )}
       >
         <input
@@ -1757,10 +1757,10 @@ const FactoryV2InlineOptionField = ({
           step={field.step}
           value={value}
           onChange={(event) => onChange(event.target.value)}
-          className="h-7 w-16 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-black outline-none"
+          className="h-7 w-16 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-[#fbf4ea] outline-none"
         />
         {field.unitLabel ? (
-          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-black/42">{field.unitLabel}</span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[#fbf4ea]/42">{field.unitLabel}</span>
         ) : null}
       </div>
     </div>
@@ -1786,8 +1786,8 @@ const FactoryV2PlayStyleOption = ({
     className={cn(
       "w-full rounded-[18px] border px-4 py-3 text-left transition-all duration-200",
       isEnabled
-        ? "border-black/16 bg-[rgba(255,252,247,0.82)] text-[#1b140f] shadow-[0_8px_20px_rgba(44,28,15,0.08)]"
-        : cn(appearanceClassName, "text-black/70 shadow-none"),
+        ? "border-white/16 bg-white/12 text-[#fbf4ea] shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
+        : cn(appearanceClassName, "text-[#fbf4ea]/70 shadow-none"),
     )}
   >
     <div className="flex items-center gap-3">
@@ -1795,13 +1795,13 @@ const FactoryV2PlayStyleOption = ({
         aria-hidden="true"
         className={cn(
           "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-200",
-          isEnabled ? "border-[#1b140f] bg-[#1b140f]" : "border-black/18 bg-transparent",
+          isEnabled ? "border-[#fbf4ea] bg-[#fbf4ea]" : "border-white/18 bg-transparent",
         )}
       >
         <span
           className={cn(
             "h-1.5 w-1.5 rounded-full transition-colors duration-200",
-            isEnabled ? "bg-[#fff7ec]" : "bg-transparent",
+            isEnabled ? "bg-[#15110f]" : "bg-transparent",
           )}
         />
       </span>
@@ -1828,7 +1828,7 @@ const FactoryV2LaunchActionBar = ({
   <div
     data-testid="factory-start-action-bar"
     className={cn(
-      "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-black/10 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(23,15,8,0.16)] backdrop-blur-xl md:static md:rounded-[22px] md:border-black/8 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
+      "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-white/10 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.22)] backdrop-blur-xl md:static md:rounded-[22px] md:border-white/8 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
       appearanceClassName,
     )}
   >
@@ -1836,7 +1836,7 @@ const FactoryV2LaunchActionBar = ({
       {launchSummaryItems.map((item) => (
         <span
           key={item}
-          className="rounded-full border border-black/10 bg-white/70 px-3 py-1 text-[11px] font-medium text-black/56"
+          className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-medium text-[#fbf4ea]/56"
         >
           {item}
         </span>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-start-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-start-workspace.tsx
@@ -714,7 +714,9 @@ const FactoryV2PresetField = ({
       <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
     </div>
     <p className="mt-3 text-sm leading-6 text-[#fbf4ea]/48">{selectedPreset.description}</p>
-    {presetFacts ? <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[#fbf4ea]/40">{presetFacts}</p> : null}
+    {presetFacts ? (
+      <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[#fbf4ea]/40">{presetFacts}</p>
+    ) : null}
   </div>
 );
 
@@ -1760,7 +1762,9 @@ const FactoryV2InlineOptionField = ({
           className="h-7 w-16 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-[#fbf4ea] outline-none"
         />
         {field.unitLabel ? (
-          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[#fbf4ea]/42">{field.unitLabel}</span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[#fbf4ea]/42">
+            {field.unitLabel}
+          </span>
         ) : null}
       </div>
     </div>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-start-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-start-workspace.tsx
@@ -51,23 +51,23 @@ const getPresetFacts = (preset: FactoryLaunchPreset) =>
   ].filter(Boolean);
 
 const FACTORY_FIELD_CONTROL_CLASS_NAME =
-  "mt-2 block h-11 w-full min-w-0 max-w-full rounded-[18px] border border-white/10 bg-white/8 px-3 text-left text-[13px] text-[#fbf4ea] outline-none transition-colors focus:border-white/25 md:px-4 md:text-center md:text-sm";
+  "mt-2 block h-11 w-full min-w-0 max-w-full rounded-[18px] border border-gold/15 bg-black/25 px-3 text-left text-[13px] text-gold outline-none transition-colors focus:border-gold/30 backdrop-blur-[6px] md:px-4 md:text-center md:text-sm";
 
 const FACTORY_SELECT_CONTROL_CLASS_NAME = `${FACTORY_FIELD_CONTROL_CLASS_NAME} appearance-none pr-11 font-medium`;
 
 const FACTORY_SCHEDULE_PANEL_CLASS_NAME =
-  "block min-w-0 overflow-hidden rounded-[20px] border border-white/8 bg-white/6 px-3 py-3 shadow-[0_8px_22px_rgba(0,0,0,0.10)] transition-colors focus-within:border-white/16";
+  "block min-w-0 overflow-hidden rounded-[20px] border border-gold/10 bg-black/20 px-3 py-3 shadow-[0_8px_22px_rgba(0,0,0,0.12)] backdrop-blur-[6px] transition-colors focus-within:border-gold/25";
 
 const FACTORY_MOBILE_PICKER_INPUT_CLASS_NAME =
   "absolute inset-0 h-full w-full min-w-0 max-w-full cursor-pointer opacity-0";
 
 const FACTORY_DESKTOP_PICKER_INPUT_CLASS_NAME =
-  "sm:static sm:mt-2 sm:block sm:h-11 sm:w-full sm:min-w-0 sm:max-w-full sm:rounded-[18px] sm:border sm:border-white/10 sm:bg-white/8 sm:px-4 sm:text-left sm:text-sm sm:font-medium sm:text-[#fbf4ea] sm:opacity-100 sm:outline-none sm:transition-colors sm:focus:border-white/25 sm:[color-scheme:dark]";
+  "sm:static sm:mt-2 sm:block sm:h-11 sm:w-full sm:min-w-0 sm:max-w-full sm:rounded-[18px] sm:border sm:border-gold/15 sm:bg-black/25 sm:px-4 sm:text-left sm:text-sm sm:font-medium sm:text-gold sm:opacity-100 sm:outline-none sm:transition-colors sm:focus:border-gold/30 sm:[color-scheme:dark]";
 
 const FACTORY_NATIVE_PICKER_INPUT_CLASS_NAME = `${FACTORY_MOBILE_PICKER_INPUT_CLASS_NAME} ${FACTORY_DESKTOP_PICKER_INPUT_CLASS_NAME}`;
 
 const FACTORY_SCHEDULE_VALUE_SURFACE_CLASS_NAME =
-  "pointer-events-none mt-2 flex h-11 items-center gap-3 rounded-[18px] border border-white/10 bg-white/8 px-4 text-left text-[13px] text-[#fbf4ea] shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] sm:hidden";
+  "pointer-events-none mt-2 flex h-11 items-center gap-3 rounded-[18px] border border-gold/15 bg-black/25 px-4 text-left text-[13px] text-gold shadow-none sm:hidden";
 
 const FACTORY_SERIES_RETRY_OPTIONS: FactorySeriesRetryIntervalMinutes[] = [5, 15, 30, 60];
 const FACTORY_ROTATION_EVALUATION_OPTIONS: FactoryRotationEvaluationIntervalMinutes[] = [5, 15, 30, 60];
@@ -247,7 +247,7 @@ function resolveStartWorkspaceState(
       modeLabel,
       seriesGameCount: seriesGames.length,
     }),
-    launchButtonClassName: isMainnet ? "bg-[#a62f28] text-white hover:bg-[#912520]" : appearance.primaryButtonClassName,
+    launchButtonClassName: isMainnet ? "bg-[#a62f28] text-gold hover:bg-[#912520]" : appearance.primaryButtonClassName,
     launchSummaryItems: resolveLaunchSummaryItems({
       isSeriesLaunch,
       isRotationLaunch,
@@ -273,7 +273,7 @@ function resolveStartWorkspaceState(
 const FactoryV2StartWorkspaceEmptyState = ({ appearanceClassName }: { appearanceClassName: string }) => (
   <article className="w-full md:mx-auto md:max-w-xl">
     <div className={cn("px-4 py-5 md:rounded-[28px] md:border md:p-7", appearanceClassName)}>
-      <div className="text-sm leading-6 text-[#fbf4ea]/58">Pick a preset first.</div>
+      <div className="text-sm leading-6 text-gold/58">Pick a preset first.</div>
     </div>
   </article>
 );
@@ -694,7 +694,7 @@ const FactoryV2PresetField = ({
   <div className="min-w-0">
     <label
       htmlFor="factory-preset"
-      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
     >
       Preset
     </label>
@@ -711,12 +711,10 @@ const FactoryV2PresetField = ({
           </option>
         ))}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
+      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gold/45" />
     </div>
-    <p className="mt-3 text-sm leading-6 text-[#fbf4ea]/48">{selectedPreset.description}</p>
-    {presetFacts ? (
-      <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-[#fbf4ea]/40">{presetFacts}</p>
-    ) : null}
+    <p className="mt-3 text-sm leading-6 text-gold/48">{selectedPreset.description}</p>
+    {presetFacts ? <p className="mt-2 text-[11px] uppercase tracking-[0.18em] text-gold/40">{presetFacts}</p> : null}
   </div>
 );
 
@@ -741,10 +739,7 @@ const FactoryV2SingleGameBasics = ({
 }) => (
   <div className="min-w-0">
     <div className="flex items-center justify-between gap-3">
-      <label
-        htmlFor="factory-game-name"
-        className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
-      >
+      <label htmlFor="factory-game-name" className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
         Game name
       </label>
       <button
@@ -764,16 +759,14 @@ const FactoryV2SingleGameBasics = ({
       value={gameName}
       onChange={(event) => onGameNameChange(event.target.value)}
       placeholder={mode === "eternum" ? "etrn-sunrise-01" : "bltz-sprint-01"}
-      className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-[#fbf4ea]/30`}
+      className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-gold/30`}
     />
     {existingRunName ? (
-      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">
-        That name is already in use. We will open that run instead.
-      </p>
+      <p className="mt-2 text-sm leading-6 text-gold/50">That name is already in use. We will open that run instead.</p>
     ) : null}
-    {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{notice}</p> : null}
+    {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-gold/50">{notice}</p> : null}
     {!existingRunName && launchDisabledReason ? (
-      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{launchDisabledReason}</p>
+      <p className="mt-2 text-sm leading-6 text-gold/50">{launchDisabledReason}</p>
     ) : null}
   </div>
 );
@@ -863,8 +856,8 @@ const FactoryV2BlitzSetupSection = ({
     ) : null}
 
     <div className="space-y-1">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Play style</div>
-      <p className="text-sm leading-5 text-[#fbf4ea]/50">Choose how players and realms are arranged for this game.</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Play style</div>
+      <p className="text-sm leading-5 text-gold/50">Choose how players and realms are arranged for this game.</p>
     </div>
     <div className="space-y-1.5">
       {blitzPlayStyleOptions.map((playStyle) => (
@@ -937,13 +930,11 @@ const FactoryV2LaunchTargetButton = ({
     onClick={onClick}
     className={cn(
       "rounded-[20px] border px-4 py-3 text-left transition-colors",
-      isSelected
-        ? "border-white/14 bg-white/12 text-[#fbf4ea] shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
-        : appearanceClassName,
+      isSelected ? "border-gold/20 bg-black/30 text-gold shadow-[0_8px_20px_rgba(0,0,0,0.16)]" : appearanceClassName,
     )}
   >
     <div className="text-[13px] font-semibold leading-5">{label}</div>
-    <div className="mt-1 text-[11px] leading-5 text-[#fbf4ea]/48">{description}</div>
+    <div className="mt-1 text-[11px] leading-5 text-gold/48">{description}</div>
   </button>
 );
 
@@ -1162,7 +1153,7 @@ const FactoryV2SeriesBasics = ({
     <div className="min-w-0">
       <label
         htmlFor="factory-series-name"
-        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
       >
         Series name
       </label>
@@ -1171,7 +1162,7 @@ const FactoryV2SeriesBasics = ({
         value={seriesName}
         onChange={(event) => onSeriesNameChange(event.target.value)}
         placeholder={mode === "eternum" ? "etrn-season-run" : "bltz-weekend-cup"}
-        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-[#fbf4ea]/30`}
+        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-gold/30`}
       />
       {seriesSuggestions.length > 0 ? (
         <div className="mt-3 flex flex-wrap justify-center gap-2">
@@ -1180,31 +1171,31 @@ const FactoryV2SeriesBasics = ({
               key={series.name}
               type="button"
               onClick={() => onSelectSeriesSuggestion(series.name)}
-              className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-medium text-[#fbf4ea]/58 transition-colors hover:bg-white/10"
+              className="rounded-full border border-gold/15 bg-black/25 px-3 py-1 text-[11px] font-medium text-gold/58 transition-colors hover:bg-gold/10"
             >
               {series.name} · next {series.nextGameNumber}
             </button>
           ))}
         </div>
       ) : null}
-      {isLoadingSeries ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">Loading your series…</p> : null}
+      {isLoadingSeries ? <p className="mt-2 text-sm leading-6 text-gold/50">Loading your series…</p> : null}
       {!isLoadingSeries && seriesLookupError ? (
-        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{seriesLookupError}</p>
+        <p className="mt-2 text-sm leading-6 text-gold/50">{seriesLookupError}</p>
       ) : null}
       {existingRunName ? (
-        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">
+        <p className="mt-2 text-sm leading-6 text-gold/50">
           This series already has a parent run. Launching again will append any new games and resume that shared run.
         </p>
       ) : null}
-      {notice ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{notice}</p> : null}
-      {launchDisabledReason ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{launchDisabledReason}</p> : null}
+      {notice ? <p className="mt-2 text-sm leading-6 text-gold/50">{notice}</p> : null}
+      {launchDisabledReason ? <p className="mt-2 text-sm leading-6 text-gold/50">{launchDisabledReason}</p> : null}
     </div>
 
     <div className="grid gap-4 sm:grid-cols-2">
       <div className="min-w-0">
         <label
           htmlFor="factory-series-count"
-          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
         >
           Game count
         </label>
@@ -1221,7 +1212,7 @@ const FactoryV2SeriesBasics = ({
       <div className="min-w-0">
         <label
           htmlFor="factory-series-retry-interval"
-          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
         >
           Retry interval
         </label>
@@ -1240,7 +1231,7 @@ const FactoryV2SeriesBasics = ({
               </option>
             ))}
           </select>
-          <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
+          <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gold/45" />
         </div>
       </div>
     </div>
@@ -1298,7 +1289,7 @@ const FactoryV2RotationBasics = ({
     <div className="min-w-0">
       <label
         htmlFor="factory-rotation-name"
-        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+        className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
       >
         Rotation name
       </label>
@@ -1307,16 +1298,16 @@ const FactoryV2RotationBasics = ({
         value={rotationName}
         onChange={(event) => onRotationNameChange(event.target.value)}
         placeholder={mode === "eternum" ? "etrn-hourly-rotation" : "bltz-ladder-loop"}
-        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-[#fbf4ea]/30`}
+        className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} placeholder:text-gold/30`}
       />
       {existingRunName ? (
-        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">
+        <p className="mt-2 text-sm leading-6 text-gold/50">
           This rotation already exists. Open it from Watch to continue it or run it now.
         </p>
       ) : null}
-      {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{notice}</p> : null}
+      {!existingRunName && notice ? <p className="mt-2 text-sm leading-6 text-gold/50">{notice}</p> : null}
       {!existingRunName && launchDisabledReason ? (
-        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/50">{launchDisabledReason}</p>
+        <p className="mt-2 text-sm leading-6 text-gold/50">{launchDisabledReason}</p>
       ) : null}
     </div>
 
@@ -1403,12 +1394,12 @@ const FactoryV2SeriesGameRow = ({
   const startTime = resolveFactoryStartTimePart(game.startAt);
 
   return (
-    <div className="rounded-[20px] border border-white/8 bg-white/6 p-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]">
+    <div className="rounded-[20px] border border-gold/10 bg-black/20 p-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
           Game {game.seriesGameNumber}
         </div>
-        <div className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/46">
+        <div className="rounded-full border border-gold/10 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/46">
           Series
         </div>
       </div>
@@ -1416,7 +1407,7 @@ const FactoryV2SeriesGameRow = ({
         <div className="min-w-0">
           <label
             htmlFor={`factory-series-game-name-${game.id}`}
-            className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38"
+            className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/38"
           >
             Game name
           </label>
@@ -1424,7 +1415,7 @@ const FactoryV2SeriesGameRow = ({
             id={`factory-series-game-name-${game.id}`}
             value={game.gameName}
             onChange={(event) => onGameNameChange(game.id, event.target.value)}
-            className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} mt-2 placeholder:text-[#fbf4ea]/30`}
+            className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} mt-2 placeholder:text-gold/30`}
           />
         </div>
         <div className="grid gap-2 sm:grid-cols-2">
@@ -1434,7 +1425,7 @@ const FactoryV2SeriesGameRow = ({
             type="date"
             value={startDate}
             displayValue={formatFactoryStartDateLabel(startDate)}
-            icon={<CalendarDays className="h-4 w-4 text-[#fbf4ea]/36" />}
+            icon={<CalendarDays className="h-4 w-4 text-gold/36" />}
             displayTestId={`factory-series-start-date-display-${game.id}`}
             onChange={(value) => onStartAtChange(game.id, buildFactoryStartAtValue(value, startTime, game.startAt))}
           />
@@ -1444,7 +1435,7 @@ const FactoryV2SeriesGameRow = ({
             type="time"
             value={startTime}
             displayValue={formatFactoryStartTimeLabel(startTime)}
-            icon={<Clock3 className="h-4 w-4 text-[#fbf4ea]/36" />}
+            icon={<Clock3 className="h-4 w-4 text-gold/36" />}
             displayTestId={`factory-series-start-time-display-${game.id}`}
             onChange={(value) => onStartAtChange(game.id, buildFactoryStartAtValue(startDate, value, game.startAt))}
           />
@@ -1459,20 +1450,20 @@ const FactoryV2RotationPreviewRow = ({ game }: { game: FactoryRotationPreviewGam
   const startTime = resolveFactoryStartTimePart(game.startAt);
 
   return (
-    <div className="rounded-[20px] border border-white/8 bg-white/6 p-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]">
+    <div className="rounded-[20px] border border-gold/10 bg-black/20 p-3 shadow-[0_8px_20px_rgba(0,0,0,0.12)]">
       <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
           Game {game.seriesGameNumber}
         </div>
-        <div className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/46">
+        <div className="rounded-full border border-gold/10 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/46">
           Rotation
         </div>
       </div>
       <div className="space-y-2">
-        <div className="text-[13px] font-semibold text-[#fbf4ea]">{game.gameName}</div>
-        <div className="flex flex-wrap items-center gap-2 text-[12px] text-[#fbf4ea]/50">
+        <div className="text-[13px] font-semibold text-gold">{game.gameName}</div>
+        <div className="flex flex-wrap items-center gap-2 text-[12px] text-gold/50">
           <span>{formatFactoryStartDateLabel(startDate)}</span>
-          <span className="text-[#fbf4ea]/28">·</span>
+          <span className="text-gold/28">·</span>
           <span>{formatFactoryStartTimeLabel(startTime)}</span>
         </div>
       </div>
@@ -1493,13 +1484,13 @@ const FactoryV2StartSectionCard = ({
 }) => (
   <section
     className={cn(
-      "space-y-4 rounded-[24px] border border-white/8 px-4 py-4 text-left sm:px-5 sm:py-5",
+      "space-y-4 rounded-[24px] border border-gold/10 px-4 py-4 text-left sm:px-5 sm:py-5",
       appearanceClassName,
     )}
   >
     <div className="mx-auto max-w-sm space-y-1 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">{title}</div>
-      <p className="text-sm leading-5 text-[#fbf4ea]/50">{description}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">{title}</div>
+      <p className="text-sm leading-5 text-gold/50">{description}</p>
     </div>
     {children}
   </section>
@@ -1522,11 +1513,11 @@ const FactoryV2StartTimeField = ({
       <div className="space-y-1 sm:flex sm:items-end sm:justify-between sm:gap-3 sm:space-y-0">
         <label
           htmlFor="factory-start-date"
-          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+          className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
         >
           Start time
         </label>
-        <span className="text-[11px] leading-5 text-[#fbf4ea]/38">Your local time</span>
+        <span className="text-[11px] leading-5 text-gold/38">Your local time</span>
       </div>
       <div className="grid min-w-0 gap-2 sm:grid-cols-2">
         <FactoryV2NativePickerField
@@ -1535,7 +1526,7 @@ const FactoryV2StartTimeField = ({
           type="date"
           value={startDate}
           displayValue={formatFactoryStartDateLabel(startDate)}
-          icon={<CalendarDays className="h-4 w-4 text-[#fbf4ea]/36" />}
+          icon={<CalendarDays className="h-4 w-4 text-gold/36" />}
           displayTestId="factory-start-date-display"
           onChange={(value) => onChange(buildFactoryStartAtValue(value, startTime, startAt))}
         />
@@ -1545,12 +1536,12 @@ const FactoryV2StartTimeField = ({
           type="time"
           value={startTime}
           displayValue={formatFactoryStartTimeLabel(startTime)}
-          icon={<Clock3 className="h-4 w-4 text-[#fbf4ea]/36" />}
+          icon={<Clock3 className="h-4 w-4 text-gold/36" />}
           displayTestId="factory-start-time-display"
           onChange={(value) => onChange(buildFactoryStartAtValue(startDate, value, startAt))}
         />
       </div>
-      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/48">{helperText}</p>
+      <p className="mt-2 text-sm leading-6 text-gold/48">{helperText}</p>
     </div>
   );
 };
@@ -1573,7 +1564,7 @@ const FactoryV2NumberField = ({
   onChange: (value: number) => void;
 }) => (
   <div className="min-w-0">
-    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
       {label}
     </label>
     <div className="relative mt-2">
@@ -1587,7 +1578,7 @@ const FactoryV2NumberField = ({
         className={`${FACTORY_FIELD_CONTROL_CLASS_NAME} text-center font-medium`}
       />
       {suffix ? (
-        <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-[0.12em] text-[#fbf4ea]/36">
+        <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[11px] uppercase tracking-[0.12em] text-gold/36">
           {suffix}
         </span>
       ) : null}
@@ -1611,7 +1602,7 @@ const FactoryV2SelectField = ({
   onChange: (value: string) => void;
 }) => (
   <div className="min-w-0">
-    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+    <label htmlFor={inputId} className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
       {label}
     </label>
     <div className="relative mt-2">
@@ -1623,7 +1614,7 @@ const FactoryV2SelectField = ({
       >
         {children}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
+      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gold/45" />
     </div>
   </div>
 );
@@ -1636,7 +1627,7 @@ const FactoryV2ScheduleMeaningList = ({
     description: string;
   }>;
 }) => (
-  <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 px-4 py-3">
+  <div className="space-y-2 rounded-[20px] border border-gold/10 bg-black/20 px-4 py-3">
     {items.map((item) => (
       <FactoryV2ScheduleMeaningItem key={item.label} label={item.label} description={item.description} />
     ))}
@@ -1645,12 +1636,12 @@ const FactoryV2ScheduleMeaningList = ({
 
 const FactoryV2ScheduleMeaningItem = ({ label, description }: { label: string; description: string }) => (
   <div className="flex items-start gap-3 text-left">
-    <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/8 text-[#fbf4ea]/42">
+    <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border border-gold/15 bg-black/25 text-gold/42">
       <Info className="h-3.5 w-3.5" />
     </span>
     <div className="min-w-0">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/42">{label}</div>
-      <p className="mt-1 text-[13px] leading-5 text-[#fbf4ea]/54">{description}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gold/42">{label}</div>
+      <p className="mt-1 text-[13px] leading-5 text-gold/54">{description}</p>
     </div>
   </div>
 );
@@ -1675,11 +1666,11 @@ const FactoryV2NativePickerField = ({
   onChange: (value: string) => void;
 }) => (
   <label className={FACTORY_SCHEDULE_PANEL_CLASS_NAME}>
-    <span className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/38">{label}</span>
+    <span className="block text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/38">{label}</span>
     <div className="relative min-w-0">
       <div data-testid={displayTestId} className={FACTORY_SCHEDULE_VALUE_SURFACE_CLASS_NAME}>
         {icon}
-        <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-[#fbf4ea]/72">{displayValue}</span>
+        <span className="min-w-0 flex-1 truncate text-[14px] font-medium text-gold/72">{displayValue}</span>
       </div>
       <input
         id={inputId}
@@ -1706,7 +1697,7 @@ const FactoryV2DurationField = ({
   <div className="min-w-0">
     <label
       htmlFor="factory-duration"
-      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42"
+      className="block text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42"
     >
       Duration
     </label>
@@ -1723,7 +1714,7 @@ const FactoryV2DurationField = ({
           </option>
         ))}
       </select>
-      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-[#fbf4ea]/45" />
+      <ChevronDown className="pointer-events-none absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-gold/45" />
     </div>
   </div>
 );
@@ -1739,16 +1730,16 @@ const FactoryV2InlineOptionField = ({
   error: string | null;
   onChange: (value: string) => void;
 }) => (
-  <label className="block rounded-[20px] border border-white/8 bg-white/8 px-4 py-3.5">
+  <label className="block rounded-[20px] border border-gold/10 bg-black/25 px-4 py-3.5">
     <div className="flex items-center gap-3">
       <div className="min-w-0 flex-1">
-        <span className="block text-[13px] font-medium leading-5 text-[#fbf4ea]/74">{field.label}</span>
-        <span className="block text-[11px] leading-4 text-[#fbf4ea]/38">{field.helperText}</span>
+        <span className="block text-[13px] font-medium leading-5 text-gold/74">{field.label}</span>
+        <span className="block text-[11px] leading-4 text-gold/38">{field.helperText}</span>
       </div>
       <div
         className={cn(
-          "flex h-9 items-center gap-1 rounded-full border bg-white/10 px-2.5 shadow-[0_1px_0_rgba(255,255,255,0.06)]",
-          error ? "border-rose-400/70" : "border-white/10",
+          "flex h-9 items-center gap-1 rounded-full border bg-black/25 px-2.5 shadow-none",
+          error ? "border-rose-400/70" : "border-gold/15",
         )}
       >
         <input
@@ -1759,12 +1750,10 @@ const FactoryV2InlineOptionField = ({
           step={field.step}
           value={value}
           onChange={(event) => onChange(event.target.value)}
-          className="h-7 w-16 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-[#fbf4ea] outline-none"
+          className="h-7 w-16 border-0 bg-transparent p-0 text-right text-[13px] font-semibold text-gold outline-none"
         />
         {field.unitLabel ? (
-          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-[#fbf4ea]/42">
-            {field.unitLabel}
-          </span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-gold/42">{field.unitLabel}</span>
         ) : null}
       </div>
     </div>
@@ -1790,8 +1779,8 @@ const FactoryV2PlayStyleOption = ({
     className={cn(
       "w-full rounded-[18px] border px-4 py-3 text-left transition-all duration-200",
       isEnabled
-        ? "border-white/16 bg-white/12 text-[#fbf4ea] shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
-        : cn(appearanceClassName, "text-[#fbf4ea]/70 shadow-none"),
+        ? "border-gold/25 bg-black/30 text-gold shadow-[0_8px_20px_rgba(0,0,0,0.16)]"
+        : cn(appearanceClassName, "text-gold/70 shadow-none"),
     )}
   >
     <div className="flex items-center gap-3">
@@ -1799,7 +1788,7 @@ const FactoryV2PlayStyleOption = ({
         aria-hidden="true"
         className={cn(
           "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors duration-200",
-          isEnabled ? "border-[#fbf4ea] bg-[#fbf4ea]" : "border-white/18 bg-transparent",
+          isEnabled ? "border-gold bg-gold" : "border-gold/25 bg-transparent",
         )}
       >
         <span
@@ -1832,7 +1821,7 @@ const FactoryV2LaunchActionBar = ({
   <div
     data-testid="factory-start-action-bar"
     className={cn(
-      "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-white/10 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.22)] backdrop-blur-xl md:static md:rounded-[22px] md:border-white/8 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
+      "sticky bottom-3 z-10 space-y-3 rounded-[24px] border border-gold/15 px-4 pb-[calc(0.875rem+env(safe-area-inset-bottom))] pt-4 text-left shadow-[0_18px_42px_rgba(0,0,0,0.22)] backdrop-blur-xl md:static md:rounded-[22px] md:border-gold/10 md:px-4 md:py-4 md:shadow-none md:backdrop-blur-0",
       appearanceClassName,
     )}
   >
@@ -1840,7 +1829,7 @@ const FactoryV2LaunchActionBar = ({
       {launchSummaryItems.map((item) => (
         <span
           key={item}
-          className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-medium text-[#fbf4ea]/56"
+          className="rounded-full border border-gold/15 bg-black/25 px-3 py-1 text-[11px] font-medium text-gold/56"
         >
           {item}
         </span>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
@@ -1217,7 +1217,9 @@ const FactoryV2WatchPendingCard = ({
 const FactoryV2WatchEmptyCard = ({ appearanceClassName }: { appearanceClassName: string }) => (
   <FactoryV2WatchSurfaceCard appearanceClassName={appearanceClassName} dataTestId="factory-watch-empty-panel">
     <div className="mx-auto max-w-sm space-y-3 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">{WATCH_SEARCH_EYEBROW}</div>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
+        {WATCH_SEARCH_EYEBROW}
+      </div>
       <h3 className="text-[1.15rem] font-semibold tracking-tight text-[#fbf4ea]">{WATCH_SEARCH_TITLE}</h3>
       <p className="text-sm leading-6 text-[#fbf4ea]/56">{WATCH_EMPTY_DESCRIPTION}</p>
     </div>
@@ -1336,7 +1338,9 @@ const FactoryV2WatchSearchPanel = ({
     )}
   >
     <div className="mx-auto max-w-sm space-y-2 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">{WATCH_SEARCH_EYEBROW}</div>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
+        {WATCH_SEARCH_EYEBROW}
+      </div>
       <h3 className="text-[1.15rem] font-semibold tracking-tight text-[#fbf4ea]">{WATCH_SEARCH_TITLE}</h3>
       <p className="text-sm leading-6 text-[#fbf4ea]/54">{WATCH_SEARCH_DESCRIPTION}</p>
     </div>

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
@@ -524,12 +524,12 @@ const FactoryV2WatchRunCard = ({
           </div>
         ) : null}
 
-        <div className="flex flex-wrap items-center justify-center gap-2 text-[10px] font-semibold uppercase tracking-[0.22em] text-black/40">
-          <span className="max-w-full truncate rounded-full border border-black/8 bg-white/62 px-3 py-1 shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
+        <div className="flex flex-wrap items-center justify-center gap-2 text-[10px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/40">
+          <span className="max-w-full truncate rounded-full border border-white/8 bg-white/6 px-3 py-1 shadow-[0_10px_24px_rgba(0,0,0,0.12)]">
             {selectedRun.name}
           </span>
           {environmentLabel ? (
-            <span className="rounded-full border border-black/8 bg-white/45 px-3 py-1">{environmentLabel}</span>
+            <span className="rounded-full border border-white/8 bg-white/5 px-3 py-1">{environmentLabel}</span>
           ) : null}
         </div>
 
@@ -546,7 +546,7 @@ const FactoryV2WatchRunCard = ({
           </div>
         ) : null}
 
-        <h3 className="text-[1.4rem] font-semibold tracking-tight text-black">{headline}</h3>
+        <h3 className="text-[1.4rem] font-semibold tracking-tight text-[#fbf4ea]">{headline}</h3>
 
         {!showsInFlightState ? (
           <FactoryV2LiveStatus pollingState={pollingState} liveStatusLabel={liveStatusLabel} />
@@ -592,10 +592,10 @@ const FactoryV2WatchRunCard = ({
 
       <div className="space-y-2.5">
         <div className="mx-auto max-w-sm space-y-1 text-center">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
             {WATCH_TIMELINE_TITLE}
           </div>
-          <p className="text-[13px] leading-5 text-black/52">{WATCH_TIMELINE_DESCRIPTION}</p>
+          <p className="text-[13px] leading-5 text-[#fbf4ea]/52">{WATCH_TIMELINE_DESCRIPTION}</p>
         </div>
         <div className="grid gap-2">
           {completedStep ? (
@@ -609,7 +609,7 @@ const FactoryV2WatchRunCard = ({
       </div>
 
       <div className="space-y-2">
-        <div className="text-center text-[13px] text-black/54">{getRunProgressLabel(timelineRun)}</div>
+        <div className="text-center text-[13px] text-[#fbf4ea]/54">{getRunProgressLabel(timelineRun)}</div>
         <FactoryV2SegmentedProgressTrack steps={timelineRun.steps} />
       </div>
 
@@ -627,13 +627,13 @@ const FactoryV2WatchRunCard = ({
       <button
         type="button"
         onClick={onToggleShowAllSteps}
-        className="inline-flex w-full items-center justify-center rounded-full border border-black/10 bg-white/58 px-4 py-3 text-sm font-medium text-black/68 transition-colors hover:bg-white/72 hover:text-black"
+        className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/6 px-4 py-3 text-sm font-medium text-[#fbf4ea]/68 transition-colors hover:bg-white/8 hover:text-[#fbf4ea]"
       >
         {showAllSteps ? "Hide details" : "See details"}
       </button>
 
       {showAllSteps ? (
-        <div className="space-y-2 rounded-[24px] border border-black/8 bg-white/38 p-3 text-left shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+        <div className="space-y-2 rounded-[24px] border border-white/8 bg-white/5 p-3 text-left shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
           {timelineRun.steps.map((step) => (
             <FactoryV2StepSummary key={step.id} step={step} />
           ))}
@@ -718,7 +718,7 @@ const FactoryV2PrizeFundingSection = ({
         type="button"
         data-testid="factory-prize-toggle"
         onClick={onTogglePrizeFunding}
-        className="inline-flex w-full items-center justify-center rounded-full border border-black/10 bg-white/58 px-4 py-3 text-sm font-medium text-black/68 transition-colors hover:bg-white/72 hover:text-black"
+        className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/6 px-4 py-3 text-sm font-medium text-[#fbf4ea]/68 transition-colors hover:bg-white/8 hover:text-[#fbf4ea]"
       >
         {showsPrizeFunding ? "Hide prize funding" : "Open prize funding"}
       </button>
@@ -768,7 +768,7 @@ const FactoryV2CurrentStepCard = ({
   return (
     <div
       className={cn(
-        "rounded-[24px] border border-black/8 px-4 py-4 text-center shadow-[0_16px_36px_rgba(30,20,10,0.08)]",
+        "rounded-[24px] border border-white/8 px-4 py-4 text-center shadow-[0_16px_36px_rgba(0,0,0,0.16)]",
         appearanceClassName,
       )}
     >
@@ -777,25 +777,25 @@ const FactoryV2CurrentStepCard = ({
           className={cn(
             "inline-flex items-center gap-2 rounded-full border px-3 py-1",
             isRunningStep
-              ? "border-[#c4a173]/75 bg-[rgba(255,250,244,0.94)] text-[#6b4a24] shadow-[0_6px_16px_rgba(90,62,29,0.08)]"
-              : "border-black/8 bg-white/60 text-black/44",
+              ? "border-white/12 bg-[rgba(32,27,22,0.94)] text-[#dfaa54] shadow-[0_6px_16px_rgba(0,0,0,0.16)]"
+              : "border-white/8 bg-white/6 text-[#fbf4ea]/44",
           )}
         >
           <span className="relative flex h-2.5 w-2.5 items-center justify-center">
-            <span className={cn("relative h-2.5 w-2.5 rounded-full", isRunningStep ? "bg-[#8b5b2e]" : "bg-black/28")} />
+            <span className={cn("relative h-2.5 w-2.5 rounded-full", isRunningStep ? "bg-[#dfaa54]" : "bg-black/28")} />
           </span>
           {statusLabel}
         </span>
-        <span className="text-black/42">{progress.stepLabel}</span>
+        <span className="text-[#fbf4ea]/42">{progress.stepLabel}</span>
       </div>
-      <div className="mt-3 text-[15px] font-semibold text-black">{currentStepLabel}</div>
-      <p className="mt-2 text-sm leading-6 text-black/56">{detailMessage}</p>
+      <div className="mt-3 text-[15px] font-semibold text-[#fbf4ea]">{currentStepLabel}</div>
+      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{detailMessage}</p>
       {statusHighlights.length > 0 ? (
         <div className="mt-3 flex flex-wrap justify-center gap-2">
           {statusHighlights.map((highlight) => (
             <span
               key={highlight}
-              className="rounded-full border border-black/8 bg-white/72 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-black/48"
+              className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/48"
             >
               {highlight}
             </span>
@@ -803,13 +803,13 @@ const FactoryV2CurrentStepCard = ({
         </div>
       ) : null}
       <div className="mt-4 space-y-2">
-        <div className="flex items-center justify-between gap-3 text-[11px] font-medium text-black/46">
+        <div className="flex items-center justify-between gap-3 text-[11px] font-medium text-[#fbf4ea]/46">
           <span>{progress.progressLabel}</span>
           <span>{progress.percentLabel}</span>
         </div>
         <div
           data-testid="factory-watch-current-progress-track"
-          className="relative h-2 overflow-hidden rounded-full bg-[#d9cabd]"
+          className="relative h-2 overflow-hidden rounded-full bg-white/12"
         >
           <div
             data-testid="factory-watch-current-progress-fill"
@@ -839,9 +839,9 @@ const FactoryV2AutoRetryCard = ({ run }: { run: FactoryRun }) => {
       : `Retrying every ${autoRetry.intervalMinutes} minutes`;
 
   return (
-    <div className="rounded-[22px] border border-black/8 bg-white/40 px-4 py-3 text-center shadow-[0_10px_24px_rgba(15,23,42,0.05)]">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Auto-retry</div>
-      <p className="mt-2 text-sm leading-6 text-black/56">{statusLabel}</p>
+    <div className="rounded-[22px] border border-white/8 bg-white/5 px-4 py-3 text-center shadow-[0_10px_24px_rgba(15,23,42,0.05)]">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Auto-retry</div>
+      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{statusLabel}</p>
     </div>
   );
 };
@@ -864,10 +864,10 @@ const FactoryV2RotationScheduleCard = ({ run }: { run: FactoryRun }) => {
   }
 
   return (
-    <div className="space-y-3 rounded-[24px] border border-black/8 bg-white/40 p-4 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+    <div className="space-y-3 rounded-[24px] border border-white/8 bg-white/5 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Rotation schedule</div>
-        <p className="text-[13px] leading-5 text-black/52">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Rotation schedule</div>
+        <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
           This rotation keeps future games queued ahead until it reaches its maximum size.
         </p>
       </div>
@@ -892,9 +892,9 @@ const FactoryV2RotationScheduleCard = ({ run }: { run: FactoryRun }) => {
 };
 
 const FactoryV2RotationMetric = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-[18px] border border-black/8 bg-white/62 px-3 py-3 text-center">
-    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-black/40">{label}</div>
-    <div className="mt-1 text-[13px] font-semibold text-black">{value}</div>
+  <div className="rounded-[18px] border border-white/8 bg-white/6 px-3 py-3 text-center">
+    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/40">{label}</div>
+    <div className="mt-1 text-[13px] font-semibold text-[#fbf4ea]">{value}</div>
   </div>
 );
 
@@ -912,10 +912,10 @@ const FactoryV2MultiGameChildrenCard = ({
   const copy = resolveMultiGameChildrenCopy(kind);
 
   return (
-    <div className="space-y-2 rounded-[24px] border border-black/8 bg-white/40 p-3 shadow-[0_12px_30px_rgba(15,23,42,0.05)]">
+    <div className="space-y-2 rounded-[24px] border border-white/8 bg-white/5 p-3 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">{copy.title}</div>
-        <p className="text-[13px] leading-5 text-black/52">{copy.description}</p>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">{copy.title}</div>
+        <p className="text-[13px] leading-5 text-[#fbf4ea]/52">{copy.description}</p>
       </div>
       <div className="space-y-2">
         {children.map((child) => {
@@ -926,22 +926,22 @@ const FactoryV2MultiGameChildrenCard = ({
           return (
             <div
               key={child.id}
-              className="space-y-3 rounded-[18px] border border-black/8 bg-white/62 px-3 py-3 text-left"
+              className="space-y-3 rounded-[18px] border border-white/8 bg-white/6 px-3 py-3 text-left"
             >
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="rounded-full border border-black/8 bg-white/72 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-black/48">
+                    <span className="rounded-full border border-white/8 bg-white/8 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/48">
                       Game {child.seriesGameNumber}
                     </span>
-                    <span className="truncate text-[13px] font-semibold text-black">{child.gameName}</span>
+                    <span className="truncate text-[13px] font-semibold text-[#fbf4ea]">{child.gameName}</span>
                   </div>
                   {fallbackSummary ? (
-                    <p className="mt-1 text-[12px] leading-5 text-black/50">{fallbackSummary}</p>
+                    <p className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/50">{fallbackSummary}</p>
                   ) : null}
                 </div>
                 <div className="flex shrink-0 items-center gap-2 self-start">
-                  <div className="rounded-full border border-black/8 bg-white/72 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-black/52">
+                  <div className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/52">
                     {resolveChildStatusLabel(child.status)}
                   </div>
                 </div>
@@ -1137,28 +1137,28 @@ const FactoryV2ChildStepGroup = ({
 function resolveChildStepGroupLabelClassName(tone: "done" | "current" | "pending" | "failed") {
   switch (tone) {
     case "done":
-      return "text-black/42";
+      return "text-[#fbf4ea]/42";
     case "current":
-      return "text-[#7a4b22]";
+      return "text-[#dfaa54]";
     case "failed":
-      return "text-rose-700";
+      return "text-rose-400";
     case "pending":
     default:
-      return "text-black/44";
+      return "text-[#fbf4ea]/44";
   }
 }
 
 function resolveChildStepChipClassName(tone: "done" | "current" | "pending" | "failed") {
   switch (tone) {
     case "done":
-      return "border-black/8 bg-black/[0.04] text-black/56";
+      return "border-white/8 bg-white/[0.06] text-[#fbf4ea]/56";
     case "current":
-      return "border-[#d4b487]/65 bg-[rgba(255,249,239,0.92)] text-[#7a4b22]";
+      return "border-white/12 bg-[rgba(32,27,22,0.92)] text-[#dfaa54]";
     case "failed":
-      return "border-rose-300/60 bg-rose-50 text-rose-700";
+      return "border-rose-300/60 bg-rose-950/30 text-rose-400";
     case "pending":
     default:
-      return "border-black/8 bg-white/68 text-black/50";
+      return "border-white/8 bg-white/8 text-[#fbf4ea]/50";
   }
 }
 
@@ -1186,12 +1186,12 @@ const FactoryV2WatchPendingCard = ({
         <FactoryV2LoaderHalo pollingState={pollingState} />
       </div>
       <div className="space-y-2">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
           {WATCH_SEARCH_EYEBROW}
         </div>
-        <h3 className="text-[1.2rem] font-semibold tracking-tight text-black">{headline}</h3>
+        <h3 className="text-[1.2rem] font-semibold tracking-tight text-[#fbf4ea]">{headline}</h3>
       </div>
-      <p className="text-sm leading-6 text-black/56">{primaryNotice}</p>
+      <p className="text-sm leading-6 text-[#fbf4ea]/56">{primaryNotice}</p>
       {noticeMessage && noticeMessage !== primaryNotice ? (
         <FactoryV2CopyableMessageBox
           label="Run details"
@@ -1202,13 +1202,13 @@ const FactoryV2WatchPendingCard = ({
       ) : null}
       <div
         className={cn(
-          "rounded-[22px] border border-black/8 px-4 py-4 text-center shadow-[0_14px_34px_rgba(30,20,10,0.07)]",
+          "rounded-[22px] border border-white/8 px-4 py-4 text-center shadow-[0_14px_34px_rgba(0,0,0,0.14)]",
           appearance.quietSurfaceClassName,
         )}
       >
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-black/42">Now</div>
-        <div className="mt-2 text-[15px] font-semibold text-black">Opening {launchPlaceholderName}</div>
-        <p className="mt-2 text-sm leading-6 text-black/56">{FIRST_UPDATE_WAIT_MESSAGE}</p>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Now</div>
+        <div className="mt-2 text-[15px] font-semibold text-[#fbf4ea]">Opening {launchPlaceholderName}</div>
+        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{FIRST_UPDATE_WAIT_MESSAGE}</p>
       </div>
     </div>
   </FactoryV2WatchSurfaceCard>
@@ -1217,9 +1217,9 @@ const FactoryV2WatchPendingCard = ({
 const FactoryV2WatchEmptyCard = ({ appearanceClassName }: { appearanceClassName: string }) => (
   <FactoryV2WatchSurfaceCard appearanceClassName={appearanceClassName} dataTestId="factory-watch-empty-panel">
     <div className="mx-auto max-w-sm space-y-3 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42">{WATCH_SEARCH_EYEBROW}</div>
-      <h3 className="text-[1.15rem] font-semibold tracking-tight text-black">{WATCH_SEARCH_TITLE}</h3>
-      <p className="text-sm leading-6 text-black/56">{WATCH_EMPTY_DESCRIPTION}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">{WATCH_SEARCH_EYEBROW}</div>
+      <h3 className="text-[1.15rem] font-semibold tracking-tight text-[#fbf4ea]">{WATCH_SEARCH_TITLE}</h3>
+      <p className="text-sm leading-6 text-[#fbf4ea]/56">{WATCH_EMPTY_DESCRIPTION}</p>
     </div>
   </FactoryV2WatchSurfaceCard>
 );
@@ -1238,7 +1238,7 @@ const FactoryV2WatchSurfaceCard = ({
   <div
     data-testid={dataTestId}
     className={cn(
-      "relative overflow-hidden rounded-[30px] border border-black/8 px-4 py-5 shadow-[0_20px_46px_rgba(30,20,10,0.11)] sm:px-5 sm:py-6 md:rounded-[28px] md:px-6 md:py-7",
+      "relative overflow-hidden rounded-[30px] border border-white/8 px-4 py-5 shadow-[0_20px_46px_rgba(0,0,0,0.18)] sm:px-5 sm:py-6 md:rounded-[28px] md:px-6 md:py-7",
       appearanceClassName,
     )}
   >
@@ -1261,7 +1261,7 @@ const FactoryV2LiveStatus = ({
   pollingState: FactoryPollingState;
   liveStatusLabel: string;
 }) => (
-  <div className="mx-auto flex w-fit max-w-full flex-wrap items-center justify-center gap-2 rounded-full border border-black/8 bg-white/45 px-3 py-1.5 text-[12px] text-black/52">
+  <div className="mx-auto flex w-fit max-w-full flex-wrap items-center justify-center gap-2 rounded-full border border-white/8 bg-white/5 px-3 py-1.5 text-[12px] text-[#fbf4ea]/52">
     <div className="relative flex h-3.5 w-3.5 items-center justify-center">
       {pollingState.status === "live" ? (
         <div className="absolute h-3.5 w-3.5 animate-ping rounded-full bg-emerald-400/55" />
@@ -1331,19 +1331,19 @@ const FactoryV2WatchSearchPanel = ({
   <div
     data-testid="factory-watch-search-panel"
     className={cn(
-      "rounded-[28px] border border-black/8 px-4 py-4 text-left shadow-[0_16px_40px_rgba(30,20,10,0.08)] sm:px-5",
+      "rounded-[28px] border border-white/8 px-4 py-4 text-left shadow-[0_16px_40px_rgba(0,0,0,0.16)] sm:px-5",
       appearanceClassName,
     )}
   >
     <div className="mx-auto max-w-sm space-y-2 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42">{WATCH_SEARCH_EYEBROW}</div>
-      <h3 className="text-[1.15rem] font-semibold tracking-tight text-black">{WATCH_SEARCH_TITLE}</h3>
-      <p className="text-sm leading-6 text-black/54">{WATCH_SEARCH_DESCRIPTION}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">{WATCH_SEARCH_EYEBROW}</div>
+      <h3 className="text-[1.15rem] font-semibold tracking-tight text-[#fbf4ea]">{WATCH_SEARCH_TITLE}</h3>
+      <p className="text-sm leading-6 text-[#fbf4ea]/54">{WATCH_SEARCH_DESCRIPTION}</p>
     </div>
     <div className="mx-auto mt-4 max-w-sm space-y-2 text-center">
       <label
         htmlFor="factory-watch-game"
-        className="block text-[11px] font-semibold uppercase tracking-[0.24em] text-black/42"
+        className="block text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42"
       >
         Run name
       </label>
@@ -1357,7 +1357,7 @@ const FactoryV2WatchSearchPanel = ({
           placeholder="Type a run name"
           disabled={Boolean(lookupDisabledReason)}
           className={cn(
-            "h-11 w-full rounded-[18px] border border-black/10 bg-white/78 px-4 pr-10 text-center text-sm font-medium text-black outline-none transition-colors placeholder:text-black/30 focus:border-black/25",
+            "h-11 w-full rounded-[18px] border border-white/10 bg-white/8 px-4 pr-10 text-center text-sm font-medium text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/30 focus:border-white/25",
             lookupDisabledReason ? "cursor-not-allowed opacity-60" : "",
             inputClassName,
           )}
@@ -1367,13 +1367,13 @@ const FactoryV2WatchSearchPanel = ({
           data-testid="factory-watch-run-picker-toggle"
           onClick={onFocusInput}
           disabled={Boolean(lookupDisabledReason)}
-          className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-black/45 transition-colors hover:bg-black/[0.04] hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+          className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-[#fbf4ea]/45 transition-colors hover:bg-white/[0.06] hover:text-[#fbf4ea] disabled:cursor-not-allowed disabled:opacity-50"
         >
           <ChevronDown className="h-4 w-4" />
         </button>
       </div>
-      {lookupDisabledReason ? <p className="text-sm leading-6 text-black/50">{lookupDisabledReason}</p> : null}
-      {isResolvingRunName ? <p className="text-sm leading-6 text-black/50">Looking for that run.</p> : null}
+      {lookupDisabledReason ? <p className="text-sm leading-6 text-[#fbf4ea]/50">{lookupDisabledReason}</p> : null}
+      {isResolvingRunName ? <p className="text-sm leading-6 text-[#fbf4ea]/50">Looking for that run.</p> : null}
       {searchNotice ? (
         <FactoryV2CopyableMessageBox
           label="Run details"
@@ -1383,11 +1383,11 @@ const FactoryV2WatchSearchPanel = ({
         />
       ) : null}
       {!lookupDisabledReason && !isResolvingRunName && !searchNotice ? (
-        <p className="text-sm leading-6 text-black/46">Press Enter to check its status.</p>
+        <p className="text-sm leading-6 text-[#fbf4ea]/46">Press Enter to check its status.</p>
       ) : null}
       {matchingRuns.length > 0 ? (
-        <div className="space-y-2 rounded-[20px] border border-black/8 bg-white/56 p-2">
-          <div className="px-2 pt-1 text-center text-[9px] font-semibold uppercase tracking-[0.24em] text-black/34">
+        <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 p-2">
+          <div className="px-2 pt-1 text-center text-[9px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/34">
             {watchGameName.trim() ? "Matching runs" : "Recent runs"}
           </div>
           <div className="grid gap-1.5">
@@ -1396,11 +1396,11 @@ const FactoryV2WatchSearchPanel = ({
                 key={run.id}
                 type="button"
                 onClick={() => onSelectRun(run)}
-                className="flex w-full flex-col items-start gap-1.5 rounded-[14px] border border-transparent bg-white/62 px-3 py-2.5 text-left text-[13px] text-black transition-colors hover:border-black/6 hover:bg-black/[0.035] sm:flex-row sm:items-center sm:justify-between"
+                className="flex w-full flex-col items-start gap-1.5 rounded-[14px] border border-transparent bg-white/6 px-3 py-2.5 text-left text-[13px] text-[#fbf4ea] transition-colors hover:border-white/6 hover:bg-white/[0.05] sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="min-w-0">
-                  <div className="truncate font-semibold text-black">{run.name}</div>
-                  <div className="mt-0.5 text-[11px] text-black/42">{getEnvironmentLabel(run.environment)}</div>
+                  <div className="truncate font-semibold text-[#fbf4ea]">{run.name}</div>
+                  <div className="mt-0.5 text-[11px] text-[#fbf4ea]/42">{getEnvironmentLabel(run.environment)}</div>
                 </div>
                 <div
                   className={cn(
@@ -1446,7 +1446,7 @@ const FactoryV2WatchActionBar = ({
   return (
     <div data-testid="factory-watch-action-bar" className="sticky bottom-3 z-10 md:static">
       <div className="mx-auto flex w-fit flex-col items-center gap-2">
-        <div className="flex items-center justify-center gap-2 rounded-full border border-black/8 bg-[rgba(250,243,233,0.72)] px-2 py-2 shadow-[0_10px_24px_rgba(23,15,8,0.06)] backdrop-blur-md">
+        <div className="flex items-center justify-center gap-2 rounded-full border border-white/8 bg-[rgba(21,17,15,0.72)] px-2 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.12)] backdrop-blur-md">
           {visiblePrimaryAction ? (
             <FactoryV2WatchActionButton
               label={visiblePrimaryAction.label}
@@ -1483,7 +1483,7 @@ const FactoryV2WatchActionBar = ({
               icon={<Pause className="h-4 w-4" />}
               onClick={onStopAutoRetry}
               disabled={stopAutoRetryDisabled}
-              className="border border-rose-200/70 bg-[rgba(255,241,242,0.88)] text-rose-700 hover:bg-[rgba(255,233,236,0.96)]"
+              className="border border-rose-200/70 bg-[rgba(166,47,40,0.15)] text-rose-400 hover:bg-[rgba(166,47,40,0.25)]"
             />
           ) : null}
 
@@ -1493,7 +1493,7 @@ const FactoryV2WatchActionBar = ({
               icon={<Trash2 className="h-4 w-4" />}
               onClick={onDeleteRun}
               disabled={deleteRunDisabled}
-              className="border border-[#d8a18f] bg-[rgba(255,244,239,0.92)] text-[#7b241c] hover:bg-[rgba(255,233,225,0.98)]"
+              className="border border-rose-700/40 bg-[rgba(123,36,28,0.15)] text-[#7b241c] hover:bg-[rgba(123,36,28,0.25)]"
             />
           ) : null}
 
@@ -1503,13 +1503,13 @@ const FactoryV2WatchActionBar = ({
               icon={<CircleHelp className="h-4 w-4" />}
               onClick={() => setShowsActionHelp((current) => !current)}
               disabled={false}
-              className="border border-black/10 bg-white/78 text-black/52 hover:bg-white hover:text-black/72"
+              className="border border-white/10 bg-white/8 text-[#fbf4ea]/52 hover:bg-white/10 hover:text-[#fbf4ea]/72"
             />
           ) : null}
         </div>
 
         {showsActionHelp ? (
-          <div className="flex flex-wrap items-center justify-center gap-1.5 text-[10px] font-medium text-black/44">
+          <div className="flex flex-wrap items-center justify-center gap-1.5 text-[10px] font-medium text-[#fbf4ea]/44">
             {visiblePrimaryAction ? (
               <FactoryV2WatchActionLegend icon={<Play className="h-3 w-3" />} label="Continue" />
             ) : null}
@@ -1561,8 +1561,8 @@ const FactoryV2WatchActionButton = ({
 );
 
 const FactoryV2WatchActionLegend = ({ icon, label }: { icon: ReactNode; label: string }) => (
-  <span className="inline-flex items-center gap-1 rounded-full border border-black/8 bg-white/58 px-2 py-1">
-    <span className="inline-flex h-3 w-3 items-center justify-center text-black/55">{icon}</span>
+  <span className="inline-flex items-center gap-1 rounded-full border border-white/8 bg-white/6 px-2 py-1">
+    <span className="inline-flex h-3 w-3 items-center justify-center text-[#fbf4ea]/55">{icon}</span>
     <span>{label}</span>
   </span>
 );
@@ -1609,29 +1609,29 @@ function resolveStepMomentToneAppearance(tone: "done" | "now" | "next") {
   switch (tone) {
     case "done":
       return {
-        containerClassName: "border-black/8 bg-black/[0.025] opacity-45 shadow-none",
+        containerClassName: "border-white/8 bg-black/[0.025] opacity-45 shadow-none",
         dotClassName: "bg-black/18",
-        labelClassName: "text-black/34",
-        stepLabelClassName: "font-medium text-black/50",
+        labelClassName: "text-[#fbf4ea]/34",
+        stepLabelClassName: "font-medium text-[#fbf4ea]/50",
         accentBarClassName: null,
         pulseClassName: null,
       };
     case "now":
       return {
-        containerClassName: "border-[#c6a777]/60 bg-[rgba(255,250,243,0.96)] shadow-[0_16px_34px_rgba(90,62,29,0.1)]",
-        dotClassName: "bg-[#8b5b2e]",
-        labelClassName: "text-[#6b4a24]",
-        stepLabelClassName: "font-semibold text-black",
+        containerClassName: "border-white/12 bg-[rgba(32,27,22,0.96)] shadow-[0_16px_34px_rgba(0,0,0,0.18)]",
+        dotClassName: "bg-[#dfaa54]",
+        labelClassName: "text-[#dfaa54]",
+        stepLabelClassName: "font-semibold text-[#fbf4ea]",
         accentBarClassName: null,
         pulseClassName: null,
       };
     case "next":
     default:
       return {
-        containerClassName: "border-dashed border-black/10 bg-white/36 opacity-70 shadow-none",
+        containerClassName: "border-dashed border-white/10 bg-white/5 opacity-70 shadow-none",
         dotClassName: "bg-black/24",
-        labelClassName: "text-black/34",
-        stepLabelClassName: "font-medium text-black/56",
+        labelClassName: "text-[#fbf4ea]/34",
+        stepLabelClassName: "font-medium text-[#fbf4ea]/56",
         accentBarClassName: null,
         pulseClassName: null,
       };
@@ -1649,7 +1649,7 @@ const FactoryV2SegmentedProgressTrack = ({ steps }: { steps: FactoryRun["steps"]
         )}
       >
         {step.status === "running" ? (
-          <span className="absolute inset-y-0 left-0 w-3/4 rounded-full bg-[#8b5b2e]" />
+          <span className="absolute inset-y-0 left-0 w-3/4 rounded-full bg-[#dfaa54]" />
         ) : null}
       </div>
     ))}
@@ -1728,11 +1728,11 @@ function resolveCurrentStepStatusLabel(
 
 function resolveCurrentProgressFillClassName(isRunningStep: boolean, runStatus: FactoryRun["status"]) {
   if (isRunningStep) {
-    return "bg-[#7a4b22]";
+    return "bg-[#dfaa54]";
   }
 
   if (runStatus === "complete") {
-    return "bg-[#1f1711]";
+    return "bg-[#dfaa54]";
   }
 
   if (runStatus === "attention") {
@@ -1767,11 +1767,11 @@ const FactoryV2StepSummary = ({ step }: { step: FactoryRun["steps"][number] }) =
   const errorMessage = resolveRunStepErrorMessage(step);
 
   return (
-    <div className="flex items-start gap-3 rounded-[16px] border border-black/8 bg-black/[0.03] px-3.5 py-3">
+    <div className="flex items-start gap-3 rounded-[16px] border border-white/8 bg-black/[0.03] px-3.5 py-3">
       <div className={cn("mt-1.5 h-2.5 w-2.5 rounded-full", statusMeta.railClassName)} />
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
-          <div className="text-sm font-semibold text-black">{getSimpleStepTitle(step)}</div>
+          <div className="text-sm font-semibold text-[#fbf4ea]">{getSimpleStepTitle(step)}</div>
           <div
             className={cn(
               "rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em]",
@@ -1781,7 +1781,7 @@ const FactoryV2StepSummary = ({ step }: { step: FactoryRun["steps"][number] }) =
             {statusMeta.label}
           </div>
         </div>
-        <div className="mt-2 text-sm leading-6 text-black/56">{getStepDetailMessage(step)}</div>
+        <div className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{getStepDetailMessage(step)}</div>
         {errorMessage ? (
           <div className="mt-3">
             <FactoryV2CopyableMessageBox
@@ -1866,7 +1866,7 @@ const FactoryV2CopyableMessageBox = ({
             void copyMessage();
           }}
           className={cn(
-            "rounded-full bg-white/80 font-semibold uppercase tracking-[0.16em] transition-colors hover:bg-white",
+            "rounded-full bg-white/10 font-semibold uppercase tracking-[0.16em] transition-colors hover:bg-white/10",
             resolveCopyableMessageActionClassName(tone),
             compact ? "px-2 py-0.5 text-[9px]" : "px-2.5 py-1 text-[10px]",
           )}
@@ -1876,7 +1876,7 @@ const FactoryV2CopyableMessageBox = ({
       </div>
       <pre
         className={cn(
-          "overflow-auto whitespace-pre-wrap break-words rounded-[12px] bg-white/70",
+          "overflow-auto whitespace-pre-wrap break-words rounded-[12px] bg-white/8",
           resolveCopyableMessagePreClassName(tone),
           compact ? "max-h-24 px-2.5 py-2 text-[10px] leading-4" : "max-h-40 px-3 py-2 text-[11px] leading-5",
         )}
@@ -1892,15 +1892,15 @@ function resolveCopyableMessageBoxClassName(tone: "info" | "error") {
     return "border border-rose-300/50 bg-rose-50/80 shadow-[0_10px_24px_rgba(190,24,93,0.06)]";
   }
 
-  return "border border-[#d6c3a0]/70 bg-[rgba(255,248,236,0.9)] shadow-[0_10px_24px_rgba(146,104,52,0.08)]";
+  return "border border-white/12 bg-[rgba(32,27,22,0.9)] shadow-[0_10px_24px_rgba(0,0,0,0.16)]";
 }
 
 function resolveCopyableMessageLabelClassName(tone: "info" | "error") {
-  return tone === "error" ? "text-rose-700" : "text-[#7e5a2b]";
+  return tone === "error" ? "text-rose-400" : "text-[#7e5a2b]";
 }
 
 function resolveCopyableMessageActionClassName(tone: "info" | "error") {
-  return tone === "error" ? "border border-rose-200/80 text-rose-700" : "border border-[#dcc7a2]/80 text-[#7e5a2b]";
+  return tone === "error" ? "border border-rose-200/80 text-rose-400" : "border border-[#dcc7a2]/80 text-[#7e5a2b]";
 }
 
 function resolveCopyableMessagePreClassName(tone: "info" | "error") {

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
@@ -524,12 +524,12 @@ const FactoryV2WatchRunCard = ({
           </div>
         ) : null}
 
-        <div className="flex flex-wrap items-center justify-center gap-2 text-[10px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/40">
-          <span className="max-w-full truncate rounded-full border border-white/8 bg-white/6 px-3 py-1 shadow-[0_10px_24px_rgba(0,0,0,0.12)]">
+        <div className="flex flex-wrap items-center justify-center gap-2 text-[10px] font-semibold uppercase tracking-[0.22em] text-gold/40">
+          <span className="max-w-full truncate rounded-full border border-gold/10 bg-black/20 px-3 py-1 shadow-[0_10px_24px_rgba(0,0,0,0.12)]">
             {selectedRun.name}
           </span>
           {environmentLabel ? (
-            <span className="rounded-full border border-white/8 bg-white/5 px-3 py-1">{environmentLabel}</span>
+            <span className="rounded-full border border-gold/10 bg-black/20 px-3 py-1">{environmentLabel}</span>
           ) : null}
         </div>
 
@@ -546,7 +546,7 @@ const FactoryV2WatchRunCard = ({
           </div>
         ) : null}
 
-        <h3 className="text-[1.4rem] font-semibold tracking-tight text-[#fbf4ea]">{headline}</h3>
+        <h3 className="text-[1.4rem] font-semibold tracking-tight text-gold">{headline}</h3>
 
         {!showsInFlightState ? (
           <FactoryV2LiveStatus pollingState={pollingState} liveStatusLabel={liveStatusLabel} />
@@ -592,10 +592,10 @@ const FactoryV2WatchRunCard = ({
 
       <div className="space-y-2.5">
         <div className="mx-auto max-w-sm space-y-1 text-center">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">
             {WATCH_TIMELINE_TITLE}
           </div>
-          <p className="text-[13px] leading-5 text-[#fbf4ea]/52">{WATCH_TIMELINE_DESCRIPTION}</p>
+          <p className="text-[13px] leading-5 text-gold/52">{WATCH_TIMELINE_DESCRIPTION}</p>
         </div>
         <div className="grid gap-2">
           {completedStep ? (
@@ -609,7 +609,7 @@ const FactoryV2WatchRunCard = ({
       </div>
 
       <div className="space-y-2">
-        <div className="text-center text-[13px] text-[#fbf4ea]/54">{getRunProgressLabel(timelineRun)}</div>
+        <div className="text-center text-[13px] text-gold/54">{getRunProgressLabel(timelineRun)}</div>
         <FactoryV2SegmentedProgressTrack steps={timelineRun.steps} />
       </div>
 
@@ -627,13 +627,13 @@ const FactoryV2WatchRunCard = ({
       <button
         type="button"
         onClick={onToggleShowAllSteps}
-        className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/6 px-4 py-3 text-sm font-medium text-[#fbf4ea]/68 transition-colors hover:bg-white/8 hover:text-[#fbf4ea]"
+        className="inline-flex w-full items-center justify-center rounded-full border border-gold/15 bg-black/20 px-4 py-3 text-sm font-medium text-gold/68 transition-colors hover:bg-gold/10 hover:text-gold"
       >
         {showAllSteps ? "Hide details" : "See details"}
       </button>
 
       {showAllSteps ? (
-        <div className="space-y-2 rounded-[24px] border border-white/8 bg-white/5 p-3 text-left shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
+        <div className="space-y-2 rounded-[24px] border border-gold/10 bg-black/20 p-3 text-left shadow-[0_12px_30px_rgba(0,0,0,0.2)]">
           {timelineRun.steps.map((step) => (
             <FactoryV2StepSummary key={step.id} step={step} />
           ))}
@@ -718,7 +718,7 @@ const FactoryV2PrizeFundingSection = ({
         type="button"
         data-testid="factory-prize-toggle"
         onClick={onTogglePrizeFunding}
-        className="inline-flex w-full items-center justify-center rounded-full border border-white/10 bg-white/6 px-4 py-3 text-sm font-medium text-[#fbf4ea]/68 transition-colors hover:bg-white/8 hover:text-[#fbf4ea]"
+        className="inline-flex w-full items-center justify-center rounded-full border border-gold/15 bg-black/20 px-4 py-3 text-sm font-medium text-gold/68 transition-colors hover:bg-gold/10 hover:text-gold"
       >
         {showsPrizeFunding ? "Hide prize funding" : "Open prize funding"}
       </button>
@@ -768,7 +768,7 @@ const FactoryV2CurrentStepCard = ({
   return (
     <div
       className={cn(
-        "rounded-[24px] border border-white/8 px-4 py-4 text-center shadow-[0_16px_36px_rgba(0,0,0,0.16)]",
+        "rounded-[24px] border border-gold/10 px-4 py-4 text-center shadow-[0_16px_36px_rgba(0,0,0,0.16)]",
         appearanceClassName,
       )}
     >
@@ -777,8 +777,8 @@ const FactoryV2CurrentStepCard = ({
           className={cn(
             "inline-flex items-center gap-2 rounded-full border px-3 py-1",
             isRunningStep
-              ? "border-white/12 bg-[rgba(32,27,22,0.94)] text-[#dfaa54] shadow-[0_6px_16px_rgba(0,0,0,0.16)]"
-              : "border-white/8 bg-white/6 text-[#fbf4ea]/44",
+              ? "border-gold/20 bg-[rgba(32,27,22,0.94)] text-[#dfaa54] shadow-[0_6px_16px_rgba(0,0,0,0.16)]"
+              : "border-gold/10 bg-black/20 text-gold/44",
           )}
         >
           <span className="relative flex h-2.5 w-2.5 items-center justify-center">
@@ -786,16 +786,16 @@ const FactoryV2CurrentStepCard = ({
           </span>
           {statusLabel}
         </span>
-        <span className="text-[#fbf4ea]/42">{progress.stepLabel}</span>
+        <span className="text-gold/42">{progress.stepLabel}</span>
       </div>
-      <div className="mt-3 text-[15px] font-semibold text-[#fbf4ea]">{currentStepLabel}</div>
-      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{detailMessage}</p>
+      <div className="mt-3 text-[15px] font-semibold text-gold">{currentStepLabel}</div>
+      <p className="mt-2 text-sm leading-6 text-gold/56">{detailMessage}</p>
       {statusHighlights.length > 0 ? (
         <div className="mt-3 flex flex-wrap justify-center gap-2">
           {statusHighlights.map((highlight) => (
             <span
               key={highlight}
-              className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/48"
+              className="rounded-full border border-gold/10 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-gold/48"
             >
               {highlight}
             </span>
@@ -803,13 +803,13 @@ const FactoryV2CurrentStepCard = ({
         </div>
       ) : null}
       <div className="mt-4 space-y-2">
-        <div className="flex items-center justify-between gap-3 text-[11px] font-medium text-[#fbf4ea]/46">
+        <div className="flex items-center justify-between gap-3 text-[11px] font-medium text-gold/46">
           <span>{progress.progressLabel}</span>
           <span>{progress.percentLabel}</span>
         </div>
         <div
           data-testid="factory-watch-current-progress-track"
-          className="relative h-2 overflow-hidden rounded-full bg-white/12"
+          className="relative h-2 overflow-hidden rounded-full bg-black/30"
         >
           <div
             data-testid="factory-watch-current-progress-fill"
@@ -839,9 +839,9 @@ const FactoryV2AutoRetryCard = ({ run }: { run: FactoryRun }) => {
       : `Retrying every ${autoRetry.intervalMinutes} minutes`;
 
   return (
-    <div className="rounded-[22px] border border-white/8 bg-white/5 px-4 py-3 text-center shadow-[0_10px_24px_rgba(15,23,42,0.05)]">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Auto-retry</div>
-      <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{statusLabel}</p>
+    <div className="rounded-[22px] border border-gold/10 bg-black/20 px-4 py-3 text-center shadow-[0_10px_24px_rgba(15,23,42,0.05)]">
+      <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Auto-retry</div>
+      <p className="mt-2 text-sm leading-6 text-gold/56">{statusLabel}</p>
     </div>
   );
 };
@@ -864,10 +864,10 @@ const FactoryV2RotationScheduleCard = ({ run }: { run: FactoryRun }) => {
   }
 
   return (
-    <div className="space-y-3 rounded-[24px] border border-white/8 bg-white/5 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
+    <div className="space-y-3 rounded-[24px] border border-gold/10 bg-black/20 p-4 shadow-[0_12px_30px_rgba(0,0,0,0.2)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Rotation schedule</div>
-        <p className="text-[13px] leading-5 text-[#fbf4ea]/52">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Rotation schedule</div>
+        <p className="text-[13px] leading-5 text-gold/52">
           This rotation keeps future games queued ahead until it reaches its maximum size.
         </p>
       </div>
@@ -892,9 +892,9 @@ const FactoryV2RotationScheduleCard = ({ run }: { run: FactoryRun }) => {
 };
 
 const FactoryV2RotationMetric = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-[18px] border border-white/8 bg-white/6 px-3 py-3 text-center">
-    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[#fbf4ea]/40">{label}</div>
-    <div className="mt-1 text-[13px] font-semibold text-[#fbf4ea]">{value}</div>
+  <div className="rounded-[18px] border border-gold/10 bg-black/20 px-3 py-3 text-center">
+    <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-gold/40">{label}</div>
+    <div className="mt-1 text-[13px] font-semibold text-gold">{value}</div>
   </div>
 );
 
@@ -912,10 +912,10 @@ const FactoryV2MultiGameChildrenCard = ({
   const copy = resolveMultiGameChildrenCopy(kind);
 
   return (
-    <div className="space-y-2 rounded-[24px] border border-white/8 bg-white/5 p-3 shadow-[0_12px_30px_rgba(0,0,0,0.14)]">
+    <div className="space-y-2 rounded-[24px] border border-gold/10 bg-black/20 p-3 shadow-[0_12px_30px_rgba(0,0,0,0.2)]">
       <div className="mx-auto max-w-sm space-y-1 text-center">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">{copy.title}</div>
-        <p className="text-[13px] leading-5 text-[#fbf4ea]/52">{copy.description}</p>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">{copy.title}</div>
+        <p className="text-[13px] leading-5 text-gold/52">{copy.description}</p>
       </div>
       <div className="space-y-2">
         {children.map((child) => {
@@ -926,22 +926,22 @@ const FactoryV2MultiGameChildrenCard = ({
           return (
             <div
               key={child.id}
-              className="space-y-3 rounded-[18px] border border-white/8 bg-white/6 px-3 py-3 text-left"
+              className="space-y-3 rounded-[18px] border border-gold/10 bg-black/20 px-3 py-3 text-left"
             >
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <div className="min-w-0">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="rounded-full border border-white/8 bg-white/8 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/48">
+                    <span className="rounded-full border border-gold/10 bg-black/25 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em] text-gold/48">
                       Game {child.seriesGameNumber}
                     </span>
-                    <span className="truncate text-[13px] font-semibold text-[#fbf4ea]">{child.gameName}</span>
+                    <span className="truncate text-[13px] font-semibold text-gold">{child.gameName}</span>
                   </div>
                   {fallbackSummary ? (
-                    <p className="mt-1 text-[12px] leading-5 text-[#fbf4ea]/50">{fallbackSummary}</p>
+                    <p className="mt-1 text-[12px] leading-5 text-gold/50">{fallbackSummary}</p>
                   ) : null}
                 </div>
                 <div className="flex shrink-0 items-center gap-2 self-start">
-                  <div className="rounded-full border border-white/8 bg-white/8 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[#fbf4ea]/52">
+                  <div className="rounded-full border border-gold/10 bg-black/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-gold/52">
                     {resolveChildStatusLabel(child.status)}
                   </div>
                 </div>
@@ -1137,28 +1137,28 @@ const FactoryV2ChildStepGroup = ({
 function resolveChildStepGroupLabelClassName(tone: "done" | "current" | "pending" | "failed") {
   switch (tone) {
     case "done":
-      return "text-[#fbf4ea]/42";
+      return "text-gold/42";
     case "current":
       return "text-[#dfaa54]";
     case "failed":
       return "text-rose-400";
     case "pending":
     default:
-      return "text-[#fbf4ea]/44";
+      return "text-gold/44";
   }
 }
 
 function resolveChildStepChipClassName(tone: "done" | "current" | "pending" | "failed") {
   switch (tone) {
     case "done":
-      return "border-white/8 bg-white/[0.06] text-[#fbf4ea]/56";
+      return "border-gold/10 bg-black/20 text-gold/56";
     case "current":
-      return "border-white/12 bg-[rgba(32,27,22,0.92)] text-[#dfaa54]";
+      return "border-gold/20 bg-[rgba(32,27,22,0.92)] text-[#dfaa54]";
     case "failed":
       return "border-rose-300/60 bg-rose-950/30 text-rose-400";
     case "pending":
     default:
-      return "border-white/8 bg-white/8 text-[#fbf4ea]/50";
+      return "border-gold/10 bg-black/25 text-gold/50";
   }
 }
 
@@ -1186,12 +1186,10 @@ const FactoryV2WatchPendingCard = ({
         <FactoryV2LoaderHalo pollingState={pollingState} />
       </div>
       <div className="space-y-2">
-        <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
-          {WATCH_SEARCH_EYEBROW}
-        </div>
-        <h3 className="text-[1.2rem] font-semibold tracking-tight text-[#fbf4ea]">{headline}</h3>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42">{WATCH_SEARCH_EYEBROW}</div>
+        <h3 className="text-[1.2rem] font-semibold tracking-tight text-gold">{headline}</h3>
       </div>
-      <p className="text-sm leading-6 text-[#fbf4ea]/56">{primaryNotice}</p>
+      <p className="text-sm leading-6 text-gold/56">{primaryNotice}</p>
       {noticeMessage && noticeMessage !== primaryNotice ? (
         <FactoryV2CopyableMessageBox
           label="Run details"
@@ -1202,13 +1200,13 @@ const FactoryV2WatchPendingCard = ({
       ) : null}
       <div
         className={cn(
-          "rounded-[22px] border border-white/8 px-4 py-4 text-center shadow-[0_14px_34px_rgba(0,0,0,0.14)]",
+          "rounded-[22px] border border-gold/10 px-4 py-4 text-center shadow-[0_14px_34px_rgba(0,0,0,0.14)]",
           appearance.quietSurfaceClassName,
         )}
       >
-        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[#fbf4ea]/42">Now</div>
-        <div className="mt-2 text-[15px] font-semibold text-[#fbf4ea]">Opening {launchPlaceholderName}</div>
-        <p className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{FIRST_UPDATE_WAIT_MESSAGE}</p>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gold/42">Now</div>
+        <div className="mt-2 text-[15px] font-semibold text-gold">Opening {launchPlaceholderName}</div>
+        <p className="mt-2 text-sm leading-6 text-gold/56">{FIRST_UPDATE_WAIT_MESSAGE}</p>
       </div>
     </div>
   </FactoryV2WatchSurfaceCard>
@@ -1217,11 +1215,9 @@ const FactoryV2WatchPendingCard = ({
 const FactoryV2WatchEmptyCard = ({ appearanceClassName }: { appearanceClassName: string }) => (
   <FactoryV2WatchSurfaceCard appearanceClassName={appearanceClassName} dataTestId="factory-watch-empty-panel">
     <div className="mx-auto max-w-sm space-y-3 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
-        {WATCH_SEARCH_EYEBROW}
-      </div>
-      <h3 className="text-[1.15rem] font-semibold tracking-tight text-[#fbf4ea]">{WATCH_SEARCH_TITLE}</h3>
-      <p className="text-sm leading-6 text-[#fbf4ea]/56">{WATCH_EMPTY_DESCRIPTION}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42">{WATCH_SEARCH_EYEBROW}</div>
+      <h3 className="text-[1.15rem] font-semibold tracking-tight text-gold">{WATCH_SEARCH_TITLE}</h3>
+      <p className="text-sm leading-6 text-gold/56">{WATCH_EMPTY_DESCRIPTION}</p>
     </div>
   </FactoryV2WatchSurfaceCard>
 );
@@ -1240,7 +1236,7 @@ const FactoryV2WatchSurfaceCard = ({
   <div
     data-testid={dataTestId}
     className={cn(
-      "relative overflow-hidden rounded-[30px] border border-white/8 px-4 py-5 shadow-[0_20px_46px_rgba(0,0,0,0.18)] sm:px-5 sm:py-6 md:rounded-[28px] md:px-6 md:py-7",
+      "relative overflow-hidden rounded-[30px] border border-gold/10 px-4 py-5 shadow-[0_20px_46px_rgba(0,0,0,0.18)] sm:px-5 sm:py-6 md:rounded-[28px] md:px-6 md:py-7",
       appearanceClassName,
     )}
   >
@@ -1263,7 +1259,7 @@ const FactoryV2LiveStatus = ({
   pollingState: FactoryPollingState;
   liveStatusLabel: string;
 }) => (
-  <div className="mx-auto flex w-fit max-w-full flex-wrap items-center justify-center gap-2 rounded-full border border-white/8 bg-white/5 px-3 py-1.5 text-[12px] text-[#fbf4ea]/52">
+  <div className="mx-auto flex w-fit max-w-full flex-wrap items-center justify-center gap-2 rounded-full border border-gold/10 bg-black/20 px-3 py-1.5 text-[12px] text-gold/52">
     <div className="relative flex h-3.5 w-3.5 items-center justify-center">
       {pollingState.status === "live" ? (
         <div className="absolute h-3.5 w-3.5 animate-ping rounded-full bg-emerald-400/55" />
@@ -1333,21 +1329,19 @@ const FactoryV2WatchSearchPanel = ({
   <div
     data-testid="factory-watch-search-panel"
     className={cn(
-      "rounded-[28px] border border-white/8 px-4 py-4 text-left shadow-[0_16px_40px_rgba(0,0,0,0.16)] sm:px-5",
+      "rounded-[28px] border border-gold/10 px-4 py-4 text-left shadow-[0_16px_40px_rgba(0,0,0,0.16)] sm:px-5",
       appearanceClassName,
     )}
   >
     <div className="mx-auto max-w-sm space-y-2 text-center">
-      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42">
-        {WATCH_SEARCH_EYEBROW}
-      </div>
-      <h3 className="text-[1.15rem] font-semibold tracking-tight text-[#fbf4ea]">{WATCH_SEARCH_TITLE}</h3>
-      <p className="text-sm leading-6 text-[#fbf4ea]/54">{WATCH_SEARCH_DESCRIPTION}</p>
+      <div className="text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42">{WATCH_SEARCH_EYEBROW}</div>
+      <h3 className="text-[1.15rem] font-semibold tracking-tight text-gold">{WATCH_SEARCH_TITLE}</h3>
+      <p className="text-sm leading-6 text-gold/54">{WATCH_SEARCH_DESCRIPTION}</p>
     </div>
     <div className="mx-auto mt-4 max-w-sm space-y-2 text-center">
       <label
         htmlFor="factory-watch-game"
-        className="block text-[11px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/42"
+        className="block text-[11px] font-semibold uppercase tracking-[0.24em] text-gold/42"
       >
         Run name
       </label>
@@ -1361,7 +1355,7 @@ const FactoryV2WatchSearchPanel = ({
           placeholder="Type a run name"
           disabled={Boolean(lookupDisabledReason)}
           className={cn(
-            "h-11 w-full rounded-[18px] border border-white/10 bg-white/8 px-4 pr-10 text-center text-sm font-medium text-[#fbf4ea] outline-none transition-colors placeholder:text-[#fbf4ea]/30 focus:border-white/25",
+            "h-11 w-full rounded-[18px] border border-gold/15 bg-black/25 px-4 pr-10 text-center text-sm font-medium text-gold outline-none transition-colors placeholder:text-gold/30 focus:border-gold/30",
             lookupDisabledReason ? "cursor-not-allowed opacity-60" : "",
             inputClassName,
           )}
@@ -1371,13 +1365,13 @@ const FactoryV2WatchSearchPanel = ({
           data-testid="factory-watch-run-picker-toggle"
           onClick={onFocusInput}
           disabled={Boolean(lookupDisabledReason)}
-          className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-[#fbf4ea]/45 transition-colors hover:bg-white/[0.06] hover:text-[#fbf4ea] disabled:cursor-not-allowed disabled:opacity-50"
+          className="absolute right-3 top-1/2 inline-flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-gold/45 transition-colors hover:bg-gold/10 hover:text-gold disabled:cursor-not-allowed disabled:opacity-50"
         >
           <ChevronDown className="h-4 w-4" />
         </button>
       </div>
-      {lookupDisabledReason ? <p className="text-sm leading-6 text-[#fbf4ea]/50">{lookupDisabledReason}</p> : null}
-      {isResolvingRunName ? <p className="text-sm leading-6 text-[#fbf4ea]/50">Looking for that run.</p> : null}
+      {lookupDisabledReason ? <p className="text-sm leading-6 text-gold/50">{lookupDisabledReason}</p> : null}
+      {isResolvingRunName ? <p className="text-sm leading-6 text-gold/50">Looking for that run.</p> : null}
       {searchNotice ? (
         <FactoryV2CopyableMessageBox
           label="Run details"
@@ -1387,11 +1381,11 @@ const FactoryV2WatchSearchPanel = ({
         />
       ) : null}
       {!lookupDisabledReason && !isResolvingRunName && !searchNotice ? (
-        <p className="text-sm leading-6 text-[#fbf4ea]/46">Press Enter to check its status.</p>
+        <p className="text-sm leading-6 text-gold/46">Press Enter to check its status.</p>
       ) : null}
       {matchingRuns.length > 0 ? (
-        <div className="space-y-2 rounded-[20px] border border-white/8 bg-white/6 p-2">
-          <div className="px-2 pt-1 text-center text-[9px] font-semibold uppercase tracking-[0.24em] text-[#fbf4ea]/34">
+        <div className="space-y-2 rounded-[20px] border border-gold/10 bg-black/20 p-2">
+          <div className="px-2 pt-1 text-center text-[9px] font-semibold uppercase tracking-[0.24em] text-gold/34">
             {watchGameName.trim() ? "Matching runs" : "Recent runs"}
           </div>
           <div className="grid gap-1.5">
@@ -1400,11 +1394,11 @@ const FactoryV2WatchSearchPanel = ({
                 key={run.id}
                 type="button"
                 onClick={() => onSelectRun(run)}
-                className="flex w-full flex-col items-start gap-1.5 rounded-[14px] border border-transparent bg-white/6 px-3 py-2.5 text-left text-[13px] text-[#fbf4ea] transition-colors hover:border-white/6 hover:bg-white/[0.05] sm:flex-row sm:items-center sm:justify-between"
+                className="flex w-full flex-col items-start gap-1.5 rounded-[14px] border border-transparent bg-black/20 px-3 py-2.5 text-left text-[13px] text-gold transition-colors hover:border-gold/10 hover:bg-gold/10 sm:flex-row sm:items-center sm:justify-between"
               >
                 <div className="min-w-0">
-                  <div className="truncate font-semibold text-[#fbf4ea]">{run.name}</div>
-                  <div className="mt-0.5 text-[11px] text-[#fbf4ea]/42">{getEnvironmentLabel(run.environment)}</div>
+                  <div className="truncate font-semibold text-gold">{run.name}</div>
+                  <div className="mt-0.5 text-[11px] text-gold/42">{getEnvironmentLabel(run.environment)}</div>
                 </div>
                 <div
                   className={cn(
@@ -1450,7 +1444,7 @@ const FactoryV2WatchActionBar = ({
   return (
     <div data-testid="factory-watch-action-bar" className="sticky bottom-3 z-10 md:static">
       <div className="mx-auto flex w-fit flex-col items-center gap-2">
-        <div className="flex items-center justify-center gap-2 rounded-full border border-white/8 bg-[rgba(21,17,15,0.72)] px-2 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.12)] backdrop-blur-md">
+        <div className="flex items-center justify-center gap-2 rounded-full border border-gold/10 bg-[rgba(21,17,15,0.72)] px-2 py-2 shadow-[0_10px_24px_rgba(0,0,0,0.12)] backdrop-blur-md">
           {visiblePrimaryAction ? (
             <FactoryV2WatchActionButton
               label={visiblePrimaryAction.label}
@@ -1507,13 +1501,13 @@ const FactoryV2WatchActionBar = ({
               icon={<CircleHelp className="h-4 w-4" />}
               onClick={() => setShowsActionHelp((current) => !current)}
               disabled={false}
-              className="border border-white/10 bg-white/8 text-[#fbf4ea]/52 hover:bg-white/10 hover:text-[#fbf4ea]/72"
+              className="border border-gold/15 bg-black/25 text-gold/52 hover:bg-gold/10 hover:text-gold/72"
             />
           ) : null}
         </div>
 
         {showsActionHelp ? (
-          <div className="flex flex-wrap items-center justify-center gap-1.5 text-[10px] font-medium text-[#fbf4ea]/44">
+          <div className="flex flex-wrap items-center justify-center gap-1.5 text-[10px] font-medium text-gold/44">
             {visiblePrimaryAction ? (
               <FactoryV2WatchActionLegend icon={<Play className="h-3 w-3" />} label="Continue" />
             ) : null}
@@ -1565,8 +1559,8 @@ const FactoryV2WatchActionButton = ({
 );
 
 const FactoryV2WatchActionLegend = ({ icon, label }: { icon: ReactNode; label: string }) => (
-  <span className="inline-flex items-center gap-1 rounded-full border border-white/8 bg-white/6 px-2 py-1">
-    <span className="inline-flex h-3 w-3 items-center justify-center text-[#fbf4ea]/55">{icon}</span>
+  <span className="inline-flex items-center gap-1 rounded-full border border-gold/10 bg-black/20 px-2 py-1">
+    <span className="inline-flex h-3 w-3 items-center justify-center text-gold/55">{icon}</span>
     <span>{label}</span>
   </span>
 );
@@ -1613,29 +1607,29 @@ function resolveStepMomentToneAppearance(tone: "done" | "now" | "next") {
   switch (tone) {
     case "done":
       return {
-        containerClassName: "border-white/8 bg-black/[0.025] opacity-45 shadow-none",
+        containerClassName: "border-gold/10 bg-black/[0.025] opacity-45 shadow-none",
         dotClassName: "bg-black/18",
-        labelClassName: "text-[#fbf4ea]/34",
-        stepLabelClassName: "font-medium text-[#fbf4ea]/50",
+        labelClassName: "text-gold/34",
+        stepLabelClassName: "font-medium text-gold/50",
         accentBarClassName: null,
         pulseClassName: null,
       };
     case "now":
       return {
-        containerClassName: "border-white/12 bg-[rgba(32,27,22,0.96)] shadow-[0_16px_34px_rgba(0,0,0,0.18)]",
+        containerClassName: "border-gold/20 bg-[rgba(32,27,22,0.96)] shadow-[0_16px_34px_rgba(0,0,0,0.18)]",
         dotClassName: "bg-[#dfaa54]",
         labelClassName: "text-[#dfaa54]",
-        stepLabelClassName: "font-semibold text-[#fbf4ea]",
+        stepLabelClassName: "font-semibold text-gold",
         accentBarClassName: null,
         pulseClassName: null,
       };
     case "next":
     default:
       return {
-        containerClassName: "border-dashed border-white/10 bg-white/5 opacity-70 shadow-none",
+        containerClassName: "border-dashed border-gold/15 bg-black/20 opacity-70 shadow-none",
         dotClassName: "bg-black/24",
-        labelClassName: "text-[#fbf4ea]/34",
-        stepLabelClassName: "font-medium text-[#fbf4ea]/56",
+        labelClassName: "text-gold/34",
+        stepLabelClassName: "font-medium text-gold/56",
         accentBarClassName: null,
         pulseClassName: null,
       };
@@ -1771,11 +1765,11 @@ const FactoryV2StepSummary = ({ step }: { step: FactoryRun["steps"][number] }) =
   const errorMessage = resolveRunStepErrorMessage(step);
 
   return (
-    <div className="flex items-start gap-3 rounded-[16px] border border-white/8 bg-black/[0.03] px-3.5 py-3">
+    <div className="flex items-start gap-3 rounded-[16px] border border-gold/10 bg-black/[0.03] px-3.5 py-3">
       <div className={cn("mt-1.5 h-2.5 w-2.5 rounded-full", statusMeta.railClassName)} />
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
-          <div className="text-sm font-semibold text-[#fbf4ea]">{getSimpleStepTitle(step)}</div>
+          <div className="text-sm font-semibold text-gold">{getSimpleStepTitle(step)}</div>
           <div
             className={cn(
               "rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.2em]",
@@ -1785,7 +1779,7 @@ const FactoryV2StepSummary = ({ step }: { step: FactoryRun["steps"][number] }) =
             {statusMeta.label}
           </div>
         </div>
-        <div className="mt-2 text-sm leading-6 text-[#fbf4ea]/56">{getStepDetailMessage(step)}</div>
+        <div className="mt-2 text-sm leading-6 text-gold/56">{getStepDetailMessage(step)}</div>
         {errorMessage ? (
           <div className="mt-3">
             <FactoryV2CopyableMessageBox
@@ -1870,7 +1864,7 @@ const FactoryV2CopyableMessageBox = ({
             void copyMessage();
           }}
           className={cn(
-            "rounded-full bg-white/10 font-semibold uppercase tracking-[0.16em] transition-colors hover:bg-white/10",
+            "rounded-full bg-black/25 font-semibold uppercase tracking-[0.16em] transition-colors hover:bg-gold/10",
             resolveCopyableMessageActionClassName(tone),
             compact ? "px-2 py-0.5 text-[9px]" : "px-2.5 py-1 text-[10px]",
           )}
@@ -1880,7 +1874,7 @@ const FactoryV2CopyableMessageBox = ({
       </div>
       <pre
         className={cn(
-          "overflow-auto whitespace-pre-wrap break-words rounded-[12px] bg-white/8",
+          "overflow-auto whitespace-pre-wrap break-words rounded-[12px] bg-black/25",
           resolveCopyableMessagePreClassName(tone),
           compact ? "max-h-24 px-2.5 py-2 text-[10px] leading-4" : "max-h-40 px-3 py-2 text-[11px] leading-5",
         )}
@@ -1896,7 +1890,7 @@ function resolveCopyableMessageBoxClassName(tone: "info" | "error") {
     return "border border-rose-300/50 bg-rose-50/80 shadow-[0_10px_24px_rgba(190,24,93,0.06)]";
   }
 
-  return "border border-white/12 bg-[rgba(32,27,22,0.9)] shadow-[0_10px_24px_rgba(0,0,0,0.16)]";
+  return "border border-gold/20 bg-[rgba(32,27,22,0.9)] shadow-[0_10px_24px_rgba(0,0,0,0.16)]";
 }
 
 function resolveCopyableMessageLabelClassName(tone: "info" | "error") {

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-workflow-switch.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-workflow-switch.tsx
@@ -20,12 +20,10 @@ export const FactoryV2WorkflowSwitch = ({
   return (
     <section className="animate-fade-in-up" style={{ animationDelay: "120ms" }}>
       <div className="space-y-2 text-center">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[#fbf4ea]/42">
-          What you want to do
-        </div>
+        <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-gold/42">What you want to do</div>
         <div
           data-testid="factory-workflow-switch"
-          className="mx-auto grid w-full grid-cols-3 gap-1.5 rounded-[22px] border border-white/8 bg-white/5 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[30rem]"
+          className="mx-auto grid w-full grid-cols-3 gap-1.5 rounded-[22px] border border-gold/10 bg-black/20 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[30rem]"
         >
           <button
             type="button"

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-workflow-switch.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-workflow-switch.tsx
@@ -20,10 +20,10 @@ export const FactoryV2WorkflowSwitch = ({
   return (
     <section className="animate-fade-in-up" style={{ animationDelay: "120ms" }}>
       <div className="space-y-2 text-center">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-black/42">What you want to do</div>
+        <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[#fbf4ea]/42">What you want to do</div>
         <div
           data-testid="factory-workflow-switch"
-          className="mx-auto grid w-full grid-cols-3 gap-1.5 rounded-[22px] border border-black/8 bg-white/45 p-1.5 shadow-[0_10px_24px_rgba(34,24,14,0.05)] md:max-w-[30rem]"
+          className="mx-auto grid w-full grid-cols-3 gap-1.5 rounded-[22px] border border-white/8 bg-white/5 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[30rem]"
         >
           <button
             type="button"

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-workflow-switch.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-workflow-switch.tsx
@@ -20,7 +20,9 @@ export const FactoryV2WorkflowSwitch = ({
   return (
     <section className="animate-fade-in-up" style={{ animationDelay: "120ms" }}>
       <div className="space-y-2 text-center">
-        <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[#fbf4ea]/42">What you want to do</div>
+        <div className="text-[10px] font-semibold uppercase tracking-[0.28em] text-[#fbf4ea]/42">
+          What you want to do
+        </div>
         <div
           data-testid="factory-workflow-switch"
           className="mx-auto grid w-full grid-cols-3 gap-1.5 rounded-[22px] border border-white/8 bg-white/5 p-1.5 shadow-[0_10px_24px_rgba(0,0,0,0.10)] md:max-w-[30rem]"

--- a/client/apps/game/src/ui/features/factory-v2/mode-appearance.ts
+++ b/client/apps/game/src/ui/features/factory-v2/mode-appearance.ts
@@ -20,49 +20,49 @@ interface FactoryModeAppearance {
 const MODE_APPEARANCES: Record<FactoryGameMode, FactoryModeAppearance> = {
   eternum: {
     canvasClassName:
-      "border-[#b6a07b] bg-[linear-gradient(180deg,rgba(221,205,178,0.98),rgba(185,160,123,0.98))] text-[#17110c] shadow-[0_28px_80px_rgba(0,0,0,0.22)]",
+      "border-white/10 bg-[linear-gradient(180deg,rgba(26,22,19,0.98),rgba(18,15,12,0.98))] text-[#fbf4ea] shadow-[0_28px_80px_rgba(0,0,0,0.32)]",
     backdropClassName:
-      "bg-[radial-gradient(circle_at_12%_14%,rgba(16,185,129,0.16),transparent_24%),radial-gradient(circle_at_82%_18%,rgba(120,113,28,0.2),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.06),transparent_46%)]",
-    sectionDividerClassName: "border-[rgba(81,60,34,0.18)]",
-    accentTextClassName: "text-[#6e5324]",
+      "bg-[radial-gradient(circle_at_12%_14%,rgba(16,185,129,0.10),transparent_24%),radial-gradient(circle_at_82%_18%,rgba(120,113,28,0.12),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.03),transparent_46%)]",
+    sectionDividerClassName: "border-[rgba(255,255,255,0.08)]",
+    accentTextClassName: "text-[#dfaa54]",
     mainSurfaceClassName:
-      "border border-[#c4ab84] bg-[linear-gradient(180deg,rgba(243,235,222,0.95),rgba(214,191,154,0.92))] shadow-[0_24px_60px_rgba(70,44,20,0.11)]",
+      "border border-white/10 bg-[linear-gradient(180deg,rgba(32,27,22,0.95),rgba(24,20,16,0.92))] shadow-[0_24px_60px_rgba(0,0,0,0.18)]",
     featureSurfaceClassName:
-      "border border-[#ccb28c] bg-[linear-gradient(180deg,rgba(246,238,225,0.97),rgba(221,197,159,0.92))] shadow-[0_18px_40px_rgba(70,44,20,0.1)]",
-    quietSurfaceClassName: "border border-[#d0ba96] bg-[rgba(232,214,187,0.74)]",
+      "border border-white/8 bg-[linear-gradient(180deg,rgba(30,25,20,0.97),rgba(22,18,14,0.92))] shadow-[0_18px_40px_rgba(0,0,0,0.16)]",
+    quietSurfaceClassName: "border border-white/8 bg-[rgba(26,22,18,0.74)]",
     listItemClassName:
-      "border border-[#d2bd9d] bg-[rgba(255,249,240,0.44)] transition-colors duration-200 hover:bg-[rgba(255,249,240,0.64)]",
-    activeToggleClassName: "bg-[#1f1711] text-[#fff7ec] shadow-[0_8px_20px_rgba(31,23,17,0.12)]",
-    inactiveToggleClassName: "text-[#5f5348] hover:bg-black/[0.04] hover:text-[#1f1711]",
-    primaryButtonClassName: "bg-[#1f1711] text-[#fff7ec] hover:bg-[#2c221b]",
+      "border border-white/8 bg-[rgba(32,27,22,0.44)] transition-colors duration-200 hover:bg-[rgba(32,27,22,0.64)]",
+    activeToggleClassName: "bg-[#fbf4ea] text-[#15110f] shadow-[0_8px_20px_rgba(0,0,0,0.18)]",
+    inactiveToggleClassName: "text-[#fbf4ea]/50 hover:bg-white/[0.06] hover:text-[#fbf4ea]/70",
+    primaryButtonClassName: "bg-[#dfaa54] text-[#15110f] hover:bg-[#e8b964]",
     secondaryButtonClassName:
-      "border border-[#ccb693] bg-[rgba(255,249,240,0.5)] text-[#302116] hover:bg-[rgba(255,249,240,0.76)]",
-    artGlowClassName: "bg-[radial-gradient(circle,rgba(16,185,129,0.22),rgba(161,98,7,0.16),transparent_68%)]",
+      "border border-white/12 bg-[rgba(32,27,22,0.5)] text-[#fbf4ea]/80 hover:bg-[rgba(42,36,28,0.76)]",
+    artGlowClassName: "bg-[radial-gradient(circle,rgba(16,185,129,0.14),rgba(161,98,7,0.10),transparent_68%)]",
     artGridClassName:
-      "bg-[linear-gradient(rgba(86,63,39,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(86,63,39,0.08)_1px,transparent_1px)] bg-[size:28px_28px]",
+      "bg-[linear-gradient(rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.04)_1px,transparent_1px)] bg-[size:28px_28px]",
   },
   blitz: {
     canvasClassName:
-      "border-[#b49973] bg-[linear-gradient(180deg,rgba(224,206,177,0.98),rgba(191,162,122,0.98))] text-[#17100b] shadow-[0_28px_80px_rgba(0,0,0,0.22)]",
+      "border-white/10 bg-[linear-gradient(180deg,rgba(26,20,16,0.98),rgba(18,14,11,0.98))] text-[#fbf4ea] shadow-[0_28px_80px_rgba(0,0,0,0.32)]",
     backdropClassName:
-      "bg-[radial-gradient(circle_at_14%_16%,rgba(180,83,9,0.22),transparent_24%),radial-gradient(circle_at_86%_18%,rgba(92,41,13,0.18),transparent_26%),linear-gradient(180deg,rgba(255,255,255,0.08),transparent_48%)]",
-    sectionDividerClassName: "border-[rgba(86,56,31,0.18)]",
-    accentTextClassName: "text-[#7a3d09]",
+      "bg-[radial-gradient(circle_at_14%_16%,rgba(180,83,9,0.14),transparent_24%),radial-gradient(circle_at_86%_18%,rgba(92,41,13,0.12),transparent_26%),linear-gradient(180deg,rgba(255,255,255,0.04),transparent_48%)]",
+    sectionDividerClassName: "border-[rgba(255,255,255,0.08)]",
+    accentTextClassName: "text-[#e8944a]",
     mainSurfaceClassName:
-      "border border-[#c5aa85] bg-[linear-gradient(180deg,rgba(244,233,216,0.95),rgba(216,189,151,0.92))] shadow-[0_24px_60px_rgba(70,44,20,0.12)]",
+      "border border-white/10 bg-[linear-gradient(180deg,rgba(30,24,18,0.95),rgba(22,17,13,0.92))] shadow-[0_24px_60px_rgba(0,0,0,0.20)]",
     featureSurfaceClassName:
-      "border border-[#ccb28d] bg-[linear-gradient(180deg,rgba(241,228,209,0.97),rgba(208,180,141,0.92))] shadow-[0_18px_40px_rgba(70,44,20,0.12)]",
-    quietSurfaceClassName: "border border-[#cdb28e] bg-[rgba(225,204,174,0.74)]",
+      "border border-white/8 bg-[linear-gradient(180deg,rgba(28,22,17,0.97),rgba(20,16,12,0.92))] shadow-[0_18px_40px_rgba(0,0,0,0.18)]",
+    quietSurfaceClassName: "border border-white/8 bg-[rgba(24,20,16,0.74)]",
     listItemClassName:
-      "border border-[#ccb28f] bg-[rgba(255,247,236,0.42)] transition-colors duration-200 hover:bg-[rgba(255,247,236,0.62)]",
-    activeToggleClassName: "bg-[#18100c] text-[#fff4e6] shadow-[0_8px_20px_rgba(24,16,12,0.16)]",
-    inactiveToggleClassName: "text-[#574535] hover:bg-black/[0.04] hover:text-[#18100c]",
-    primaryButtonClassName: "bg-[#18100c] text-[#fff4e6] hover:bg-[#261913]",
+      "border border-white/8 bg-[rgba(30,24,18,0.42)] transition-colors duration-200 hover:bg-[rgba(30,24,18,0.62)]",
+    activeToggleClassName: "bg-[#fbf4ea] text-[#15110f] shadow-[0_8px_20px_rgba(0,0,0,0.22)]",
+    inactiveToggleClassName: "text-[#fbf4ea]/50 hover:bg-white/[0.06] hover:text-[#fbf4ea]/70",
+    primaryButtonClassName: "bg-[#e8944a] text-[#15110f] hover:bg-[#f0a35c]",
     secondaryButtonClassName:
-      "border border-[#c5aa86] bg-[rgba(255,246,234,0.5)] text-[#302116] hover:bg-[rgba(255,246,234,0.76)]",
-    artGlowClassName: "bg-[radial-gradient(circle,rgba(217,119,6,0.34),rgba(120,53,15,0.12),transparent_68%)]",
+      "border border-white/12 bg-[rgba(30,24,18,0.5)] text-[#fbf4ea]/80 hover:bg-[rgba(40,32,24,0.76)]",
+    artGlowClassName: "bg-[radial-gradient(circle,rgba(217,119,6,0.20),rgba(120,53,15,0.08),transparent_68%)]",
     artGridClassName:
-      "bg-[linear-gradient(rgba(120,53,15,0.08)_1px,transparent_1px),linear-gradient(90deg,rgba(120,53,15,0.08)_1px,transparent_1px)] bg-[size:28px_28px]",
+      "bg-[linear-gradient(rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.04)_1px,transparent_1px)] bg-[size:28px_28px]",
   },
 };
 

--- a/client/apps/game/src/ui/features/factory-v2/mode-appearance.ts
+++ b/client/apps/game/src/ui/features/factory-v2/mode-appearance.ts
@@ -20,49 +20,45 @@ interface FactoryModeAppearance {
 const MODE_APPEARANCES: Record<FactoryGameMode, FactoryModeAppearance> = {
   eternum: {
     canvasClassName:
-      "border-white/10 bg-[linear-gradient(180deg,rgba(26,22,19,0.98),rgba(18,15,12,0.98))] text-[#fbf4ea] shadow-[0_28px_80px_rgba(0,0,0,0.32)]",
+      "border-gold/15 bg-black/25 text-gold/90 shadow-[0_28px_80px_rgba(0,0,0,0.4)] backdrop-blur-[12px]",
     backdropClassName:
-      "bg-[radial-gradient(circle_at_12%_14%,rgba(16,185,129,0.10),transparent_24%),radial-gradient(circle_at_82%_18%,rgba(120,113,28,0.12),transparent_28%),linear-gradient(180deg,rgba(255,255,255,0.03),transparent_46%)]",
-    sectionDividerClassName: "border-[rgba(255,255,255,0.08)]",
-    accentTextClassName: "text-[#dfaa54]",
-    mainSurfaceClassName:
-      "border border-white/10 bg-[linear-gradient(180deg,rgba(32,27,22,0.95),rgba(24,20,16,0.92))] shadow-[0_24px_60px_rgba(0,0,0,0.18)]",
+      "bg-[radial-gradient(circle_at_12%_14%,rgba(16,185,129,0.06),transparent_24%),radial-gradient(circle_at_82%_18%,rgba(223,170,84,0.06),transparent_28%)]",
+    sectionDividerClassName: "border-gold/10",
+    accentTextClassName: "text-gold",
+    mainSurfaceClassName: "border border-gold/15 bg-black/30 shadow-[0_24px_60px_rgba(0,0,0,0.2)] backdrop-blur-[8px]",
     featureSurfaceClassName:
-      "border border-white/8 bg-[linear-gradient(180deg,rgba(30,25,20,0.97),rgba(22,18,14,0.92))] shadow-[0_18px_40px_rgba(0,0,0,0.16)]",
-    quietSurfaceClassName: "border border-white/8 bg-[rgba(26,22,18,0.74)]",
+      "border border-gold/10 bg-black/25 shadow-[0_18px_40px_rgba(0,0,0,0.18)] backdrop-blur-[8px]",
+    quietSurfaceClassName: "border border-gold/10 bg-black/20 backdrop-blur-[6px]",
     listItemClassName:
-      "border border-white/8 bg-[rgba(32,27,22,0.44)] transition-colors duration-200 hover:bg-[rgba(32,27,22,0.64)]",
-    activeToggleClassName: "bg-[#fbf4ea] text-[#15110f] shadow-[0_8px_20px_rgba(0,0,0,0.18)]",
-    inactiveToggleClassName: "text-[#fbf4ea]/50 hover:bg-white/[0.06] hover:text-[#fbf4ea]/70",
-    primaryButtonClassName: "bg-[#dfaa54] text-[#15110f] hover:bg-[#e8b964]",
-    secondaryButtonClassName:
-      "border border-white/12 bg-[rgba(32,27,22,0.5)] text-[#fbf4ea]/80 hover:bg-[rgba(42,36,28,0.76)]",
-    artGlowClassName: "bg-[radial-gradient(circle,rgba(16,185,129,0.14),rgba(161,98,7,0.10),transparent_68%)]",
+      "border border-gold/10 bg-black/20 transition-colors duration-200 hover:bg-black/30 hover:border-gold/20",
+    activeToggleClassName: "bg-gold text-black shadow-[0_0_12px_rgba(223,170,84,0.3)]",
+    inactiveToggleClassName: "text-gold/50 hover:bg-gold/10 hover:text-gold/70",
+    primaryButtonClassName: "bg-gold text-black hover:bg-gold/90 shadow-[0_0_16px_rgba(223,170,84,0.2)]",
+    secondaryButtonClassName: "border border-gold/20 bg-black/20 text-gold/80 hover:bg-gold/10 hover:border-gold/30",
+    artGlowClassName: "bg-[radial-gradient(circle,rgba(16,185,129,0.08),rgba(223,170,84,0.06),transparent_68%)]",
     artGridClassName:
-      "bg-[linear-gradient(rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.04)_1px,transparent_1px)] bg-[size:28px_28px]",
+      "bg-[linear-gradient(rgba(223,170,84,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(223,170,84,0.04)_1px,transparent_1px)] bg-[size:28px_28px]",
   },
   blitz: {
     canvasClassName:
-      "border-white/10 bg-[linear-gradient(180deg,rgba(26,20,16,0.98),rgba(18,14,11,0.98))] text-[#fbf4ea] shadow-[0_28px_80px_rgba(0,0,0,0.32)]",
+      "border-gold/15 bg-black/25 text-gold/90 shadow-[0_28px_80px_rgba(0,0,0,0.4)] backdrop-blur-[12px]",
     backdropClassName:
-      "bg-[radial-gradient(circle_at_14%_16%,rgba(180,83,9,0.14),transparent_24%),radial-gradient(circle_at_86%_18%,rgba(92,41,13,0.12),transparent_26%),linear-gradient(180deg,rgba(255,255,255,0.04),transparent_48%)]",
-    sectionDividerClassName: "border-[rgba(255,255,255,0.08)]",
+      "bg-[radial-gradient(circle_at_14%_16%,rgba(232,148,74,0.08),transparent_24%),radial-gradient(circle_at_86%_18%,rgba(223,170,84,0.06),transparent_26%)]",
+    sectionDividerClassName: "border-gold/10",
     accentTextClassName: "text-[#e8944a]",
-    mainSurfaceClassName:
-      "border border-white/10 bg-[linear-gradient(180deg,rgba(30,24,18,0.95),rgba(22,17,13,0.92))] shadow-[0_24px_60px_rgba(0,0,0,0.20)]",
+    mainSurfaceClassName: "border border-gold/15 bg-black/30 shadow-[0_24px_60px_rgba(0,0,0,0.22)] backdrop-blur-[8px]",
     featureSurfaceClassName:
-      "border border-white/8 bg-[linear-gradient(180deg,rgba(28,22,17,0.97),rgba(20,16,12,0.92))] shadow-[0_18px_40px_rgba(0,0,0,0.18)]",
-    quietSurfaceClassName: "border border-white/8 bg-[rgba(24,20,16,0.74)]",
+      "border border-gold/10 bg-black/25 shadow-[0_18px_40px_rgba(0,0,0,0.2)] backdrop-blur-[8px]",
+    quietSurfaceClassName: "border border-gold/10 bg-black/20 backdrop-blur-[6px]",
     listItemClassName:
-      "border border-white/8 bg-[rgba(30,24,18,0.42)] transition-colors duration-200 hover:bg-[rgba(30,24,18,0.62)]",
-    activeToggleClassName: "bg-[#fbf4ea] text-[#15110f] shadow-[0_8px_20px_rgba(0,0,0,0.22)]",
-    inactiveToggleClassName: "text-[#fbf4ea]/50 hover:bg-white/[0.06] hover:text-[#fbf4ea]/70",
-    primaryButtonClassName: "bg-[#e8944a] text-[#15110f] hover:bg-[#f0a35c]",
-    secondaryButtonClassName:
-      "border border-white/12 bg-[rgba(30,24,18,0.5)] text-[#fbf4ea]/80 hover:bg-[rgba(40,32,24,0.76)]",
-    artGlowClassName: "bg-[radial-gradient(circle,rgba(217,119,6,0.20),rgba(120,53,15,0.08),transparent_68%)]",
+      "border border-gold/10 bg-black/20 transition-colors duration-200 hover:bg-black/30 hover:border-gold/20",
+    activeToggleClassName: "bg-gold text-black shadow-[0_0_12px_rgba(223,170,84,0.3)]",
+    inactiveToggleClassName: "text-gold/50 hover:bg-gold/10 hover:text-gold/70",
+    primaryButtonClassName: "bg-[#e8944a] text-black hover:bg-[#f0a35c] shadow-[0_0_16px_rgba(232,148,74,0.2)]",
+    secondaryButtonClassName: "border border-gold/20 bg-black/20 text-gold/80 hover:bg-gold/10 hover:border-gold/30",
+    artGlowClassName: "bg-[radial-gradient(circle,rgba(232,148,74,0.10),rgba(223,170,84,0.06),transparent_68%)]",
     artGridClassName:
-      "bg-[linear-gradient(rgba(255,255,255,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.04)_1px,transparent_1px)] bg-[size:28px_28px]",
+      "bg-[linear-gradient(rgba(223,170,84,0.04)_1px,transparent_1px),linear-gradient(90deg,rgba(223,170,84,0.04)_1px,transparent_1px)] bg-[size:28px_28px]",
   },
 };
 

--- a/client/apps/game/src/ui/features/factory-v2/presenters.ts
+++ b/client/apps/game/src/ui/features/factory-v2/presenters.ts
@@ -192,8 +192,7 @@ export const getRunStatusMeta = (status: FactoryRunStatus) => {
     default:
       return {
         label: "In progress",
-        className:
-          "border border-white/12 bg-[rgba(32,27,22,0.9)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
+        className: "border border-white/12 bg-[rgba(32,27,22,0.9)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
       };
   }
 };

--- a/client/apps/game/src/ui/features/factory-v2/presenters.ts
+++ b/client/apps/game/src/ui/features/factory-v2/presenters.ts
@@ -181,18 +181,18 @@ export const getRunStatusMeta = (status: FactoryRunStatus) => {
     case "waiting":
       return {
         label: "Getting Ready",
-        className: "border border-white/8 bg-white/6 text-[#fbf4ea]/62",
+        className: "border border-gold/10 bg-black/20 text-gold/62",
       };
     case "complete":
       return {
         label: "Ready",
-        className: "border border-white/8 bg-white/8 text-[#fbf4ea]/70",
+        className: "border border-gold/10 bg-black/25 text-gold/70",
       };
     case "running":
     default:
       return {
         label: "In progress",
-        className: "border border-white/12 bg-[rgba(32,27,22,0.9)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
+        className: "border border-gold/20 bg-[rgba(32,27,22,0.9)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
       };
   }
 };
@@ -202,20 +202,19 @@ export const getStepStatusMeta = (status: FactoryStepStatus) => {
     case "succeeded":
       return {
         label: "Done",
-        className: "border border-white/8 bg-white/6 text-[#fbf4ea]/58",
-        railClassName: "bg-white/18",
+        className: "border border-gold/10 bg-black/20 text-gold/58",
+        railClassName: "bg-gold/25",
       };
     case "already_done":
       return {
         label: "Done",
-        className: "border border-white/8 bg-white/6 text-[#fbf4ea]/52",
-        railClassName: "bg-white/16",
+        className: "border border-gold/10 bg-black/20 text-gold/52",
+        railClassName: "bg-gold/20",
       };
     case "running":
       return {
         label: "Current",
-        className:
-          "border border-white/12 bg-[rgba(32,27,22,0.92)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
+        className: "border border-gold/20 bg-[rgba(32,27,22,0.92)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
         railClassName: "bg-[#dfaa54]",
       };
     case "blocked":
@@ -234,8 +233,8 @@ export const getStepStatusMeta = (status: FactoryStepStatus) => {
     default:
       return {
         label: "Up next",
-        className: "border border-white/8 bg-white/5 text-[#fbf4ea]/52",
-        railClassName: "bg-white/12",
+        className: "border border-gold/10 bg-black/20 text-gold/52",
+        railClassName: "bg-black/30",
       };
   }
 };

--- a/client/apps/game/src/ui/features/factory-v2/presenters.ts
+++ b/client/apps/game/src/ui/features/factory-v2/presenters.ts
@@ -176,24 +176,24 @@ export const getRunStatusMeta = (status: FactoryRunStatus) => {
     case "attention":
       return {
         label: "Needs attention",
-        className: "border border-rose-300/50 bg-rose-50 text-rose-700",
+        className: "border border-rose-300/50 bg-rose-950/30 text-rose-400",
       };
     case "waiting":
       return {
         label: "Getting Ready",
-        className: "border border-black/8 bg-white/55 text-black/62",
+        className: "border border-white/8 bg-white/6 text-[#fbf4ea]/62",
       };
     case "complete":
       return {
         label: "Ready",
-        className: "border border-black/8 bg-white/68 text-black/70",
+        className: "border border-white/8 bg-white/8 text-[#fbf4ea]/70",
       };
     case "running":
     default:
       return {
         label: "In progress",
         className:
-          "border border-[#d4b487]/65 bg-[rgba(255,249,239,0.9)] text-[#8a5416] shadow-[0_8px_18px_rgba(186,129,44,0.12)]",
+          "border border-white/12 bg-[rgba(32,27,22,0.9)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
       };
   }
 };
@@ -203,40 +203,40 @@ export const getStepStatusMeta = (status: FactoryStepStatus) => {
     case "succeeded":
       return {
         label: "Done",
-        className: "border border-black/8 bg-white/58 text-black/58",
-        railClassName: "bg-black/18",
+        className: "border border-white/8 bg-white/6 text-[#fbf4ea]/58",
+        railClassName: "bg-white/18",
       };
     case "already_done":
       return {
         label: "Done",
-        className: "border border-black/8 bg-white/52 text-black/52",
-        railClassName: "bg-black/16",
+        className: "border border-white/8 bg-white/6 text-[#fbf4ea]/52",
+        railClassName: "bg-white/16",
       };
     case "running":
       return {
         label: "Current",
         className:
-          "border border-[#d4b487]/65 bg-[rgba(255,249,239,0.92)] text-[#8a5416] shadow-[0_8px_18px_rgba(186,129,44,0.12)]",
-        railClassName: "bg-[#d9b16f]",
+          "border border-white/12 bg-[rgba(32,27,22,0.92)] text-[#dfaa54] shadow-[0_8px_18px_rgba(0,0,0,0.18)]",
+        railClassName: "bg-[#dfaa54]",
       };
     case "blocked":
       return {
         label: "Needs attention",
-        className: "border border-rose-300/50 bg-rose-50 text-rose-700",
+        className: "border border-rose-300/50 bg-rose-950/30 text-rose-400",
         railClassName: "bg-rose-300",
       };
     case "failed":
       return {
         label: "Needs attention",
-        className: "border border-rose-300/50 bg-rose-50 text-rose-700",
+        className: "border border-rose-300/50 bg-rose-950/30 text-rose-400",
         railClassName: "bg-rose-400",
       };
     case "pending":
     default:
       return {
         label: "Up next",
-        className: "border border-black/8 bg-white/40 text-black/52",
-        railClassName: "bg-black/12",
+        className: "border border-white/8 bg-white/5 text-[#fbf4ea]/52",
+        railClassName: "bg-white/12",
       };
   }
 };

--- a/client/apps/game/src/ui/features/landing/components/landing-header.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-header.tsx
@@ -170,13 +170,20 @@ export const LandingHeader = ({ walletButton, onSettingsClick, className }: Land
                 className={cn(
                   "relative px-4 py-2 text-sm font-medium uppercase tracking-wider",
                   "transition-all duration-200",
-                  "hover:text-gold",
-                  isActive ? "text-gold" : "text-gold/50",
-                  // Underline effect on hover and active
-                  "after:absolute after:bottom-0 after:left-1/2 after:h-0.5 after:w-0 after:-translate-x-1/2",
-                  "after:bg-gold after:transition-all after:duration-200",
-                  "hover:after:w-1/2",
-                  isActive && "after:w-3/4 after:shadow-[0_0_8px_rgba(223,170,84,0.5)]",
+                  item.primary
+                    ? cn(
+                        "rounded-full border border-gold/40 bg-gold/10 px-5 text-gold",
+                        "hover:bg-gold/20 hover:border-gold/60",
+                        isActive && "border-gold/60 bg-gold/20 shadow-[0_0_12px_rgba(223,170,84,0.25)]",
+                      )
+                    : cn(
+                        "hover:text-gold",
+                        isActive ? "text-gold" : "text-gold/50",
+                        "after:absolute after:bottom-0 after:left-1/2 after:h-0.5 after:w-0 after:-translate-x-1/2",
+                        "after:bg-gold after:transition-all after:duration-200",
+                        "hover:after:w-1/2",
+                        isActive && "after:w-3/4 after:shadow-[0_0_8px_rgba(223,170,84,0.5)]",
+                      ),
                 )}
               >
                 {item.label}

--- a/client/apps/game/src/ui/features/landing/context/navigation-config.factory-tab.test.ts
+++ b/client/apps/game/src/ui/features/landing/context/navigation-config.factory-tab.test.ts
@@ -7,6 +7,8 @@ describe("Landing home navigation factory tab", () => {
   it("includes a factory submenu item on home", () => {
     const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/context/navigation-config.ts"), "utf8");
 
-    expect(source).toContain('{ id: "factory", label: "CREATE GAME", tab: "factory", href: "/factory", primary: true }');
+    expect(source).toContain(
+      '{ id: "factory", label: "CREATE GAME", tab: "factory", href: "/factory", primary: true }',
+    );
   });
 });

--- a/client/apps/game/src/ui/features/landing/context/navigation-config.factory-tab.test.ts
+++ b/client/apps/game/src/ui/features/landing/context/navigation-config.factory-tab.test.ts
@@ -7,6 +7,6 @@ describe("Landing home navigation factory tab", () => {
   it("includes a factory submenu item on home", () => {
     const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/context/navigation-config.ts"), "utf8");
 
-    expect(source).toContain('{ id: "factory", label: "FACTORY", tab: "factory", href: "/factory" }');
+    expect(source).toContain('{ id: "factory", label: "CREATE GAME", tab: "factory", href: "/factory", primary: true }');
   });
 });

--- a/client/apps/game/src/ui/features/landing/context/navigation-config.ts
+++ b/client/apps/game/src/ui/features/landing/context/navigation-config.ts
@@ -8,6 +8,8 @@ interface SubMenuItem {
   /** Tab parameter value (used in URL query string) */
   tab: string | null;
   href: string;
+  /** When true, the nav item is rendered with a prominent call-to-action style */
+  primary?: boolean;
 }
 
 interface SectionConfig {
@@ -29,7 +31,7 @@ export const NAVIGATION_SECTIONS: SectionConfig[] = [
       { id: "play", label: "PLAY", tab: null, href: "/" },
       { id: "learn", label: "LEARN", tab: "learn", href: "/learn" },
       { id: "news", label: "NEWS", tab: "news", href: "/news" },
-      { id: "factory", label: "FACTORY", tab: "factory", href: "/factory" },
+      { id: "factory", label: "CREATE GAME", tab: "factory", href: "/factory", primary: true },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Converts the Factory v2 page from a beige/cream light theme to a dark theme matching the rest of the site
- Updates `mode-appearance.ts` with dark brown gradients, cream text, gold/orange accents for both eternum and blitz modes
- Converts all 13 component files: `text-black/` → `text-[#fbf4ea]/`, `border-black/` → `border-white/`, high-opacity white backgrounds → low-opacity dark-friendly overlays
- Updates presenter status badge classes and native picker color schemes to dark variants

## Test plan
- [ ] Open Factory v2 page and verify dark theme renders correctly
- [ ] Toggle between Eternum and Blitz modes — confirm distinct accent colors (gold vs orange)
- [ ] Verify all form controls (inputs, selects, date/time pickers) are readable on dark background
- [ ] Check Watch, Manage Indexers, and Developer Tools tabs for consistent dark styling
- [ ] Test on mobile viewport for sticky action bar and native picker rendering