### PR TITLE
fix: queue armies arriving before chunk commit on first load

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.pre-commit-queue.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.pre-commit-queue.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readSource(relativePath: string): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, relativePath), "utf8");
+}
+
+describe("ArmyManager pre-commit army queue", () => {
+  it("declares a preCommitArmyQueue as a Set<ID>", () => {
+    const source = readSource("./army-manager.ts");
+
+    const setDeclaration =
+      source.includes("preCommitArmyQueue: Set<") || source.includes("preCommitArmyQueue = new Set");
+
+    expect(setDeclaration).toBe(true);
+  });
+
+  it("renderArmyIntoCurrentChunkIfVisible queues to preCommitArmyQueue when chunk is uncommitted", () => {
+    const source = readSource("./army-manager.ts");
+
+    const methodStart = source.indexOf("renderArmyIntoCurrentChunkIfVisible(entityId: ID)");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const bodyAfterMethod = source.substring(methodStart);
+
+    // Find the uncommitted chunk guard
+    const uncommittedGuardIdx = bodyAfterMethod.indexOf("if (!isCommittedManagerChunk");
+    expect(uncommittedGuardIdx).toBeGreaterThan(-1);
+
+    // The guard body should add to preCommitArmyQueue instead of just returning false
+    const guardBody = bodyAfterMethod.substring(uncommittedGuardIdx, uncommittedGuardIdx + 200);
+    expect(guardBody).toContain("this.preCommitArmyQueue.add(entityId)");
+  });
+
+  it("drainPreCommitArmyQueue method exists and drains the queue", () => {
+    const source = readSource("./army-manager.ts");
+
+    const methodStart = source.indexOf("drainPreCommitArmyQueue(): void");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    // Extract just this method body (up to the next private/public method)
+    const bodyAfterMethod = source.substring(methodStart, methodStart + 500);
+
+    // Should copy, clear, then iterate — same pattern as drainDeferredArmyQueue
+    const spreadIdx = bodyAfterMethod.indexOf("[...this.preCommitArmyQueue]");
+    const clearIdx = bodyAfterMethod.indexOf("this.preCommitArmyQueue.clear()");
+    const forOfIdx = bodyAfterMethod.indexOf("for (const entityId of");
+
+    expect(spreadIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(forOfIdx).toBeGreaterThan(-1);
+
+    // Order: copy → clear → iterate
+    expect(spreadIdx).toBeLessThan(clearIdx);
+    expect(clearIdx).toBeLessThan(forOfIdx);
+  });
+
+  it("executeRenderForChunk drains preCommitArmyQueue in its finally block", () => {
+    const source = readSource("./army-manager.ts");
+
+    // Find the executeRenderForChunk method definition (private async)
+    const methodStart = source.indexOf("private async executeRenderForChunk(");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const methodBody = source.substring(methodStart);
+    const finallyIdx = methodBody.indexOf("} finally {");
+    expect(finallyIdx).toBeGreaterThan(-1);
+
+    const finallyBlock = methodBody.substring(finallyIdx, finallyIdx + 500);
+
+    expect(finallyBlock).toContain("this.drainPreCommitArmyQueue()");
+  });
+
+  it("drainPreCommitArmyQueue is called after drainDeferredArmyQueue in executeRenderForChunk finally block", () => {
+    const source = readSource("./army-manager.ts");
+
+    const methodStart = source.indexOf("private async executeRenderForChunk(");
+    expect(methodStart).toBeGreaterThan(-1);
+
+    const methodBody = source.substring(methodStart);
+    const finallyIdx = methodBody.indexOf("} finally {");
+    expect(finallyIdx).toBeGreaterThan(-1);
+
+    const finallyBlock = methodBody.substring(finallyIdx, finallyIdx + 500);
+
+    const deferredDrainIdx = finallyBlock.indexOf("this.drainDeferredArmyQueue()");
+    const preCommitDrainIdx = finallyBlock.indexOf("this.drainPreCommitArmyQueue()");
+
+    expect(deferredDrainIdx).toBeGreaterThan(-1);
+    expect(preCommitDrainIdx).toBeGreaterThan(-1);
+
+    // preCommitArmyQueue drain must come after deferredArmyQueue drain
+    expect(preCommitDrainIdx).toBeGreaterThan(deferredDrainIdx);
+  });
+
+  it("preCommitArmyQueue is cleared during destroy", () => {
+    const source = readSource("./army-manager.ts");
+
+    // Find destroy method
+    const destroyIdx = source.indexOf("destroy()");
+    expect(destroyIdx).toBeGreaterThan(-1);
+
+    const bodyAfterDestroy = source.substring(destroyIdx);
+
+    expect(bodyAfterDestroy).toContain("this.preCommitArmyQueue.clear()");
+  });
+});

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -209,6 +209,8 @@ export class ArmyManager {
   private isDestroyed = false;
   private isArmyChunkTransitioning = false;
   private deferredArmyQueue: Set<ID> = new Set();
+  // Armies that arrived before any chunk was committed — drained on first executeRenderForChunk
+  private preCommitArmyQueue: Set<ID> = new Set();
   // Track source buckets for moving armies to keep them visible during animation
   private movingArmySourceBuckets: Map<ID, MovingArmySourceState> = new Map();
   // Armies that have been visually hidden but not yet fully removed — all rendering
@@ -1280,6 +1282,7 @@ export class ArmyManager {
     } finally {
       this.isArmyChunkTransitioning = false;
       this.drainDeferredArmyQueue();
+      this.drainPreCommitArmyQueue();
       recordWorldmapRenderDuration("executeRenderForChunk", performance.now() - renderStartedAt);
       setWorldmapRenderGauge("visibleArmies", this.visibleArmyOrder.length);
       setWorldmapRenderGauge("activePaths", this.getActivePathCount());
@@ -1543,6 +1546,17 @@ export class ArmyManager {
     }
   }
 
+  private drainPreCommitArmyQueue(): void {
+    if (this.preCommitArmyQueue.size === 0) return;
+    const queued = [...this.preCommitArmyQueue];
+    this.preCommitArmyQueue.clear();
+    for (const entityId of queued) {
+      if (!this.suppressedArmies.has(entityId)) {
+        void this.renderArmyIntoCurrentChunkIfVisible(entityId);
+      }
+    }
+  }
+
   private async renderArmyIntoCurrentChunkIfVisible(entityId: ID): Promise<boolean> {
     if (this.isArmyChunkTransitioning) {
       this.deferredArmyQueue.add(entityId);
@@ -1550,6 +1564,7 @@ export class ArmyManager {
     }
 
     if (!isCommittedManagerChunk(this.currentChunkKey)) {
+      this.preCommitArmyQueue.add(entityId);
       return false;
     }
 
@@ -3027,6 +3042,7 @@ ${
     this.armyPaths.clear();
     this.movingArmySourceBuckets.clear();
     this.suppressedArmies.clear();
+    this.preCommitArmyQueue.clear();
     this.chunkToArmies.clear();
     this.movementStartListeners.clear();
     this.movementCompleteListeners.clear();


### PR DESCRIPTION
## Summary
- Armies arriving via Torii stream before the first chunk was committed were silently dropped in `renderArmyIntoCurrentChunkIfVisible`, causing invisible units on initial map load
- Added a `preCommitArmyQueue` that captures these early-arriving armies and drains them once the first `executeRenderForChunk` completes
- Includes source-inspection tests verifying the queue declaration, drain ordering, and cleanup in destroy

## Test plan
- [x] All 73 existing army-manager tests pass
- [x] 6 new pre-commit-queue tests pass
- [ ] Manual: load into game, navigate to army units — they should be visible immediately without needing to zoom out/pan to force a chunk refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)