### PR TITLE
Fix worldmap ghost chunk convergence

### DIFF
--- a/client/apps/game/src/three/WORLDMAP_GHOST_ENTITY_CHUNK_CONVERGENCE_PRD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_GHOST_ENTITY_CHUNK_CONVERGENCE_PRD_TDD.md
@@ -1,0 +1,253 @@
+# Worldmap Ghost Entity Chunk Convergence PRD / TDD
+
+## Status
+
+- Status: Proposed for implementation
+- Scope: `client/apps/game/src/three/scenes/worldmap.tsx`
+- Scope: `client/apps/game/src/three/scenes/worldmap-refresh-commit-runtime.ts`
+- Scope: `client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.ts`
+- Scope: `client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.ts`
+- Scope: worldmap chunk commit ordering, visible entity catch-up, and ghost-state recovery
+
+## Problem Statement
+
+The worldmap currently commits visible terrain before the visible entity managers necessarily converge to the same chunk
+token.
+
+That separation is survivable when the follow-up manager fanout lands immediately, but it becomes visible under staged
+streaming and recovery refreshes:
+
+1. hydration prepares terrain for the current chunk
+2. the scene commits terrain and bounds
+3. the visible scene can still contain stale building or unit presentation from the previous commit
+4. the deferred manager fanout catches up later, or a second repair refresh is needed
+
+This creates the player-facing ghost state:
+
+- new terrain with stale units
+- repaired terrain with stale buildings
+- recovery paths that fix terrain first and leave entity presentation one phase behind
+
+## Findings From The Trace
+
+### Stable facts
+
+1. Asset loading is not the primary suspect.
+   - chunk hydration prewarms structure assets before terrain preparation
+   - `ArmyManager` and `StructureManager` preload required models before binding instances
+
+2. Terrain presentation commits before visible manager convergence.
+   - committed chunk switches apply prepared terrain before staged manager catch-up
+   - same-chunk refreshes apply prepared terrain before staged manager catch-up
+
+3. Same-chunk refresh is the weakest path.
+   - staged streaming defers the refresh manager catch-up
+   - route reload, duplicate-tile repair, offscreen recovery, and terrain self-heal all reuse that path
+
+4. The code already carries anti-ghosting guardrails.
+   - armies have suppressed-visual, stale-position, deferred-removal, and recovery-refresh logic
+   - structures defer world bounds until after instance rebuild and fence async visible passes
+
+### Most important implication
+
+The system needs a stronger visible-commit contract, not a loader rewrite:
+
+> once terrain for the visible chunk is committed, the visible building and unit managers must converge to the same
+> chunk token before the refresh or switch is considered complete
+
+## Goals
+
+### User goals
+
+- Visible chunk repairs must not leave ghost units or ghost buildings behind.
+- Hard reload into the map route must not show terrain from one commit and entities from another.
+- Recovery refreshes must converge the scene instead of only repairing terrain.
+- Panning or self-heal should not require an extra follow-up refresh to make entities match terrain.
+
+### Engineering goals
+
+- Define a single visible-commit contract for terrain plus critical visible managers.
+- Preserve staged streaming for non-critical/background work.
+- Keep chunk/token ownership deterministic.
+- Improve diagnostics around visible commit convergence.
+
+## Non-goals
+
+- Reworking GLTF/model loading
+- Changing chunk geometry, fetch area size, or prefetch policy
+- Disabling staged streaming globally
+- Rewriting the army or structure spatial indices
+
+## Proposed Behavior
+
+### Visible commit contract
+
+For any commit that changes the visible worldmap terrain:
+
+1. commit authority and terrain
+2. update chunk bounds
+3. immediately reconcile the critical visible managers
+4. only then resolve the switch or refresh promise
+5. defer non-critical manager work afterward
+
+### Critical vs non-critical managers
+
+- Critical visible managers
+  - `ArmyManager`
+  - `StructureManager`
+
+- Deferred non-critical manager
+  - `ChestManager`
+
+### Chunk switch behavior
+
+Committed chunk switches should:
+
+1. keep authority ownership exactly where it is today
+2. commit terrain before manager work
+3. immediately await army catch-up
+4. immediately await structure catch-up
+5. schedule chest catch-up on the staged deferred queue
+
+### Same-chunk refresh behavior
+
+Committed same-chunk refreshes should:
+
+1. keep the current stale-token and stale-chunk drop rules
+2. commit terrain for the current chunk
+3. immediately await army catch-up
+4. immediately await structure catch-up
+5. schedule chest catch-up on the staged deferred queue
+
+### Failure behavior
+
+If immediate critical catch-up fails:
+
+1. record explicit critical-manager diagnostics
+2. log the failing manager label and chunk key
+3. keep the committed terrain in place
+4. schedule one guarded `visibility_recovery` refresh on the next turn of the event loop
+5. reuse the existing chunk-recovery cooldown and dedupe behavior
+
+## Architecture
+
+## 1. Make visible chunk commits atomic for critical managers
+
+Visible commit completion means:
+
+- terrain committed
+- bounds applied
+- army visuals reconciled
+- structure visuals reconciled
+
+## 2. Preserve staged streaming for non-critical work
+
+The deferred queue remains, but its correctness responsibility narrows to non-critical work:
+
+- chest catch-up
+- future non-critical managers if added later
+
+## 3. Keep token ownership unchanged
+
+Do not loosen:
+
+- `shouldRunManagerUpdate(...)`
+- `shouldAcceptManagerChunkRequest(...)`
+- manager pass fences
+- structure deferred-bounds logic
+- army suppressed and stale-position logic
+
+The fix is ordering, not token semantics.
+
+## 4. Add targeted diagnostics
+
+Add critical-manager diagnostics so we can answer:
+
+- did terrain commit before critical managers converged
+- how long critical convergence took
+- which manager failed when ghosting is reported
+
+## Implementation Plan
+
+### Step 1. Add this PRD / TDD doc
+
+Create `WORLDMAP_GHOST_ENTITY_CHUNK_CONVERGENCE_PRD_TDD.md`.
+
+### Step 2. Add critical manager catch-up helpers
+
+In `worldmap.tsx` add:
+
+- `updateCriticalManagersForChunk(...)`
+- `deferNonCriticalManagerCatchUpForChunk(...)`
+
+### Step 3. Change committed-switch catch-up policy
+
+Update `catchUpCommittedWorldmapChunkManagers(...)` so staged mode performs:
+
+- immediate critical catch-up
+- deferred non-critical catch-up
+
+### Step 4. Change same-chunk refresh catch-up policy
+
+Update `handleWorldmapRefreshCommitRuntime(...)` so staged mode performs:
+
+- immediate critical catch-up
+- deferred non-critical catch-up
+
+### Step 5. Keep deferred queue only for non-critical managers
+
+Retain the existing queueing and budget logic, but only enqueue chest catch-up from the visible commit path.
+
+### Step 6. Add the user-facing feature note
+
+Add a top entry to `latest-features.ts` describing the fix from the player’s perspective.
+
+## TDD Plan
+
+## Red phase
+
+Add or update tests that assert:
+
+1. committed switch catch-up runs critical managers immediately and only defers non-critical work
+2. staged same-chunk refresh runs critical managers immediately after terrain commit
+3. critical manager failure records failure and schedules one recovery refresh
+4. diagnostics track critical manager catch-up starts, failures, and durations
+5. worldmap wiring uses the new critical/deferred split
+
+## Green phase
+
+Implement the smallest clean orchestration change that satisfies those tests.
+
+## Refactor phase
+
+Keep orchestration readable:
+
+- visible commit helpers orchestrate
+- runtime helpers encode the staged-policy split
+- deferred queue helpers only queue non-critical work
+- diagnostics helpers record diagnostics
+
+## Verification
+
+Targeted tests:
+
+- `worldmap-committed-chunk-manager-catchup.test.ts`
+- `worldmap-fast-commit-manager-catchup.test.ts`
+- `worldmap-refresh-commit-runtime.test.ts`
+- `warp-travel-chunk-switch-commit.test.ts`
+- `worldmap-critical-manager-catchup-runtime.test.ts`
+- `worldmap-critical-manager-catchup.wiring.test.ts`
+
+Broader checks:
+
+- `pnpm run format`
+- `pnpm run knip`
+
+## Expected Outcome
+
+After the fix:
+
+- visible terrain repair no longer resolves before visible units and structures do
+- route reload and self-heal stop producing mixed terrain/entity frames that can persist as ghosts
+- the post-commit queue still exists, but it no longer owns correctness for visible armies and buildings
+- the loading sequence stays largely the same; correctness improves because visible commit ordering is stricter

