### PR TITLE
fix(game): unify sidebar structure stats

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.structure-status.source.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.structure-status.source.test.ts
@@ -1,17 +1,12 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const sidebarSource = readFileSync(
-  new URL("./left-command-sidebar.tsx", import.meta.url),
-  "utf8",
-);
+const sidebarSource = readFileSync(new URL("./left-command-sidebar.tsx", import.meta.url), "utf8");
 
 describe("left-command-sidebar structure status wiring", () => {
   it("routes structure stat rendering through the shared status snapshot resolver", () => {
     expect(sidebarSource).toContain("resolveStructureStatusSnapshot");
-    expect(sidebarSource).not.toContain(
-      "populationCapacity = Number(structureBuildings?.population.max ?? 0) +",
-    );
+    expect(sidebarSource).not.toContain("populationCapacity = Number(structureBuildings?.population.max ?? 0) +");
     expect(sidebarSource).not.toContain(
       "Number(liveStructureBuildings?.population.max ?? selectedStructureMetadata?.populationCapacity ?? 0) +",
     );

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.structure-status.source.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.structure-status.source.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const sidebarSource = readFileSync(new URL("./left-command-sidebar.tsx", import.meta.url), "utf8");
+
+describe("left-command-sidebar structure status wiring", () => {
+  it("routes structure stat rendering through the shared status snapshot resolver", () => {
+    expect(sidebarSource).toContain("resolveStructureStatusSnapshot");
+    expect(sidebarSource).not.toContain("populationCapacity = Number(structureBuildings?.population.max ?? 0) +");
+    expect(sidebarSource).not.toContain("Number(liveStructureBuildings?.population.max ?? selectedStructureMetadata?.populationCapacity ?? 0) +");
+    expect(sidebarSource).not.toContain("Number(liveStructureBuildings?.population.max ?? structure.populationCapacity ?? 0) +");
+  });
+});

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.structure-status.source.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.structure-status.source.test.ts
@@ -1,13 +1,22 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-const sidebarSource = readFileSync(new URL("./left-command-sidebar.tsx", import.meta.url), "utf8");
+const sidebarSource = readFileSync(
+  new URL("./left-command-sidebar.tsx", import.meta.url),
+  "utf8",
+);
 
 describe("left-command-sidebar structure status wiring", () => {
   it("routes structure stat rendering through the shared status snapshot resolver", () => {
     expect(sidebarSource).toContain("resolveStructureStatusSnapshot");
-    expect(sidebarSource).not.toContain("populationCapacity = Number(structureBuildings?.population.max ?? 0) +");
-    expect(sidebarSource).not.toContain("Number(liveStructureBuildings?.population.max ?? selectedStructureMetadata?.populationCapacity ?? 0) +");
-    expect(sidebarSource).not.toContain("Number(liveStructureBuildings?.population.max ?? structure.populationCapacity ?? 0) +");
+    expect(sidebarSource).not.toContain(
+      "populationCapacity = Number(structureBuildings?.population.max ?? 0) +",
+    );
+    expect(sidebarSource).not.toContain(
+      "Number(liveStructureBuildings?.population.max ?? selectedStructureMetadata?.populationCapacity ?? 0) +",
+    );
+    expect(sidebarSource).not.toContain(
+      "Number(liveStructureBuildings?.population.max ?? structure.populationCapacity ?? 0) +",
+    );
   });
 });

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -33,9 +33,8 @@ import {
 } from "@/ui/features/world/containers/top-header/structure-groups";
 import {
   countOccupiedBuildingTilesByStructure,
-  formatAvailableBuildingTilesLabel,
-  formatPopulationStatusLabel,
-  resolveAvailableBuildingTiles,
+  resolveStructureStatusSnapshot,
+  type StructureStatusSnapshot,
 } from "@/ui/features/world/containers/structure-status";
 import { useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
 import { BaseContainer } from "@/ui/shared/containers/base-container";
@@ -104,11 +103,8 @@ type StructureWithMetadata = Structure & {
   displayName: string;
   originalName: string;
   realmLevel: number;
-  realmLevelLabel: string | null;
-  population: number;
-  populationCapacity: number;
-  buildingTilesAvailable: number | null;
-  buildingTilesTotal: number | null;
+  occupiedBuildingTiles: number | null;
+  statusSnapshot: StructureStatusSnapshot;
   groupColor: StructureGroupColor | null;
   isFavorite: boolean;
   canUpgrade: boolean;
@@ -220,16 +216,50 @@ const StructureStatusStats = ({
   populationLabel,
   buildingTilesLabel,
 }: {
-  populationLabel: string;
+  populationLabel: string | null;
   buildingTilesLabel: string | null;
 }) => (
   <div className="flex flex-wrap items-center gap-1.5">
-    <StructureInfoStat icon={Users} label={populationLabel} title="Population used / capacity" />
+    {populationLabel ? <StructureInfoStat icon={Users} label={populationLabel} title="Population used / capacity" /> : null}
     {buildingTilesLabel ? (
       <StructureInfoStat icon={Hexagon} label={buildingTilesLabel} title="Available / total building tiles" />
     ) : null}
   </div>
 );
+
+const normalizeStructureLevel = (value: bigint | number | null | undefined) =>
+  typeof value === "bigint" ? Number(value) : Number(value ?? 0);
+
+const resolveSidebarStructureStatus = ({
+  structureCategory,
+  structureLevel,
+  structureBuildings,
+  occupiedBuildingTiles,
+  fallbackStatus,
+}: {
+  structureCategory: StructureType | undefined;
+  structureLevel: number;
+  structureBuildings: { population?: { current?: bigint | number | null; max?: bigint | number | null } | null } | null;
+  occupiedBuildingTiles: number | null | undefined;
+  fallbackStatus?: StructureStatusSnapshot;
+}) => {
+  if (!structureBuildings && fallbackStatus) {
+    return fallbackStatus;
+  }
+
+  const structureCapabilities = resolveStructureUiCapabilities({ category: structureCategory });
+  const basePopulationCapacity = structureCapabilities.hasPopulationDetails
+    ? Math.max(Number(configManager.getBasePopulationCapacity() ?? 0), 6)
+    : 0;
+
+  return resolveStructureStatusSnapshot({
+    structureCategory,
+    structureLevel,
+    structureBuildings,
+    occupiedBuildingTiles,
+    basePopulationCapacity,
+  });
+};
 
 const getResponsiveButtonSize = (itemCount: number): CircleButtonProps["size"] => {
   // Panel width is 420px, padding is 24px (px-3 on each side), available ~396px
@@ -335,34 +365,22 @@ const LeftPanelHeader = memo(
     const structuresWithMetadata = useMemo<StructureWithMetadata[]>(() => {
       // Force recomputation when a local rename occurs.
       void nameUpdateVersion;
-      const basePopulationCapacityValue = configManager.getBasePopulationCapacity();
       const maxRealmLevel = configManager.getMaxLevel(StructureType.Realm);
       return structures.map((structure) => {
         const { name, originalName } = mode.structure.getName(structure.structure);
-        const structureCapabilities = resolveStructureUiCapabilities(structure.structure);
         const baseLevel = structure.structure.base?.level;
-        const normalizedLevel =
-          typeof baseLevel === "number" ? baseLevel : typeof baseLevel === "bigint" ? Number(baseLevel) : 0;
-        const realmLevelLabel = structureCapabilities.hasPopulationDetails
-          ? getLevelName(Math.min(Math.max(normalizedLevel, RealmLevels.Settlement), RealmLevels.Empire) as RealmLevels)
-          : null;
+        const normalizedLevel = normalizeStructureLevel(baseLevel);
         const structureEntity = getEntityIdFromKeys([BigInt(structure.entityId)]);
         const structureBuildings = components.StructureBuildings
           ? getComponentValue(components.StructureBuildings, structureEntity)
           : null;
-        const population = Number(structureBuildings?.population.current ?? 0);
-        const normalizedBasePopulationCapacity = structureCapabilities.hasPopulationDetails
-          ? Math.max(Number(basePopulationCapacityValue ?? 0), 6)
-          : 0;
-        const populationCapacity = Number(structureBuildings?.population.max ?? 0) + normalizedBasePopulationCapacity;
-        const occupiedBuildingTiles = buildingTileCountsByStructure[structure.entityId];
-        const buildingTileSummary =
-          structureCapabilities.hasPopulationDetails && occupiedBuildingTiles !== undefined
-            ? resolveAvailableBuildingTiles({
-                level: normalizedLevel,
-                occupiedBuildingTiles,
-              })
-            : null;
+        const occupiedBuildingTiles = buildingTileCountsByStructure[structure.entityId] ?? null;
+        const statusSnapshot = resolveSidebarStructureStatus({
+          structureCategory: structure.category,
+          structureLevel: normalizedLevel,
+          structureBuildings,
+          occupiedBuildingTiles,
+        });
         const groupColor = structureGroups[structure.entityId] ?? null;
 
         const isFavorite = favoritesSet.has(structure.entityId);
@@ -372,11 +390,8 @@ const LeftPanelHeader = memo(
           displayName: name,
           originalName,
           realmLevel: normalizedLevel,
-          realmLevelLabel,
-          population,
-          populationCapacity,
-          buildingTilesAvailable: buildingTileSummary?.available ?? null,
-          buildingTilesTotal: buildingTileSummary?.total ?? null,
+          occupiedBuildingTiles,
+          statusSnapshot,
           groupColor,
           isFavorite,
           canUpgrade: structure.category === StructureType.Realm && normalizedLevel < maxRealmLevel,
@@ -428,38 +443,24 @@ const LeftPanelHeader = memo(
       selectedStructureMetadata?.realmLevel ??
       selectedStructureMetadata?.structure.base?.level ??
       0;
-    const normalizedLevel =
-      typeof normalizedLevelRaw === "bigint" ? Number(normalizedLevelRaw) : Number(normalizedLevelRaw ?? 0);
+    const normalizedLevel = normalizeStructureLevel(normalizedLevelRaw);
     const selectedStructureCapabilities = resolveStructureUiCapabilities(selectedStructureMetadata?.structure);
     const levelLabel = selectedStructureCapabilities.hasPopulationDetails
       ? getLevelName(Math.min(Math.max(normalizedLevel, RealmLevels.Settlement), RealmLevels.Empire) as RealmLevels)
       : selectedStructureMetadata
         ? `Level ${normalizedLevel}`
         : "Level —";
-    const basePopulationCapacity = selectedStructureCapabilities.hasPopulationDetails
-      ? configManager.getBasePopulationCapacity()
-      : 0;
-    const normalizedBasePopulationCapacity = selectedStructureCapabilities.hasPopulationDetails
-      ? Math.max(Number(basePopulationCapacity ?? 0), 6)
-      : 0;
-    const livePopulation = Number(
-      liveStructureBuildings?.population.current ?? selectedStructureMetadata?.population ?? 0,
-    );
-    const livePopulationCapacity =
-      Number(liveStructureBuildings?.population.max ?? selectedStructureMetadata?.populationCapacity ?? 0) +
-      normalizedBasePopulationCapacity;
-    const populationStatusLabel = selectedStructureMetadata
-      ? formatPopulationStatusLabel(livePopulation, livePopulationCapacity)
+    const selectedStructureStatus = selectedStructureMetadata
+      ? resolveSidebarStructureStatus({
+          structureCategory: selectedStructureMetadata.category,
+          structureLevel: normalizedLevel,
+          structureBuildings: liveStructureBuildings,
+          occupiedBuildingTiles: selectedStructureMetadata.occupiedBuildingTiles,
+          fallbackStatus: selectedStructureMetadata.statusSnapshot,
+        })
       : null;
-    const buildingTilesStatusLabel =
-      selectedStructureMetadata &&
-      selectedStructureMetadata.buildingTilesAvailable !== null &&
-      selectedStructureMetadata.buildingTilesTotal !== null
-        ? formatAvailableBuildingTilesLabel(
-            selectedStructureMetadata.buildingTilesAvailable,
-            selectedStructureMetadata.buildingTilesTotal,
-          )
-        : null;
+    const populationStatusLabel = selectedStructureStatus?.populationLabel ?? null;
+    const buildingTilesStatusLabel = selectedStructureStatus?.buildingTilesLabel ?? null;
     const showDetailedStats = Boolean(selectedStructureMetadata && selectedStructureCapabilities.hasPopulationDetails);
     const headerTitle =
       selectedStructureMetadata?.displayName ??
@@ -496,15 +497,19 @@ const LeftPanelHeader = memo(
               >
                 {headerTitle}
               </p>
-              {showDetailedStats && populationStatusLabel && (
+              {showDetailedStats && (
                 <div className="flex items-center gap-2 flex-shrink-0 text-xs text-gold/70">
                   <span className="text-gold/40">•</span>
                   <span>{levelLabel}</span>
-                  <span className="text-gold/40">•</span>
-                  <StructureStatusStats
-                    populationLabel={populationStatusLabel}
-                    buildingTilesLabel={buildingTilesStatusLabel}
-                  />
+                  {(populationStatusLabel || buildingTilesStatusLabel) && (
+                    <>
+                      <span className="text-gold/40">•</span>
+                      <StructureStatusStats
+                        populationLabel={populationStatusLabel}
+                        buildingTilesLabel={buildingTilesStatusLabel}
+                      />
+                    </>
+                  )}
                 </div>
               )}
             </div>
@@ -633,29 +638,21 @@ const StructureListItem = memo(
 
     const structureCapabilities = resolveStructureUiCapabilities(structure.structure);
     const rawLevel = liveStructure?.base?.level ?? structure.structure.base?.level ?? 0;
-    const normalizedLevel = typeof rawLevel === "bigint" ? Number(rawLevel) : Number(rawLevel ?? 0);
+    const normalizedLevel = normalizeStructureLevel(rawLevel);
     const levelLabel = structureCapabilities.hasPopulationDetails
       ? getLevelName(Math.min(Math.max(normalizedLevel, RealmLevels.Settlement), RealmLevels.Empire) as RealmLevels)
       : null;
-
-    const basePopulationCapacity = structureCapabilities.hasPopulationDetails
-      ? configManager.getBasePopulationCapacity()
-      : 0;
-    const normalizedBasePopulationCapacity = structureCapabilities.hasPopulationDetails
-      ? Math.max(Number(basePopulationCapacity ?? 0), 6)
-      : 0;
-
-    const population = Number(liveStructureBuildings?.population.current ?? structure.population ?? 0);
-    const populationCapacity =
-      Number(liveStructureBuildings?.population.max ?? structure.populationCapacity ?? 0) +
-      normalizedBasePopulationCapacity;
+    const structureStatus = resolveSidebarStructureStatus({
+      structureCategory: structure.category,
+      structureLevel: normalizedLevel,
+      structureBuildings: liveStructureBuildings,
+      occupiedBuildingTiles: structure.occupiedBuildingTiles,
+      fallbackStatus: structure.statusSnapshot,
+    });
 
     const showInfoLine = structureCapabilities.hasPopulationDetails;
-    const populationStatusLabel = formatPopulationStatusLabel(population, populationCapacity);
-    const buildingTilesStatusLabel =
-      structure.buildingTilesAvailable !== null && structure.buildingTilesTotal !== null
-        ? formatAvailableBuildingTilesLabel(structure.buildingTilesAvailable, structure.buildingTilesTotal)
-        : null;
+    const populationStatusLabel = structureStatus.populationLabel;
+    const buildingTilesStatusLabel = structureStatus.buildingTilesLabel;
     const infoLineLabel = levelLabel ?? `Level ${normalizedLevel}`;
 
     const handleSelectStructure = useCallback(

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/ui/features/world/containers/top-header/structure-groups";
 import {
   countOccupiedBuildingTilesByStructure,
+  resolveOccupiedBuildingTilesForStructureStatus,
   resolveStructureStatusSnapshot,
   type StructureStatusSnapshot,
 } from "@/ui/features/world/containers/structure-status";
@@ -377,7 +378,10 @@ const LeftPanelHeader = memo(
         const structureBuildings = components.StructureBuildings
           ? getComponentValue(components.StructureBuildings, structureEntity)
           : null;
-        const occupiedBuildingTiles = buildingTileCountsByStructure[structure.entityId] ?? null;
+        const occupiedBuildingTiles = resolveOccupiedBuildingTilesForStructureStatus({
+          occupiedBuildingTiles: buildingTileCountsByStructure[structure.entityId],
+          hasStructureBuildings: Boolean(structureBuildings),
+        });
         const statusSnapshot = resolveSidebarStructureStatus({
           structureCategory: structure.category,
           structureLevel: normalizedLevel,

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -239,7 +239,10 @@ const resolveSidebarStructureStatus = ({
 }: {
   structureCategory: StructureType | undefined;
   structureLevel: number;
-  structureBuildings: { population?: { current?: bigint | number | null; max?: bigint | number | null } | null } | null;
+  structureBuildings:
+    | { population?: { current?: bigint | number | null; max?: bigint | number | null } | null }
+    | null
+    | undefined;
   occupiedBuildingTiles: number | null | undefined;
   fallbackStatus?: StructureStatusSnapshot;
 }) => {

--- a/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-command-sidebar.tsx
@@ -221,7 +221,9 @@ const StructureStatusStats = ({
   buildingTilesLabel: string | null;
 }) => (
   <div className="flex flex-wrap items-center gap-1.5">
-    {populationLabel ? <StructureInfoStat icon={Users} label={populationLabel} title="Population used / capacity" /> : null}
+    {populationLabel ? (
+      <StructureInfoStat icon={Users} label={populationLabel} title="Population used / capacity" />
+    ) : null}
     {buildingTilesLabel ? (
       <StructureInfoStat icon={Hexagon} label={buildingTilesLabel} title="Available / total building tiles" />
     ) : null}

--- a/client/apps/game/src/ui/features/world/containers/structure-status.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/structure-status.test.ts
@@ -4,6 +4,7 @@ import {
   countOccupiedBuildingTilesByStructure,
   formatAvailableBuildingTilesLabel,
   formatPopulationStatusLabel,
+  resolveOccupiedBuildingTilesForStructureStatus,
   resolveAvailableBuildingTiles,
   resolveStructureStatusSnapshot,
 } from "./structure-status";
@@ -64,6 +65,15 @@ describe("structure-status", () => {
       occupied: 6,
       total: 6,
     });
+  });
+
+  it("treats missing building rows as zero occupied tiles once structure buildings have synced", () => {
+    expect(
+      resolveOccupiedBuildingTilesForStructureStatus({ occupiedBuildingTiles: undefined, hasStructureBuildings: true }),
+    ).toBe(0);
+    expect(
+      resolveOccupiedBuildingTilesForStructureStatus({ occupiedBuildingTiles: undefined, hasStructureBuildings: false }),
+    ).toBeNull();
   });
 
   it("resolves population totals by adding base capacity exactly once", () => {

--- a/client/apps/game/src/ui/features/world/containers/structure-status.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/structure-status.test.ts
@@ -1,10 +1,11 @@
-import { BUILDINGS_CENTER, RealmLevels } from "@bibliothecadao/types";
+import { BUILDINGS_CENTER, RealmLevels, StructureType } from "@bibliothecadao/types";
 import { describe, expect, it } from "vitest";
 import {
   countOccupiedBuildingTilesByStructure,
   formatAvailableBuildingTilesLabel,
   formatPopulationStatusLabel,
   resolveAvailableBuildingTiles,
+  resolveStructureStatusSnapshot,
 } from "./structure-status";
 
 describe("structure-status", () => {
@@ -62,6 +63,82 @@ describe("structure-status", () => {
       available: 0,
       occupied: 6,
       total: 6,
+    });
+  });
+
+  it("resolves population totals by adding base capacity exactly once", () => {
+    expect(
+      resolveStructureStatusSnapshot({
+        structureCategory: StructureType.Realm,
+        structureLevel: RealmLevels.City,
+        basePopulationCapacity: 6,
+        occupiedBuildingTiles: 3,
+        structureBuildings: {
+          population: {
+            current: 25,
+            max: 24,
+          },
+        },
+      }),
+    ).toMatchObject({
+      populationCurrent: 25,
+      populationCapacityRaw: 24,
+      populationCapacityTotal: 30,
+      populationLabel: "25/30",
+      buildingTilesAvailable: 15,
+      buildingTilesTotal: 18,
+      buildingTilesLabel: "15/18",
+      hasAuthoritativePopulation: true,
+      hasAuthoritativeBuildingTiles: true,
+    });
+  });
+
+  it("withholds population stats when structure buildings have not synced", () => {
+    expect(
+      resolveStructureStatusSnapshot({
+        structureCategory: StructureType.Realm,
+        structureLevel: RealmLevels.City,
+        basePopulationCapacity: 6,
+        occupiedBuildingTiles: 0,
+        structureBuildings: null,
+      }),
+    ).toMatchObject({
+      populationCurrent: null,
+      populationCapacityRaw: null,
+      populationCapacityTotal: null,
+      populationLabel: null,
+      hasAuthoritativePopulation: false,
+      buildingTilesAvailable: 18,
+      buildingTilesTotal: 18,
+      buildingTilesLabel: "18/18",
+      hasAuthoritativeBuildingTiles: true,
+    });
+  });
+
+  it("omits all compact stats for structures without population details", () => {
+    expect(
+      resolveStructureStatusSnapshot({
+        structureCategory: StructureType.FragmentMine,
+        structureLevel: 0,
+        basePopulationCapacity: 6,
+        occupiedBuildingTiles: 0,
+        structureBuildings: {
+          population: {
+            current: 5,
+            max: 7,
+          },
+        },
+      }),
+    ).toEqual({
+      populationCurrent: null,
+      populationCapacityRaw: null,
+      populationCapacityTotal: null,
+      populationLabel: null,
+      buildingTilesAvailable: null,
+      buildingTilesTotal: null,
+      buildingTilesLabel: null,
+      hasAuthoritativePopulation: false,
+      hasAuthoritativeBuildingTiles: false,
     });
   });
 });

--- a/client/apps/game/src/ui/features/world/containers/structure-status.ts
+++ b/client/apps/game/src/ui/features/world/containers/structure-status.ts
@@ -73,6 +73,20 @@ type StructureBuildingsLike = {
   } | null;
 } | null;
 
+export const resolveOccupiedBuildingTilesForStructureStatus = ({
+  occupiedBuildingTiles,
+  hasStructureBuildings,
+}: {
+  occupiedBuildingTiles: number | null | undefined;
+  hasStructureBuildings: boolean;
+}) => {
+  if (occupiedBuildingTiles !== null && occupiedBuildingTiles !== undefined) {
+    return occupiedBuildingTiles;
+  }
+
+  return hasStructureBuildings ? 0 : null;
+};
+
 export type StructureStatusSnapshot = {
   populationCurrent: number | null;
   populationCapacityRaw: number | null;

--- a/client/apps/game/src/ui/features/world/containers/structure-status.ts
+++ b/client/apps/game/src/ui/features/world/containers/structure-status.ts
@@ -1,8 +1,18 @@
-import { BUILDINGS_CENTER } from "@bibliothecadao/types";
+import { StructureType, BUILDINGS_CENTER } from "@bibliothecadao/types";
+import { resolveStructureUiCapabilities } from "@/ui/lib/structure-capabilities";
 
 const normalizeNonNegativeInteger = (value: number) => {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.trunc(value));
+};
+
+const normalizeOptionalNonNegativeInteger = (value: bigint | number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  const normalizedValue = typeof value === "bigint" ? Number(value) : value;
+  return Number.isFinite(normalizedValue) ? Math.max(0, Math.trunc(normalizedValue)) : null;
 };
 
 const resolveBuildRadius = (level: number) => normalizeNonNegativeInteger(level) + 1;
@@ -53,5 +63,86 @@ export const resolveAvailableBuildingTiles = ({
     available: total - occupied,
     occupied,
     total,
+  };
+};
+
+type StructureBuildingsLike = {
+  population?: {
+    current?: bigint | number | null;
+    max?: bigint | number | null;
+  } | null;
+} | null;
+
+export type StructureStatusSnapshot = {
+  populationCurrent: number | null;
+  populationCapacityRaw: number | null;
+  populationCapacityTotal: number | null;
+  populationLabel: string | null;
+  buildingTilesAvailable: number | null;
+  buildingTilesTotal: number | null;
+  buildingTilesLabel: string | null;
+  hasAuthoritativePopulation: boolean;
+  hasAuthoritativeBuildingTiles: boolean;
+};
+
+const buildEmptyStructureStatusSnapshot = (): StructureStatusSnapshot => ({
+  populationCurrent: null,
+  populationCapacityRaw: null,
+  populationCapacityTotal: null,
+  populationLabel: null,
+  buildingTilesAvailable: null,
+  buildingTilesTotal: null,
+  buildingTilesLabel: null,
+  hasAuthoritativePopulation: false,
+  hasAuthoritativeBuildingTiles: false,
+});
+
+export const resolveStructureStatusSnapshot = ({
+  structureCategory,
+  structureLevel,
+  structureBuildings,
+  occupiedBuildingTiles,
+  basePopulationCapacity,
+}: {
+  structureCategory: StructureType | undefined;
+  structureLevel: number;
+  structureBuildings: StructureBuildingsLike | undefined;
+  occupiedBuildingTiles: number | null | undefined;
+  basePopulationCapacity: number;
+}): StructureStatusSnapshot => {
+  if (!resolveStructureUiCapabilities({ category: structureCategory }).hasPopulationDetails) {
+    return buildEmptyStructureStatusSnapshot();
+  }
+
+  const populationCurrent = normalizeOptionalNonNegativeInteger(structureBuildings?.population?.current);
+  const populationCapacityRaw = normalizeOptionalNonNegativeInteger(structureBuildings?.population?.max);
+  const normalizedBasePopulationCapacity = normalizeNonNegativeInteger(basePopulationCapacity);
+  const populationCapacityTotal =
+    populationCapacityRaw === null ? null : populationCapacityRaw + normalizedBasePopulationCapacity;
+  const hasAuthoritativePopulation = populationCurrent !== null && populationCapacityTotal !== null;
+
+  const buildingTileSummary =
+    occupiedBuildingTiles === null || occupiedBuildingTiles === undefined
+      ? null
+      : resolveAvailableBuildingTiles({
+          level: structureLevel,
+          occupiedBuildingTiles,
+        });
+
+  return {
+    populationCurrent,
+    populationCapacityRaw,
+    populationCapacityTotal,
+    populationLabel:
+      hasAuthoritativePopulation && populationCapacityTotal !== null
+        ? formatPopulationStatusLabel(populationCurrent, populationCapacityTotal)
+        : null,
+    buildingTilesAvailable: buildingTileSummary?.available ?? null,
+    buildingTilesTotal: buildingTileSummary?.total ?? null,
+    buildingTilesLabel: buildingTileSummary
+      ? formatAvailableBuildingTilesLabel(buildingTileSummary.available, buildingTileSummary.total)
+      : null,
+    hasAuthoritativePopulation,
+    hasAuthoritativeBuildingTiles: Boolean(buildingTileSummary),
   };
 };

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-14",
+    title: "Sidebar Structure Values Fix",
+    description:
+      "Realm and village cards in the left sidebar now derive population and building capacity from one authoritative status snapshot, so synced structures stop showing inflated or invented values.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-14",
     title: "Reliable Auto-Settle Entry",
     description:
       "Auto-settle now keeps freshly registered Blitz players on the settlement path until their realm setup is ready, so dashboard handoffs stop dropping new entrants into the game as spectators.",


### PR DESCRIPTION
This fixes the world left sidebar structure cards so population and building-capacity values come from one shared status snapshot instead of three separate derivations.

It removes the double-counted base population fallback and stops rendering invented population values when `StructureBuildings` has not synced yet.

The change also adds targeted resolver coverage, a source-level guard for the shared sidebar path, and a latest-features note.

Verification: `git diff --check` passed; `pnpm run format`, `pnpm run knip`, and targeted Vitest runs are currently blocked because this workspace does not have installed dependencies and the local Node is `v20.9.0` while the app requires `>=20.19.0`.
