### PR TITLE
fix: clear realm full warning after realm upgrade

### DIFF
--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -146,6 +146,10 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const setSelectedBuildingHex = useUIStore((state) => state.setSelectedBuildingHex);
 
   const realm = getRealmInfo(getEntityIdFromKeys([BigInt(entityId)]), dojo.setup.components);
+  const structure = useComponentValue(
+    dojo.setup.components.Structure,
+    getEntityIdFromKeys([BigInt(entityId)]),
+  );
   const structureBuildings = useComponentValue(
     dojo.setup.components.StructureBuildings,
     getEntityIdFromKeys([BigInt(entityId)]),
@@ -197,6 +201,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
     entityId,
     realm?.position?.x,
     realm?.position?.y,
+    structure?.base?.level,
     structureBuildings,
   ]);
   const hasAvailableBuildingTile = useMemo(() => {
@@ -227,6 +232,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
     entityId,
     realm?.position?.x,
     realm?.position?.y,
+    structure?.base?.level,
     pendingBuilds,
     pendingDestroys,
     structureBuildings,

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -146,10 +146,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const setSelectedBuildingHex = useUIStore((state) => state.setSelectedBuildingHex);
 
   const realm = getRealmInfo(getEntityIdFromKeys([BigInt(entityId)]), dojo.setup.components);
-  const structure = useComponentValue(
-    dojo.setup.components.Structure,
-    getEntityIdFromKeys([BigInt(entityId)]),
-  );
+  const structure = useComponentValue(dojo.setup.components.Structure, getEntityIdFromKeys([BigInt(entityId)]));
   const structureBuildings = useComponentValue(
     dojo.setup.components.StructureBuildings,
     getEntityIdFromKeys([BigInt(entityId)]),


### PR DESCRIPTION
## Summary
- After upgrading a Realm, the "Realm full" warning persisted and blocked building selection even though capacity increased
- Root cause: `hasAvailableBuildingTile` useMemo and reconciliation useEffect were missing a reactive dependency on the Structure component's level
- Added `useComponentValue` subscription for the Structure component and included `structure.base.level` in both dependency arrays so they recalculate when the realm upgrades

## Test plan
- [ ] Upgrade a realm that is at max building capacity
- [ ] Verify the "Realm full" warning clears and new building slots become available without page reload