### PR TITLE
fix: surface worldmap chunk loading failures

### DIFF
--- a/client/apps/game/src/dojo/torii-stream-manager.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.ts
@@ -172,7 +172,9 @@ export class ToriiStreamManager {
 
     this.switchQueue = task.then(
       () => undefined,
-      () => undefined,
+      (error) => {
+        console.warn("[ToriiStreamManager] Bounds switch failed in queue", error);
+      },
     );
     this.pendingSwitch = task;
 

--- a/client/apps/game/src/three/scenes/warp-travel-chunk-hydration.ts
+++ b/client/apps/game/src/three/scenes/warp-travel-chunk-hydration.ts
@@ -35,7 +35,9 @@ export async function hydrateWarpTravelChunk<TPreparedTerrain>(
   input.updatePinnedChunks(input.surroundingChunks);
   const boundsSwitchPromise = input.updateBoundsSubscription(input.chunkKey, input.transitionToken);
   input.surroundingChunks.forEach((chunkKey) => {
-    void input.computeTileEntities(chunkKey);
+    void input.computeTileEntities(chunkKey).catch((error) => {
+      console.warn(`[ChunkHydration] Prefetch failed for surrounding chunk "${chunkKey}"`, error);
+    });
   });
 
   return prepareWorldmapChunkPresentation({

--- a/client/apps/game/src/three/scenes/worldmap-async-timeout.ts
+++ b/client/apps/game/src/three/scenes/worldmap-async-timeout.ts
@@ -10,6 +10,10 @@ export type WorldmapAsyncStageResult<T> =
     }
   | {
       status: "timed_out";
+    }
+  | {
+      status: "rejected";
+      error: unknown;
     };
 
 interface SettleWorldmapAsyncStageInput<T, TLabel extends string> {
@@ -26,20 +30,37 @@ export async function settleWorldmapAsyncStage<T, TLabel extends string>({
   onTimeout,
 }: SettleWorldmapAsyncStageInput<T, TLabel>): Promise<WorldmapAsyncStageResult<T>> {
   if (timeoutMs === undefined || timeoutMs <= 0) {
-    return {
-      status: "resolved",
-      value: await promise,
-    };
+    try {
+      return {
+        status: "resolved",
+        value: await promise,
+      };
+    } catch (error) {
+      console.warn(`[WorldmapAsync] Phase "${label}" rejected without timeout`, error);
+      return {
+        status: "rejected",
+        error,
+      };
+    }
   }
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
   try {
     const result = await Promise.race<WorldmapAsyncStageResult<T>>([
-      promise.then((value) => ({
-        status: "resolved",
-        value,
-      })),
+      promise.then(
+        (value) => ({
+          status: "resolved" as const,
+          value,
+        }),
+        (error) => {
+          console.warn(`[WorldmapAsync] Phase "${label}" rejected`, error);
+          return {
+            status: "rejected" as const,
+            error,
+          };
+        },
+      ),
       new Promise<WorldmapAsyncStageResult<T>>((resolve) => {
         timeoutId = setTimeout(() => {
           onTimeout?.({

--- a/client/apps/game/src/three/scenes/worldmap-chunk-presentation.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-presentation.ts
@@ -128,20 +128,20 @@ export async function prepareWorldmapChunkPresentation<TPreparedTerrain>(
       }),
     ]);
 
-  const timedOutPhase =
-    (tileFetchResult.status === "timed_out" && "tile_fetch") ||
-    (tileHydrationResult.status === "timed_out" && "tile_hydration") ||
-    (boundsReadyResult.status === "timed_out" && "bounds_ready") ||
-    (structureReadyResult.status === "timed_out" && "structure_hydration") ||
-    (assetPrewarmResult.status === "timed_out" && "asset_prewarm") ||
+  const failedPhase =
+    (tileFetchResult.status !== "resolved" && "tile_fetch") ||
+    (tileHydrationResult.status !== "resolved" && "tile_hydration") ||
+    (boundsReadyResult.status !== "resolved" && "bounds_ready") ||
+    (structureReadyResult.status !== "resolved" && "structure_hydration") ||
+    (assetPrewarmResult.status !== "resolved" && "asset_prewarm") ||
     undefined;
 
-  if (timedOutPhase) {
+  if (failedPhase) {
     input.onChunkReady?.(input.chunkKey);
     return {
       tileFetchSucceeded: false,
       preparedTerrain: null,
-      timedOutPhase,
+      timedOutPhase: failedPhase,
     };
   }
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -7443,6 +7443,18 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private traceChunk(event: WorldmapChunkTraceEvent, details: Record<string, unknown> = {}): void {
+    const isErrorEvent =
+      event === "torii_bounds_switch_failed" ||
+      event === "torii_bounds_switch_timeout" ||
+      event === "torii_resubscribe_failed" ||
+      event === "chunk_presentation_timeout" ||
+      event === "chunk_recovery_scheduled" ||
+      event === "chunk_recovery_executed";
+
+    if (isErrorEvent) {
+      console.warn(`[WorldmapChunk] ${event}`, details);
+    }
+
     if (!import.meta.env.DEV) {
       return;
     }


### PR DESCRIPTION
## Summary
Adds defensive handling for rejected worldmap async stages so chunk presentation returns a failed result instead of throwing through the hydration path.
Logs Torii bounds queue failures, surrounding chunk prefetch failures, and selected chunk recovery/error trace events so blank-screen recovery paths are easier to diagnose in production.

## Test plan
Not run; this workspace has no node_modules and the local Node is v20.9.0, while the repo requires >=20.19.0.