### PR TITLE
fix: army position collapse when moving multiple units

### DIFF
--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -1392,6 +1392,7 @@ export class ArmyModel {
         elapsedTime: 0,
         arrivalSlamTimer: 0,
         isArrivalSlamming: false,
+        endpointCache: new Vector3(),
       });
     }
   }
@@ -1568,7 +1569,6 @@ export class ArmyModel {
   // Pre-allocated vectors for spline sampling (avoid GC pressure)
   private readonly splinePositionTarget: Vector3 = new Vector3();
   private readonly splineTangentTarget: Vector3 = new Vector3();
-  private readonly splineEndpointCache: Vector3 = new Vector3();
 
   private updateSplineMovement(
     splineData: SplineMovementData,
@@ -1656,8 +1656,8 @@ export class ArmyModel {
           .clone()
           .normalize();
         // Cache endpoint once for the entire settlement phase
-        resolveSplinePosition(splineData.spline, 1, EasingType.Linear, this.splineEndpointCache);
-        instanceData.position.copy(this.splineEndpointCache);
+        resolveSplinePosition(splineData.spline, 1, EasingType.Linear, splineData.endpointCache);
+        instanceData.position.copy(splineData.endpointCache);
       }
     }
 
@@ -1683,13 +1683,13 @@ export class ArmyModel {
           ArmyModel.OVERSHOOT_DISTANCE,
         );
         // Use cached endpoint — no recomputation
-        instanceData.position.copy(this.splineEndpointCache);
+        instanceData.position.copy(splineData.endpointCache);
         instanceData.position.x += splineData.finalTangent.x * offset;
         instanceData.position.z += splineData.finalTangent.z * offset;
       }
 
       if (splineData.settlementTimer >= ArmyModel.SETTLEMENT_DURATION) {
-        instanceData.position.copy(this.splineEndpointCache);
+        instanceData.position.copy(splineData.endpointCache);
         instanceData.scale.copy(this.normalScale);
         this.splineMovingInstances.delete(entityId);
         this.stopMovement(entityId);

--- a/client/apps/game/src/three/types/army.ts
+++ b/client/apps/game/src/three/types/army.ts
@@ -39,6 +39,7 @@ export interface SplineMovementData {
   isAnticipating: boolean;
   isSettling: boolean;
   finalTangent: Vector3 | null;
+  endpointCache: Vector3;
   // Terrain speed
   currentSpeedMultiplier: number;
   // Rhythmic bob + arrival slam


### PR DESCRIPTION
## Summary
- Fixed a bug where moving 2+ armies simultaneously caused them to visually collapse onto the same hex
- Root cause: `ArmyModel` had a single shared `splineEndpointCache` Vector3 used by all armies during the settlement animation phase — when two armies settled in nearby frames, one would overwrite the other's cached endpoint
- Fix moves the endpoint cache from a shared class field to a per-entity field on `SplineMovementData`, so each army tracks its own destination independently

## Test plan
- [ ] Move 2 armies simultaneously and verify they arrive at their correct separate destinations
- [ ] Verify single army movement still animates correctly (settlement overshoot + slam)
- [ ] Confirm no visual glitches when many armies move at once