### PR TITLE
Fix Blitz settlement realm count

### DIFF
--- a/client/apps/game/src/hooks/use-world-availability.registration-capacity.test.ts
+++ b/client/apps/game/src/hooks/use-world-availability.registration-capacity.test.ts
@@ -8,8 +8,10 @@ describe("World availability registration capacity metadata", () => {
     const source = readFileSync(resolve(process.cwd(), "src/hooks/use-world-availability.ts"), "utf8");
 
     expect(source).toContain('"blitz_registration_config.registration_count_max" AS registration_count_max');
+    expect(source).toContain('"blitz_settlement_config.single_realm_mode" AS single_realm_mode');
     expect(source).toContain('"blitz_settlement_config.two_player_mode" AS two_player_mode');
     expect(source).toContain("registrationCountMax");
+    expect(source).toContain("singleRealmMode");
     expect(source).toContain("twoPlayerMode");
   });
 

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -24,7 +24,7 @@ const ZERO_OWNER_ADDRESS = "0x00000000000000000000000000000000000000000000000000
 const WORLD_MODE_QUERY = `SELECT "blitz_mode_on" AS blitz_mode_on FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
 
 // Note: registration_end_at uses start_main_at because registration ends when the main game starts.
-const WORLD_CONFIG_BLITZ_QUERY = `SELECT "season_config.start_settling_at" AS start_settling_at, "season_config.start_main_at" AS start_main_at, "season_config.end_at" AS end_at, "season_config.dev_mode_on" AS dev_mode_on, "blitz_registration_config.registration_count" AS registration_count, "blitz_registration_config.registration_count_max" AS registration_count_max, "blitz_registration_config.entry_token_address" AS entry_token_address, "blitz_registration_config.fee_token" AS fee_token, "blitz_registration_config.fee_amount" AS fee_amount, "blitz_registration_config.registration_start_at" AS registration_start_at, "season_config.start_main_at" AS registration_end_at, "mmr_config.enabled" AS mmr_enabled, "blitz_hypers_settlement_config.max_ring_count" AS max_ring_count, "blitz_settlement_config.two_player_mode" AS two_player_mode FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
+const WORLD_CONFIG_BLITZ_QUERY = `SELECT "season_config.start_settling_at" AS start_settling_at, "season_config.start_main_at" AS start_main_at, "season_config.end_at" AS end_at, "season_config.dev_mode_on" AS dev_mode_on, "blitz_registration_config.registration_count" AS registration_count, "blitz_registration_config.registration_count_max" AS registration_count_max, "blitz_registration_config.entry_token_address" AS entry_token_address, "blitz_registration_config.fee_token" AS fee_token, "blitz_registration_config.fee_amount" AS fee_amount, "blitz_registration_config.registration_start_at" AS registration_start_at, "season_config.start_main_at" AS registration_end_at, "mmr_config.enabled" AS mmr_enabled, "blitz_hypers_settlement_config.max_ring_count" AS max_ring_count, "blitz_settlement_config.single_realm_mode" AS single_realm_mode, "blitz_settlement_config.two_player_mode" AS two_player_mode FROM "${WORLD_CONFIG_TABLE}" LIMIT 1;`;
 
 // Eternum worlds do not rely on blitz_registration_config. Fetch season timing + spacing config instead.
 const WORLD_CONFIG_ETERNUM_QUERY = `
@@ -163,6 +163,7 @@ export interface WorldConfigMeta {
   villagePassAddress: string | null;
   registrationCount: number | null;
   registrationCountMax: number | null;
+  singleRealmMode: boolean;
   twoPlayerMode: boolean;
   // Blitz registration config
   entryTokenAddress: string | null;
@@ -306,6 +307,7 @@ const fetchWorldConfigMeta = async (
     villagePassAddress: null,
     registrationCount: null,
     registrationCountMax: null,
+    singleRealmMode: false,
     twoPlayerMode: false,
     entryTokenAddress: null,
     feeTokenAddress: null,
@@ -367,6 +369,7 @@ const fetchWorldConfigMeta = async (
         if (row.registration_end_at != null)
           meta.registrationEndAt = parseMaybeHexToNumber(row.registration_end_at) ?? null;
 
+        meta.singleRealmMode = parseMaybeBooleanFlag(row.single_realm_mode) ?? false;
         meta.twoPlayerMode = parseMaybeBooleanFlag(row.two_player_mode) ?? false;
 
         // Calculate hyperstructures left from max_ring_count

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts
@@ -19,6 +19,8 @@ describe("Game entry modal auto-settle", () => {
     expect(source).toContain('if (!autoSettleEnabled || phase !== "settlement"');
     expect(source).toContain("void handleSettle();");
     expect(source).toContain("runBlitzSettlementFlow({");
+    expect(source).toContain("const singleRealmMode = worldMeta?.singleRealmMode ?? false;");
+    expect(source).not.toContain('const singleRealmMode = chain === "mainnet";');
     expect(source).toContain('if (result.status === "completed")');
     expect(source).toContain('if (result.status === "syncing")');
     expect(source).toContain("beginBlitzSettlementVerification(result.pendingTargetSettleCount);");

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -4948,7 +4948,7 @@ export const GameEntryModal = ({
 
     try {
       const isMainnet = env.VITE_PUBLIC_CHAIN === "mainnet";
-      const singleRealmMode = chain === "mainnet";
+      const singleRealmMode = worldMeta?.singleRealmMode ?? false;
       const blitzRealmSystemsAddress = resolveWorldSystemAddress("blitz_realm_systems");
       const signer = account as unknown as Account;
       const vrfProviderAddress = env.VITE_PUBLIC_VRF_PROVIDER_ADDRESS;
@@ -4998,13 +4998,13 @@ export const GameEntryModal = ({
     autoSettleEntryKey,
     account,
     beginBlitzSettlementVerification,
-    chain,
     finalizeFailedBlitzSettlement,
     finalizeSuccessfulBlitzSettlement,
     isBlitzMode,
     markSettling,
     submitAssignedRealmSettlement,
     submitRemainingRealmSettlement,
+    worldMeta?.singleRealmMode,
     worldName,
     readSettlementSnapshot,
     resolveWorldSystemAddress,


### PR DESCRIPTION
Fixes Blitz settlement so the entry flow uses the deployed `single_realm_mode` world config instead of assuming all mainnet games are single-realm.

This lets normal Blitz games target all 3 realm settlements while preserving true single-realm worlds, and adds source regression guards for the metadata query and modal behavior.

Verification: `pnpm dlx node@20.19.0 /usr/local/bin/pnpm --dir client/apps/game test src/hooks/use-world-availability.registration-capacity.test.ts src/ui/features/landing/components/game-entry-modal.auto-settle.source.test.ts src/ui/features/landing/components/game-entry-settlement.utils.test.ts src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts`; `pnpm dlx node@20.19.0 /usr/local/bin/pnpm run format`; `pnpm dlx node@20.19.0 /usr/local/bin/pnpm run knip`; `pnpm dlx node@20.19.0 /usr/local/bin/pnpm --dir client/apps/game typecheck`.