--- a/client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.test.ts
+++ b/client/apps/game/src/three/scenes/warp-travel-chunk-switch-commit.test.ts
@@ -174,6 +174,56 @@ describe("finalizeWarpTravelChunkSwitch", () => {
     expect(unregisterPreviousChunkOnNextFrame).toHaveBeenCalledWith("0,0");
   });
 
+  it("keeps manager scheduling after visibility work so the visible commit can await critical convergence later", async () => {
+    const phaseOrder: string[] = [];
+
+    await finalizeWarpTravelChunkSwitch({
+      fetchSucceeded: true,
+      isCurrentTransition: true,
+      targetChunk: "24,24",
+      previousChunk: "0,0",
+      currentChunk: "0,0",
+      previousPinnedChunks: [],
+      hasFiniteOldChunkCoordinates: false,
+      oldChunkCoordinates: null,
+      startRow: 24,
+      startCol: 24,
+      force: true,
+      transitionToken: 23,
+      preparedTerrain: { chunkKey: "24,24" },
+      applyPreparedTerrain: vi.fn(() => {
+        phaseOrder.push("terrain");
+      }),
+      setCurrentChunk: vi.fn(() => {
+        phaseOrder.push("authority");
+      }),
+      updatePinnedChunks: vi.fn(),
+      unregisterChunk: vi.fn(),
+      restorePreviousChunkVisuals: async () => undefined,
+      clearSceneChunkBounds: vi.fn(),
+      forceVisibilityUpdate: vi.fn(() => {
+        phaseOrder.push("visibility");
+      }),
+      updateCurrentChunkBounds: vi.fn(() => {
+        phaseOrder.push("bounds");
+      }),
+      scheduleManagerCatchUp: vi.fn(() => {
+        phaseOrder.push("critical-manager-catch-up");
+        phaseOrder.push("deferred-non-critical-scheduled");
+      }),
+      unregisterPreviousChunkOnNextFrame: vi.fn(),
+    });
+
+    expect(phaseOrder).toEqual([
+      "authority",
+      "terrain",
+      "bounds",
+      "visibility",
+      "critical-manager-catch-up",
+      "deferred-non-critical-scheduled",
+    ]);
+  });
+
   it("advances chunk authority before manager fanout on committed switches", async () => {
     let currentChunk = "0,0";
     const setCurrentChunk = vi.fn((chunkKey: string) => {

--- a/client/apps/game/src/three/scenes/worldmap-chunk-diagnostics.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-diagnostics.test.ts
@@ -16,6 +16,8 @@ describe("worldmap-chunk-diagnostics", () => {
     expect(diagnostics.transitionPrepareStaleDropped).toBe(0);
     expect(diagnostics.managerUpdateStarted).toBe(0);
     expect(diagnostics.managerUpdateSkippedStale).toBe(0);
+    expect(diagnostics.criticalManagerCatchUpStarted).toBe(0);
+    expect(diagnostics.criticalManagerCatchUpFailed).toBe(0);
     expect(diagnostics.tileFetchStarted).toBe(0);
     expect(diagnostics.tileFetchSucceeded).toBe(0);
     expect(diagnostics.tileFetchFailed).toBe(0);
@@ -48,6 +50,9 @@ describe("worldmap-chunk-diagnostics", () => {
     expect(diagnostics.managerCatchUpDurationMsTotal).toBe(0);
     expect(diagnostics.managerCatchUpDurationMsMax).toBe(0);
     expect(diagnostics.managerCatchUpDurationMsSamples).toEqual([]);
+    expect(diagnostics.criticalManagerCatchUpDurationMsTotal).toBe(0);
+    expect(diagnostics.criticalManagerCatchUpDurationMsMax).toBe(0);
+    expect(diagnostics.criticalManagerCatchUpDurationMsSamples).toEqual([]);
     expect(diagnostics.preparedChunkPrewarmHit).toBe(0);
     expect(diagnostics.preparedChunkPrewarmMiss).toBe(0);
   });
@@ -62,6 +67,8 @@ describe("worldmap-chunk-diagnostics", () => {
       "manager_update_started",
       "manager_update_skipped_stale",
       "manager_update_failed",
+      "critical_manager_catch_up_started",
+      "critical_manager_catch_up_failed",
       "tile_fetch_started",
       "tile_fetch_succeeded",
       "tile_fetch_failed",
@@ -92,6 +99,8 @@ describe("worldmap-chunk-diagnostics", () => {
     expect(diagnostics.managerUpdateStarted).toBe(1);
     expect(diagnostics.managerUpdateSkippedStale).toBe(1);
     expect(diagnostics.managerUpdateFailed).toBe(1);
+    expect(diagnostics.criticalManagerCatchUpStarted).toBe(1);
+    expect(diagnostics.criticalManagerCatchUpFailed).toBe(1);
     expect(diagnostics.tileFetchStarted).toBe(1);
     expect(diagnostics.tileFetchSucceeded).toBe(1);
     expect(diagnostics.tileFetchFailed).toBe(1);
@@ -128,6 +137,8 @@ describe("worldmap-chunk-diagnostics", () => {
     recordChunkDiagnosticsEvent(diagnostics, "manager_duration_recorded", { durationMs: 9 });
     recordChunkDiagnosticsEvent(diagnostics, "manager_catch_up_duration_recorded", { durationMs: 6 });
     recordChunkDiagnosticsEvent(diagnostics, "manager_catch_up_duration_recorded", { durationMs: 9 });
+    recordChunkDiagnosticsEvent(diagnostics, "critical_manager_catch_up_duration_recorded", { durationMs: 7 });
+    recordChunkDiagnosticsEvent(diagnostics, "critical_manager_catch_up_duration_recorded", { durationMs: 10 });
 
     expect(diagnostics.switchDurationMsTotal).toBeCloseTo(17);
     expect(diagnostics.switchDurationMsMax).toBeCloseTo(12.5);
@@ -147,6 +158,9 @@ describe("worldmap-chunk-diagnostics", () => {
     expect(diagnostics.managerCatchUpDurationMsTotal).toBeCloseTo(15);
     expect(diagnostics.managerCatchUpDurationMsMax).toBeCloseTo(9);
     expect(diagnostics.managerCatchUpDurationMsSamples).toEqual([6, 9]);
+    expect(diagnostics.criticalManagerCatchUpDurationMsTotal).toBeCloseTo(17);
+    expect(diagnostics.criticalManagerCatchUpDurationMsMax).toBeCloseTo(10);
+    expect(diagnostics.criticalManagerCatchUpDurationMsSamples).toEqual([7, 10]);
   });
 
   it("caps duration samples to the latest bounded window", () => {
@@ -169,6 +183,7 @@ describe("worldmap-chunk-diagnostics", () => {
       recordChunkDiagnosticsEvent(diagnostics, "terrain_commit_duration_recorded", { durationMs: i });
       recordChunkDiagnosticsEvent(diagnostics, "first_visible_commit_duration_recorded", { durationMs: i });
       recordChunkDiagnosticsEvent(diagnostics, "manager_catch_up_duration_recorded", { durationMs: i });
+      recordChunkDiagnosticsEvent(diagnostics, "critical_manager_catch_up_duration_recorded", { durationMs: i });
     }
 
     expect(diagnostics.terrainReadyDurationMsSamples).toHaveLength(512);
@@ -177,6 +192,7 @@ describe("worldmap-chunk-diagnostics", () => {
     expect(diagnostics.terrainCommitDurationMsSamples).toHaveLength(512);
     expect(diagnostics.firstVisibleCommitDurationMsSamples).toHaveLength(512);
     expect(diagnostics.managerCatchUpDurationMsSamples).toHaveLength(512);
+    expect(diagnostics.criticalManagerCatchUpDurationMsSamples).toHaveLength(512);
   });
 });
 

--- a/client/apps/game/src/three/scenes/worldmap-chunk-diagnostics.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-diagnostics.ts
@@ -6,6 +6,8 @@ export type WorldmapChunkDiagnosticsEvent =
   | "manager_update_started"
   | "manager_update_skipped_stale"
   | "manager_update_failed"
+  | "critical_manager_catch_up_started"
+  | "critical_manager_catch_up_failed"
   | "tile_fetch_started"
   | "tile_fetch_succeeded"
   | "tile_fetch_failed"
@@ -30,6 +32,7 @@ export type WorldmapChunkDiagnosticsEvent =
   | "first_visible_commit_duration_recorded"
   | "manager_duration_recorded"
   | "manager_catch_up_duration_recorded"
+  | "critical_manager_catch_up_duration_recorded"
   | "prepared_chunk_prewarm_hit"
   | "prepared_chunk_prewarm_miss"
   | "terrain_visible_commit"
@@ -53,6 +56,8 @@ export interface WorldmapChunkDiagnostics {
   managerUpdateStarted: number;
   managerUpdateSkippedStale: number;
   managerUpdateFailed: number;
+  criticalManagerCatchUpStarted: number;
+  criticalManagerCatchUpFailed: number;
   tileFetchStarted: number;
   tileFetchSucceeded: number;
   tileFetchFailed: number;
@@ -101,6 +106,9 @@ export interface WorldmapChunkDiagnostics {
   managerCatchUpDurationMsTotal: number;
   managerCatchUpDurationMsMax: number;
   managerCatchUpDurationMsSamples: number[];
+  criticalManagerCatchUpDurationMsTotal: number;
+  criticalManagerCatchUpDurationMsMax: number;
+  criticalManagerCatchUpDurationMsSamples: number[];
   preparedChunkPrewarmHit: number;
   preparedChunkPrewarmMiss: number;
   updatedAtMs: number;
@@ -121,6 +129,8 @@ export function createWorldmapChunkDiagnostics(): WorldmapChunkDiagnostics {
     managerUpdateStarted: 0,
     managerUpdateSkippedStale: 0,
     managerUpdateFailed: 0,
+    criticalManagerCatchUpStarted: 0,
+    criticalManagerCatchUpFailed: 0,
     tileFetchStarted: 0,
     tileFetchSucceeded: 0,
     tileFetchFailed: 0,
@@ -169,6 +179,9 @@ export function createWorldmapChunkDiagnostics(): WorldmapChunkDiagnostics {
     managerCatchUpDurationMsTotal: 0,
     managerCatchUpDurationMsMax: 0,
     managerCatchUpDurationMsSamples: [],
+    criticalManagerCatchUpDurationMsTotal: 0,
+    criticalManagerCatchUpDurationMsMax: 0,
+    criticalManagerCatchUpDurationMsSamples: [],
     preparedChunkPrewarmHit: 0,
     preparedChunkPrewarmMiss: 0,
     updatedAtMs: Date.now(),
@@ -211,6 +224,12 @@ export function recordChunkDiagnosticsEvent(
       break;
     case "manager_update_failed":
       diagnostics.managerUpdateFailed += 1;
+      break;
+    case "critical_manager_catch_up_started":
+      diagnostics.criticalManagerCatchUpStarted += 1;
+      break;
+    case "critical_manager_catch_up_failed":
+      diagnostics.criticalManagerCatchUpFailed += 1;
       break;
     case "tile_fetch_started":
       diagnostics.tileFetchStarted += 1;
@@ -348,6 +367,16 @@ export function recordChunkDiagnosticsEvent(
       diagnostics.managerCatchUpDurationMsTotal += durationMs;
       diagnostics.managerCatchUpDurationMsMax = Math.max(diagnostics.managerCatchUpDurationMsMax, durationMs);
       recordDurationSample(diagnostics.managerCatchUpDurationMsSamples, durationMs);
+      break;
+    }
+    case "critical_manager_catch_up_duration_recorded": {
+      const durationMs = options?.durationMs ?? 0;
+      diagnostics.criticalManagerCatchUpDurationMsTotal += durationMs;
+      diagnostics.criticalManagerCatchUpDurationMsMax = Math.max(
+        diagnostics.criticalManagerCatchUpDurationMsMax,
+        durationMs,
+      );
+      recordDurationSample(diagnostics.criticalManagerCatchUpDurationMsSamples, durationMs);
       break;
     }
   }

--- a/client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { catchUpCommittedWorldmapChunkManagers } from "./worldmap-committed-chunk-manager-catchup";
 
 describe("catchUpCommittedWorldmapChunkManagers", () => {
-  it("runs structure catch-up before deferring the remaining managers on the staged path", async () => {
+  it("runs critical catch-up before deferring the non-critical managers on the staged path", async () => {
     const events: string[] = [];
 
     await catchUpCommittedWorldmapChunkManagers({
@@ -11,15 +11,15 @@ describe("catchUpCommittedWorldmapChunkManagers", () => {
       runImmediateFullManagerCatchUp: vi.fn(async () => {
         events.push("full");
       }),
-      runImmediateStructureCatchUp: vi.fn(async () => {
-        events.push("structure");
+      runImmediateCriticalManagerCatchUp: vi.fn(async () => {
+        events.push("critical");
       }),
-      scheduleDeferredRemainingManagerCatchUp: vi.fn(() => {
-        events.push("defer-remaining");
+      scheduleDeferredNonCriticalManagerCatchUp: vi.fn(() => {
+        events.push("defer-non-critical");
       }),
     });
 
-    expect(events).toEqual(["structure", "defer-remaining"]);
+    expect(events).toEqual(["critical", "defer-non-critical"]);
   });
 
   it("keeps the legacy path on the full immediate manager catch-up", async () => {
@@ -30,11 +30,11 @@ describe("catchUpCommittedWorldmapChunkManagers", () => {
       runImmediateFullManagerCatchUp: vi.fn(async () => {
         events.push("full");
       }),
-      runImmediateStructureCatchUp: vi.fn(async () => {
-        events.push("structure");
+      runImmediateCriticalManagerCatchUp: vi.fn(async () => {
+        events.push("critical");
       }),
-      scheduleDeferredRemainingManagerCatchUp: vi.fn(() => {
-        events.push("defer-remaining");
+      scheduleDeferredNonCriticalManagerCatchUp: vi.fn(() => {
+        events.push("defer-non-critical");
       }),
     });
 

--- a/client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.ts
+++ b/client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.ts
@@ -1,7 +1,7 @@
 interface CatchUpCommittedWorldmapChunkManagersInput {
   runImmediateFullManagerCatchUp: () => Promise<void>;
-  runImmediateStructureCatchUp: () => Promise<void>;
-  scheduleDeferredRemainingManagerCatchUp: () => void;
+  runImmediateCriticalManagerCatchUp: () => Promise<void>;
+  scheduleDeferredNonCriticalManagerCatchUp: () => void;
   stagedPathEnabled: boolean;
 }
 
@@ -13,9 +13,9 @@ export async function catchUpCommittedWorldmapChunkManagers(
     return;
   }
 
-  // Terrain commits before the staged manager fanout. Keep structure presentation
-  // in lockstep with that terrain commit so buildings do not cull against stale
-  // chunk bounds while the new biome slice is already visible.
-  await input.runImmediateStructureCatchUp();
-  input.scheduleDeferredRemainingManagerCatchUp();
+  // Terrain commits before the staged manager fanout. Keep critical visible
+  // managers in lockstep with that terrain commit so the current chunk
+  // does not present mixed terrain/entity state while deferred work drains.
+  await input.runImmediateCriticalManagerCatchUp();
+  input.scheduleDeferredNonCriticalManagerCatchUp();
 }

--- a/client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-committed-chunk-manager-catchup.wiring.test.ts
@@ -9,12 +9,14 @@ function readSceneSource(relativePath: string): string {
 }
 
 describe("worldmap committed chunk manager catch-up wiring", () => {
-  it("prioritizes structure catch-up before deferring the staged fanout", () => {
+  it("prioritizes critical catch-up before deferring the staged fanout", () => {
     const worldmapSource = readSceneSource("./worldmap.tsx");
 
     expect(worldmapSource).toMatch(/catchUpCommittedWorldmapChunkManagers\(\{/);
-    expect(worldmapSource).toMatch(/runImmediateStructureCatchUp: \(\) => this\.updateStructureManagerForChunk/);
-    expect(worldmapSource).toMatch(/scheduleDeferredRemainingManagerCatchUp: \(\) =>/);
-    expect(worldmapSource).toMatch(/this\.deferRemainingManagerCatchUpForChunk\(targetChunkKey, managerOptions\)/);
+    expect(worldmapSource).toMatch(/runImmediateCriticalManagerCatchUp: \(\) => this\.updateCriticalManagersForChunk/);
+    expect(worldmapSource).toMatch(/scheduleDeferredNonCriticalManagerCatchUp: \(\) =>/);
+    expect(worldmapSource).toMatch(
+      /this\.deferNonCriticalManagerCatchUpForCommittedChunk\(targetChunkKey, managerOptions\)/,
+    );
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-critical-manager-catchup-runtime.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-critical-manager-catchup-runtime.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { handleWorldmapCriticalManagerCatchUpFailures } from "./worldmap-critical-manager-catchup-runtime";
+
+describe("handleWorldmapCriticalManagerCatchUpFailures", () => {
+  it("records each critical failure and schedules one recovery refresh", () => {
+    const onManagerFailure = vi.fn();
+    const scheduleRecovery = vi.fn();
+
+    const failureCount = handleWorldmapCriticalManagerCatchUpFailures({
+      chunkKey: "24,24",
+      failures: [
+        { label: "army", reason: new Error("army failed") },
+        { label: "structure", reason: new Error("structure failed") },
+      ],
+      onManagerFailure,
+      scheduleRecovery,
+    });
+
+    expect(failureCount).toBe(2);
+    expect(onManagerFailure).toHaveBeenCalledTimes(2);
+    expect(scheduleRecovery).toHaveBeenCalledTimes(1);
+    expect(scheduleRecovery).toHaveBeenCalledWith("24,24", ["army", "structure"]);
+  });
+
+  it("does nothing when all critical managers succeed", () => {
+    const onManagerFailure = vi.fn();
+    const scheduleRecovery = vi.fn();
+
+    const failureCount = handleWorldmapCriticalManagerCatchUpFailures({
+      chunkKey: "24,24",
+      failures: [],
+      onManagerFailure,
+      scheduleRecovery,
+    });
+
+    expect(failureCount).toBe(0);
+    expect(onManagerFailure).not.toHaveBeenCalled();
+    expect(scheduleRecovery).not.toHaveBeenCalled();
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-critical-manager-catchup-runtime.ts
+++ b/client/apps/game/src/three/scenes/worldmap-critical-manager-catchup-runtime.ts
@@ -1,0 +1,30 @@
+export interface WorldmapCriticalManagerCatchUpFailure {
+  label: string;
+  reason: unknown;
+}
+
+interface HandleWorldmapCriticalManagerCatchUpFailuresInput {
+  chunkKey: string;
+  failures: WorldmapCriticalManagerCatchUpFailure[];
+  onManagerFailure: (failure: WorldmapCriticalManagerCatchUpFailure) => void;
+  scheduleRecovery: (chunkKey: string, failingManagers: string[]) => void;
+}
+
+export function handleWorldmapCriticalManagerCatchUpFailures(
+  input: HandleWorldmapCriticalManagerCatchUpFailuresInput,
+): number {
+  if (input.failures.length === 0) {
+    return 0;
+  }
+
+  input.failures.forEach((failure) => {
+    input.onManagerFailure(failure);
+  });
+
+  input.scheduleRecovery(
+    input.chunkKey,
+    input.failures.map((failure) => failure.label),
+  );
+
+  return input.failures.length;
+}

--- a/client/apps/game/src/three/scenes/worldmap-critical-manager-catchup.wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-critical-manager-catchup.wiring.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readSceneSource(relativePath: string): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, relativePath), "utf8");
+}
+
+describe("worldmap critical manager catch-up wiring", () => {
+  it("uses Promise.allSettled and schedules one visibility recovery through the shared chunk recovery path", () => {
+    const worldmapSource = readSceneSource("./worldmap.tsx");
+
+    expect(worldmapSource).toMatch(/private async updateCriticalManagersForChunk\(/);
+    expect(worldmapSource).toMatch(/Promise\.allSettled\(\[/);
+    expect(worldmapSource).toMatch(/critical_manager_catch_up_failed/);
+    expect(worldmapSource).toMatch(/scheduleChunkRecoveryWithReason\(/);
+    expect(worldmapSource).toMatch(/"visibility_recovery"/);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-fast-commit-manager-catchup.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-fast-commit-manager-catchup.test.ts
@@ -9,17 +9,20 @@ function readSceneSource(relativePath: string): string {
 }
 
 describe("worldmap fast commit manager catch-up wiring", () => {
-  it("defers switch manager catch-up instead of awaiting it in the finalize path", () => {
-    const finalizeSource = readSceneSource("./warp-travel-chunk-switch-commit.ts");
-
-    expect(finalizeSource).toMatch(/scheduleManagerCatchUp\(/);
-    expect(finalizeSource).not.toMatch(/await input\.updateManagersForChunk\(/);
-  });
-
-  it("defers same-chunk refresh manager catch-up after terrain commit", () => {
+  it("routes staged switch commits through immediate critical catch-up and deferred non-critical catch-up", () => {
     const worldmapSource = readSceneSource("./worldmap.tsx");
 
-    expect(worldmapSource).toMatch(/deferManagerCatchUpForChunk\(/);
+    expect(worldmapSource).toMatch(/updateCriticalManagersForChunk\(/);
+    expect(worldmapSource).toMatch(/deferNonCriticalManagerCatchUpForCommittedChunk\(/);
+    expect(worldmapSource).toMatch(/WORLDMAP_STREAMING_ROLLOUT\.stagedPathEnabled/);
+  });
+
+  it("keeps same-chunk refresh critical catch-up immediate after terrain commit", () => {
+    const worldmapSource = readSceneSource("./worldmap.tsx");
+
+    expect(worldmapSource).toMatch(/runImmediateCriticalManagerCatchUp:/);
+    expect(worldmapSource).toMatch(/scheduleDeferredNonCriticalManagerCatchUp:/);
+    expect(worldmapSource).not.toMatch(/scheduleDeferredManagerCatchUp:/);
     expect(worldmapSource).toMatch(/WORLDMAP_STREAMING_ROLLOUT\.stagedPathEnabled/);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-refresh-commit-runtime.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-refresh-commit-runtime.test.ts
@@ -13,8 +13,9 @@ describe("handleWorldmapRefreshCommitRuntime", () => {
       preparedTerrain: { chunkKey: "24,24" },
       recordChunkDiagnosticsEvent: vi.fn(),
       refreshDecision: { shouldCommit: false, shouldDropAsStale: false },
-      runImmediateManagerCatchUp: vi.fn(async () => undefined),
-      scheduleDeferredManagerCatchUp: vi.fn(),
+      runImmediateFullManagerCatchUp: vi.fn(async () => undefined),
+      runImmediateCriticalManagerCatchUp: vi.fn(async () => undefined),
+      scheduleDeferredNonCriticalManagerCatchUp: vi.fn(),
       stagedPathEnabled: true,
       tileFetchSucceeded: false,
       transitionToken: 7,
@@ -34,8 +35,9 @@ describe("handleWorldmapRefreshCommitRuntime", () => {
       preparedTerrain: { chunkKey: "24,24" },
       recordChunkDiagnosticsEvent,
       refreshDecision: { shouldCommit: false, shouldDropAsStale: true },
-      runImmediateManagerCatchUp: vi.fn(async () => undefined),
-      scheduleDeferredManagerCatchUp: vi.fn(),
+      runImmediateFullManagerCatchUp: vi.fn(async () => undefined),
+      runImmediateCriticalManagerCatchUp: vi.fn(async () => undefined),
+      scheduleDeferredNonCriticalManagerCatchUp: vi.fn(),
       stagedPathEnabled: true,
       tileFetchSucceeded: true,
       transitionToken: 9,
@@ -45,9 +47,10 @@ describe("handleWorldmapRefreshCommitRuntime", () => {
     expect(recordChunkDiagnosticsEvent).toHaveBeenCalledWith({ id: "diagnostics" }, "stale_terrain_refresh_dropped");
   });
 
-  it("commits terrain and schedules deferred manager catch-up when staged rollout is enabled", async () => {
+  it("commits terrain, runs immediate critical catch-up, and defers non-critical catch-up when staged rollout is enabled", async () => {
     const commitPreparedTerrain = vi.fn();
-    const scheduleDeferredManagerCatchUp = vi.fn();
+    const runImmediateCriticalManagerCatchUp = vi.fn(async () => undefined);
+    const scheduleDeferredNonCriticalManagerCatchUp = vi.fn();
 
     const result = await handleWorldmapRefreshCommitRuntime({
       chunkKey: "48,48",
@@ -58,8 +61,9 @@ describe("handleWorldmapRefreshCommitRuntime", () => {
       preparedTerrain: { chunkKey: "48,48" },
       recordChunkDiagnosticsEvent: vi.fn(),
       refreshDecision: { shouldCommit: true, shouldDropAsStale: false },
-      runImmediateManagerCatchUp: vi.fn(async () => undefined),
-      scheduleDeferredManagerCatchUp,
+      runImmediateFullManagerCatchUp: vi.fn(async () => undefined),
+      runImmediateCriticalManagerCatchUp,
+      scheduleDeferredNonCriticalManagerCatchUp,
       stagedPathEnabled: true,
       tileFetchSucceeded: true,
       transitionToken: 11,
@@ -67,11 +71,15 @@ describe("handleWorldmapRefreshCommitRuntime", () => {
 
     expect(result).toBe("committed");
     expect(commitPreparedTerrain).toHaveBeenCalledWith({ chunkKey: "48,48" });
-    expect(scheduleDeferredManagerCatchUp).toHaveBeenCalledWith("48,48", { force: true, transitionToken: 11 });
+    expect(runImmediateCriticalManagerCatchUp).toHaveBeenCalledWith("48,48", { force: true, transitionToken: 11 });
+    expect(scheduleDeferredNonCriticalManagerCatchUp).toHaveBeenCalledWith("48,48", {
+      force: true,
+      transitionToken: 11,
+    });
   });
 
   it("commits terrain and runs immediate manager catch-up when staged rollout is disabled", async () => {
-    const runImmediateManagerCatchUp = vi.fn(async () => undefined);
+    const runImmediateFullManagerCatchUp = vi.fn(async () => undefined);
 
     const result = await handleWorldmapRefreshCommitRuntime({
       chunkKey: "72,72",
@@ -82,14 +90,15 @@ describe("handleWorldmapRefreshCommitRuntime", () => {
       preparedTerrain: { chunkKey: "72,72" },
       recordChunkDiagnosticsEvent: vi.fn(),
       refreshDecision: { shouldCommit: true, shouldDropAsStale: false },
-      runImmediateManagerCatchUp,
-      scheduleDeferredManagerCatchUp: vi.fn(),
+      runImmediateFullManagerCatchUp,
+      runImmediateCriticalManagerCatchUp: vi.fn(async () => undefined),
+      scheduleDeferredNonCriticalManagerCatchUp: vi.fn(),
       stagedPathEnabled: false,
       tileFetchSucceeded: true,
       transitionToken: 13,
     });
 
     expect(result).toBe("committed");
-    expect(runImmediateManagerCatchUp).toHaveBeenCalledWith("72,72", { force: true, transitionToken: 13 });
+    expect(runImmediateFullManagerCatchUp).toHaveBeenCalledWith("72,72", { force: true, transitionToken: 13 });
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-refresh-commit-runtime.ts
+++ b/client/apps/game/src/three/scenes/worldmap-refresh-commit-runtime.ts
@@ -12,8 +12,18 @@ interface HandleWorldmapRefreshCommitRuntimeInput {
     shouldCommit: boolean;
     shouldDropAsStale: boolean;
   };
-  runImmediateManagerCatchUp: (chunkKey: string, options: { force: boolean; transitionToken: number }) => Promise<void>;
-  scheduleDeferredManagerCatchUp: (chunkKey: string, options: { force: boolean; transitionToken: number }) => void;
+  runImmediateFullManagerCatchUp: (
+    chunkKey: string,
+    options: { force: boolean; transitionToken: number },
+  ) => Promise<void>;
+  runImmediateCriticalManagerCatchUp: (
+    chunkKey: string,
+    options: { force: boolean; transitionToken: number },
+  ) => Promise<void>;
+  scheduleDeferredNonCriticalManagerCatchUp: (
+    chunkKey: string,
+    options: { force: boolean; transitionToken: number },
+  ) => void;
   stagedPathEnabled: boolean;
   tileFetchSucceeded: boolean;
   transitionToken: number;
@@ -38,12 +48,16 @@ export async function handleWorldmapRefreshCommitRuntime(
 
   input.commitPreparedTerrain(input.preparedTerrain);
   if (input.stagedPathEnabled) {
-    input.scheduleDeferredManagerCatchUp(input.chunkKey, {
+    await input.runImmediateCriticalManagerCatchUp(input.chunkKey, {
+      force: input.force,
+      transitionToken: input.transitionToken,
+    });
+    input.scheduleDeferredNonCriticalManagerCatchUp(input.chunkKey, {
       force: input.force,
       transitionToken: input.transitionToken,
     });
   } else {
-    await input.runImmediateManagerCatchUp(input.chunkKey, {
+    await input.runImmediateFullManagerCatchUp(input.chunkKey, {
       force: input.force,
       transitionToken: input.transitionToken,
     });

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -168,6 +168,10 @@ import {
 import { handleWorldmapRefreshCommitRuntime } from "./worldmap-refresh-commit-runtime";
 import { runWorldmapRefreshRuntime } from "./worldmap-refresh-runtime";
 import {
+  handleWorldmapCriticalManagerCatchUpFailures,
+  type WorldmapCriticalManagerCatchUpFailure,
+} from "./worldmap-critical-manager-catchup-runtime";
+import {
   commitWorldmapPreparedTerrainPresentation,
   recordWorldmapTerrainReadyDuration,
 } from "./worldmap-terrain-commit-runtime";
@@ -4545,7 +4549,7 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
-  private deferManagerCatchUpForChunk(
+  private deferNonCriticalManagerCatchUpForChunk(
     chunkKey: string,
     options?: {
       force?: boolean;
@@ -4553,17 +4557,14 @@ export default class WorldmapScene extends WarpTravel {
     },
   ): void {
     if (!WORLDMAP_STREAMING_ROLLOUT.stagedPathEnabled) {
-      void this.updateManagersForChunk(chunkKey, options).catch((error) => {
-        console.error("[WorldMap] Legacy manager catch-up failed:", error);
+      void this.updateNonCriticalManagersForChunk(chunkKey, options).catch((error) => {
+        console.error("[WorldMap] Legacy non-critical manager catch-up failed:", error);
       });
       return;
     }
 
     const uploadWork = classifyWorldmapUploadWork({
-      matrixInstanceCount:
-        this.armyManager.getVisibleCount() +
-        this.structureManager.getVisibleCount() +
-        this.chestManager.getVisibleCount(),
+      matrixInstanceCount: this.chestManager.getVisibleCount(),
       colorInstanceCount: 0,
       isCachedReplay: false,
       stage: "visible_commit",
@@ -4599,18 +4600,17 @@ export default class WorldmapScene extends WarpTravel {
     });
   }
 
-  private deferRemainingManagerCatchUpForChunk(
+  private deferNonCriticalManagerCatchUpForCommittedChunk(
     chunkKey: string,
     options?: {
       force?: boolean;
       transitionToken?: number;
     },
   ): void {
-    this.deferManagerCatchUpForChunk(chunkKey, {
+    this.deferNonCriticalManagerCatchUpForChunk(chunkKey, {
       ...options,
-      // Structure presentation already caught up to the committed chunk. Let the
-      // deferred fanout refresh the remaining managers without forcing structure
-      // through the same rebuild again.
+      // Critical visible managers already caught up to the committed chunk.
+      // Let the deferred fanout refresh only the remaining non-critical work.
       force: false,
     });
   }
@@ -4627,7 +4627,7 @@ export default class WorldmapScene extends WarpTravel {
       onTaskError: (_task, error) => {
         console.error("[WorldMap] Deferred manager catch-up failed:", error);
       },
-      runTask: (task) => this.updateManagersForChunk(task.chunkKey, task.options),
+      runTask: (task) => this.updateNonCriticalManagersForChunk(task.chunkKey, task.options),
       scheduleDrain: () => {
         this.schedulePostCommitManagerCatchUpDrain();
       },
@@ -5535,6 +5535,15 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private scheduleChunkRecovery(reason: string, chunkKey: string, details: Record<string, unknown> = {}): void {
+    this.scheduleChunkRecoveryWithReason(reason, chunkKey, details, "default");
+  }
+
+  private scheduleChunkRecoveryWithReason(
+    reason: string,
+    chunkKey: string,
+    details: Record<string, unknown> = {},
+    refreshReason: WorldmapForceRefreshReason,
+  ): void {
     if (this.isSwitchedOff || !chunkKey || chunkKey === "null") {
       return;
     }
@@ -5558,7 +5567,7 @@ export default class WorldmapScene extends WarpTravel {
         chunkKey,
         ...details,
       });
-      this.requestChunkRefresh(true, "default");
+      this.requestChunkRefresh(true, refreshReason);
     }, 0);
   }
 
@@ -6816,9 +6825,9 @@ export default class WorldmapScene extends WarpTravel {
     return catchUpCommittedWorldmapChunkManagers({
       stagedPathEnabled: WORLDMAP_STREAMING_ROLLOUT.stagedPathEnabled,
       runImmediateFullManagerCatchUp: () => this.updateManagersForChunk(targetChunkKey, managerOptions),
-      runImmediateStructureCatchUp: () => this.updateStructureManagerForChunk(targetChunkKey, managerOptions),
-      scheduleDeferredRemainingManagerCatchUp: () =>
-        this.deferRemainingManagerCatchUpForChunk(targetChunkKey, managerOptions),
+      runImmediateCriticalManagerCatchUp: () => this.updateCriticalManagersForChunk(targetChunkKey, managerOptions),
+      scheduleDeferredNonCriticalManagerCatchUp: () =>
+        this.deferNonCriticalManagerCatchUpForCommittedChunk(targetChunkKey, managerOptions),
     });
   }
 
@@ -7058,9 +7067,12 @@ export default class WorldmapScene extends WarpTravel {
           preparedTerrain,
           recordChunkDiagnosticsEvent,
           refreshDecision: commitDecision,
-          runImmediateManagerCatchUp: (targetChunkKey, options) => this.updateManagersForChunk(targetChunkKey, options),
-          scheduleDeferredManagerCatchUp: (targetChunkKey, options) =>
-            this.deferManagerCatchUpForChunk(targetChunkKey, options),
+          runImmediateFullManagerCatchUp: (targetChunkKey, options) =>
+            this.updateManagersForChunk(targetChunkKey, options),
+          runImmediateCriticalManagerCatchUp: (targetChunkKey, options) =>
+            this.updateCriticalManagersForChunk(targetChunkKey, options),
+          scheduleDeferredNonCriticalManagerCatchUp: (targetChunkKey, options) =>
+            this.deferNonCriticalManagerCatchUpForChunk(targetChunkKey, options),
           stagedPathEnabled: WORLDMAP_STREAMING_ROLLOUT.stagedPathEnabled,
           tileFetchSucceeded,
           transitionToken,
@@ -7170,17 +7182,116 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
-  private async updateStructureManagerForChunk(
+  private async updateCriticalManagersForChunk(
     chunkKey: string,
     options?: { force?: boolean; transitionToken?: number },
   ) {
+    if (
+      !shouldRunManagerUpdate({
+        transitionToken: options?.transitionToken,
+        expectedTransitionToken: this.chunkTransitionToken,
+        currentChunk: this.currentChunk,
+        targetChunk: chunkKey,
+      })
+    ) {
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_update_skipped_stale");
+      return;
+    }
+
+    const managerStartedAt = performance.now();
+    recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_update_started");
+    recordChunkDiagnosticsEvent(this.chunkDiagnostics, "critical_manager_catch_up_started");
+
+    let failures: WorldmapCriticalManagerCatchUpFailure[] = [];
+
     try {
-      await this.structureManager.updateChunk(chunkKey, options);
+      const [armyResult, structureResult] = await Promise.allSettled([
+        this.armyManager.updateChunk(chunkKey, options),
+        this.structureManager.updateChunk(chunkKey, options),
+      ]);
+
+      failures = [armyResult, structureResult].flatMap((result, index) =>
+        result.status === "rejected"
+          ? [
+              {
+                label: index === 0 ? "army" : "structure",
+                reason: result.reason,
+              },
+            ]
+          : [],
+      );
+    } finally {
+      const durationMs = performance.now() - managerStartedAt;
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_duration_recorded", {
+        durationMs,
+      });
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_catch_up_duration_recorded", {
+        durationMs,
+      });
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "critical_manager_catch_up_duration_recorded", {
+        durationMs,
+      });
+      recordWorldmapRenderDuration("chunkManagerCatchUpMs", durationMs);
+      recordWorldmapRenderDuration("updateManagersForChunk", durationMs);
+      setWorldmapRenderGauge("visibleArmies", this.armyManager.getVisibleCount());
+      setWorldmapRenderGauge("visibleStructures", this.structureManager.getVisibleCount());
+      setWorldmapRenderGauge("activePaths", this.armyManager.getActivePathCount());
+      setWorldmapRenderGauge("activeLabels", this.hoverLabelManager.getActiveLabelCount());
+    }
+
+    handleWorldmapCriticalManagerCatchUpFailures({
+      chunkKey,
+      failures,
+      onManagerFailure: (failure) => {
+        recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_update_failed");
+        recordChunkDiagnosticsEvent(this.chunkDiagnostics, "critical_manager_catch_up_failed");
+        console.error(`[CHUNK SYNC] Critical ${failure.label} manager failed for chunk ${chunkKey}`, failure.reason);
+      },
+      scheduleRecovery: (failedChunkKey, failingManagers) => {
+        this.scheduleChunkRecoveryWithReason(
+          "critical_manager_failure",
+          failedChunkKey,
+          { failingManagers },
+          "visibility_recovery",
+        );
+      },
+    });
+  }
+
+  private async updateNonCriticalManagersForChunk(
+    chunkKey: string,
+    options?: { force?: boolean; transitionToken?: number },
+  ) {
+    if (
+      !shouldRunManagerUpdate({
+        transitionToken: options?.transitionToken,
+        expectedTransitionToken: this.chunkTransitionToken,
+        currentChunk: this.currentChunk,
+        targetChunk: chunkKey,
+      })
+    ) {
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_update_skipped_stale");
+      return;
+    }
+
+    const managerStartedAt = performance.now();
+    recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_update_started");
+
+    try {
+      await this.chestManager.updateChunk(chunkKey, options);
     } catch (reason) {
       recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_update_failed");
-      console.error(`[CHUNK SYNC] structure manager failed for chunk ${chunkKey}`, reason);
+      console.error(`[CHUNK SYNC] chest manager failed for chunk ${chunkKey}`, reason);
     } finally {
-      setWorldmapRenderGauge("visibleStructures", this.structureManager.getVisibleCount());
+      const durationMs = performance.now() - managerStartedAt;
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_duration_recorded", {
+        durationMs,
+      });
+      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "manager_catch_up_duration_recorded", {
+        durationMs,
+      });
+      recordWorldmapRenderDuration("chunkManagerCatchUpMs", durationMs);
+      recordWorldmapRenderDuration("updateManagersForChunk", durationMs);
     }
   }
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-14",
+    title: "Map Chunk Sync Fix",
+    description:
+      "World-map chunk repairs now wait for visible armies and structures to catch up before they settle, so terrain self-heals and reload recovery stop leaving ghost units or buildings behind.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-14",
     title: "Reliable Auto-Settle Entry",
     description:
       "Auto-settle now keeps freshly registered Blitz players on the settlement path until their realm setup is ready, so dashboard handoffs stop dropping new entrants into the game as spectators.",


### PR DESCRIPTION
This tightens worldmap chunk commits so visible terrain now waits for critical army and structure catch-up before staged work settles. It narrows deferred post-commit fanout to chest updates, adds critical convergence diagnostics and recovery coverage, and documents the behavior in a PRD/TDD. Verification: targeted worldmap and ghost regression tests, pnpm run format, and pnpm run knip.