### PR TITLE
Fix stale stamina source selection in web UI

### DIFF
--- a/client/apps/game/src/hooks/store/use-pending-stamina-store.ts
+++ b/client/apps/game/src/hooks/store/use-pending-stamina-store.ts
@@ -1,0 +1,57 @@
+import { ID } from "@bibliothecadao/types";
+import { create } from "zustand";
+
+const STALE_PENDING_STAMINA_MS = 60_000;
+
+type PendingStaminaActionKind = "travel" | "explore" | "attack" | "raid";
+
+interface PendingStaminaOverlay {
+  entityId: ID;
+  amount: bigint;
+  updatedTick: number;
+  createdAt: number;
+  actionKind: PendingStaminaActionKind;
+}
+
+interface PendingStaminaState {
+  overlays: Record<string, PendingStaminaOverlay>;
+  setPendingStamina: (overlay: PendingStaminaOverlay) => void;
+  clearPendingStamina: (entityId: ID) => void;
+}
+
+const getOverlayKey = (entityId: ID) => String(entityId);
+
+export const usePendingStaminaStore = create<PendingStaminaState>((set) => ({
+  overlays: {},
+  setPendingStamina: (overlay) =>
+    set((state) => ({
+      overlays: {
+        ...state.overlays,
+        [getOverlayKey(overlay.entityId)]: overlay,
+      },
+    })),
+  clearPendingStamina: (entityId) =>
+    set((state) => {
+      const nextOverlays = { ...state.overlays };
+      delete nextOverlays[getOverlayKey(entityId)];
+      return {
+        overlays: nextOverlays,
+      };
+    }),
+}));
+
+export const getFreshPendingStaminaOverlay = (
+  entityId: ID,
+  nowMs: number = Date.now(),
+): PendingStaminaOverlay | undefined => {
+  const overlay = usePendingStaminaStore.getState().overlays[getOverlayKey(entityId)];
+  if (!overlay) {
+    return undefined;
+  }
+
+  if (nowMs - overlay.createdAt > STALE_PENDING_STAMINA_MS) {
+    return undefined;
+  }
+
+  return overlay;
+};

--- a/client/apps/game/src/index.css
+++ b/client/apps/game/src/index.css
@@ -216,6 +216,74 @@
   animation: scroll 30s linear infinite;
 }
 
