### PR TITLE
fix: preserve chest material blending for webgpu

### DIFF
--- a/client/apps/game/src/three/managers/instanced-model.material-semantics.test.ts
+++ b/client/apps/game/src/three/managers/instanced-model.material-semantics.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial, PlaneGeometry, SphereGeometry } from "three";
+
+vi.mock("../utils/contact-shadow", () => ({
+  disposeContactShadowResources: vi.fn(),
+  getContactShadowResources: () => ({
+    geometry: new PlaneGeometry(1, 1),
+    material: new MeshBasicMaterial({ color: 0x000000 }),
+  }),
+}));
+
+function createInstancedModelTestGltf(material: MeshStandardMaterial) {
+  const scene = new Group();
+  const mesh = new Mesh(new SphereGeometry(1, 8, 8), material);
+  mesh.name = "chest";
+  scene.add(mesh);
+
+  return {
+    scene,
+    animations: [],
+  };
+}
+
+describe("InstancedModel material semantics", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    });
+    vi.stubGlobal("navigator", {
+      getBattery: vi.fn(async () => ({ charging: false })),
+      userAgent: "vitest",
+    });
+  });
+
+  it("preserves blended chest materials instead of forcing alpha-cutout depth writes", async () => {
+    const { default: InstancedModel } = await import("./instanced-model");
+    const transparentChestMaterial = new MeshStandardMaterial({
+      transparent: true,
+      depthWrite: false,
+      opacity: 0.7,
+      emissiveIntensity: 4,
+    });
+
+    const model = new InstancedModel(createInstancedModelTestGltf(transparentChestMaterial), 1, false, "Chest");
+    const chestMesh = model.instancedMeshes[0];
+    const resolvedMaterial = chestMesh.material as MeshStandardMaterial;
+
+    expect(resolvedMaterial.transparent).toBe(true);
+    expect(resolvedMaterial.depthWrite).toBe(false);
+    expect(resolvedMaterial.alphaTest).toBe(0);
+    expect(resolvedMaterial.emissiveIntensity).toBe(1.5);
+  });
+});

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -38,6 +38,26 @@ const rotationMatrix = new Matrix4();
 const zeroMatrix = new Matrix4().makeScale(0, 0, 0);
 const DEFAULT_INITIAL_CAPACITY = 32;
 
+function shouldApplyStructureAlphaCutoutFallback(material: MeshStandardMaterial): boolean {
+  return !material.depthWrite && !material.transparent;
+}
+
+function applyStructureMaterialOverrides(material: MeshStandardMaterial, modelName: string): void {
+  if (modelName.includes("Quest") || modelName.includes("Chest")) {
+    if (shouldApplyStructureAlphaCutoutFallback(material)) {
+      material.depthWrite = true;
+      material.alphaTest = 0.075;
+    }
+    if (material.emissiveIntensity > 1) {
+      material.emissiveIntensity = 1.5;
+    }
+  }
+
+  if (modelName.includes("FragmentMine") && material.emissiveIntensity > 1) {
+    material.emissiveIntensity = 15;
+  }
+}
+
 interface AnimatedInstancedMesh extends InstancedMesh {
   animated: boolean;
 }
@@ -100,22 +120,8 @@ export default class InstancedModel {
         if (child.scale.x !== 1) {
           return;
         }
-        let material = child.material;
-        if (name.includes("Quest") || name.includes("Chest")) {
-          if (!material.depthWrite) {
-            material.depthWrite = true;
-            material.alphaTest = 0.075;
-          }
-          if (material.emissiveIntensity > 1) {
-            material.emissiveIntensity = 1.5;
-          }
-        }
-        //name.includes("FragmentMine")
-        if (name.includes("FragmentMine")) {
-          if (material.emissiveIntensity > 1) {
-            material.emissiveIntensity = 15;
-          }
-        }
+        let material = child.material as MeshStandardMaterial;
+        applyStructureMaterialOverrides(material, name);
         if (name === StructureType[StructureType.FragmentMine] && child.material.name.includes("crystal")) {
           material = new MeshStandardMaterial(MinesMaterialsParams[ResourcesIds.AncientFragment]);
         }

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -62,6 +62,12 @@ interface AnimatedInstancedMesh extends InstancedMesh {
   animated: boolean;
 }
 
+function createAnimatedInstancedMesh(geometry: Mesh["geometry"], material: MeshStandardMaterial, capacity: number) {
+  return Object.assign(new InstancedMesh(geometry, material, capacity), {
+    animated: false,
+  }) as AnimatedInstancedMesh;
+}
+
 // Number of time offset buckets for batched animation updates
 const ANIMATION_BUCKETS = 16;
 
@@ -125,7 +131,7 @@ export default class InstancedModel {
         if (name === StructureType[StructureType.FragmentMine] && child.material.name.includes("crystal")) {
           material = new MeshStandardMaterial(MinesMaterialsParams[ResourcesIds.AncientFragment]);
         }
-        const tmp = new InstancedMesh(child.geometry, material, this.capacity) as AnimatedInstancedMesh;
+        const tmp = createAnimatedInstancedMesh(child.geometry, material, this.capacity);
         tmp.renderOrder = 10;
         const biomeMesh = child;
         if (gltf.animations.length > 0) {


### PR DESCRIPTION
## Summary
Preserve blended chest and quest materials in InstancedModel by only applying the alpha-cutout fallback to non-transparent materials, which avoids the WebGPU chest pipeline failure path. Add a regression test that locks the transparent chest material semantics in place.

## Verification
Passed:
- `pnpm --dir client/apps/game test -- src/three/managers/instanced-model.material-semantics.test.ts src/three/managers/instanced-model.bounds-authority.test.ts`
- `pnpm run format`
- `pnpm run knip`

Known workspace blocker: `pnpm --dir client/apps/game build` currently fails on unrelated existing package/type issues, including missing `@bibliothecadao/react` resolution and multiple pre-existing `@bibliothecadao/eternum` export mismatches.