### PR TITLE
Gate Blitz auto-settle on game countdown

### DIFF
--- a/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
@@ -146,7 +146,6 @@ describe("useAutoSettleStore", () => {
       }),
     );
 
-    useAutoSettleStore.setState({ entries: {} });
     await useAutoSettleStore.persist.rehydrate();
 
     expect(useAutoSettleStore.getState().getEntry(key)?.opensOnUnlockEdge).toBe(true);

--- a/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
@@ -13,7 +13,7 @@ const baseEntry: AutoSettleEntryRecord = {
   chain: "mainnet",
   worldName: "aurora-blitz",
   worldKey: "mainnet:aurora-blitz",
-  settleAtSec: 1_234,
+  unlockAtSec: 1_234,
   armedAtMs: 100,
   status: "armed",
   lastError: null,

--- a/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.test.ts
@@ -15,6 +15,7 @@ const baseEntry: AutoSettleEntryRecord = {
   worldKey: "mainnet:aurora-blitz",
   unlockAtSec: 1_234,
   armedAtMs: 100,
+  opensOnUnlockEdge: true,
   status: "armed",
   lastError: null,
   lastAttemptAtMs: null,
@@ -40,7 +41,7 @@ describe("useAutoSettleStore", () => {
   it("arms auto-settle by default and lets the player turn it off again", () => {
     const key = createAutoSettleEntryKey(baseEntry);
 
-    useAutoSettleStore.getState().upsertEntry(key, baseEntry);
+    useAutoSettleStore.getState().armEntry(key, baseEntry);
     expect(useAutoSettleStore.getState().getEntry(key)).toEqual(baseEntry);
 
     useAutoSettleStore.getState().setEnabled(key, false);
@@ -53,7 +54,7 @@ describe("useAutoSettleStore", () => {
 
   it("tracks opening, failure, and completion for a single armed entry", () => {
     const key = createAutoSettleEntryKey(baseEntry);
-    useAutoSettleStore.getState().upsertEntry(key, baseEntry);
+    useAutoSettleStore.getState().armEntry(key, baseEntry);
 
     useAutoSettleStore.getState().markOpening(key, 200);
     expect(useAutoSettleStore.getState().getEntry(key)).toMatchObject({
@@ -78,7 +79,7 @@ describe("useAutoSettleStore", () => {
 
   it("persists armed entries in local storage so reloads can resume the watcher", () => {
     const key = createAutoSettleEntryKey(baseEntry);
-    useAutoSettleStore.getState().upsertEntry(key, baseEntry);
+    useAutoSettleStore.getState().armEntry(key, baseEntry);
 
     const persisted = window.localStorage.getItem(AUTO_SETTLE_STORAGE_KEY);
     expect(persisted).toContain('"mainnet:aurora-blitz:0x123"');
@@ -89,5 +90,66 @@ describe("useAutoSettleStore", () => {
         },
       },
     });
+  });
+
+  it("stores arming policy for entries that should wait for a future unlock edge", () => {
+    const key = createAutoSettleEntryKey(baseEntry);
+
+    useAutoSettleStore.getState().armEntry(key, {
+      ...baseEntry,
+      opensOnUnlockEdge: true,
+    });
+
+    expect(useAutoSettleStore.getState().getEntry(key)).toMatchObject({
+      status: "armed",
+      enabled: true,
+      opensOnUnlockEdge: true,
+    });
+  });
+
+  it("stores manual-ready entries without future auto-open eligibility", () => {
+    const key = createAutoSettleEntryKey(baseEntry);
+
+    useAutoSettleStore.getState().armEntry(key, {
+      ...baseEntry,
+      opensOnUnlockEdge: false,
+    });
+
+    expect(useAutoSettleStore.getState().getEntry(key)).toMatchObject({
+      status: "armed",
+      enabled: true,
+      opensOnUnlockEdge: false,
+    });
+  });
+
+  it("migrates persisted entries by backfilling unlock-edge policy from unlock timing", async () => {
+    const key = createAutoSettleEntryKey(baseEntry);
+    window.localStorage.setItem(
+      AUTO_SETTLE_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          entries: {
+            [key]: {
+              ...baseEntry,
+              opensOnUnlockEdge: undefined,
+            },
+            stale: {
+              ...baseEntry,
+              worldName: "late-world",
+              worldKey: "mainnet:late-world",
+              unlockAtSec: 50,
+              armedAtMs: 100_000,
+            },
+          },
+        },
+        version: 2,
+      }),
+    );
+
+    useAutoSettleStore.setState({ entries: {} });
+    await useAutoSettleStore.persist.rehydrate();
+
+    expect(useAutoSettleStore.getState().getEntry(key)?.opensOnUnlockEdge).toBe(true);
+    expect(useAutoSettleStore.getState().getEntry("stale")?.opensOnUnlockEdge).toBe(false);
   });
 });

--- a/client/apps/game/src/hooks/store/use-auto-settle-store.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.ts
@@ -12,6 +12,7 @@ export interface AutoSettleEntryRecord {
   worldKey: string;
   unlockAtSec: number;
   armedAtMs: number;
+  opensOnUnlockEdge: boolean;
   status: AutoSettleStatus;
   lastError: string | null;
   lastAttemptAtMs: number | null;
@@ -20,6 +21,7 @@ export interface AutoSettleEntryRecord {
 interface AutoSettleStoreState {
   entries: Record<string, AutoSettleEntryRecord>;
   getEntry: (key: string) => AutoSettleEntryRecord | undefined;
+  armEntry: (key: string, entry: AutoSettleEntryRecord) => void;
   upsertEntry: (key: string, entry: AutoSettleEntryRecord) => void;
   setEnabled: (key: string, enabled: boolean) => void;
   markOpening: (key: string, attemptedAtMs: number) => void;
@@ -72,6 +74,17 @@ const updateEntry = (
   };
 };
 
+const resolveMigratedUnlockEdgePolicy = (entry: Record<string, unknown>): boolean => {
+  if (typeof entry.opensOnUnlockEdge === "boolean") {
+    return entry.opensOnUnlockEdge;
+  }
+
+  const unlockAtSec = typeof entry.unlockAtSec === "number" ? entry.unlockAtSec : entry.settleAtSec;
+  const armedAtMs = typeof entry.armedAtMs === "number" ? entry.armedAtMs : 0;
+
+  return typeof unlockAtSec === "number" && unlockAtSec > armedAtMs / 1000;
+};
+
 const migrateAutoSettleEntries = (persistedState: unknown): Record<string, AutoSettleEntryRecord> => {
   if (!persistedState || typeof persistedState !== "object") {
     return {};
@@ -93,6 +106,7 @@ const migrateAutoSettleEntries = (persistedState: unknown): Record<string, AutoS
             : typeof entry.settleAtSec === "number"
               ? entry.settleAtSec
               : 0,
+        opensOnUnlockEdge: resolveMigratedUnlockEdgePolicy(entry),
       },
     ]),
   ) as Record<string, AutoSettleEntryRecord>;
@@ -103,6 +117,19 @@ export const useAutoSettleStore = create<AutoSettleStoreState>()(
     (set, get) => ({
       entries: {},
       getEntry: (key) => get().entries[key],
+      armEntry: (key, entry) =>
+        set((state) => ({
+          entries: {
+            ...state.entries,
+            [key]: {
+              ...entry,
+              enabled: true,
+              status: "armed",
+              lastError: null,
+              lastAttemptAtMs: null,
+            },
+          },
+        })),
       upsertEntry: (key, entry) =>
         set((state) => ({
           entries: {
@@ -166,7 +193,7 @@ export const useAutoSettleStore = create<AutoSettleStoreState>()(
     }),
     {
       name: AUTO_SETTLE_STORAGE_KEY,
-      version: 2,
+      version: 3,
       storage: createJSONStorage(createLocalStorage),
       partialize: (state) => ({ entries: state.entries }),
       migrate: (persistedState) => ({

--- a/client/apps/game/src/hooks/store/use-auto-settle-store.ts
+++ b/client/apps/game/src/hooks/store/use-auto-settle-store.ts
@@ -10,7 +10,7 @@ export interface AutoSettleEntryRecord {
   chain: Chain;
   worldName: string;
   worldKey: string;
-  settleAtSec: number;
+  unlockAtSec: number;
   armedAtMs: number;
   status: AutoSettleStatus;
   lastError: string | null;
@@ -70,6 +70,32 @@ const updateEntry = (
     ...entries,
     [key]: updater(current),
   };
+};
+
+const migrateAutoSettleEntries = (persistedState: unknown): Record<string, AutoSettleEntryRecord> => {
+  if (!persistedState || typeof persistedState !== "object") {
+    return {};
+  }
+
+  const entries =
+    "entries" in persistedState && persistedState.entries && typeof persistedState.entries === "object"
+      ? (persistedState.entries as Record<string, Record<string, unknown>>)
+      : {};
+
+  return Object.fromEntries(
+    Object.entries(entries).map(([key, entry]) => [
+      key,
+      {
+        ...entry,
+        unlockAtSec:
+          typeof entry.unlockAtSec === "number"
+            ? entry.unlockAtSec
+            : typeof entry.settleAtSec === "number"
+              ? entry.settleAtSec
+              : 0,
+      },
+    ]),
+  ) as Record<string, AutoSettleEntryRecord>;
 };
 
 export const useAutoSettleStore = create<AutoSettleStoreState>()(
@@ -140,9 +166,12 @@ export const useAutoSettleStore = create<AutoSettleStoreState>()(
     }),
     {
       name: AUTO_SETTLE_STORAGE_KEY,
-      version: 1,
+      version: 2,
       storage: createJSONStorage(createLocalStorage),
       partialize: (state) => ({ entries: state.entries }),
+      migrate: (persistedState) => ({
+        entries: migrateAutoSettleEntries(persistedState),
+      }),
     },
   ),
 );

--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-timing.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-timing.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBlitzSettlementAvailability } from "./game-entry-blitz-timing";
+
+describe("resolveBlitzSettlementAvailability", () => {
+  it("keeps settlement locked until the main game timer ends", () => {
+    expect(resolveBlitzSettlementAvailability({ startMainAt: 130, nowSec: 100 })).toEqual({
+      unlockAtSec: 130,
+      isUnlocked: false,
+      secondsUntilUnlock: 30,
+    });
+  });
+
+  it("unlocks settlement exactly when the main game timer ends", () => {
+    expect(resolveBlitzSettlementAvailability({ startMainAt: 130, nowSec: 130 })).toEqual({
+      unlockAtSec: 130,
+      isUnlocked: true,
+      secondsUntilUnlock: 0,
+    });
+  });
+
+  it("stays locked when no unlock timestamp is available", () => {
+    expect(resolveBlitzSettlementAvailability({ startMainAt: null, nowSec: 130 })).toEqual({
+      unlockAtSec: null,
+      isUnlocked: false,
+      secondsUntilUnlock: null,
+    });
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-timing.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-timing.ts
@@ -1,9 +1,9 @@
-export interface ResolveBlitzSettlementAvailabilityInput {
+interface ResolveBlitzSettlementAvailabilityInput {
   startMainAt: number | null;
   nowSec: number;
 }
 
-export interface BlitzSettlementAvailability {
+interface BlitzSettlementAvailability {
   unlockAtSec: number | null;
   isUnlocked: boolean;
   secondsUntilUnlock: number | null;

--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-timing.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-timing.ts
@@ -1,0 +1,31 @@
+export interface ResolveBlitzSettlementAvailabilityInput {
+  startMainAt: number | null;
+  nowSec: number;
+}
+
+export interface BlitzSettlementAvailability {
+  unlockAtSec: number | null;
+  isUnlocked: boolean;
+  secondsUntilUnlock: number | null;
+}
+
+export const resolveBlitzSettlementAvailability = ({
+  startMainAt,
+  nowSec,
+}: ResolveBlitzSettlementAvailabilityInput): BlitzSettlementAvailability => {
+  if (startMainAt == null) {
+    return {
+      unlockAtSec: null,
+      isUnlocked: false,
+      secondsUntilUnlock: null,
+    };
+  }
+
+  const secondsUntilUnlock = Math.max(0, startMainAt - nowSec);
+
+  return {
+    unlockAtSec: startMainAt,
+    isUnlocked: secondsUntilUnlock === 0,
+    secondsUntilUnlock,
+  };
+};

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts
@@ -13,6 +13,9 @@ describe("Game entry modal auto-settle", () => {
     );
 
     expect(source).toContain("autoSettleEnabled?: boolean");
+    expect(source).toContain('"settlement-waiting"');
+    expect(source).toContain("resolveBlitzSettlementAvailability");
+    expect(source).toContain("Settlement Opens Soon");
     expect(source).toContain('if (!autoSettleEnabled || phase !== "settlement"');
     expect(source).toContain("void handleSettle();");
     expect(source).toContain("runBlitzSettlementFlow({");

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -1041,11 +1041,7 @@ const SettlementPhase = ({
   );
 };
 
-const SettlementWaitingPhase = ({
-  secondsUntilUnlock,
-}: {
-  secondsUntilUnlock: number | null;
-}) => {
+const SettlementWaitingPhase = ({ secondsUntilUnlock }: { secondsUntilUnlock: number | null }) => {
   const countdownLabel =
     secondsUntilUnlock == null
       ? "Waiting for the game timer to unlock settlement."

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -66,6 +66,7 @@ import {
   resolveGameEntryModalPhase,
   type GameEntryModalPhase as ModalPhase,
 } from "./game-entry-phase";
+import { resolveBlitzSettlementAvailability } from "./game-entry-blitz-timing";
 import { SeasonPlacementMap, type SeasonPlacementMapSlot } from "./season-placement-map";
 import { SeasonPassOptionCard } from "./season-pass-option-card";
 import { SettlementPlannerMap } from "./settlement-planner-map";
@@ -112,6 +113,19 @@ const debugLog = (_worldName: string | null, ..._args: unknown[]) => {
   if (DEBUG_MODAL) {
     console.log("[GameEntryModal]", ..._args);
   }
+};
+
+const formatUnlockCountdown = (secondsLeft: number): string => {
+  const total = Math.max(0, Math.floor(secondsLeft));
+  const hours = Math.floor(total / 3600)
+    .toString()
+    .padStart(2, "0");
+  const minutes = Math.floor((total % 3600) / 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = (total % 60).toString().padStart(2, "0");
+
+  return `${hours}:${minutes}:${seconds}`;
 };
 
 const extractTransactionHash = (value: unknown): string | null => {
@@ -1023,6 +1037,40 @@ const SettlementPhase = ({
       {viewModel.showError && (
         <p className="text-xs text-red-300 text-center mt-2">Settlement failed. Please try again.</p>
       )}
+    </div>
+  );
+};
+
+const SettlementWaitingPhase = ({
+  secondsUntilUnlock,
+}: {
+  secondsUntilUnlock: number | null;
+}) => {
+  const countdownLabel =
+    secondsUntilUnlock == null
+      ? "Waiting for the game timer to unlock settlement."
+      : formatUnlockCountdown(secondsUntilUnlock);
+
+  return (
+    <div className="flex flex-col">
+      <div className="text-center mb-4">
+        <img src="/images/logos/eternum-loader.png" className="mx-auto w-20 mb-3" alt="Settlement pending" />
+        <h2 className="text-lg font-semibold text-gold">Settlement Opens Soon</h2>
+        <p className="text-xs text-gold/60 mt-1">
+          You are registered, but realm settlement stays locked until the visible game timer ends.
+        </p>
+      </div>
+
+      <div className="rounded-lg border border-gold/20 bg-black/25 px-4 py-5 text-center">
+        <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-gold/30 bg-gold/10">
+          <AlertCircle className="h-5 w-5 text-gold" />
+        </div>
+        <p className="text-[10px] uppercase tracking-[0.14em] text-gold/60">Settlement Unlock</p>
+        <p className="mt-2 font-mono text-2xl text-gold">{countdownLabel}</p>
+        <p className="mt-2 text-xs text-white/60">
+          This entry flow will switch to settlement automatically once the countdown reaches zero.
+        </p>
+      </div>
     </div>
   );
 };
@@ -2983,6 +3031,7 @@ export const GameEntryModal = ({
   const [preflightError, setPreflightError] = useState<Error | null>(null);
   const [preflightRetryNonce, setPreflightRetryNonce] = useState(0);
   const [settlementCheckComplete, setSettlementCheckComplete] = useState(false);
+  const [nowSec, setNowSec] = useState(() => Math.floor(Date.now() / 1000));
 
   // Settlement state
   const [settleStage, setSettleStage] = useState<SettleStage>("idle");
@@ -3481,7 +3530,24 @@ export const GameEntryModal = ({
     plannerOpenedRef.current = false;
   }, []);
 
-  const nowSeconds = Date.now() / 1000;
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setNowSec(Math.floor(Date.now() / 1000));
+    const id = window.setInterval(() => {
+      setNowSec(Math.floor(Date.now() / 1000));
+    }, 1000);
+
+    return () => window.clearInterval(id);
+  }, [isOpen]);
+
+  const blitzSettlementAvailability = resolveBlitzSettlementAvailability({
+    startMainAt: worldMeta?.startMainAt ?? null,
+    nowSec,
+  });
+  const nowSeconds = nowSec;
   const seasonStartAt = worldMeta?.startSettlingAt ?? worldMeta?.startMainAt ?? null;
   const seasonHasStarted = seasonStartAt != null && seasonStartAt <= nowSeconds;
   const seasonNotEnded = worldMeta?.endAt == null || worldMeta.endAt === 0 || nowSeconds <= worldMeta.endAt;
@@ -3646,6 +3712,7 @@ export const GameEntryModal = ({
       checksComplete,
       needsHyperstructureInit,
       needsSettlement,
+      isBlitzSettlementUnlocked: blitzSettlementAvailability.isUnlocked,
     });
 
     debugLog(worldName, "Phase determined:", result, {
@@ -3659,6 +3726,7 @@ export const GameEntryModal = ({
       hyperstructureCheckComplete,
       needsHyperstructureInit,
       needsSettlement,
+      isBlitzSettlementUnlocked: blitzSettlementAvailability.isUnlocked,
       worldMode,
       startSettlingAt: worldMeta?.startSettlingAt,
       startMainAt: worldMeta?.startMainAt,
@@ -3704,6 +3772,7 @@ export const GameEntryModal = ({
     hyperstructureCheckComplete,
     needsHyperstructureInit,
     needsSettlement,
+    blitzSettlementAvailability.isUnlocked,
     isEternumMode,
     isLoadingEternumPrereqs,
     isCheckingWorldAvailability,
@@ -5317,6 +5386,16 @@ export const GameEntryModal = ({
                   onInitialize={handleInitializeHyperstructure}
                   onInitializeAll={handleInitializeAllHyperstructures}
                 />
+              </motion.div>
+            )}
+            {phase === "settlement-waiting" && (
+              <motion.div
+                key="settlement-waiting"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+              >
+                <SettlementWaitingPhase secondsUntilUnlock={blitzSettlementAvailability.secondsUntilUnlock} />
               </motion.div>
             )}
             {phase === "settlement" && (

--- a/client/apps/game/src/ui/features/landing/components/game-entry-phase.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-phase.test.ts
@@ -41,8 +41,67 @@ describe("game entry phase resolution", () => {
       checksComplete: true,
       needsHyperstructureInit: false,
       needsSettlement: false,
+      isBlitzSettlementUnlocked: false,
     });
 
     expect(phase).toBe("error");
+  });
+
+  it("holds registered blitz players in a waiting phase before settlement unlocks", () => {
+    const phase = resolveGameEntryModalPhase({
+      bootstrapStatus: "ready",
+      hasPhaseError: false,
+      isForgeMode: false,
+      isBlitzMode: true,
+      isSpectateMode: false,
+      worldMode: "blitz",
+      isCheckingWorldAvailability: false,
+      hasWorldMeta: true,
+      isEternumMode: false,
+      isLoadingEternumPrereqs: false,
+      hasVillageRevealResult: false,
+      unifiedSettlementPlannerEnabled: false,
+      hasSettledRealm: false,
+      eternumEntryIntent: "play",
+      seasonSettlementComplete: false,
+      eternumSettlementMode: "realm",
+      hasVillagePass: false,
+      hasSeasonPass: false,
+      checksComplete: true,
+      needsHyperstructureInit: false,
+      needsSettlement: true,
+      isBlitzSettlementUnlocked: false,
+    });
+
+    expect(phase).toBe("settlement-waiting");
+  });
+
+  it("moves registered blitz players into settlement once the unlock timer ends", () => {
+    const phase = resolveGameEntryModalPhase({
+      bootstrapStatus: "ready",
+      hasPhaseError: false,
+      isForgeMode: false,
+      isBlitzMode: true,
+      isSpectateMode: false,
+      worldMode: "blitz",
+      isCheckingWorldAvailability: false,
+      hasWorldMeta: true,
+      isEternumMode: false,
+      isLoadingEternumPrereqs: false,
+      hasVillageRevealResult: false,
+      unifiedSettlementPlannerEnabled: false,
+      hasSettledRealm: false,
+      eternumEntryIntent: "play",
+      seasonSettlementComplete: false,
+      eternumSettlementMode: "realm",
+      hasVillagePass: false,
+      hasSeasonPass: false,
+      checksComplete: true,
+      needsHyperstructureInit: false,
+      needsSettlement: true,
+      isBlitzSettlementUnlocked: true,
+    });
+
+    expect(phase).toBe("settlement");
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-entry-phase.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-phase.ts
@@ -4,6 +4,7 @@ export type GameEntryModalPhase =
   | "loading"
   | "forge"
   | "hyperstructure"
+  | "settlement-waiting"
   | "settlement"
   | "settlement-planner"
   | "season-pass-required"
@@ -44,6 +45,7 @@ interface ResolveGameEntryModalPhaseInput {
   checksComplete: boolean;
   needsHyperstructureInit: boolean;
   needsSettlement: boolean;
+  isBlitzSettlementUnlocked: boolean;
 }
 
 export const resolveGameEntryBlockingError = ({
@@ -94,6 +96,7 @@ export const resolveGameEntryModalPhase = ({
   checksComplete,
   needsHyperstructureInit,
   needsSettlement,
+  isBlitzSettlementUnlocked,
 }: ResolveGameEntryModalPhaseInput): GameEntryModalPhase => {
   if (isForgeMode && isBlitzMode) {
     return "forge";
@@ -150,6 +153,10 @@ export const resolveGameEntryModalPhase = ({
   }
 
   if (needsSettlement) {
+    if (isBlitzMode && !isBlitzSettlementUnlocked) {
+      return "settlement-waiting";
+    }
+
     return "settlement";
   }
 

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
@@ -5,7 +5,7 @@ import { resolveAutoSettleRuntimeState, type AutoSettleRuntimeInput } from "./au
 const createInput = (overrides: Partial<AutoSettleRuntimeInput> = {}): AutoSettleRuntimeInput => ({
   enabled: true,
   persistedStatus: "armed",
-  settleAtSec: 130,
+  unlockAtSec: 130,
   nowSec: 100,
   hasConnectedWallet: true,
   hasCompatibleNetwork: true,
@@ -54,6 +54,13 @@ describe("resolveAutoSettleRuntimeState", () => {
       phase: "opening",
       shouldOpenEntry: true,
       shouldRefreshAvailability: true,
+    });
+  });
+
+  it("stays armed while the visible game countdown is still running", () => {
+    expect(resolveAutoSettleRuntimeState(createInput({ nowSec: 124 }))).toMatchObject({
+      phase: "prewarming",
+      shouldOpenEntry: false,
     });
   });
 

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
@@ -7,6 +7,7 @@ const createInput = (overrides: Partial<AutoSettleRuntimeInput> = {}): AutoSettl
   persistedStatus: "armed",
   unlockAtSec: 130,
   nowSec: 100,
+  opensOnUnlockEdge: true,
   hasConnectedWallet: true,
   hasCompatibleNetwork: true,
   ...overrides,
@@ -57,6 +58,21 @@ describe("resolveAutoSettleRuntimeState", () => {
     });
   });
 
+  it("keeps auto-settle armed without auto-opening when the entry was armed after unlock", () => {
+    expect(
+      resolveAutoSettleRuntimeState(
+        createInput({
+          nowSec: 130,
+          opensOnUnlockEdge: false,
+        }),
+      ),
+    ).toMatchObject({
+      phase: "ready-manual",
+      shouldOpenEntry: false,
+      shouldPrimeAssets: false,
+    });
+  });
+
   it("stays armed while the visible game countdown is still running", () => {
     expect(resolveAutoSettleRuntimeState(createInput({ nowSec: 124 }))).toMatchObject({
       phase: "prewarming",
@@ -74,6 +90,21 @@ describe("resolveAutoSettleRuntimeState", () => {
       ),
     ).toMatchObject({
       phase: "failed",
+      shouldOpenEntry: false,
+    });
+  });
+
+  it("keeps paused wallet/network logic for unlock-edge armed entries", () => {
+    expect(
+      resolveAutoSettleRuntimeState(
+        createInput({
+          nowSec: 130,
+          opensOnUnlockEdge: true,
+          hasConnectedWallet: false,
+        }),
+      ),
+    ).toMatchObject({
+      phase: "paused-wallet",
       shouldOpenEntry: false,
     });
   });

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
@@ -6,6 +6,7 @@ type AutoSettleRuntimePhase =
   | "off"
   | "armed"
   | "prewarming"
+  | "ready-manual"
   | "paused-wallet"
   | "paused-network"
   | "opening"
@@ -18,6 +19,7 @@ export interface AutoSettleRuntimeInput {
   persistedStatus: AutoSettleStatus;
   unlockAtSec: number | null;
   nowSec: number;
+  opensOnUnlockEdge: boolean;
   hasConnectedWallet: boolean;
   hasCompatibleNetwork: boolean;
 }
@@ -37,6 +39,7 @@ export const resolveAutoSettleRuntimeState = ({
   persistedStatus,
   unlockAtSec,
   nowSec,
+  opensOnUnlockEdge,
   hasConnectedWallet,
   hasCompatibleNetwork,
 }: AutoSettleRuntimeInput): AutoSettleRuntimeState => {
@@ -91,10 +94,17 @@ export const resolveAutoSettleRuntimeState = ({
   });
   const resolvedUnlockAtSec = availability.unlockAtSec;
   const isDue = availability.isUnlocked;
-  const inPrewarmWindow =
-    resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - PREWARM_WINDOW_SECONDS;
-  const inRefreshWindow =
-    resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - REFRESH_WINDOW_SECONDS;
+  const inPrewarmWindow = resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - PREWARM_WINDOW_SECONDS;
+  const inRefreshWindow = resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - REFRESH_WINDOW_SECONDS;
+
+  if (!opensOnUnlockEdge && isDue) {
+    return {
+      phase: "ready-manual",
+      shouldPrimeAssets: false,
+      shouldRefreshAvailability: false,
+      shouldOpenEntry: false,
+    };
+  }
 
   if (!hasConnectedWallet) {
     return {
@@ -183,6 +193,11 @@ export const describeAutoSettleRuntimePhase = ({
       return {
         title: "Prewarming entry",
         detail: `Settles in ${formatCountdown(secondsUntilUnlock)}`,
+      };
+    case "ready-manual":
+      return {
+        title: "Settlement ready",
+        detail: "Auto-settle is armed, but this registration stays on the dashboard.",
       };
     case "paused-wallet":
       return {

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
@@ -1,5 +1,7 @@
 import type { AutoSettleStatus } from "@/hooks/store/use-auto-settle-store";
 
+import { resolveBlitzSettlementAvailability } from "../game-entry-blitz-timing";
+
 type AutoSettleRuntimePhase =
   | "off"
   | "armed"
@@ -14,7 +16,7 @@ type AutoSettleRuntimePhase =
 export interface AutoSettleRuntimeInput {
   enabled: boolean;
   persistedStatus: AutoSettleStatus;
-  settleAtSec: number;
+  unlockAtSec: number | null;
   nowSec: number;
   hasConnectedWallet: boolean;
   hasCompatibleNetwork: boolean;
@@ -33,7 +35,7 @@ const REFRESH_WINDOW_SECONDS = 5;
 export const resolveAutoSettleRuntimeState = ({
   enabled,
   persistedStatus,
-  settleAtSec,
+  unlockAtSec,
   nowSec,
   hasConnectedWallet,
   hasCompatibleNetwork,
@@ -83,9 +85,16 @@ export const resolveAutoSettleRuntimeState = ({
     };
   }
 
-  const isDue = nowSec >= settleAtSec;
-  const inPrewarmWindow = nowSec >= settleAtSec - PREWARM_WINDOW_SECONDS;
-  const inRefreshWindow = nowSec >= settleAtSec - REFRESH_WINDOW_SECONDS;
+  const availability = resolveBlitzSettlementAvailability({
+    startMainAt: unlockAtSec,
+    nowSec,
+  });
+  const resolvedUnlockAtSec = availability.unlockAtSec;
+  const isDue = availability.isUnlocked;
+  const inPrewarmWindow =
+    resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - PREWARM_WINDOW_SECONDS;
+  const inRefreshWindow =
+    resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - REFRESH_WINDOW_SECONDS;
 
   if (!hasConnectedWallet) {
     return {
@@ -147,12 +156,18 @@ const formatCountdown = (secondsLeft: number): string => {
 export const describeAutoSettleRuntimePhase = ({
   phase,
   nowSec,
-  settleAtSec,
+  unlockAtSec,
 }: {
   phase: AutoSettleRuntimePhase;
   nowSec: number;
-  settleAtSec: number;
+  unlockAtSec: number | null;
 }) => {
+  const availability = resolveBlitzSettlementAvailability({
+    startMainAt: unlockAtSec,
+    nowSec,
+  });
+  const secondsUntilUnlock = availability.secondsUntilUnlock ?? 0;
+
   switch (phase) {
     case "off":
       return {
@@ -162,12 +177,12 @@ export const describeAutoSettleRuntimePhase = ({
     case "armed":
       return {
         title: "Auto-settle on",
-        detail: `Settles in ${formatCountdown(settleAtSec - nowSec)}`,
+        detail: `Settles in ${formatCountdown(secondsUntilUnlock)}`,
       };
     case "prewarming":
       return {
         title: "Prewarming entry",
-        detail: `Settles in ${formatCountdown(settleAtSec - nowSec)}`,
+        detail: `Settles in ${formatCountdown(secondsUntilUnlock)}`,
       };
     case "paused-wallet":
       return {

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.auto-settle.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.auto-settle.source.test.ts
@@ -14,8 +14,9 @@ describe("Game card auto-settle wiring", () => {
     expect(source).toContain("resolveAutoSettleRuntimeState");
     expect(source).toContain("resolveBlitzSettlementAvailability");
     expect(source).toContain("const unlockAtSec = game.startMainAt;");
+    expect(source).toContain("const opensOnUnlockEdge = nowSec < unlockAtSec;");
     expect(source).toContain("Auto-settle");
-    expect(source).toContain("setEnabled(autoSettleEntryKey, true");
+    expect(source).toContain("armEntry(autoSettleEntryKey");
     expect(source).toContain("markOpening(autoSettleEntryKey");
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.auto-settle.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.auto-settle.source.test.ts
@@ -12,6 +12,8 @@ describe("Game card auto-settle wiring", () => {
 
     expect(source).toContain("useAutoSettleStore");
     expect(source).toContain("resolveAutoSettleRuntimeState");
+    expect(source).toContain("resolveBlitzSettlementAvailability");
+    expect(source).toContain("const unlockAtSec = game.startMainAt;");
     expect(source).toContain("Auto-settle");
     expect(source).toContain("setEnabled(autoSettleEntryKey, true");
     expect(source).toContain("markOpening(autoSettleEntryKey");

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -375,7 +375,7 @@ const GameCard = ({
   const autoSettleEntry = useAutoSettleStore((state) =>
     autoSettleEntryKey ? state.entries[autoSettleEntryKey] : undefined,
   );
-  const upsertAutoSettleEntry = useAutoSettleStore((state) => state.upsertEntry);
+  const armEntry = useAutoSettleStore((state) => state.armEntry);
   const setEnabled = useAutoSettleStore((state) => state.setEnabled);
   const showRegistered = game.isRegistered || registrationStage === "done";
   const blitzSettlementAvailability = resolveBlitzSettlementAvailability({
@@ -390,6 +390,7 @@ const GameCard = ({
     persistedStatus: autoSettleEntry?.status ?? "idle",
     unlockAtSec,
     nowSec,
+    opensOnUnlockEdge: autoSettleEntry?.opensOnUnlockEdge ?? false,
     hasConnectedWallet,
     hasCompatibleNetwork: canInteractOnChain(game.chain),
   });
@@ -474,9 +475,10 @@ const GameCard = ({
 
   const handleAutoSettleToggle = useCallback(() => {
     if (!autoSettleEntryKey || unlockAtSec == null || !playerAddress) return;
+    const opensOnUnlockEdge = nowSec < unlockAtSec;
 
-    if (!autoSettleEntry) {
-      upsertAutoSettleEntry(autoSettleEntryKey, {
+    if (!autoSettleEntry || !autoSettleEntry.enabled) {
+      armEntry(autoSettleEntryKey, {
         enabled: true,
         walletAddress: playerAddress,
         chain: game.chain,
@@ -484,6 +486,7 @@ const GameCard = ({
         worldKey: game.worldKey,
         unlockAtSec,
         armedAtMs: Date.now(),
+        opensOnUnlockEdge,
         status: "armed",
         lastError: null,
         lastAttemptAtMs: null,
@@ -498,10 +501,11 @@ const GameCard = ({
     game.chain,
     game.name,
     game.worldKey,
+    nowSec,
     playerAddress,
+    armEntry,
     setEnabled,
     unlockAtSec,
-    upsertAutoSettleEntry,
   ]);
 
   // Show success toast when registration completes
@@ -514,10 +518,9 @@ const GameCard = ({
     if (handledRegistrationStageRef.current) return;
     handledRegistrationStageRef.current = true;
 
-    if (autoSettleEntryKey && autoSettleEntry) {
-      setEnabled(autoSettleEntryKey, true);
-    } else if (autoSettleEntryKey && unlockAtSec != null) {
-      upsertAutoSettleEntry(autoSettleEntryKey, {
+    if (autoSettleEntryKey && unlockAtSec != null) {
+      const opensOnUnlockEdge = nowSec < unlockAtSec;
+      armEntry(autoSettleEntryKey, {
         enabled: true,
         walletAddress: playerAddress!,
         chain: game.chain,
@@ -525,6 +528,7 @@ const GameCard = ({
         worldKey: game.worldKey,
         unlockAtSec,
         armedAtMs: Date.now(),
+        opensOnUnlockEdge,
         status: "armed",
         lastError: null,
         lastAttemptAtMs: null,
@@ -536,17 +540,16 @@ const GameCard = ({
     });
     onRegistrationComplete?.(game.worldKey);
   }, [
-    autoSettleEntry,
     autoSettleEntryKey,
     game.chain,
     game.name,
     game.worldKey,
+    nowSec,
     onRegistrationComplete,
     playerAddress,
     registrationStage,
-    setEnabled,
+    armEntry,
     unlockAtSec,
-    upsertAutoSettleEntry,
   ]);
 
   // Status colors - enhanced yellow for upcoming
@@ -1406,6 +1409,7 @@ export const UnifiedGameGrid = ({
         persistedStatus: autoSettleEntry.status,
         unlockAtSec,
         nowSec,
+        opensOnUnlockEdge: autoSettleEntry.opensOnUnlockEdge,
         hasConnectedWallet: landingNetworkState.hasConnectedWallet,
         hasCompatibleNetwork: canInteractWithLandingChain(
           landingNetworkState,

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -34,6 +34,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { primeGameEntry } from "@/game-entry-preload";
 import { describeAutoSettleRuntimePhase, resolveAutoSettleRuntimeState } from "./auto-settle-runtime";
+import { resolveBlitzSettlementAvailability } from "../game-entry-blitz-timing";
 import {
   createPendingNetworkAction,
   resolvePendingNetworkSwitchOutcome,
@@ -377,13 +378,17 @@ const GameCard = ({
   const upsertAutoSettleEntry = useAutoSettleStore((state) => state.upsertEntry);
   const setEnabled = useAutoSettleStore((state) => state.setEnabled);
   const showRegistered = game.isRegistered || registrationStage === "done";
-  const startSettlingAt = game.config?.startSettlingAt ?? null;
+  const blitzSettlementAvailability = resolveBlitzSettlementAvailability({
+    startMainAt: game.startMainAt,
+    nowSec,
+  });
+  const unlockAtSec = blitzSettlementAvailability.unlockAtSec;
   const canShowAutoSettleControl =
-    isBlitzMode && showRegistered && playerAddress !== null && startSettlingAt !== null && !isEnded;
+    isBlitzMode && showRegistered && playerAddress !== null && unlockAtSec !== null && !isEnded;
   const autoSettleRuntimeState = resolveAutoSettleRuntimeState({
     enabled: autoSettleEntry?.enabled ?? false,
     persistedStatus: autoSettleEntry?.status ?? "idle",
-    settleAtSec: startSettlingAt ?? 0,
+    unlockAtSec,
     nowSec,
     hasConnectedWallet,
     hasCompatibleNetwork: canInteractOnChain(game.chain),
@@ -392,7 +397,7 @@ const GameCard = ({
     ? describeAutoSettleRuntimePhase({
         phase: autoSettleRuntimeState.phase,
         nowSec,
-        settleAtSec: startSettlingAt ?? 0,
+        unlockAtSec,
       })
     : null;
   const autoSettleToggleDisabled =
@@ -468,7 +473,7 @@ const GameCard = ({
   );
 
   const handleAutoSettleToggle = useCallback(() => {
-    if (!autoSettleEntryKey || !startSettlingAt || !playerAddress) return;
+    if (!autoSettleEntryKey || unlockAtSec == null || !playerAddress) return;
 
     if (!autoSettleEntry) {
       upsertAutoSettleEntry(autoSettleEntryKey, {
@@ -477,7 +482,7 @@ const GameCard = ({
         chain: game.chain,
         worldName: game.name,
         worldKey: game.worldKey,
-        settleAtSec: startSettlingAt,
+        unlockAtSec,
         armedAtMs: Date.now(),
         status: "armed",
         lastError: null,
@@ -495,7 +500,7 @@ const GameCard = ({
     game.worldKey,
     playerAddress,
     setEnabled,
-    startSettlingAt,
+    unlockAtSec,
     upsertAutoSettleEntry,
   ]);
 
@@ -511,14 +516,14 @@ const GameCard = ({
 
     if (autoSettleEntryKey && autoSettleEntry) {
       setEnabled(autoSettleEntryKey, true);
-    } else if (autoSettleEntryKey && startSettlingAt) {
+    } else if (autoSettleEntryKey && unlockAtSec != null) {
       upsertAutoSettleEntry(autoSettleEntryKey, {
         enabled: true,
         walletAddress: playerAddress!,
         chain: game.chain,
         worldName: game.name,
         worldKey: game.worldKey,
-        settleAtSec: startSettlingAt,
+        unlockAtSec,
         armedAtMs: Date.now(),
         status: "armed",
         lastError: null,
@@ -540,7 +545,7 @@ const GameCard = ({
     playerAddress,
     registrationStage,
     setEnabled,
-    startSettlingAt,
+    unlockAtSec,
     upsertAutoSettleEntry,
   ]);
 
@@ -1385,8 +1390,8 @@ export const UnifiedGameGrid = ({
     resolvedGames.forEach((game) => {
       if (game.config?.mode !== "blitz" || game.isRegistered !== true) return;
 
-      const settleAtSec = game.config?.startSettlingAt;
-      if (!settleAtSec) return;
+      const unlockAtSec = game.startMainAt;
+      if (unlockAtSec == null) return;
 
       const autoSettleEntryKey = createAutoSettleEntryKey({
         chain: game.chain,
@@ -1399,7 +1404,7 @@ export const UnifiedGameGrid = ({
       const runtimeState = resolveAutoSettleRuntimeState({
         enabled: autoSettleEntry.enabled,
         persistedStatus: autoSettleEntry.status,
-        settleAtSec,
+        unlockAtSec,
         nowSec,
         hasConnectedWallet: landingNetworkState.hasConnectedWallet,
         hasCompatibleNetwork: canInteractWithLandingChain(

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-14",
+    title: "Blitz Auto-Settle Timer Gate",
+    description:
+      "Blitz auto-settle and manual entry now wait for the visible game countdown to finish before showing realm settlement, so registering early no longer pushes you into settling before the timer ends.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-14",
     title: "Blitz Settlement Status Fix",
     description:
       "Blitz settlement now treats indexed realm creation as a successful finish and keeps the progress UI in sync, so completed entries no longer flash a false failure warning before you enter the game.",


### PR DESCRIPTION
## Summary
This gates Blitz settlement on the visible game countdown by introducing a shared unlock-time helper, aligning auto-settle with `startMainAt`, and persisting the renamed `unlockAtSec` field with a storage migration.
It adds a new `settlement-waiting` entry phase and waiting panel so early manual or automatic entry stays in a non-actionable countdown state until settlement is actually unlocked.
It updates the landing card and modal flows together, adds focused tests for the timing helper/runtime/phase wiring, and records the user-facing fix in `latest-features`.
Verification in this workspace is dependency-blocked: targeted Vitest runs, `pnpm run format`, and `pnpm run knip` could not complete because `node_modules` are missing and the local Node version is below the app's required `>=20.19.0`.