+.stamina-recharging-track {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 226, 147, 0.12),
+    0 0 10px rgba(245, 197, 66, 0.12);
+}
+
+.stamina-recharging-fill {
+  position: relative;
+  overflow: hidden;
+  animation: staminaRechargePulse 1.8s ease-in-out infinite;
+}
+
+.stamina-recharging-fill::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(110deg, transparent 0%, rgba(255, 255, 255, 0.38) 45%, transparent 100%);
+  transform: translateX(-140%);
+  animation: staminaRechargeSweep 1.9s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.stamina-recharging-text {
+  animation: staminaRechargeTextPulse 1.8s ease-in-out infinite;
+}
+
+@keyframes staminaRechargePulse {
+  0%,
+  100% {
+    filter: brightness(1);
+    box-shadow:
+      0 0 0 rgba(255, 213, 102, 0),
+      0 0 8px rgba(255, 213, 102, 0.12);
+  }
+  50% {
+    filter: brightness(1.12);
+    box-shadow:
+      0 0 0 rgba(255, 213, 102, 0),
+      0 0 14px rgba(255, 213, 102, 0.28);
+  }
+}
+
+@keyframes staminaRechargeSweep {
+  0% {
+    transform: translateX(-140%);
+    opacity: 0;
+  }
+  25% {
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateX(140%);
+    opacity: 0;
+  }
+}
+
+@keyframes staminaRechargeTextPulse {
+  0%,
+  100% {
+    opacity: 0.86;
+    text-shadow: 0 0 0 rgba(255, 226, 147, 0);
+  }
+  50% {
+    opacity: 1;
+    text-shadow: 0 0 10px rgba(255, 226, 147, 0.45);
+  }
+}
+
 /* Add any other global styles or overrides here */
 body {
   overscroll-behavior: none;

--- a/client/apps/game/src/three/managers/army-label-content.test.ts
+++ b/client/apps/game/src/three/managers/army-label-content.test.ts
@@ -15,6 +15,7 @@ function createArmyLabelData(overrides: Partial<ArmyLabelContentFields> = {}): A
   return {
     troopCount: 10,
     currentStamina: 9,
+    displayStaminaRatio: 0.4,
     battleTimerLeft: 8,
     isMine: true,
     owner: {
@@ -30,7 +31,7 @@ function createArmyLabelData(overrides: Partial<ArmyLabelContentFields> = {}): A
 
 describe("buildArmyLabelDataKey", () => {
   it("includes the label fields that drive army label content", () => {
-    expect(buildArmyLabelDataKey(createArmyLabelData())).toBe("10-9-8-true-Alice-45-90");
+    expect(buildArmyLabelDataKey(createArmyLabelData())).toBe("10-9-400-8-true-Alice-45-90");
   });
 });
 
@@ -76,7 +77,7 @@ describe("syncArmyLabelContentState", () => {
       renderLabel,
     });
 
-    expect(label.userData.lastDataKey).toBe("22-9-8-true-Alice-45-90");
+    expect(label.userData.lastDataKey).toBe("22-9-400-8-true-Alice-45-90");
     expect(renderLabel).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/apps/game/src/three/managers/army-label-content.ts
+++ b/client/apps/game/src/three/managers/army-label-content.ts
@@ -11,6 +11,7 @@ export type ArmyLabelContentFields = Pick<
   ArmyData,
   | "troopCount"
   | "currentStamina"
+  | "displayStaminaRatio"
   | "battleTimerLeft"
   | "isMine"
   | "owner"
@@ -19,7 +20,7 @@ export type ArmyLabelContentFields = Pick<
 >;
 
 export function buildArmyLabelDataKey(army: ArmyLabelContentFields): string {
-  return `${army.troopCount}-${army.currentStamina}-${army.battleTimerLeft ?? 0}-${army.isMine}-${army.owner.ownerName}-${army.attackedFromDegrees ?? ""}-${army.attackedTowardDegrees ?? ""}`;
+  return `${army.troopCount}-${army.currentStamina}-${Math.round((army.displayStaminaRatio ?? 0) * 1000)}-${army.battleTimerLeft ?? 0}-${army.isMine}-${army.owner.ownerName}-${army.attackedFromDegrees ?? ""}-${army.attackedTowardDegrees ?? ""}`;
 }
 
 export function syncArmyLabelContentState(input: {

--- a/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
@@ -132,4 +132,61 @@ describe("ArmyManager stamina sync", () => {
     expect(getComponentValueMock).toHaveBeenCalled();
     expect(army.currentStamina).toBe(50);
   });
+
+  it("falls back to cached on-chain stamina when the live explorer snapshot is older", () => {
+    const army = {
+      entityId: 1,
+      troopCount: 10,
+      category: "Knight",
+      tier: 1,
+      onChainStamina: { amount: 40n, updatedTick: 6 },
+      currentStamina: 0,
+    };
+
+    const staleLiveTroops = {
+      category: "Knight",
+      tier: 1,
+      count: 10n,
+      stamina: {
+        amount: 10n,
+        updated_tick: 3n,
+      },
+      boosts: {
+        incr_stamina_regen_percent_num: 0,
+        incr_stamina_regen_tick_count: 0,
+        incr_explore_reward_percent_num: 0,
+        incr_explore_reward_end_tick: 0,
+        incr_damage_dealt_percent_num: 0,
+        incr_damage_dealt_end_tick: 0,
+        decr_damage_gotten_percent_num: 0,
+        decr_damage_gotten_end_tick: 0,
+      },
+      battle_cooldown_end: 0,
+    };
+
+    getComponentValueMock.mockReturnValue({
+      troops: staleLiveTroops,
+    });
+
+    getStaminaMock.mockImplementation((troops: typeof staleLiveTroops) => ({
+      amount: troops.stamina.updated_tick === 3n ? 10n : 40n,
+      updated_tick: troops.stamina.updated_tick,
+    }));
+
+    const fakeManager = {
+      armies: new Map([[1, army]]),
+      entityIdLabels: new Map(),
+      components: {
+        ExplorerTroops: {},
+      },
+      resolveLiveExplorerTroops(entityId: number) {
+        return ArmyManager.prototype["resolveLiveExplorerTroops"].call(this, entityId);
+      },
+      updateArmyLabelData: vi.fn(),
+    };
+
+    ArmyManager.prototype["recomputeStaminaForAllArmies"].call(fakeManager);
+
+    expect(army.currentStamina).toBe(40);
+  });
 });

--- a/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.stamina-sync.test.ts
@@ -124,6 +124,15 @@ describe("ArmyManager stamina sync", () => {
       resolveLiveExplorerTroops(entityId: number) {
         return ArmyManager.prototype["resolveLiveExplorerTroops"].call(this, entityId);
       },
+      resolveArmyStaminaSnapshot(input: {
+        entityId: number;
+        troopCount: number;
+        onChainStamina: { amount: bigint; updatedTick: number };
+        category: any;
+        tier: any;
+      }) {
+        return ArmyManager.prototype["resolveArmyStaminaSnapshot"].call(this, input);
+      },
       updateArmyLabelData: vi.fn(),
     };
 
@@ -181,6 +190,15 @@ describe("ArmyManager stamina sync", () => {
       },
       resolveLiveExplorerTroops(entityId: number) {
         return ArmyManager.prototype["resolveLiveExplorerTroops"].call(this, entityId);
+      },
+      resolveArmyStaminaSnapshot(input: {
+        entityId: number;
+        troopCount: number;
+        onChainStamina: { amount: bigint; updatedTick: number };
+        category: any;
+        tier: any;
+      }) {
+        return ArmyManager.prototype["resolveArmyStaminaSnapshot"].call(this, input);
       },
       updateArmyLabelData: vi.fn(),
     };

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1,4 +1,7 @@
 import { useAccountStore } from "@/hooks/store/use-account-store";
+import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
+import { getFreshPendingStaminaOverlay } from "@/hooks/store/use-pending-stamina-store";
+import { buildProjectedStaminaDisplayModel } from "@/ui/shared/lib/stamina-visuals";
 import { getExplorerStaminaSnapshot } from "@/utils/explorer-stamina";
 import { ArmyModel } from "@/three/managers/army-model";
 import { CameraView, HexagonScene } from "@/three/scenes/hexagon-scene";
@@ -1713,6 +1716,15 @@ export class ArmyManager {
       owner: { address: finalOwnerAddress || 0n },
     });
 
+    const initialStaminaPresentation = this.resolveArmyStaminaSnapshot({
+      entityId: params.entityId,
+      troopCount: finalTroopCount,
+      onChainStamina: finalOnChainStamina,
+      category: params.category,
+      tier: params.tier,
+    });
+    finalCurrentStamina = initialStaminaPresentation?.current ?? finalCurrentStamina;
+
     this.armies.set(
       params.entityId,
       createArmyRecord({
@@ -1737,6 +1749,7 @@ export class ArmyManager {
         troopCount: finalTroopCount,
         currentStamina: finalCurrentStamina,
         maxStamina: finalMaxStamina,
+        displayStaminaRatio: initialStaminaPresentation?.displayRatio,
         // we need to check if there's any pending before we set it because onchain stamina might be 0 from the map data store in the system-manager
         onChainStamina: finalOnChainStamina,
         attackedFromDegrees: attackedFromDegrees ?? undefined,
@@ -2749,9 +2762,10 @@ ${
     onChainStamina: { amount: bigint; updatedTick: number };
     category: TroopType;
     tier: TroopTier;
-  }): { current: number; max: number } | null {
-    const { currentArmiesTick } = getBlockTimestamp();
-    return getExplorerStaminaSnapshot({
+  }): { current: number; max: number; displayRatio: number } | null {
+    const { currentArmiesTick, armiesTickTimeRemaining } = useBlockTimestampStore.getState();
+    const pendingStamina = getFreshPendingStaminaOverlay(input.entityId);
+    const staminaSnapshot = getExplorerStaminaSnapshot({
       currentArmiesTick,
       liveTroops: this.resolveLiveExplorerTroops(input.entityId),
       fallbackArmy: {
@@ -2760,31 +2774,50 @@ ${
         troopCount: input.troopCount,
         onChainStamina: input.onChainStamina,
       },
+      pendingStamina: pendingStamina
+        ? {
+            amount: pendingStamina.amount,
+            updatedTick: pendingStamina.updatedTick,
+          }
+        : null,
     });
+    if (!staminaSnapshot) {
+      return null;
+    }
+
+    const staminaDisplay = buildProjectedStaminaDisplayModel({
+      committedCurrent: staminaSnapshot.current,
+      committedMax: staminaSnapshot.max,
+      armiesTickTimeRemaining,
+      currentArmiesTick,
+      troops: staminaSnapshot.troops,
+    });
+
+    return {
+      current: staminaSnapshot.current,
+      max: staminaSnapshot.max,
+      displayRatio: staminaDisplay.displayRatio,
+    };
   }
 
   /**
    * Recompute stamina for all armies and update visible labels when armies tick changes
    */
   private recomputeStaminaForAllArmies(): void {
-    const { currentArmiesTick } = getBlockTimestamp();
-
     // Update all army data in cache
     this.armies.forEach((army, entityId) => {
-      const staminaSnapshot = getExplorerStaminaSnapshot({
-        currentArmiesTick,
-        liveTroops: this.resolveLiveExplorerTroops(entityId),
-        fallbackArmy: {
-          category: army.category,
-          tier: army.tier,
-          troopCount: army.troopCount,
-          onChainStamina: army.onChainStamina,
-        },
+      const staminaSnapshot = this.resolveArmyStaminaSnapshot({
+        entityId,
+        troopCount: army.troopCount,
+        onChainStamina: army.onChainStamina,
+        category: army.category,
+        tier: army.tier,
       });
 
       // Update cached army data with new stamina
       army.currentStamina = staminaSnapshot?.current ?? army.currentStamina;
       army.maxStamina = staminaSnapshot?.max ?? army.maxStamina;
+      army.displayStaminaRatio = staminaSnapshot?.displayRatio ?? army.displayStaminaRatio;
 
       // Update visible label if it exists
       const label = this.entityIdLabels.get(entityId);
@@ -2904,6 +2937,7 @@ ${
     });
     army.currentStamina = staminaSnapshot?.current ?? army.currentStamina;
     army.maxStamina = staminaSnapshot?.max ?? army.maxStamina;
+    army.displayStaminaRatio = staminaSnapshot?.displayRatio ?? army.displayStaminaRatio;
 
     army.troopCount = update.troopCount;
 

--- a/client/apps/game/src/three/managers/army-record.ts
+++ b/client/apps/game/src/three/managers/army-record.ts
@@ -19,6 +19,7 @@ export function createArmyRecord(input: ArmyData): ArmyData {
     troopCount: input.troopCount,
     currentStamina: input.currentStamina,
     maxStamina: input.maxStamina,
+    displayStaminaRatio: input.displayStaminaRatio,
     onChainStamina: input.onChainStamina,
     attackedFromDegrees: input.attackedFromDegrees,
     attackedTowardDegrees: input.attackedTowardDegrees,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/dojo/torii-stream-manager";
 import { useConnectionStore } from "@/hooks/store/use-connection-store";
 import { useAccountStore } from "@/hooks/store/use-account-store";
+import { usePendingStaminaStore } from "@/hooks/store/use-pending-stamina-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { getCurrentPlayRouteBootToken, usePlayRouteReadinessStore } from "@/game-entry/play-route-readiness-store";
 import { LoadingStateKey } from "@/hooks/store/use-world-loading";
@@ -1034,6 +1035,7 @@ export default class WorldmapScene extends WarpTravel {
       });
       if (plan.shouldClearPendingMovement && plan.entityId !== undefined) {
         this.clearPendingArmyMovement(plan.entityId);
+        usePendingStaminaStore.getState().clearPendingStamina(plan.entityId);
         this.disposePendingMovementVisualLifecycle(plan.entityId);
         this.arrivalGhostManager?.clearArrivalGhost(plan.entityId, "tx_failed");
       }
@@ -2448,9 +2450,19 @@ export default class WorldmapScene extends WarpTravel {
 
       // Monitor memory usage before army movement action
       this.memoryMonitor?.getCurrentStats(`worldmap-moveArmy-start-${selectedEntityId}`);
+      const currentArmiesTick = getBlockTimestamp().currentArmiesTick;
+      if (selectedArmy) {
+        this.queuePendingMovementStamina({
+          entityId: selectedEntityId,
+          currentStamina: selectedArmy.currentStamina,
+          currentArmiesTick,
+          actionPath,
+          actionKind: isTravelAction ? "travel" : "explore",
+        });
+      }
 
       armyActionManager
-        .moveArmy(account!, actionPath, isTravelAction, getBlockTimestamp().currentArmiesTick)
+        .moveArmy(account!, actionPath, isTravelAction, currentArmiesTick)
         .then((result: any) => {
           // Track txHash → entityId so provider transactionFailed events can clear pending state
           const txHash = result?.transaction_hash;
@@ -2475,6 +2487,7 @@ export default class WorldmapScene extends WarpTravel {
         .catch((e) => {
           // Transaction failed at submission, remove from pending and cleanup
           this.clearPendingArmyMovement(selectedEntityId);
+          usePendingStaminaStore.getState().clearPendingStamina(selectedEntityId);
           this.disposePendingMovementVisualLifecycle(selectedEntityId);
           this.arrivalGhostManager.clearArrivalGhost(selectedEntityId, "tx_failed");
           cleanup();
@@ -2720,6 +2733,27 @@ export default class WorldmapScene extends WarpTravel {
     this.schedulePendingArmyMovementFallback(entityId);
   }
 
+  private queuePendingMovementStamina(input: {
+    entityId: ID;
+    currentStamina: number;
+    currentArmiesTick: number;
+    actionPath: ActionPath[];
+    actionKind: "travel" | "explore";
+  }): void {
+    const staminaCost = input.actionPath.reduce((total, pathStep) => total + (pathStep.staminaCost ?? 0), 0);
+    if (!Number.isFinite(staminaCost) || staminaCost <= 0) {
+      return;
+    }
+
+    usePendingStaminaStore.getState().setPendingStamina({
+      entityId: input.entityId,
+      amount: BigInt(Math.max(0, Math.floor(input.currentStamina) - Math.floor(staminaCost))),
+      updatedTick: input.currentArmiesTick,
+      createdAt: Date.now(),
+      actionKind: input.actionKind,
+    });
+  }
+
   private hasPendingTravelEffectForHex(key: string): boolean {
     for (const [entityId, trackedEffect] of this.travelEffectsByEntity.entries()) {
       if (trackedEffect.key === key && this.pendingArmyMovements.has(entityId)) {
@@ -2928,6 +2962,7 @@ export default class WorldmapScene extends WarpTravel {
       }
 
       this.clearPendingArmyMovement(entityId);
+      usePendingStaminaStore.getState().clearPendingStamina(entityId);
       this.disposePendingMovementVisualLifecycle(entityId);
       this.arrivalGhostManager.clearArrivalGhost(entityId, "stale_timeout");
       if (fallbackPlan.shouldRequestChunkRefresh) {

--- a/client/apps/game/src/three/types/common.ts
+++ b/client/apps/game/src/three/types/common.ts
@@ -62,6 +62,7 @@ export interface ArmyData {
   troopCount: number;
   currentStamina: number;
   maxStamina: number;
+  displayStaminaRatio?: number;
   onChainStamina: { amount: bigint; updatedTick: number };
   attackedFromDegrees?: number; // Degrees from which this army has been attacked
   attackedTowardDegrees?: number; // Degrees in which this army has attacked someone

--- a/client/apps/game/src/three/utils/labels/army-label-type.ts
+++ b/client/apps/game/src/three/utils/labels/army-label-type.ts
@@ -29,6 +29,7 @@ export interface ArmyLabelData extends LabelData {
   troopCount: number;
   currentStamina: number;
   maxStamina: number;
+  displayStaminaRatio?: number;
   attackedFromDegrees?: number;
   attackedTowardDegrees?: number;
   battleTimerLeft?: number;
@@ -92,14 +93,14 @@ export const ArmyLabelType: LabelTypeDefinition<ArmyLabelData> = {
       data.maxStamina !== undefined &&
       data.maxStamina > 0
     ) {
-      const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView);
+      const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView, data.displayStaminaRatio);
       troopCountDisplay.appendChild(staminaBar);
       staminaHandledInline = true;
     }
 
     if (!staminaHandledInline) {
       if (data.currentStamina !== undefined && data.maxStamina !== undefined && data.maxStamina > 0) {
-        const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView);
+        const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView, data.displayStaminaRatio);
         textContainer.appendChild(staminaBar);
       } else if (data.currentStamina !== undefined && cameraView !== CameraView.Medium) {
         const staminaInfo = document.createElement("div");
@@ -237,14 +238,19 @@ export const ArmyLabelType: LabelTypeDefinition<ArmyLabelData> = {
         data.maxStamina !== undefined &&
         data.maxStamina > 0
       ) {
-        const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView);
+        const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView, data.displayStaminaRatio);
         troopCountDisplay.appendChild(staminaBar);
         staminaHandledInline = true;
       }
 
       if (!staminaHandledInline) {
         if (data.currentStamina !== undefined && data.maxStamina !== undefined && data.maxStamina > 0) {
-          const staminaBar = createStaminaBar(data.currentStamina, data.maxStamina, cameraView);
+          const staminaBar = createStaminaBar(
+            data.currentStamina,
+            data.maxStamina,
+            cameraView,
+            data.displayStaminaRatio,
+          );
           contentContainer.appendChild(staminaBar);
         } else if (data.currentStamina !== undefined && cameraView !== CameraView.Medium) {
           const staminaInfo = document.createElement("div");
@@ -275,7 +281,7 @@ export const ArmyLabelType: LabelTypeDefinition<ArmyLabelData> = {
 
     const staminaBar = element.querySelector('[data-component="stamina-bar"]');
     if (staminaBar && data.currentStamina !== undefined && data.maxStamina !== undefined) {
-      updateStaminaBar(staminaBar as HTMLElement, data.currentStamina, data.maxStamina);
+      updateStaminaBar(staminaBar as HTMLElement, data.currentStamina, data.maxStamina, data.displayStaminaRatio);
     }
 
     const directionIndicators = updateDirectionIndicators(

--- a/client/apps/game/src/three/utils/labels/label-components.ts
+++ b/client/apps/game/src/three/utils/labels/label-components.ts
@@ -290,9 +290,19 @@ export const createOwnerDisplayElement = (options: OwnerDisplayOptions): HTMLEle
 /**
  * Create stamina bar component
  */
-export const createStaminaBar = (currentStamina: number, maxStamina: number, inputView: CameraView): HTMLElement => {
+export const createStaminaBar = (
+  currentStamina: number,
+  maxStamina: number,
+  inputView: CameraView,
+  displayRatio?: number,
+): HTMLElement => {
   const cameraView = resolveCameraView(inputView);
   const recharging = isStaminaRecharging(currentStamina, maxStamina);
+  const committedPercentage = Math.max(0, Math.min(100, (currentStamina / maxStamina) * 100));
+  const projectedPercentage = Math.max(
+    committedPercentage,
+    Math.min(100, Math.max(0, (displayRatio ?? committedPercentage / 100) * 100)),
+  );
   const container = document.createElement("div");
   container.setAttribute("data-component", "stamina-bar");
 
@@ -346,6 +356,7 @@ export const createStaminaBar = (currentStamina: number, maxStamina: number, inp
   }
 
   const progressFill = document.createElement("div");
+  const projectedFill = document.createElement("div");
   progressFill.style.position = "absolute";
   progressFill.style.top = "0";
   progressFill.style.left = "0";
@@ -353,22 +364,34 @@ export const createStaminaBar = (currentStamina: number, maxStamina: number, inp
   progressFill.style.borderRadius = "9999px";
   progressFill.style.transition = "width 0.3s ease-in-out";
   progressFill.setAttribute("data-role", "progress-fill");
+  progressFill.style.opacity = "0.4";
+  progressFill.style.width = `${committedPercentage}%`;
+
+  projectedFill.style.position = "absolute";
+  projectedFill.style.top = "0";
+  projectedFill.style.left = "0";
+  projectedFill.style.height = "100%";
+  projectedFill.style.borderRadius = "9999px";
+  projectedFill.style.transition = "width 1s linear";
+  projectedFill.setAttribute("data-role", "projected-progress-fill");
   if (recharging) {
-    progressFill.classList.add(STAMINA_RECHARGING_FILL_CLASS);
+    projectedFill.classList.add(STAMINA_RECHARGING_FILL_CLASS);
   }
+  projectedFill.style.width = `${projectedPercentage}%`;
 
-  const percentage = Math.max(0, Math.min(100, (currentStamina / maxStamina) * 100));
-  progressFill.style.width = `${percentage}%`;
-
-  if (percentage > 66) {
+  if (committedPercentage > 66) {
     progressFill.style.backgroundColor = "#10b981";
-  } else if (percentage > 33) {
+    projectedFill.style.backgroundColor = "#34d399";
+  } else if (committedPercentage > 33) {
     progressFill.style.backgroundColor = "#f59e0b";
+    projectedFill.style.backgroundColor = "#fbbf24";
   } else {
     progressFill.style.backgroundColor = "#ef4444";
+    projectedFill.style.backgroundColor = "#fb7185";
   }
 
   progressBar.appendChild(progressFill);
+  progressBar.appendChild(projectedFill);
   container.appendChild(progressBar);
 
   const text = document.createElement("span");
@@ -823,10 +846,16 @@ export const updateIncomingTroopDisplay = (
 /**
  * Update an existing stamina bar with new values
  */
-export const updateStaminaBar = (staminaBarElement: HTMLElement, currentStamina: number, maxStamina: number): void => {
+export const updateStaminaBar = (
+  staminaBarElement: HTMLElement,
+  currentStamina: number,
+  maxStamina: number,
+  displayRatio?: number,
+): void => {
   const percentElement = staminaBarElement.querySelector("[data-role='stamina-percent']") as HTMLElement | null;
   const progressContainer = staminaBarElement.querySelector("[data-role='progress-container']") as HTMLElement | null;
   const progressFill = staminaBarElement.querySelector("[data-role='progress-fill']") as HTMLElement;
+  const projectedFill = staminaBarElement.querySelector("[data-role='projected-progress-fill']") as HTMLElement | null;
   const textElement = staminaBarElement.querySelector("[data-role='stamina-text']") as HTMLElement;
   const recharging = isStaminaRecharging(currentStamina, maxStamina);
 
@@ -846,17 +875,35 @@ export const updateStaminaBar = (staminaBarElement: HTMLElement, currentStamina:
   }
 
   if (progressFill) {
-    const percentage = Math.max(0, Math.min(100, (currentStamina / maxStamina) * 100));
-    progressFill.style.width = `${percentage}%`;
+    const committedPercentage = Math.max(0, Math.min(100, (currentStamina / maxStamina) * 100));
+    const projectedPercentage = Math.max(
+      committedPercentage,
+      Math.min(100, Math.max(0, (displayRatio ?? committedPercentage / 100) * 100)),
+    );
+    progressFill.style.width = `${committedPercentage}%`;
     progressFill.classList.toggle(STAMINA_RECHARGING_FILL_CLASS, recharging);
 
     // Color based on stamina level
-    if (percentage > 66) {
+    if (committedPercentage > 66) {
       progressFill.style.backgroundColor = "#10b981"; // green-500
-    } else if (percentage > 33) {
+      if (projectedFill) {
+        projectedFill.style.backgroundColor = "#34d399";
+      }
+    } else if (committedPercentage > 33) {
       progressFill.style.backgroundColor = "#f59e0b"; // amber-500
+      if (projectedFill) {
+        projectedFill.style.backgroundColor = "#fbbf24";
+      }
     } else {
       progressFill.style.backgroundColor = "#ef4444"; // red-500
+      if (projectedFill) {
+        projectedFill.style.backgroundColor = "#fb7185";
+      }
+    }
+
+    if (projectedFill) {
+      projectedFill.style.width = `${projectedPercentage}%`;
+      projectedFill.classList.toggle(STAMINA_RECHARGING_FILL_CLASS, recharging);
     }
   }
 

--- a/client/apps/game/src/three/utils/labels/label-components.ts
+++ b/client/apps/game/src/three/utils/labels/label-components.ts
@@ -1,4 +1,10 @@
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
+import {
+  isStaminaRecharging,
+  STAMINA_RECHARGING_FILL_CLASS,
+  STAMINA_RECHARGING_TEXT_CLASS,
+  STAMINA_RECHARGING_TRACK_CLASS,
+} from "@/ui/shared/lib/stamina-visuals";
 import type { IncomingTroopArrival } from "@bibliothecadao/eternum";
 import { BANDITS_NAME, BuildingType, ResourcesIds, TroopTier } from "@bibliothecadao/types";
 import { CameraView } from "../../scenes/hexagon-scene";
@@ -286,6 +292,7 @@ export const createOwnerDisplayElement = (options: OwnerDisplayOptions): HTMLEle
  */
 export const createStaminaBar = (currentStamina: number, maxStamina: number, inputView: CameraView): HTMLElement => {
   const cameraView = resolveCameraView(inputView);
+  const recharging = isStaminaRecharging(currentStamina, maxStamina);
   const container = document.createElement("div");
   container.setAttribute("data-component", "stamina-bar");
 
@@ -295,11 +302,17 @@ export const createStaminaBar = (currentStamina: number, maxStamina: number, inp
     const icon = document.createElement("span");
     icon.textContent = "⚡";
     icon.classList.add("text-yellow-400");
+    if (recharging) {
+      icon.classList.add(STAMINA_RECHARGING_TEXT_CLASS);
+    }
     container.appendChild(icon);
 
     const percent = document.createElement("span");
     percent.textContent = formatStaminaPercent(currentStamina, maxStamina);
     percent.classList.add("font-semibold", "tracking-tight");
+    if (recharging) {
+      percent.classList.add(STAMINA_RECHARGING_TEXT_CLASS);
+    }
     percent.style.color = SOFT_LABEL_COLOR;
     percent.setAttribute("data-role", "stamina-percent");
     container.appendChild(percent);
@@ -328,6 +341,9 @@ export const createStaminaBar = (currentStamina: number, maxStamina: number, inp
   progressBar.style.overflow = "hidden";
   progressBar.style.border = "1px solid rgba(255, 255, 255, 0.2)";
   progressBar.setAttribute("data-role", "progress-container");
+  if (recharging) {
+    progressBar.classList.add(STAMINA_RECHARGING_TRACK_CLASS);
+  }
 
   const progressFill = document.createElement("div");
   progressFill.style.position = "absolute";
@@ -337,6 +353,9 @@ export const createStaminaBar = (currentStamina: number, maxStamina: number, inp
   progressFill.style.borderRadius = "9999px";
   progressFill.style.transition = "width 0.3s ease-in-out";
   progressFill.setAttribute("data-role", "progress-fill");
+  if (recharging) {
+    progressFill.classList.add(STAMINA_RECHARGING_FILL_CLASS);
+  }
 
   const percentage = Math.max(0, Math.min(100, (currentStamina / maxStamina) * 100));
   progressFill.style.width = `${percentage}%`;
@@ -358,6 +377,9 @@ export const createStaminaBar = (currentStamina: number, maxStamina: number, inp
   text.style.fontFamily = "monospace";
   text.style.fontSize = "10px";
   text.style.fontWeight = "500";
+  if (recharging) {
+    text.classList.add(STAMINA_RECHARGING_TEXT_CLASS);
+  }
   text.setAttribute("data-role", "stamina-text");
   container.appendChild(text);
 
@@ -803,20 +825,30 @@ export const updateIncomingTroopDisplay = (
  */
 export const updateStaminaBar = (staminaBarElement: HTMLElement, currentStamina: number, maxStamina: number): void => {
   const percentElement = staminaBarElement.querySelector("[data-role='stamina-percent']") as HTMLElement | null;
+  const progressContainer = staminaBarElement.querySelector("[data-role='progress-container']") as HTMLElement | null;
   const progressFill = staminaBarElement.querySelector("[data-role='progress-fill']") as HTMLElement;
   const textElement = staminaBarElement.querySelector("[data-role='stamina-text']") as HTMLElement;
+  const recharging = isStaminaRecharging(currentStamina, maxStamina);
 
   if (percentElement) {
     percentElement.textContent = formatStaminaPercent(currentStamina, maxStamina);
+    percentElement.classList.toggle(STAMINA_RECHARGING_TEXT_CLASS, recharging);
   }
 
   if (textElement) {
     textElement.textContent = `${currentStamina}/${maxStamina}`;
+    textElement.classList.toggle(STAMINA_RECHARGING_TEXT_CLASS, recharging);
+  }
+
+  const iconElement = staminaBarElement.firstElementChild as HTMLElement | null;
+  if (iconElement) {
+    iconElement.classList.toggle(STAMINA_RECHARGING_TEXT_CLASS, recharging);
   }
 
   if (progressFill) {
     const percentage = Math.max(0, Math.min(100, (currentStamina / maxStamina) * 100));
     progressFill.style.width = `${percentage}%`;
+    progressFill.classList.toggle(STAMINA_RECHARGING_FILL_CLASS, recharging);
 
     // Color based on stamina level
     if (percentage > 66) {
@@ -826,6 +858,10 @@ export const updateStaminaBar = (staminaBarElement: HTMLElement, currentStamina:
     } else {
       progressFill.style.backgroundColor = "#ef4444"; // red-500
     }
+  }
+
+  if (progressContainer) {
+    progressContainer.classList.toggle(STAMINA_RECHARGING_TRACK_CLASS, recharging);
   }
 };
 

--- a/client/apps/game/src/ui/features/military/battle/combat-container.tsx
+++ b/client/apps/game/src/ui/features/military/battle/combat-container.tsx
@@ -64,6 +64,27 @@ enum AttackerType {
   Army,
 }
 
+const buildProjectedTroopSnapshot = (input: {
+  troops: Troops;
+  stamina: { amount: bigint; updated_tick: bigint };
+}): Troops => ({
+  count: input.troops.count || 0n,
+  category: input.troops.category as TroopType,
+  tier: input.troops.tier as TroopTier,
+  stamina: input.stamina,
+  boosts: input.troops.boosts || {
+    incr_damage_dealt_percent_num: 0,
+    incr_damage_dealt_end_tick: 0,
+    decr_damage_gotten_percent_num: 0,
+    decr_damage_gotten_end_tick: 0,
+    incr_stamina_regen_percent_num: 0,
+    incr_stamina_regen_tick_count: 0,
+    incr_explore_reward_percent_num: 0,
+    incr_explore_reward_end_tick: 0,
+  },
+  battle_cooldown_end: input.troops.battle_cooldown_end || 0,
+});
+
 // Add the new function before the CombatContainer component
 const getFormattedCombatTweet = ({
   attackerArmyData,
@@ -200,73 +221,53 @@ export const CombatContainer = ({
 
       const selectedGuard = structureGuards.find((guard) => guard.slot === selectedGuardSlot);
       if (!selectedGuard) return null;
+      const staminaSnapshot = getGuardStaminaSnapshot(selectedGuard.troops, currentArmiesTick);
+      const stamina = BigInt(Math.floor(staminaSnapshot?.current ?? Number(selectedGuard.troops.stamina.amount ?? 0n)));
 
       return {
-        troops: {
-          count: selectedGuard.troops.count || 0n,
-          category: selectedGuard.troops.category as TroopType,
-          tier: selectedGuard.troops.tier as TroopTier,
-          stamina: selectedGuard.troops.stamina || { amount: 0n, updated_tick: 0n },
-          boosts: selectedGuard.troops.boosts || {
-            incr_damage_dealt_percent_num: 0,
-            incr_damage_dealt_end_tick: 0,
-            decr_damage_gotten_percent_num: 0,
-            decr_damage_gotten_end_tick: 0,
-            incr_stamina_regen_percent_num: 0,
-            incr_stamina_regen_tick_count: 0,
-            incr_explore_reward_percent_num: 0,
-            incr_explore_reward_end_tick: 0,
+        troops: buildProjectedTroopSnapshot({
+          troops: selectedGuard.troops,
+          stamina: {
+            amount: stamina,
+            updated_tick: BigInt(currentArmiesTick),
           },
-          battle_cooldown_end: 0,
-        },
+        }),
       };
     } else {
       // attacker always synced already
       const army = getComponentValue(ExplorerTroops, getEntityIdFromKeys([BigInt(attackerEntityId)]));
+      if (!army) {
+        return null;
+      }
 
       return {
-        troops: {
-          count: army?.troops.count || 0n,
-          category: army?.troops.category as TroopType,
-          tier: army?.troops.tier as TroopTier,
-          stamina: army?.troops.stamina || { amount: 0n, updated_tick: 0n },
-          boosts: army?.troops.boosts || {
-            incr_damage_dealt_percent_num: 0,
-            incr_damage_dealt_end_tick: 0,
-            decr_damage_gotten_percent_num: 0,
-            decr_damage_gotten_end_tick: 0,
-            incr_stamina_regen_percent_num: 0,
-            incr_stamina_regen_tick_count: 0,
-            incr_explore_reward_percent_num: 0,
-            incr_explore_reward_end_tick: 0,
+        troops: buildProjectedTroopSnapshot({
+          troops: army.troops,
+          stamina: {
+            amount: attackerStamina,
+            updated_tick: BigInt(currentArmiesTick),
           },
-          battle_cooldown_end: army?.troops.battle_cooldown_end || 0,
-        },
+        }),
       };
     }
-  }, [attackerEntityId, attackerType, selectedGuardSlot, structureGuards]);
+  }, [
+    ExplorerTroops,
+    attackerEntityId,
+    attackerStamina,
+    attackerType,
+    currentArmiesTick,
+    selectedGuardSlot,
+    structureGuards,
+  ]);
 
   const targetArmyData: { troops: Troops } | null = useMemo(() => {
     if (!target?.info[0]) return null;
 
     return {
-      troops: {
-        count: target.info[0].count || 0n,
-        category: target.info[0].category as TroopType,
-        tier: target.info[0].tier as TroopTier,
+      troops: buildProjectedTroopSnapshot({
+        troops: target.info[0],
         stamina: target.info[0].stamina,
-        boosts: target.info[0].boosts || {
-          incr_damage_dealt_percent_num: 0,
-          incr_damage_dealt_end_tick: 0,
-          decr_damage_gotten_percent_num: 0,
-          decr_damage_gotten_end_tick: 0,
-          incr_stamina_regen_percent_num: 0,
-          incr_stamina_regen_tick_count: 0,
-          incr_explore_reward_percent_num: 0,
-          incr_explore_reward_end_tick: 0,
-        },
-        battle_cooldown_end: target.info[0].battle_cooldown_end || 0,
-      },
+      }),
     };
   }, [target]);
 

--- a/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
+++ b/client/apps/game/src/ui/features/military/battle/quick-attack-preview.tsx
@@ -77,6 +77,14 @@ const buildTroopSnapshot = (troops: Troops) => ({
   battle_cooldown_end: troops.battle_cooldown_end || 0,
 });
 
+const buildProjectedTroopSnapshot = (
+  troops: Troops,
+  stamina: { amount: bigint; updated_tick: bigint } = troops.stamina || { amount: 0n, updated_tick: 0n },
+) => ({
+  ...buildTroopSnapshot(troops),
+  stamina,
+});
+
 const toRelicResourceIds = (effects: RelicEffectWithEndTick[]): ResourcesIds[] =>
   effects.map((effect) => Number(effect.id)) as ResourcesIds[];
 
@@ -176,16 +184,28 @@ export const QuickAttackPreview = ({ attacker, target }: QuickAttackPreviewProps
     if (attackerType === AttackerType.Structure) {
       const guard = structureGuards[0];
       if (!guard) return null;
-      return { troops: buildTroopSnapshot(guard.troops) };
+      return {
+        troops: buildProjectedTroopSnapshot(guard.troops, {
+          amount: attackerStamina,
+          updated_tick: BigInt(currentArmiesTick),
+        }),
+      };
     }
 
     const army = getComponentValue(ExplorerTroops, getEntityIdFromKeys([BigInt(attacker.id)]));
-    return army ? { troops: buildTroopSnapshot(army.troops) } : null;
-  }, [attackerType, structureGuards, ExplorerTroops, attacker.id]);
+    return army
+      ? {
+          troops: buildProjectedTroopSnapshot(army.troops, {
+            amount: attackerStamina,
+            updated_tick: BigInt(currentArmiesTick),
+          }),
+        }
+      : null;
+  }, [ExplorerTroops, attacker.id, attackerStamina, attackerType, currentArmiesTick, structureGuards]);
 
   const targetTroopSnapshots = useMemo(() => {
     if (!targetData?.info) return [];
-    return targetData.info.map((info) => buildTroopSnapshot(info));
+    return targetData.info.map((info) => buildProjectedTroopSnapshot(info, info.stamina));
   }, [targetData]);
 
   const isStructureTarget = targetData?.targetType === TargetType.Structure;

--- a/client/apps/game/src/ui/features/military/battle/raid-container.test.tsx
+++ b/client/apps/game/src/ui/features/military/battle/raid-container.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+
+import { act, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RaidContainer } from "./raid-container";
+
+const mocks = vi.hoisted(() => ({
+  currentArmiesTick: 2,
+  getArmy: vi.fn(() => ({
+    totalCapacity: 100,
+    troops: {
+      count: 1000n,
+      category: 1,
+      tier: 1,
+      stamina: {
+        amount: 0n,
+        updated_tick: 0n,
+      },
+      battle_cooldown_end: 0,
+    },
+  })),
+  getStamina: vi.fn((_troops: unknown, currentArmiesTick: number) => ({
+    amount: BigInt(currentArmiesTick * 10),
+    updated_tick: BigInt(currentArmiesTick),
+  })),
+  getComponentValue: vi.fn(() => ({
+    balances: {},
+  })),
+  raidExplorerVsGuard: vi.fn(async () => undefined),
+  updateSelectedEntityId: vi.fn(),
+}));
+
+vi.mock("@/hooks/helpers/use-block-timestamp", () => ({
+  useCurrentArmiesTick: () => mocks.currentArmiesTick,
+}));
+
+vi.mock("@/hooks/store/use-ui-store", () => ({
+  useUIStore: (
+    selector: (state: {
+      selectedHex: { col: number; row: number };
+      updateEntityActionSelectedEntityId: typeof mocks.updateSelectedEntityId;
+    }) => unknown,
+  ) =>
+    selector({
+      selectedHex: { col: 10, row: 10 },
+      updateEntityActionSelectedEntityId: mocks.updateSelectedEntityId,
+    }),
+}));
+
+vi.mock("@/ui/design-system/atoms/button", () => ({
+  default: ({
+    children,
+    isLoading: _isLoading,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement> & { isLoading?: boolean }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/ui/design-system/atoms", () => ({
+  Panel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/ui/design-system/molecules/resource-icon", () => ({
+  ResourceIcon: () => <span data-testid="resource-icon" />,
+}));
+
+vi.mock("@/ui/features", () => ({
+  BiomeInfoPanel: () => <div>Biome Info</div>,
+}));
+
+vi.mock("../../world/components/entities/active-relic-effects", () => ({
+  ActiveRelicEffects: () => null,
+}));
+
+vi.mock("./raid-result", () => ({
+  RaidResult: () => <div>Raid Result</div>,
+}));
+
+vi.mock("@bibliothecadao/react", () => ({
+  useDojo: () => ({
+    account: {
+      account: {
+        address: "0x123",
+      },
+    },
+    setup: {
+      systemCalls: {
+        raid_explorer_vs_guard: mocks.raidExplorerVsGuard,
+      },
+      components: {
+        Resource: Symbol("Resource"),
+      },
+    },
+  }),
+}));
+
+vi.mock("@dojoengine/recs", () => ({
+  getComponentValue: mocks.getComponentValue,
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  Biome: {
+    getBiome: () => "forest",
+  },
+  CombatSimulator: class CombatSimulator {
+    calculateStaminaModifier() {
+      return 1;
+    }
+  },
+  RaidSimulator: class RaidSimulator {
+    simulateRaid() {
+      return {
+        successChance: 100,
+        raiderDamageTaken: 0,
+        defenderDamageTaken: 0,
+        damageTakenPerDefender: [0],
+      };
+    }
+  },
+  configManager: {
+    getCombatConfig: () => ({
+      stamina_attack_req: 50,
+    }),
+    getBiomeCombatBonus: () => 0,
+    getCapacityConfigKg: () => 1,
+    getResourceWeightKg: () => 1,
+  },
+  divideByPrecision: (value: number) => value,
+  getArmy: mocks.getArmy,
+  getEntityIdFromKeys: () => "entity",
+  getRemainingCapacityInKg: () => 100,
+  StaminaManager: {
+    getStamina: mocks.getStamina,
+  },
+}));
+
+describe("RaidContainer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.currentArmiesTick = 2;
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("refreshes attacker stamina when the armies tick advances without a refetch", async () => {
+    const target = {
+      info: [
+        {
+          count: 500n,
+          category: 1,
+          tier: 1,
+          stamina: { amount: 30n, updated_tick: 2n },
+          battle_cooldown_end: 0,
+        },
+      ],
+      id: 2,
+      targetType: 0,
+      structureCategory: 1,
+      hex: { x: 11, y: 10 },
+      addressOwner: null,
+    };
+
+    await act(async () => {
+      root.render(
+        <RaidContainer
+          attackerEntityId={1 as never}
+          target={target as never}
+          targetResources={[{ resourceId: 1, amount: 10 }]}
+          attackerActiveRelicEffects={[]}
+          targetActiveRelicEffects={[]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("20 / 50 required");
+
+    mocks.currentArmiesTick = 6;
+
+    await act(async () => {
+      root.render(
+        <RaidContainer
+          attackerEntityId={1 as never}
+          target={target as never}
+          targetResources={[{ resourceId: 1, amount: 10 }]}
+          attackerActiveRelicEffects={[]}
+          targetActiveRelicEffects={[]}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain("60 / 50 required");
+  });
+});

--- a/client/apps/game/src/ui/features/military/battle/raid-container.tsx
+++ b/client/apps/game/src/ui/features/military/battle/raid-container.tsx
@@ -3,6 +3,13 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import Button from "@/ui/design-system/atoms/button";
 import { Panel } from "@/ui/design-system/atoms";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import {
+  isStaminaRecharging,
+  STAMINA_RECHARGING_FILL_CLASS,
+  STAMINA_RECHARGING_TEXT_CLASS,
+  STAMINA_RECHARGING_TRACK_CLASS,
+} from "@/ui/shared/lib/stamina-visuals";
 import { BiomeInfoPanel } from "@/ui/features";
 import { formatStringNumber } from "@/ui/utils/utils";
 import {
@@ -96,6 +103,8 @@ export const RaidContainer = ({
       },
     };
   }, [account.address, attackerEntityId, components, currentArmiesTick]);
+  const attackerCurrentStaminaValue = Number(attackerArmyData?.troops.stamina.amount ?? 0n);
+  const attackerRecharging = isStaminaRecharging(attackerCurrentStaminaValue, combatConfig.stamina_attack_req);
 
   const params = configManager.getCombatConfig();
   const combatSimulator = useMemo(() => new CombatSimulator(params), [params]);
@@ -332,10 +341,23 @@ export const RaidContainer = ({
 
                           <div className="mt-3 flex items-center justify-between">
                             <div className="flex items-center gap-2">
-                              <span className="text-gold/70">Current Stamina:</span>
-                              <div className="w-28 h-3 bg-brown-800 rounded-full overflow-hidden">
+                              <span className={cn("text-gold/70", attackerRecharging && STAMINA_RECHARGING_TEXT_CLASS)}>
+                                Current Stamina:
+                              </span>
+                              <div
+                                className={cn(
+                                  "w-28 h-3 bg-brown-800 rounded-full overflow-hidden",
+                                  attackerRecharging && STAMINA_RECHARGING_TRACK_CLASS,
+                                )}
+                              >
                                 <div
-                                  className={`h-full ${Number(attackerArmyData.troops.stamina.amount) >= combatConfig.stamina_attack_req ? "bg-green-600" : "bg-red-600"}`}
+                                  className={cn(
+                                    "h-full",
+                                    Number(attackerArmyData.troops.stamina.amount) >= combatConfig.stamina_attack_req
+                                      ? "bg-green-600"
+                                      : "bg-red-600",
+                                    attackerRecharging && STAMINA_RECHARGING_FILL_CLASS,
+                                  )}
                                   style={{
                                     width: `${Math.min(100, (Number(attackerArmyData.troops.stamina.amount) / 100) * 100)}%`,
                                   }}
@@ -343,7 +365,13 @@ export const RaidContainer = ({
                               </div>
                             </div>
                             <span
-                              className={`text-sm font-medium ${Number(attackerArmyData.troops.stamina.amount) >= combatConfig.stamina_attack_req ? "text-green-400" : "text-red-400"}`}
+                              className={cn(
+                                "text-sm font-medium",
+                                Number(attackerArmyData.troops.stamina.amount) >= combatConfig.stamina_attack_req
+                                  ? "text-green-400"
+                                  : "text-red-400",
+                                attackerRecharging && STAMINA_RECHARGING_TEXT_CLASS,
+                              )}
                             >
                               {Number(attackerArmyData.troops.stamina.amount)} / {combatConfig.stamina_attack_req}{" "}
                               required

--- a/client/apps/game/src/ui/features/military/battle/raid-container.tsx
+++ b/client/apps/game/src/ui/features/military/battle/raid-container.tsx
@@ -1,11 +1,10 @@
+import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import Button from "@/ui/design-system/atoms/button";
 import { Panel } from "@/ui/design-system/atoms";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { BiomeInfoPanel } from "@/ui/features";
 import { formatStringNumber } from "@/ui/utils/utils";
-import { getBlockTimestamp } from "@bibliothecadao/eternum";
-
 import {
   Biome,
   CombatSimulator,
@@ -69,6 +68,7 @@ export const RaidContainer = ({
 
   const updateSelectedEntityId = useUIStore((state) => state.updateEntityActionSelectedEntityId);
   const selectedHex = useUIStore((state) => state.selectedHex);
+  const currentArmiesTick = useCurrentArmiesTick();
 
   const combatConfig = useMemo(() => {
     return configManager.getCombatConfig();
@@ -81,10 +81,9 @@ export const RaidContainer = ({
   // Get the current army states for display
   const attackerArmyData = useMemo(() => {
     const army = getArmy(attackerEntityId, ContractAddress(account.address), components);
-    const { currentArmiesTick } = getBlockTimestamp();
-
-    // Convert attacker relic effects to resource IDs for StaminaManager
-    const attackerRelicResourceIds = attackerActiveRelicEffects.map((effect) => Number(effect.id)) as ResourcesIds[];
+    const projectedStamina = army
+      ? StaminaManager.getStamina(army.troops, currentArmiesTick)
+      : { amount: 0n, updated_tick: 0n };
 
     return {
       capacity: army?.totalCapacity,
@@ -92,11 +91,11 @@ export const RaidContainer = ({
         count: Number(army?.troops.count || 0),
         category: army?.troops.category as TroopType,
         tier: army?.troops.tier as TroopTier,
-        stamina: army ? StaminaManager.getStamina(army?.troops, currentArmiesTick) : { amount: 0n, updated_tick: 0n },
+        stamina: projectedStamina,
         battle_cooldown_end: army?.troops.battle_cooldown_end || 0,
       },
     };
-  }, [attackerEntityId, attackerActiveRelicEffects]);
+  }, [account.address, attackerEntityId, components, currentArmiesTick]);
 
   const params = configManager.getCombatConfig();
   const combatSimulator = useMemo(() => new CombatSimulator(params), [params]);
@@ -105,8 +104,6 @@ export const RaidContainer = ({
   // Simulate raid outcome
   const raidSimulation = useMemo(() => {
     if (!attackerArmyData) return null;
-
-    const { currentArmiesTick } = getBlockTimestamp();
 
     // Convert game armies to simulator armies
     const attackerArmy = {
@@ -160,8 +157,6 @@ export const RaidContainer = ({
   }, [
     attackerEntityId,
     target,
-    account,
-    components,
     attackerArmyData,
     biome,
     combatConfig,
@@ -178,7 +173,7 @@ export const RaidContainer = ({
       remainingCapacity -
       (raidSimulation?.raiderDamageTaken || 0) * configManager.getCapacityConfigKg(CapacityConfig.Army);
     return { beforeRaid: remainingCapacity, afterRaid: remainingCapacityAfterRaid };
-  }, [raidSimulation]);
+  }, [attackerEntityId, components.Resource, raidSimulation]);
 
   const stealableResources = useMemo(() => {
     let capacityAfterRaid = remainingCapacity.afterRaid;

--- a/client/apps/game/src/ui/features/military/components/guard-stamina-bar.tsx
+++ b/client/apps/game/src/ui/features/military/components/guard-stamina-bar.tsx
@@ -1,4 +1,9 @@
 import { cn } from "@/ui/design-system/atoms/lib/utils";
+import {
+  isStaminaRecharging,
+  STAMINA_RECHARGING_FILL_CLASS,
+  STAMINA_RECHARGING_TRACK_CLASS,
+} from "@/ui/shared/lib/stamina-visuals";
 
 interface GuardStaminaBarProps {
   current?: number | bigint | null;
@@ -23,15 +28,24 @@ export const GuardStaminaBar = ({ current, max, className }: GuardStaminaBarProp
   const percentage = (clampedCurrent / maxValue) * 100;
   const roundedCurrent = Math.round(clampedCurrent);
   const roundedMax = Math.round(maxValue);
+  const recharging = isStaminaRecharging(clampedCurrent, maxValue);
 
   return (
     <div
-      className={cn("h-1 w-full overflow-hidden rounded-full border border-gold/20 bg-dark-brown/70", className)}
+      className={cn(
+        "h-1 w-full overflow-hidden rounded-full border border-gold/20 bg-dark-brown/70",
+        recharging && STAMINA_RECHARGING_TRACK_CLASS,
+        className,
+      )}
       title={`Stamina ${roundedCurrent}/${roundedMax}`}
       aria-label={`Stamina ${roundedCurrent}/${roundedMax}`}
     >
       <div
-        className={cn("h-full transition-all duration-300", getStaminaFillClass(clampedCurrent, percentage))}
+        className={cn(
+          "h-full transition-all duration-300",
+          getStaminaFillClass(clampedCurrent, percentage),
+          recharging && STAMINA_RECHARGING_FILL_CLASS,
+        )}
         style={{ width: `${Math.min(100, Math.max(0, percentage))}%` }}
       />
     </div>

--- a/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
@@ -6,6 +6,12 @@ import { ReactComponent as Lightning } from "@/assets/icons/common/lightning.svg
 import { usePlayerAvatarByUsername } from "@/hooks/use-player-avatar";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { TroopChip } from "@/ui/features/military/components/troop-chip";
+import {
+  isStaminaRecharging,
+  STAMINA_RECHARGING_FILL_CLASS,
+  STAMINA_RECHARGING_TEXT_CLASS,
+  STAMINA_RECHARGING_TRACK_CLASS,
+} from "@/ui/shared/lib/stamina-visuals";
 import { configManager } from "@bibliothecadao/eternum";
 import { BiomeType, EntityType, ID, RelicRecipientType, TroopType } from "@bibliothecadao/types";
 import { ActiveRelicEffects } from "../active-relic-effects";
@@ -190,6 +196,7 @@ const InlineStaminaBar = ({
   const staminaValue = Number(stamina.amount);
   const percentage = (staminaValue / maxStamina) * 100;
   const minTravelCost = configManager.getTravelStaminaCost(BiomeType.Ocean, TroopType.Crossbowman);
+  const recharging = isStaminaRecharging(staminaValue, maxStamina);
 
   let fillClass = "bg-progress-bar-danger";
   if (staminaValue >= minTravelCost) {
@@ -199,14 +206,25 @@ const InlineStaminaBar = ({
 
   return (
     <div className="flex items-center gap-2 text-xxs text-gold/80">
-      <Lightning className="h-3 w-3 fill-order-power" />
-      <div className="flex-1 h-2 rounded-full border border-gray-600 overflow-hidden">
+      <Lightning className={cn("h-3 w-3 fill-order-power", recharging && STAMINA_RECHARGING_TEXT_CLASS)} />
+      <div
+        className={cn(
+          "flex-1 h-2 rounded-full border border-gray-600 overflow-hidden",
+          recharging && STAMINA_RECHARGING_TRACK_CLASS,
+        )}
+      >
         <div
-          className={`${fillClass} h-full rounded-full transition-all duration-300`}
+          className={cn(
+            fillClass,
+            "h-full rounded-full transition-all duration-300",
+            recharging && STAMINA_RECHARGING_FILL_CLASS,
+          )}
           style={{ width: `${Math.min(100, Math.max(0, percentage))}%` }}
         />
       </div>
-      <span className="whitespace-nowrap">{`${staminaValue}/${maxStamina}`}</span>
+      <span className={cn("whitespace-nowrap", recharging && STAMINA_RECHARGING_TEXT_CLASS)}>
+        {`${staminaValue}/${maxStamina}`}
+      </span>
     </div>
   );
 };

--- a/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
@@ -125,7 +125,12 @@ const ArmyBannerEntityDetailContent = memo(
         <div className="flex flex-col gap-2">
           <TroopChip troops={explorer.troops} size="sm" className="w-full" />
           {derivedData.stamina && derivedData.maxStamina ? (
-            <InlineStaminaBar stamina={derivedData.stamina} maxStamina={derivedData.maxStamina} />
+            <InlineStaminaBar
+              stamina={derivedData.stamina}
+              maxStamina={derivedData.maxStamina}
+              displayRatio={derivedData.staminaDisplay?.displayRatio}
+              isRecharging={derivedData.staminaDisplay?.isRecharging}
+            />
           ) : null}
         </div>
 
@@ -188,15 +193,23 @@ ArmyBannerEntityDetail.displayName = "ArmyBannerEntityDetail";
 const InlineStaminaBar = ({
   stamina,
   maxStamina,
+  displayRatio,
+  isRecharging,
 }: {
   stamina: { amount: bigint; updated_tick: bigint };
   maxStamina: number;
+  displayRatio?: number;
+  isRecharging?: boolean | null;
 }) => {
   if (!stamina || maxStamina === 0) return null;
   const staminaValue = Number(stamina.amount);
   const percentage = (staminaValue / maxStamina) * 100;
+  const projectedPercentage = Math.max(
+    percentage,
+    Math.min(100, Math.max(0, (displayRatio ?? percentage / 100) * 100)),
+  );
   const minTravelCost = configManager.getTravelStaminaCost(BiomeType.Ocean, TroopType.Crossbowman);
-  const recharging = isStaminaRecharging(staminaValue, maxStamina);
+  const recharging = isRecharging ?? isStaminaRecharging(staminaValue, maxStamina);
 
   let fillClass = "bg-progress-bar-danger";
   if (staminaValue >= minTravelCost) {
@@ -214,12 +227,16 @@ const InlineStaminaBar = ({
         )}
       >
         <div
+          className={cn(fillClass, "h-full rounded-full opacity-45 transition-all duration-300")}
+          style={{ width: `${Math.min(100, Math.max(0, percentage))}%` }}
+        />
+        <div
           className={cn(
             fillClass,
-            "h-full rounded-full transition-all duration-300",
+            "h-full rounded-full transition-all duration-1000 -mt-2",
             recharging && STAMINA_RECHARGING_FILL_CLASS,
           )}
-          style={{ width: `${Math.min(100, Math.max(0, percentage))}%` }}
+          style={{ width: `${projectedPercentage}%` }}
         />
       </div>
       <span className={cn("whitespace-nowrap", recharging && STAMINA_RECHARGING_TEXT_CLASS)}>

--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx
@@ -40,7 +40,7 @@ vi.mock("@/hooks/helpers/use-block-timestamp", () => ({
     currentBlockTimestamp: 0,
     currentDefaultTick: 0,
     currentArmiesTick: 5,
-    armiesTickTimeRemaining: 0,
+    armiesTickTimeRemaining: 5,
   }),
 }));
 
@@ -62,6 +62,9 @@ vi.mock("@bibliothecadao/torii", () => ({
 }));
 
 vi.mock("@bibliothecadao/eternum", () => ({
+  configManager: {
+    getTick: () => 10,
+  },
   ContractAddress: (value: string | bigint) => value,
   getAddressName: getAddressNameMock,
   getArmyRelicEffects: () => [],
@@ -100,9 +103,25 @@ const liveTroops = {
   stamina: { amount: 20n, updated_tick: 5n },
 };
 
+const sameTickLiveTroops = {
+  ...snapshotTroops,
+  stamina: { amount: 80n, updated_tick: 5n },
+};
+
+const sameTickSnapshotTroops = {
+  ...snapshotTroops,
+  stamina: { amount: 20n, updated_tick: 5n },
+};
+
 const Probe = () => {
   const { derivedData } = useArmyEntityDetail({ armyEntityId: 1 as never });
-  return <div>{derivedData ? `${Number(derivedData.stamina.amount)}/${derivedData.maxStamina}` : "loading"}</div>;
+  return (
+    <div>
+      {derivedData
+        ? `${Number(derivedData.stamina.amount)}/${derivedData.maxStamina}:${derivedData.staminaDisplay?.displayCurrent ?? 0}`
+        : "loading"}
+    </div>
+  );
 };
 
 describe("useArmyEntityDetail stamina sync", () => {
@@ -186,7 +205,7 @@ describe("useArmyEntityDetail stamina sync", () => {
       root.render(<Probe />);
     });
 
-    expect(container.textContent).toContain("20/120");
+    expect(container.textContent).toContain("20/120:");
   });
 
   it("prefers the newer Torii troop stamina when the live troop snapshot is stale", async () => {
@@ -247,6 +266,58 @@ describe("useArmyEntityDetail stamina sync", () => {
       root.render(<Probe />);
     });
 
-    expect(container.textContent).toContain("65/120");
+    expect(container.textContent).toContain("65/120:");
+  });
+
+  it("prefers the Torii snapshot when both snapshots share the same tick but differ in amount", async () => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: [string] }) => {
+      if (queryKey[0] === "explorer") {
+        return {
+          data: {
+            explorer: {
+              troops: sameTickSnapshotTroops,
+              owner: "0x123",
+            },
+            resources: [],
+            relicEffects: [],
+          },
+          isLoading: false,
+          refetch: vi.fn(),
+        };
+      }
+
+      return {
+        data: {
+          structure: {
+            owner: "0x123",
+          },
+          resources: [],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+    });
+
+    useComponentValueMock.mockReturnValue({
+      troops: sameTickLiveTroops,
+    });
+
+    getStaminaMock.mockImplementation((troops: typeof snapshotTroops, currentTick: number) => {
+      if (troops === sameTickSnapshotTroops) {
+        return { amount: currentTick === 5 ? 20n : 40n, updated_tick: BigInt(currentTick) };
+      }
+
+      if (troops === sameTickLiveTroops) {
+        return { amount: 80n, updated_tick: 5n };
+      }
+
+      return { amount: 80n, updated_tick: 5n };
+    });
+
+    await act(async () => {
+      root.render(<Probe />);
+    });
+
+    expect(container.textContent).toContain("20/120:30");
   });
 });

--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx
@@ -188,4 +188,65 @@ describe("useArmyEntityDetail stamina sync", () => {
 
     expect(container.textContent).toContain("20/120");
   });
+
+  it("prefers the newer Torii troop stamina when the live troop snapshot is stale", async () => {
+    const newerSnapshotTroops = {
+      ...snapshotTroops,
+      stamina: { amount: 65n, updated_tick: 9n },
+    };
+    const staleLiveTroops = {
+      ...liveTroops,
+      stamina: { amount: 20n, updated_tick: 5n },
+    };
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: [string] }) => {
+      if (queryKey[0] === "explorer") {
+        return {
+          data: {
+            explorer: {
+              troops: newerSnapshotTroops,
+              owner: "0x123",
+            },
+            resources: [],
+            relicEffects: [],
+          },
+          isLoading: false,
+          refetch: vi.fn(),
+        };
+      }
+
+      return {
+        data: {
+          structure: {
+            owner: "0x123",
+          },
+          resources: [],
+        },
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+    });
+
+    useComponentValueMock.mockReturnValue({
+      troops: staleLiveTroops,
+    });
+
+    getStaminaMock.mockImplementation((troops: typeof snapshotTroops) => {
+      if (troops === staleLiveTroops) {
+        return { amount: 20n, updated_tick: 5n };
+      }
+
+      if (troops === newerSnapshotTroops) {
+        return { amount: 65n, updated_tick: 9n };
+      }
+
+      return { amount: 80n, updated_tick: 5n };
+    });
+
+    await act(async () => {
+      root.render(<Probe />);
+    });
+
+    expect(container.textContent).toContain("65/120");
+  });
 });

--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-army-entity-detail.ts
@@ -1,4 +1,7 @@
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
+import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { usePendingStaminaStore } from "@/hooks/store/use-pending-stamina-store";
+import { buildProjectedStaminaDisplayModel, type ProjectedStaminaDisplayModel } from "@/ui/shared/lib/stamina-visuals";
 import { getCharacterName } from "@/utils/agent";
 import { getExplorerStaminaSnapshot } from "@/utils/explorer-stamina";
 import { getAddressName, getArmyRelicEffects, getGuildFromPlayerAddress } from "@bibliothecadao/eternum";
@@ -8,7 +11,6 @@ import { ArmyInfo, ContractAddress, HexPosition, ID, TroopTier, TroopType } from
 import { useComponentValue } from "@dojoengine/react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useQuery } from "@tanstack/react-query";
-import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
 import { useCallback, useMemo, useState } from "react";
 
 interface UseArmyEntityDetailOptions {
@@ -18,6 +20,7 @@ interface UseArmyEntityDetailOptions {
 interface DerivedArmyData {
   stamina: { amount: bigint; updated_tick: bigint };
   maxStamina: number;
+  staminaDisplay: ProjectedStaminaDisplayModel | null;
   playerGuild?: { name: string } | undefined;
   addressName?: string;
   isMine: boolean;
@@ -40,11 +43,12 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
   } = useDojo();
   const mode = useGameModeConfig();
 
-  const currentArmiesTick = useCurrentArmiesTick();
+  const { currentArmiesTick, armiesTickTimeRemaining } = useBlockTimestamp();
   const userAddress = ContractAddress(account.address);
   const [isLoadingDelete, setIsLoadingDelete] = useState(false);
   const [lastRefresh, setLastRefresh] = useState(0);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const pendingStamina = usePendingStaminaStore((state) => state.overlays[String(armyEntityId)]);
   const liveExplorerTroops = useComponentValue(
     components.ExplorerTroops,
     getEntityIdFromKeys([BigInt(armyEntityId)]),
@@ -71,8 +75,15 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
         currentArmiesTick,
         snapshotTroops: explorer?.troops,
         liveTroops: liveExplorerTroops,
+        pendingStamina:
+          pendingStamina && Date.now() - pendingStamina.createdAt <= 60_000
+            ? {
+                amount: pendingStamina.amount,
+                updatedTick: pendingStamina.updatedTick,
+              }
+            : null,
       }),
-    [currentArmiesTick, explorer?.troops, liveExplorerTroops],
+    [currentArmiesTick, explorer?.troops, liveExplorerTroops, pendingStamina],
   );
   const currentTroops = staminaSnapshot?.troops ?? null;
   const relicEffects = useMemo(
@@ -118,6 +129,15 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
 
     const stamina = staminaSnapshot?.stamina ?? { amount: 0n, updated_tick: 0n };
     const maxStamina = staminaSnapshot?.max ?? 0;
+    const staminaDisplay = staminaSnapshot
+      ? buildProjectedStaminaDisplayModel({
+          committedCurrent: Number(stamina.amount),
+          committedMax: maxStamina,
+          armiesTickTimeRemaining,
+          currentArmiesTick,
+          troops: staminaSnapshot.troops,
+        })
+      : null;
 
     const guild = structure ? getGuildFromPlayerAddress(ContractAddress(structure.owner), components) : undefined;
     const isMine = structure?.owner === userAddress;
@@ -131,12 +151,23 @@ export const useArmyEntityDetail = ({ armyEntityId }: UseArmyEntityDetailOptions
     return {
       stamina,
       maxStamina,
+      staminaDisplay,
       playerGuild: guild,
       addressName,
       isMine: Boolean(isMine),
       structureOwnerName,
     };
-  }, [explorer, structure, components, userAddress, armyEntityId, mode, staminaSnapshot]);
+  }, [
+    armiesTickTimeRemaining,
+    armyEntityId,
+    components,
+    currentArmiesTick,
+    explorer,
+    mode,
+    staminaSnapshot,
+    structure,
+    userAddress,
+  ]);
 
   const alignmentBadge: AlignmentBadge | undefined = useMemo(() => {
     if (!derivedData) return undefined;

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-15",
+    title: "Live Army Stamina Refresh",
+    description:
+      "Army stamina now stays in sync across world-map labels, selected-army details, and attack screens, so passive regeneration appears over time without waiting for another action to refresh the display.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-14",
     title: "Blitz Settlement Status Fix",
     description:

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-15",
+    title: "Animated Stamina Recharge",
+    description:
+      "Recharging army stamina now shows a soft pulse and sweep across world-map bars, labels, and attack panels, so it is clearer at a glance when stamina is actively refilling over time.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-15",
     title: "Live Army Stamina Refresh",
     description:
       "Army stamina now stays in sync across world-map labels, selected-army details, and attack screens, so passive regeneration appears over time without waiting for another action to refresh the display.",

--- a/client/apps/game/src/ui/shared/lib/stamina-visuals.test.ts
+++ b/client/apps/game/src/ui/shared/lib/stamina-visuals.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { isStaminaRecharging } from "./stamina-visuals";
+
+describe("isStaminaRecharging", () => {
+  it("treats partially filled stamina as recharging", () => {
+    expect(isStaminaRecharging(40, 100)).toBe(true);
+  });
+
+  it("treats full stamina as stable", () => {
+    expect(isStaminaRecharging(100, 100)).toBe(false);
+  });
+
+  it("guards invalid inputs", () => {
+    expect(isStaminaRecharging(Number.NaN, 100)).toBe(false);
+    expect(isStaminaRecharging(20, 0)).toBe(false);
+  });
+});

--- a/client/apps/game/src/ui/shared/lib/stamina-visuals.test.ts
+++ b/client/apps/game/src/ui/shared/lib/stamina-visuals.test.ts
@@ -1,8 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { isStaminaRecharging } from "./stamina-visuals";
+const { getNextTickStaminaMock, getTickMock } = vi.hoisted(() => ({
+  getNextTickStaminaMock: vi.fn((_troops: unknown, nextTick: number) => ({
+    amount: BigInt(nextTick === 6 ? 100 : 80),
+    updated_tick: BigInt(nextTick),
+  })),
+  getTickMock: vi.fn(() => 10),
+}));
 
-describe("isStaminaRecharging", () => {
+vi.mock("@bibliothecadao/eternum", () => ({
+  configManager: {
+    getTick: getTickMock,
+  },
+  StaminaManager: {
+    getStamina: getNextTickStaminaMock,
+  },
+}));
+
+vi.mock("@bibliothecadao/types", () => ({
+  TickIds: {
+    Armies: "armies",
+  },
+}));
+
+import { buildProjectedStaminaDisplayModel, isStaminaRecharging } from "./stamina-visuals";
+
+describe("stamina visuals", () => {
   it("treats partially filled stamina as recharging", () => {
     expect(isStaminaRecharging(40, 100)).toBe(true);
   });
@@ -14,5 +37,54 @@ describe("isStaminaRecharging", () => {
   it("guards invalid inputs", () => {
     expect(isStaminaRecharging(Number.NaN, 100)).toBe(false);
     expect(isStaminaRecharging(20, 0)).toBe(false);
+  });
+
+  it("builds projected fill growth between armies ticks", () => {
+    const display = buildProjectedStaminaDisplayModel({
+      committedCurrent: 80,
+      committedMax: 120,
+      armiesTickTimeRemaining: 5,
+      currentArmiesTick: 5,
+      troops: {
+        category: "Knight",
+        tier: 1,
+        count: 10n,
+        stamina: {
+          amount: 80n,
+          updated_tick: 5n,
+        },
+        boosts: {
+          incr_damage_dealt_percent_num: 0,
+          incr_damage_dealt_end_tick: 0,
+          decr_damage_gotten_percent_num: 0,
+          decr_damage_gotten_end_tick: 0,
+          incr_stamina_regen_percent_num: 0,
+          incr_stamina_regen_tick_count: 0,
+          incr_explore_reward_percent_num: 0,
+          incr_explore_reward_end_tick: 0,
+        },
+        battle_cooldown_end: 0,
+      } as never,
+    });
+
+    expect(display.isRecharging).toBe(true);
+    expect(display.nextTickGain).toBe(20);
+    expect(display.progressToNextTick).toBe(0.5);
+    expect(display.displayCurrent).toBe(90);
+    expect(display.displayRatio).toBe(0.75);
+  });
+
+  it("disables projected growth when stamina is full", () => {
+    const display = buildProjectedStaminaDisplayModel({
+      committedCurrent: 120,
+      committedMax: 120,
+      armiesTickTimeRemaining: 5,
+      currentArmiesTick: 5,
+      troops: null,
+    });
+
+    expect(display.isRecharging).toBe(false);
+    expect(display.nextTickGain).toBe(0);
+    expect(display.displayCurrent).toBe(120);
   });
 });

--- a/client/apps/game/src/ui/shared/lib/stamina-visuals.ts
+++ b/client/apps/game/src/ui/shared/lib/stamina-visuals.ts
@@ -1,3 +1,6 @@
+import { configManager, StaminaManager } from "@bibliothecadao/eternum";
+import { TickIds, Troops } from "@bibliothecadao/types";
+
 export const STAMINA_RECHARGING_FILL_CLASS = "stamina-recharging-fill";
 export const STAMINA_RECHARGING_TRACK_CLASS = "stamina-recharging-track";
 export const STAMINA_RECHARGING_TEXT_CLASS = "stamina-recharging-text";
@@ -12,4 +15,62 @@ export const isStaminaRecharging = (current: number, max: number): boolean => {
   }
 
   return current >= 0 && current < max;
+};
+
+export interface ProjectedStaminaDisplayModel {
+  committedCurrent: number;
+  committedMax: number;
+  isRecharging: boolean;
+  progressToNextTick: number;
+  nextTickGain: number;
+  displayCurrent: number;
+  committedRatio: number;
+  displayRatio: number;
+}
+
+export const buildProjectedStaminaDisplayModel = (input: {
+  committedCurrent: number;
+  committedMax: number;
+  armiesTickTimeRemaining: number;
+  currentArmiesTick: number;
+  troops?: Troops | null;
+}): ProjectedStaminaDisplayModel => {
+  const committedCurrent = Number.isFinite(input.committedCurrent) ? Math.max(0, input.committedCurrent) : 0;
+  const committedMax = Number.isFinite(input.committedMax) ? Math.max(0, input.committedMax) : 0;
+  const committedRatio = committedMax > 0 ? Math.min(1, committedCurrent / committedMax) : 0;
+
+  if (committedMax <= 0 || committedCurrent >= committedMax || !input.troops) {
+    return {
+      committedCurrent,
+      committedMax,
+      isRecharging: isStaminaRecharging(committedCurrent, committedMax),
+      progressToNextTick: 0,
+      nextTickGain: 0,
+      displayCurrent: committedCurrent,
+      committedRatio,
+      displayRatio: committedRatio,
+    };
+  }
+
+  const tickDuration = Number(configManager.getTick(TickIds.Armies));
+  const safeTickDuration = Number.isFinite(tickDuration) && tickDuration > 0 ? tickDuration : 0;
+  const progressToNextTick =
+    safeTickDuration > 0
+      ? Math.min(1, Math.max(0, (safeTickDuration - input.armiesTickTimeRemaining) / safeTickDuration))
+      : 0;
+  const nextTickCurrent = Number(StaminaManager.getStamina(input.troops, input.currentArmiesTick + 1).amount);
+  const nextTickGain = Math.max(0, Math.min(committedMax - committedCurrent, nextTickCurrent - committedCurrent));
+  const displayCurrent = committedCurrent + nextTickGain * progressToNextTick;
+  const displayRatio = committedMax > 0 ? Math.min(1, Math.max(committedRatio, displayCurrent / committedMax)) : 0;
+
+  return {
+    committedCurrent,
+    committedMax,
+    isRecharging: nextTickGain > 0 && committedCurrent < committedMax,
+    progressToNextTick,
+    nextTickGain,
+    displayCurrent,
+    committedRatio,
+    displayRatio,
+  };
 };

--- a/client/apps/game/src/ui/shared/lib/stamina-visuals.ts
+++ b/client/apps/game/src/ui/shared/lib/stamina-visuals.ts
@@ -1,0 +1,15 @@
+export const STAMINA_RECHARGING_FILL_CLASS = "stamina-recharging-fill";
+export const STAMINA_RECHARGING_TRACK_CLASS = "stamina-recharging-track";
+export const STAMINA_RECHARGING_TEXT_CLASS = "stamina-recharging-text";
+
+export const isStaminaRecharging = (current: number, max: number): boolean => {
+  if (!Number.isFinite(current) || !Number.isFinite(max)) {
+    return false;
+  }
+
+  if (max <= 0) {
+    return false;
+  }
+
+  return current >= 0 && current < max;
+};

--- a/client/apps/game/src/utils/explorer-stamina.test.ts
+++ b/client/apps/game/src/utils/explorer-stamina.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { getStaminaMock, getMaxStaminaMock } = vi.hoisted(() => ({
+  getStaminaMock: vi.fn((troops: { stamina: { amount: bigint; updated_tick: bigint } }) => ({
+    amount: troops.stamina.amount,
+    updated_tick: troops.stamina.updated_tick,
+  })),
+  getMaxStaminaMock: vi.fn(() => 120),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  StaminaManager: {
+    getStamina: getStaminaMock,
+    getMaxStamina: getMaxStaminaMock,
+  },
+}));
+
+import {
+  getExplorerStaminaSnapshot,
+  getTroopsStaminaUpdatedTick,
+  selectFreshestTroopsSnapshot,
+} from "./explorer-stamina";
+
+const buildTroops = (updatedTick: bigint, amount: bigint) => ({
+  category: "Knight",
+  tier: 1,
+  count: 10n,
+  stamina: { amount, updated_tick: updatedTick },
+  boosts: {
+    incr_damage_dealt_percent_num: 0,
+    incr_damage_dealt_end_tick: 0,
+    decr_damage_gotten_percent_num: 0,
+    decr_damage_gotten_end_tick: 0,
+    incr_stamina_regen_percent_num: 0,
+    incr_stamina_regen_tick_count: 0,
+    incr_explore_reward_percent_num: 0,
+    incr_explore_reward_end_tick: 0,
+  },
+  battle_cooldown_end: 0,
+});
+
+describe("explorer stamina source selection", () => {
+  it("reads the updated tick from troop stamina snapshots", () => {
+    expect(getTroopsStaminaUpdatedTick(buildTroops(7n, 30n) as never)).toBe(7n);
+    expect(getTroopsStaminaUpdatedTick(null)).toBe(0n);
+  });
+
+  it("prefers the newer snapshot over a stale live troop snapshot", () => {
+    const liveTroops = buildTroops(4n, 10n);
+    const snapshotTroops = buildTroops(6n, 25n);
+
+    expect(
+      selectFreshestTroopsSnapshot({
+        liveTroops: liveTroops as never,
+        snapshotTroops: snapshotTroops as never,
+      }),
+    ).toBe(snapshotTroops);
+  });
+
+  it("prefers live troops when both snapshots are equally fresh", () => {
+    const liveTroops = buildTroops(6n, 10n);
+    const snapshotTroops = buildTroops(6n, 25n);
+
+    expect(
+      selectFreshestTroopsSnapshot({
+        liveTroops: liveTroops as never,
+        snapshotTroops: snapshotTroops as never,
+      }),
+    ).toBe(liveTroops);
+  });
+
+  it("falls back to synthesized troops when no troop snapshot is available", () => {
+    expect(
+      selectFreshestTroopsSnapshot({
+        fallbackArmy: {
+          category: "Knight" as never,
+          tier: 1 as never,
+          troopCount: 10,
+          onChainStamina: {
+            amount: 33n,
+            updatedTick: 9,
+          },
+        },
+      }),
+    ).toMatchObject({
+      count: 10n,
+      stamina: {
+        amount: 33n,
+        updated_tick: 9n,
+      },
+    });
+  });
+
+  it("projects stamina from the freshest selected source", () => {
+    const liveTroops = buildTroops(4n, 10n);
+    const snapshotTroops = buildTroops(6n, 25n);
+
+    const staminaSnapshot = getExplorerStaminaSnapshot({
+      currentArmiesTick: 8,
+      liveTroops: liveTroops as never,
+      snapshotTroops: snapshotTroops as never,
+    });
+
+    expect(staminaSnapshot?.troops).toBe(snapshotTroops);
+    expect(staminaSnapshot?.stamina.amount).toBe(25n);
+  });
+});

--- a/client/apps/game/src/utils/explorer-stamina.test.ts
+++ b/client/apps/game/src/utils/explorer-stamina.test.ts
@@ -57,7 +57,7 @@ describe("explorer stamina source selection", () => {
     ).toBe(snapshotTroops);
   });
 
-  it("prefers live troops when both snapshots are equally fresh", () => {
+  it("prefers the authoritative snapshot when both snapshots are equally fresh", () => {
     const liveTroops = buildTroops(6n, 10n);
     const snapshotTroops = buildTroops(6n, 25n);
 
@@ -66,7 +66,19 @@ describe("explorer stamina source selection", () => {
         liveTroops: liveTroops as never,
         snapshotTroops: snapshotTroops as never,
       }),
-    ).toBe(liveTroops);
+    ).toBe(snapshotTroops);
+  });
+
+  it("prefers the authoritative snapshot when stamina amount differs at the same tick", () => {
+    const liveTroops = buildTroops(6n, 80n);
+    const snapshotTroops = buildTroops(6n, 50n);
+
+    expect(
+      selectFreshestTroopsSnapshot({
+        liveTroops: liveTroops as never,
+        snapshotTroops: snapshotTroops as never,
+      }),
+    ).toBe(snapshotTroops);
   });
 
   it("falls back to synthesized troops when no troop snapshot is available", () => {
@@ -87,6 +99,27 @@ describe("explorer stamina source selection", () => {
       stamina: {
         amount: 33n,
         updated_tick: 9n,
+      },
+    });
+  });
+
+  it("prefers a pending local stamina overlay over same-tick remote snapshots", () => {
+    const liveTroops = buildTroops(6n, 80n);
+    const snapshotTroops = buildTroops(6n, 50n);
+
+    expect(
+      selectFreshestTroopsSnapshot({
+        liveTroops: liveTroops as never,
+        snapshotTroops: snapshotTroops as never,
+        pendingStamina: {
+          amount: 20n,
+          updatedTick: 6,
+        },
+      }),
+    ).toMatchObject({
+      stamina: {
+        amount: 20n,
+        updated_tick: 6n,
       },
     });
   });

--- a/client/apps/game/src/utils/explorer-stamina.ts
+++ b/client/apps/game/src/utils/explorer-stamina.ts
@@ -15,49 +15,58 @@ interface ExplorerStaminaSnapshotInput {
   fallbackArmy?: ExplorerArmyFallback | null;
 }
 
-const resolveExplorerTroopsForStamina = (input: {
+const buildFallbackTroopsSnapshot = (fallbackArmy: ExplorerArmyFallback): Troops => ({
+  category: fallbackArmy.category,
+  tier: fallbackArmy.tier,
+  count: BigInt(fallbackArmy.troopCount),
+  stamina: {
+    amount: fallbackArmy.onChainStamina.amount,
+    updated_tick: BigInt(fallbackArmy.onChainStamina.updatedTick),
+  },
+  boosts: {
+    incr_damage_dealt_percent_num: 0,
+    incr_damage_dealt_end_tick: 0,
+    decr_damage_gotten_percent_num: 0,
+    decr_damage_gotten_end_tick: 0,
+    incr_stamina_regen_percent_num: 0,
+    incr_stamina_regen_tick_count: 0,
+    incr_explore_reward_percent_num: 0,
+    incr_explore_reward_end_tick: 0,
+  },
+  battle_cooldown_end: 0,
+});
+
+export const getTroopsStaminaUpdatedTick = (troops: Troops | null | undefined): bigint => {
+  const updatedTick = troops?.stamina?.updated_tick;
+  return typeof updatedTick === "bigint" ? updatedTick : 0n;
+};
+
+export const selectFreshestTroopsSnapshot = (input: {
   snapshotTroops?: Troops | null;
   liveTroops?: Troops | null;
   fallbackArmy?: ExplorerArmyFallback | null;
 }): Troops | null => {
-  if (input.liveTroops) {
-    return input.liveTroops;
-  }
+  const fallbackTroops = input.fallbackArmy ? buildFallbackTroopsSnapshot(input.fallbackArmy) : null;
+  const candidates = [input.liveTroops ?? null, input.snapshotTroops ?? null, fallbackTroops];
+  const availableCandidates = candidates.filter((candidate): candidate is Troops => candidate !== null);
 
-  if (input.snapshotTroops) {
-    return input.snapshotTroops;
-  }
-
-  if (!input.fallbackArmy) {
+  if (availableCandidates.length === 0) {
     return null;
   }
 
-  return {
-    category: input.fallbackArmy.category,
-    tier: input.fallbackArmy.tier,
-    count: BigInt(input.fallbackArmy.troopCount),
-    stamina: {
-      amount: input.fallbackArmy.onChainStamina.amount,
-      updated_tick: BigInt(input.fallbackArmy.onChainStamina.updatedTick),
-    },
-    boosts: {
-      incr_damage_dealt_percent_num: 0,
-      incr_damage_dealt_end_tick: 0,
-      decr_damage_gotten_percent_num: 0,
-      decr_damage_gotten_end_tick: 0,
-      incr_stamina_regen_percent_num: 0,
-      incr_stamina_regen_tick_count: 0,
-      incr_explore_reward_percent_num: 0,
-      incr_explore_reward_end_tick: 0,
-    },
-    battle_cooldown_end: 0,
-  };
+  return availableCandidates.reduce((freshest, candidate) => {
+    if (getTroopsStaminaUpdatedTick(candidate) > getTroopsStaminaUpdatedTick(freshest)) {
+      return candidate;
+    }
+
+    return freshest;
+  });
 };
 
 export const getExplorerStaminaSnapshot = (
   input: ExplorerStaminaSnapshotInput,
 ): { current: number; max: number; stamina: { amount: bigint; updated_tick: bigint }; troops: Troops } | null => {
-  const troops = resolveExplorerTroopsForStamina(input);
+  const troops = selectFreshestTroopsSnapshot(input);
   if (!troops) {
     return null;
   }

--- a/client/apps/game/src/utils/explorer-stamina.ts
+++ b/client/apps/game/src/utils/explorer-stamina.ts
@@ -1,6 +1,11 @@
 import { StaminaManager } from "@bibliothecadao/eternum";
 import { Troops, TroopTier, TroopType } from "@bibliothecadao/types";
 
+interface PendingStaminaCandidate {
+  amount: bigint;
+  updatedTick: number;
+}
+
 interface ExplorerArmyFallback {
   category: TroopType;
   tier: TroopTier;
@@ -13,6 +18,7 @@ interface ExplorerStaminaSnapshotInput {
   snapshotTroops?: Troops | null;
   liveTroops?: Troops | null;
   fallbackArmy?: ExplorerArmyFallback | null;
+  pendingStamina?: PendingStaminaCandidate | null;
 }
 
 const buildFallbackTroopsSnapshot = (fallbackArmy: ExplorerArmyFallback): Troops => ({
@@ -41,26 +47,82 @@ export const getTroopsStaminaUpdatedTick = (troops: Troops | null | undefined): 
   return typeof updatedTick === "bigint" ? updatedTick : 0n;
 };
 
+const buildPendingTroopsSnapshot = (input: {
+  snapshotTroops?: Troops | null;
+  liveTroops?: Troops | null;
+  fallbackTroops?: Troops | null;
+  pendingStamina?: PendingStaminaCandidate | null;
+}): Troops | null => {
+  if (!input.pendingStamina) {
+    return null;
+  }
+
+  const baseTroops = input.snapshotTroops ?? input.liveTroops ?? input.fallbackTroops;
+  if (!baseTroops) {
+    return null;
+  }
+
+  const pendingTick = BigInt(input.pendingStamina.updatedTick);
+  const pendingAmount = input.pendingStamina.amount;
+  const authoritativeTick = getTroopsStaminaUpdatedTick(baseTroops);
+  const authoritativeAmount = baseTroops.stamina?.amount ?? 0n;
+
+  if (authoritativeTick > pendingTick) {
+    return null;
+  }
+
+  if (authoritativeTick === pendingTick && authoritativeAmount === pendingAmount) {
+    return null;
+  }
+
+  return {
+    ...baseTroops,
+    stamina: {
+      ...(baseTroops.stamina ?? { amount: 0n, updated_tick: 0n }),
+      amount: pendingAmount,
+      updated_tick: pendingTick,
+    },
+  };
+};
+
 export const selectFreshestTroopsSnapshot = (input: {
   snapshotTroops?: Troops | null;
   liveTroops?: Troops | null;
   fallbackArmy?: ExplorerArmyFallback | null;
+  pendingStamina?: PendingStaminaCandidate | null;
 }): Troops | null => {
   const fallbackTroops = input.fallbackArmy ? buildFallbackTroopsSnapshot(input.fallbackArmy) : null;
-  const candidates = [input.liveTroops ?? null, input.snapshotTroops ?? null, fallbackTroops];
-  const availableCandidates = candidates.filter((candidate): candidate is Troops => candidate !== null);
+  const pendingTroops = buildPendingTroopsSnapshot({
+    snapshotTroops: input.snapshotTroops,
+    liveTroops: input.liveTroops,
+    fallbackTroops,
+    pendingStamina: input.pendingStamina,
+  });
+  const candidates = [
+    { troops: pendingTroops, priority: 0 },
+    { troops: input.snapshotTroops ?? null, priority: 1 },
+    { troops: input.liveTroops ?? null, priority: 2 },
+    { troops: fallbackTroops, priority: 3 },
+  ].filter((candidate): candidate is { troops: Troops; priority: number } => candidate.troops !== null);
 
-  if (availableCandidates.length === 0) {
+  if (candidates.length === 0) {
     return null;
   }
 
-  return availableCandidates.reduce((freshest, candidate) => {
-    if (getTroopsStaminaUpdatedTick(candidate) > getTroopsStaminaUpdatedTick(freshest)) {
+  return candidates.reduce((freshest, candidate) => {
+    const freshestTick = getTroopsStaminaUpdatedTick(freshest.troops);
+    const candidateTick = getTroopsStaminaUpdatedTick(candidate.troops);
+
+    if (candidateTick > freshestTick) {
+      return candidate;
+    }
+
+    if (candidateTick === freshestTick && candidate.priority < freshest.priority) {
       return candidate;
     }
 
     return freshest;
-  });
+  }).troops;
 };
 
 export const getExplorerStaminaSnapshot = (

--- a/packages/core/src/systems/army-stamina-source.ts
+++ b/packages/core/src/systems/army-stamina-source.ts
@@ -26,7 +26,7 @@ export const resolveFreshestArmyStaminaSource = (input: {
     return "live";
   }
 
-  return getArmyStaminaUpdatedTick(input.liveSnapshot) >= getArmyStaminaUpdatedTick(input.enhancedSnapshot)
+  return getArmyStaminaUpdatedTick(input.liveSnapshot) > getArmyStaminaUpdatedTick(input.enhancedSnapshot)
     ? "live"
     : "enhanced";
 };

--- a/packages/core/src/systems/army-stamina-source.ts
+++ b/packages/core/src/systems/army-stamina-source.ts
@@ -1,0 +1,32 @@
+interface ArmyStaminaSnapshot {
+  onChainStamina?: {
+    amount: bigint;
+    updatedTick: number;
+  };
+}
+
+const getArmyStaminaUpdatedTick = (snapshot: ArmyStaminaSnapshot | null | undefined): number => {
+  const updatedTick = snapshot?.onChainStamina?.updatedTick;
+  return Number.isFinite(updatedTick) ? Number(updatedTick) : 0;
+};
+
+export const resolveFreshestArmyStaminaSource = (input: {
+  liveSnapshot?: ArmyStaminaSnapshot | undefined;
+  enhancedSnapshot?: ArmyStaminaSnapshot | undefined;
+}): "live" | "enhanced" | undefined => {
+  if (!input.liveSnapshot && !input.enhancedSnapshot) {
+    return undefined;
+  }
+
+  if (!input.liveSnapshot) {
+    return "enhanced";
+  }
+
+  if (!input.enhancedSnapshot) {
+    return "live";
+  }
+
+  return getArmyStaminaUpdatedTick(input.liveSnapshot) >= getArmyStaminaUpdatedTick(input.enhancedSnapshot)
+    ? "live"
+    : "enhanced";
+};

--- a/packages/core/src/systems/world-update-listener.test.ts
+++ b/packages/core/src/systems/world-update-listener.test.ts
@@ -366,6 +366,83 @@ describe("WorldUpdateListener army tile bootstrap", () => {
     );
   });
 
+  it("uses enhanced stamina when updated ticks tie but amounts differ", async () => {
+    isComponentUpdateMock.mockReturnValue(true);
+    tileOptToTileMock.mockReturnValue({
+      occupier_type: 1,
+      occupier_id: 779,
+      col: 12,
+      row: 34,
+    });
+    getExplorerInfoFromTileOccupierMock.mockReturnValue({
+      troopType: "Knight",
+      troopTier: "T1",
+      isDaydreamsAgent: false,
+    });
+    getComponentValueMock.mockReturnValue({
+      owner: 99,
+      troops: {
+        count: 500n,
+        category: "Knight",
+        tier: "T1",
+        stamina: {
+          amount: 80n,
+          updated_tick: 7n,
+        },
+        boosts: {
+          incr_damage_dealt_percent_num: 0,
+          incr_damage_dealt_end_tick: 0,
+          decr_damage_gotten_percent_num: 0,
+          decr_damage_gotten_end_tick: 0,
+          incr_stamina_regen_percent_num: 0,
+          incr_stamina_regen_tick_count: 0,
+          incr_explore_reward_percent_num: 0,
+          incr_explore_reward_end_tick: 0,
+        },
+        battle_cooldown_end: 0,
+      },
+    });
+    enhanceArmyDataMock.mockResolvedValue({
+      troopCount: 500,
+      currentStamina: 45,
+      onChainStamina: {
+        amount: 45n,
+        updatedTick: 7,
+      },
+      owner: { address: 123n, ownerName: "Alice", guildName: "" },
+      ownerStructureId: 99,
+      battleData: undefined,
+    });
+
+    const listener = new WorldUpdateListener(
+      {
+        network: { world: {} },
+        components: {
+          TileOpt: {},
+          ExplorerTroops: {},
+        },
+      } as any,
+      {} as any,
+    );
+
+    const callback = vi.fn();
+    listener.Army.onTileUpdate(callback);
+
+    const handleUpdate = defineComponentSystemMock.mock.calls[0][2];
+    await handleUpdate({ value: [{ value: "tile" }, undefined] });
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId: 779,
+        currentStamina: 45,
+        onChainStamina: {
+          amount: 45n,
+          updatedTick: 7,
+        },
+      }),
+    );
+  });
+
   it("falls back to type-based structure name when Structure component is unavailable", async () => {
     isComponentUpdateMock.mockReturnValue(true);
     tileOptToTileMock.mockReturnValue({

--- a/packages/core/src/systems/world-update-listener.test.ts
+++ b/packages/core/src/systems/world-update-listener.test.ts
@@ -288,6 +288,84 @@ describe("WorldUpdateListener army tile bootstrap", () => {
     );
   });
 
+  it("uses enhanced stamina when it is fresher than the live explorer troop snapshot", async () => {
+    isComponentUpdateMock.mockReturnValue(true);
+    tileOptToTileMock.mockReturnValue({
+      occupier_type: 1,
+      occupier_id: 778,
+      col: 12,
+      row: 34,
+    });
+    getExplorerInfoFromTileOccupierMock.mockReturnValue({
+      troopType: "Knight",
+      troopTier: "T1",
+      isDaydreamsAgent: false,
+    });
+    getComponentValueMock.mockReturnValue({
+      owner: 99,
+      troops: {
+        count: 500n,
+        category: "Knight",
+        tier: "T1",
+        stamina: {
+          amount: 15n,
+          updated_tick: 3n,
+        },
+        boosts: {
+          incr_damage_dealt_percent_num: 0,
+          incr_damage_dealt_end_tick: 0,
+          decr_damage_gotten_percent_num: 0,
+          decr_damage_gotten_end_tick: 0,
+          incr_stamina_regen_percent_num: 0,
+          incr_stamina_regen_tick_count: 0,
+          incr_explore_reward_percent_num: 0,
+          incr_explore_reward_end_tick: 0,
+        },
+        battle_cooldown_end: 0,
+      },
+    });
+    enhanceArmyDataMock.mockResolvedValue({
+      troopCount: 500,
+      currentStamina: 45,
+      onChainStamina: {
+        amount: 45n,
+        updatedTick: 7,
+      },
+      owner: { address: 123n, ownerName: "Alice", guildName: "" },
+      ownerStructureId: 99,
+      battleData: undefined,
+    });
+
+    const listener = new WorldUpdateListener(
+      {
+        network: { world: {} },
+        components: {
+          TileOpt: {},
+          ExplorerTroops: {},
+        },
+      } as any,
+      {} as any,
+    );
+
+    const callback = vi.fn();
+    listener.Army.onTileUpdate(callback);
+
+    const handleUpdate = defineComponentSystemMock.mock.calls[0][2];
+    await handleUpdate({ value: [{ value: "tile" }, undefined] });
+
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityId: 778,
+        troopCount: 500,
+        currentStamina: 45,
+        onChainStamina: {
+          amount: 45n,
+          updatedTick: 7,
+        },
+      }),
+    );
+  });
+
   it("falls back to type-based structure name when Structure component is unavailable", async () => {
     isComponentUpdateMock.mockReturnValue(true);
     tileOptToTileMock.mockReturnValue({

--- a/packages/core/src/systems/world-update-listener.ts
+++ b/packages/core/src/systems/world-update-listener.ts
@@ -34,6 +34,7 @@ import { getStructureName } from "../utils/entities";
 import { getBlockTimestamp } from "../utils/timestamp";
 import { DataEnhancer } from "./data-enhancer";
 import { recordArmyMovementLatencyPhase } from "./army-movement-latency-trace";
+import { resolveFreshestArmyStaminaSource } from "./army-stamina-source";
 import {
   type BattleEventSystemUpdate,
   type BuildingSystemUpdate,
@@ -109,7 +110,20 @@ export class WorldUpdateListener {
     // console.trace(`🔍 [WorldUpdateListener] Missing entityId stack trace (${context})`);
   }
 
-  private resolveLiveArmySnapshot(entityId: ID, currentArmiesTick: number) {
+  private resolveLiveArmySnapshot(
+    entityId: ID,
+    currentArmiesTick: number,
+  ):
+    | {
+        troopCount: number;
+        currentStamina: number;
+        onChainStamina?: {
+          amount: bigint;
+          updatedTick: number;
+        };
+        ownerStructureId?: ID;
+      }
+    | undefined {
     try {
       const explorerTroops = getComponentValue(
         this.setup.components.ExplorerTroops,
@@ -369,6 +383,12 @@ export class WorldUpdateListener {
                   normalizedStructureOwnerId,
                 );
                 const liveArmySnapshot = this.resolveLiveArmySnapshot(rawOccupierId, currentArmiesTick);
+                const freshestArmyStaminaSource = resolveFreshestArmyStaminaSource({
+                  liveSnapshot: liveArmySnapshot,
+                  enhancedSnapshot: enhancedData,
+                });
+                const freshestArmyStaminaSnapshot =
+                  freshestArmyStaminaSource === "live" ? liveArmySnapshot : enhancedData;
 
                 const maxStamina = StaminaManager.getMaxStamina(explorer.troopType, explorer.troopTier);
 
@@ -389,8 +409,8 @@ export class WorldUpdateListener {
                     null,
                   // Enhanced data from DataEnhancer
                   troopCount: liveArmySnapshot?.troopCount ?? enhancedData.troopCount,
-                  currentStamina: liveArmySnapshot?.currentStamina ?? enhancedData.currentStamina,
-                  onChainStamina: liveArmySnapshot?.onChainStamina ?? enhancedData.onChainStamina,
+                  currentStamina: freshestArmyStaminaSnapshot?.currentStamina ?? enhancedData.currentStamina,
+                  onChainStamina: freshestArmyStaminaSnapshot?.onChainStamina ?? enhancedData.onChainStamina,
                   battleData: enhancedData.battleData,
                   maxStamina,
                 };


### PR DESCRIPTION
## Summary
This updates web stamina displays to choose the freshest snapshot by `updated_tick` instead of always trusting live RECS troops. It fixes stale passive regen in three-scene army labels, the selected-army panel, and battle surfaces including raid, combat, and quick attack preview.

## Testing
- `pnpm --dir client/apps/game test -- src/utils/explorer-stamina.test.ts src/ui/features/world/components/entities/hooks/use-army-entity-detail.stamina-sync.test.tsx src/three/managers/army-manager.stamina-sync.test.ts src/ui/features/military/battle/raid-container.test.tsx src/ui/features/military/battle/quick-attack-preview.test.tsx src/ui/features/military/battle/hooks/use-attack-target.test.tsx`
- `pnpm --dir packages/core exec vitest run src/systems/world-update-listener.test.ts`
- `pnpm run format`
- `pnpm run knip`
