### PR TITLE
Stabilize production automation

### DIFF
--- a/client/apps/game/src/hooks/automation-scheduler.test.ts
+++ b/client/apps/game/src/hooks/automation-scheduler.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { PROCESS_INTERVAL_MS } from "@/ui/features/infrastructure/automation/model/automation-processor";
+import {
+  computeNextEligibleMs,
+  computePostPassSchedulerUpdate,
+  computeScheduleDelayMs,
+  shouldAdvanceSchedulerBookkeeping,
+} from "./automation-scheduler";
+
+describe("computeNextEligibleMs", () => {
+  it("picks the later of (lastRun + interval) and automationEnabledAt", () => {
+    const lastRun = 1_000;
+    const enabledAt = 5_000;
+    expect(computeNextEligibleMs(lastRun, enabledAt)).toBe(Math.max(lastRun + PROCESS_INTERVAL_MS, enabledAt));
+  });
+
+  it("defaults to lastRun + interval when enable-gate is in the past", () => {
+    const lastRun = 100_000;
+    expect(computeNextEligibleMs(lastRun, 0)).toBe(lastRun + PROCESS_INTERVAL_MS);
+  });
+
+  it("honours a future enable-gate even when lastRun is recent", () => {
+    const lastRun = 0;
+    const enabledAt = lastRun + PROCESS_INTERVAL_MS + 10_000;
+    expect(computeNextEligibleMs(lastRun, enabledAt)).toBe(enabledAt);
+  });
+});
+
+describe("computeScheduleDelayMs", () => {
+  it("aligns to the next whole-second boundary", () => {
+    // 1700000000.250 → next boundary 1700000001.000 → 750ms
+    expect(computeScheduleDelayMs(1_700_000_000_250)).toBe(750);
+  });
+
+  it("applies a 250ms minimum floor when already near the boundary", () => {
+    // 1700000000.999 → next boundary 1700000001.000 → 1ms, floored to 250
+    expect(computeScheduleDelayMs(1_700_000_000_999)).toBe(250);
+  });
+
+  it("returns 1000 at an exact whole second", () => {
+    expect(computeScheduleDelayMs(1_700_000_000_000)).toBe(1000);
+  });
+});
+
+describe("shouldAdvanceSchedulerBookkeeping", () => {
+  it("only advances when the pass ran and no prune happened mid-flight", () => {
+    expect(shouldAdvanceSchedulerBookkeeping(true, false)).toBe(true);
+    expect(shouldAdvanceSchedulerBookkeeping(true, true)).toBe(false);
+    expect(shouldAdvanceSchedulerBookkeeping(false, false)).toBe(false);
+    expect(shouldAdvanceSchedulerBookkeeping(false, true)).toBe(false);
+  });
+});
+
+describe("computePostPassSchedulerUpdate", () => {
+  it("sets lastRun to now and enableAt/nextRun to now + interval", () => {
+    const nowMs = 10_000;
+    expect(computePostPassSchedulerUpdate(nowMs)).toEqual({
+      lastRunMs: nowMs,
+      automationEnabledAtMs: nowMs + PROCESS_INTERVAL_MS,
+      nextRunMs: nowMs + PROCESS_INTERVAL_MS,
+    });
+  });
+});

--- a/client/apps/game/src/hooks/automation-scheduler.ts
+++ b/client/apps/game/src/hooks/automation-scheduler.ts
@@ -24,10 +24,8 @@ export const computeScheduleDelayMs = (nowMs: number): number => {
  * the game state didn't change under us mid-run (pruneForGame resets during an
  * in-flight run must win over the pass's clock advance).
  */
-export const shouldAdvanceSchedulerBookkeeping = (
-  ran: boolean,
-  pruneDuringProcessing: boolean,
-): boolean => ran && !pruneDuringProcessing;
+export const shouldAdvanceSchedulerBookkeeping = (ran: boolean, pruneDuringProcessing: boolean): boolean =>
+  ran && !pruneDuringProcessing;
 
 /**
  * Compute the updated scheduler refs after a successful pass, returning the

--- a/client/apps/game/src/hooks/automation-scheduler.ts
+++ b/client/apps/game/src/hooks/automation-scheduler.ts
@@ -1,0 +1,42 @@
+import { PROCESS_INTERVAL_MS } from "@/ui/features/infrastructure/automation/model/automation-processor";
+
+/**
+ * Earliest wall-clock time (ms) at which the next production pass is allowed.
+ * - Enforces the global tick spacing (lastRun + PROCESS_INTERVAL_MS).
+ * - Respects any enable-gate (`automationEnabledAtMs`) installed after enabling
+ *   automation or after a `pruneForGame` reset, which should defer the first
+ *   pass even if `lastRunMs` is old or missing.
+ */
+export const computeNextEligibleMs = (lastRunMs: number, automationEnabledAtMs: number): number =>
+  Math.max(lastRunMs + PROCESS_INTERVAL_MS, automationEnabledAtMs);
+
+/**
+ * Align the next scheduler check to the next whole-second boundary, with a
+ * 250ms minimum floor so back-to-back triggers don't spin the timer hot.
+ */
+export const computeScheduleDelayMs = (nowMs: number): number => {
+  const nextBlockMs = (Math.floor(nowMs / 1000) + 1) * 1000;
+  return Math.max(250, nextBlockMs - nowMs);
+};
+
+/**
+ * Only advance the scheduler bookkeeping when the pass actually executed and
+ * the game state didn't change under us mid-run (pruneForGame resets during an
+ * in-flight run must win over the pass's clock advance).
+ */
+export const shouldAdvanceSchedulerBookkeeping = (
+  ran: boolean,
+  pruneDuringProcessing: boolean,
+): boolean => ran && !pruneDuringProcessing;
+
+/**
+ * Compute the updated scheduler refs after a successful pass, returning the
+ * value to assign to `lastRunTimestampRef`, `automationEnabledAtRef`, and
+ * `nextRunTimestampRef`.
+ */
+export const computePostPassSchedulerUpdate = (
+  nowMs: number,
+): { lastRunMs: number; automationEnabledAtMs: number; nextRunMs: number } => {
+  const enabledAt = nowMs + PROCESS_INTERVAL_MS;
+  return { lastRunMs: nowMs, automationEnabledAtMs: enabledAt, nextRunMs: enabledAt };
+};

--- a/client/apps/game/src/hooks/exploration-automation-planner.test.ts
+++ b/client/apps/game/src/hooks/exploration-automation-planner.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import type { ActionPath } from "@bibliothecadao/eternum";
+import { ActionType } from "@bibliothecadao/eternum";
+import { describe, expect, it } from "vitest";
+
+import {
+  computeEffectiveStaminaCost,
+  filterFreshExplorationPaths,
+  getPathStaminaCost,
+  normalizeExplorationNextRunAt,
+  selectDueEntries,
+  shouldRepeatExplore,
+} from "./exploration-automation-planner";
+
+const step = (cost: number, actionType: ActionType = ActionType.Move): ActionPath => ({
+  hex: { col: 0, row: 0 },
+  actionType,
+  staminaCost: cost,
+});
+
+describe("getPathStaminaCost", () => {
+  it("sums staminaCost across steps", () => {
+    expect(getPathStaminaCost([step(1), step(2), step(3)])).toBe(6);
+  });
+
+  it("treats missing staminaCost as zero", () => {
+    expect(getPathStaminaCost([{ staminaCost: undefined }, { staminaCost: 5 }])).toBe(5);
+  });
+
+  it("returns 0 for an empty path", () => {
+    expect(getPathStaminaCost([])).toBe(0);
+  });
+});
+
+describe("computeEffectiveStaminaCost", () => {
+  it("uses path cost when positive", () => {
+    expect(computeEffectiveStaminaCost([step(2), step(3)], ActionType.Explore, 10)).toBe(5);
+  });
+
+  it("falls back to exploreStaminaCost only when path cost is 0 and action is Explore", () => {
+    expect(computeEffectiveStaminaCost([], ActionType.Explore, 12)).toBe(12);
+    expect(computeEffectiveStaminaCost([step(0)], ActionType.Explore, 9)).toBe(9);
+  });
+
+  it("keeps zero cost for non-Explore actions", () => {
+    expect(computeEffectiveStaminaCost([], ActionType.Move, 12)).toBe(0);
+  });
+});
+
+describe("shouldRepeatExplore", () => {
+  it("repeats only when action is Explore and remaining stamina >= cost", () => {
+    expect(shouldRepeatExplore(ActionType.Explore, 10, 10)).toBe(true);
+    expect(shouldRepeatExplore(ActionType.Explore, 9, 10)).toBe(false);
+    expect(shouldRepeatExplore(ActionType.Move, 100, 10)).toBe(false);
+    expect(shouldRepeatExplore(undefined, 100, 10)).toBe(false);
+  });
+});
+
+describe("normalizeExplorationNextRunAt", () => {
+  it("passes through finite numbers", () => {
+    expect(normalizeExplorationNextRunAt(123)).toBe(123);
+  });
+
+  it("coerces numeric strings", () => {
+    expect(normalizeExplorationNextRunAt("42")).toBe(42);
+  });
+
+  it("returns null for null/undefined/NaN/non-numeric", () => {
+    expect(normalizeExplorationNextRunAt(null)).toBeNull();
+    expect(normalizeExplorationNextRunAt(undefined)).toBeNull();
+    expect(normalizeExplorationNextRunAt("abc")).toBeNull();
+    expect(normalizeExplorationNextRunAt(Number.NaN)).toBeNull();
+  });
+});
+
+describe("selectDueEntries", () => {
+  it("returns entries with null nextRunAt or nextRunAt <= now", () => {
+    const now = 1_000;
+    const entries = [
+      { id: "a", nextRunAt: null },
+      { id: "b", nextRunAt: 500 },
+      { id: "c", nextRunAt: 2_000 },
+      { id: "d", nextRunAt: 1_000 },
+      { id: "e", nextRunAt: "not-a-number" as unknown as number },
+    ];
+    const due = selectDueEntries(entries, now);
+    expect(due.map((e) => e.id)).toEqual(["a", "b", "d", "e"]);
+  });
+});
+
+describe("filterFreshExplorationPaths", () => {
+  const buildPath = (actionType: ActionType, col: number, row: number): ActionPath[] => [
+    { hex: { col: 0, row: 0 }, actionType, staminaCost: 0 },
+    { hex: { col, row }, actionType, staminaCost: 0 },
+  ];
+
+  const identityNormalize = (hex: { col: number; row: number }) => ({ x: hex.col, y: hex.row });
+
+  it("keeps only Explore paths whose endpoint is not recently explored", () => {
+    const actionPathMap = new Map<string, ActionPath[]>([
+      ["a", buildPath(ActionType.Explore, 1, 1)],
+      ["b", buildPath(ActionType.Explore, 2, 2)],
+      ["c", buildPath(ActionType.Move, 3, 3)],
+    ]);
+    const recentlyExplored = new Set<string>(["1,1"]);
+    const result = filterFreshExplorationPaths(actionPathMap, recentlyExplored, identityNormalize);
+    expect(Array.from(result.keys())).toEqual(["b"]);
+  });
+
+  it("ignores paths without an endpoint hex", () => {
+    const actionPathMap = new Map<string, ActionPath[]>([["a", []]]);
+    const result = filterFreshExplorationPaths(actionPathMap, new Set(), identityNormalize);
+    expect(result.size).toBe(0);
+  });
+
+  it("passes hex coords through the normalize callback", () => {
+    const actionPathMap = new Map<string, ActionPath[]>([["a", buildPath(ActionType.Explore, 5, 7)]]);
+    const normalize = (hex: { col: number; row: number }) => ({ x: hex.col + 10, y: hex.row + 10 });
+    // After normalization -> "15,17" — we mark it recently explored, should filter it out.
+    const recentlyExplored = new Set<string>(["15,17"]);
+    const result = filterFreshExplorationPaths(actionPathMap, recentlyExplored, normalize);
+    expect(result.size).toBe(0);
+  });
+});

--- a/client/apps/game/src/hooks/exploration-automation-planner.ts
+++ b/client/apps/game/src/hooks/exploration-automation-planner.ts
@@ -1,0 +1,55 @@
+import type { ActionPath } from "@bibliothecadao/eternum";
+import { ActionPaths, ActionType } from "@bibliothecadao/eternum";
+
+export const getPathStaminaCost = (path: ReadonlyArray<{ staminaCost?: number }>): number =>
+  path.reduce((total, step) => total + (step.staminaCost ?? 0), 0);
+
+export const computeEffectiveStaminaCost = (
+  path: ReadonlyArray<{ staminaCost?: number }>,
+  actionType: ActionType | undefined,
+  exploreStaminaCost: number,
+): number => {
+  const pathCost = getPathStaminaCost(path);
+  if (pathCost > 0) return pathCost;
+  if (actionType !== ActionType.Explore) return pathCost;
+  return exploreStaminaCost;
+};
+
+export const shouldRepeatExplore = (
+  actionType: ActionType | undefined,
+  remainingStamina: number,
+  exploreStaminaCost: number,
+): boolean => actionType === ActionType.Explore && remainingStamina >= exploreStaminaCost;
+
+export const normalizeExplorationNextRunAt = (value: unknown): number | null => {
+  if (value === null || value === undefined) return null;
+  const numeric = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+export const selectDueEntries = <T extends { nextRunAt?: number | null | undefined }>(
+  entries: readonly T[],
+  nowMs: number,
+): T[] =>
+  entries.filter((entry) => {
+    const nextRunAt = normalizeExplorationNextRunAt(entry.nextRunAt);
+    if (nextRunAt === null) return true;
+    return nextRunAt <= nowMs;
+  });
+
+export const filterFreshExplorationPaths = (
+  actionPathMap: Map<string, ActionPath[]>,
+  recentlyExplored: Set<string>,
+  normalizeHex: (hex: { col: number; row: number }) => { x: number; y: number },
+): Map<string, ActionPath[]> => {
+  const filtered = new Map<string, ActionPath[]>();
+  actionPathMap.forEach((path, key) => {
+    if (ActionPaths.getActionType(path) !== ActionType.Explore) return;
+    const endHex = path[path.length - 1]?.hex;
+    if (!endHex) return;
+    const normalized = normalizeHex(endHex);
+    if (recentlyExplored.has(`${normalized.x},${normalized.y}`)) return;
+    filtered.set(key, path);
+  });
+  return filtered;
+};

--- a/client/apps/game/src/hooks/store/use-automation-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-automation-store.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+
+// Stub localStorage so Zustand `persist` middleware doesn't throw under node env.
+class MemoryStorage {
+  private data = new Map<string, string>();
+  getItem(key: string) {
+    return this.data.has(key) ? (this.data.get(key) as string) : null;
+  }
+  setItem(key: string, value: string) {
+    this.data.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.data.delete(key);
+  }
+  clear() {
+    this.data.clear();
+  }
+  key(i: number) {
+    return Array.from(this.data.keys())[i] ?? null;
+  }
+  get length() {
+    return this.data.size;
+  }
+}
+(globalThis as unknown as { localStorage: Storage }).localStorage = new MemoryStorage() as unknown as Storage;
+import {
+  DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES,
+  DONKEY_DEFAULT_RESOURCE_PERCENT,
+  MAX_RESOURCE_ALLOCATION_PERCENT,
+  isAutomationResourceBlocked,
+  useAutomationStore,
+  type RealmAutomationConfig,
+} from "./use-automation-store";
+
+const resetStore = () => {
+  useAutomationStore.setState({
+    realms: {},
+    nextRunTimestamp: null,
+    hydrated: true,
+    gameId: "test-game",
+  });
+};
+
+describe("isAutomationResourceBlocked", () => {
+  it("blocks Wheat and Labor as outputs", () => {
+    expect(isAutomationResourceBlocked(ResourcesIds.Wheat, "realm", "output")).toBe(true);
+    expect(isAutomationResourceBlocked(ResourcesIds.Labor, "realm", "output")).toBe(true);
+  });
+
+  it("never blocks a resource when role is input", () => {
+    expect(isAutomationResourceBlocked(ResourcesIds.Wheat, "realm", "input")).toBe(false);
+    expect(isAutomationResourceBlocked(ResourcesIds.Labor, "realm", "input")).toBe(false);
+  });
+
+  it("does not block non-blocked resources", () => {
+    expect(isAutomationResourceBlocked(ResourcesIds.Knight, "realm", "output")).toBe(false);
+  });
+});
+
+describe("useAutomationStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  describe("upsertRealm", () => {
+    it("creates a realm with smart preset and autoBalance true by default", () => {
+      useAutomationStore.getState().upsertRealm("1", { realmName: "Alpha" });
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.realmName).toBe("Alpha");
+      expect(realm.presetId).toBe("smart");
+      expect(realm.autoBalance).toBe(true);
+      expect(realm.entityType).toBe("realm");
+      expect(realm.customPercentages).toEqual({});
+    });
+
+    it("updates realm metadata without dropping percentages", () => {
+      useAutomationStore.getState().upsertRealm("1", { realmName: "Alpha" });
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, { resourceToResource: 10 });
+
+      useAutomationStore.getState().upsertRealm("1", { realmName: "Beta" });
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.realmName).toBe("Beta");
+      expect(realm.customPercentages[ResourcesIds.Wood].resourceToResource).toBe(10);
+    });
+
+    it("normalizes unknown preset ids to smart when creating", () => {
+      useAutomationStore.getState().upsertRealm("1", { presetId: "bogus" as unknown as RealmAutomationConfig["presetId"] });
+      expect(useAutomationStore.getState().realms["1"].presetId).toBe("smart");
+    });
+  });
+
+  describe("setRealmPreset", () => {
+    it("updates preset on an existing realm", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setRealmPreset("1", "idle");
+      expect(useAutomationStore.getState().realms["1"].presetId).toBe("idle");
+    });
+
+    it("no-ops when the realm does not exist", () => {
+      useAutomationStore.getState().setRealmPreset("nope", "idle");
+      expect(useAutomationStore.getState().realms["nope"]).toBeUndefined();
+    });
+
+    it("normalizes a bogus preset to smart", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore
+        .getState()
+        .setRealmPreset("1", "something-weird" as unknown as RealmAutomationConfig["presetId"]);
+      expect(useAutomationStore.getState().realms["1"].presetId).toBe("smart");
+    });
+  });
+
+  describe("setResourcePercentages", () => {
+    it("switches the preset to custom when percentages change", () => {
+      useAutomationStore.getState().upsertRealm("1", { presetId: "smart" });
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, { resourceToResource: 25 });
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.presetId).toBe("custom");
+      expect(realm.customPercentages[ResourcesIds.Wood]).toEqual({ resourceToResource: 25, laborToResource: 5 });
+    });
+
+    it("clamps values above MAX and floors negatives", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, {
+        resourceToResource: 999,
+        laborToResource: -50,
+      });
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.customPercentages[ResourcesIds.Wood]).toEqual({
+        resourceToResource: MAX_RESOURCE_ALLOCATION_PERCENT,
+        laborToResource: 0,
+      });
+    });
+
+    it("ignores blocked output resources", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wheat, { resourceToResource: 50 });
+      expect(useAutomationStore.getState().realms["1"].customPercentages[ResourcesIds.Wheat]).toBeUndefined();
+    });
+
+    it("forces Donkey laborToResource to 0", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Donkey, {
+        resourceToResource: 20,
+        laborToResource: 30,
+      });
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.customPercentages[ResourcesIds.Donkey]).toEqual({ resourceToResource: 20, laborToResource: 0 });
+    });
+
+    it("uses DONKEY_DEFAULT_RESOURCE_PERCENT as the default when Donkey is first set via a labor-only patch", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Donkey, { laborToResource: 0 });
+      expect(useAutomationStore.getState().realms["1"].customPercentages[ResourcesIds.Donkey]).toEqual({
+        resourceToResource: DONKEY_DEFAULT_RESOURCE_PERCENT,
+        laborToResource: 0,
+      });
+    });
+
+    it("no-ops when the new value equals the existing value", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, { resourceToResource: 10 });
+      const firstUpdatedAt = useAutomationStore.getState().realms["1"].updatedAt;
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, { resourceToResource: 10 });
+      // Unchanged state should not bump updatedAt.
+      expect(useAutomationStore.getState().realms["1"].updatedAt).toBe(firstUpdatedAt);
+    });
+  });
+
+  describe("removeRealm / resetRealm / resetAll", () => {
+    it("removeRealm drops the realm", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().removeRealm("1");
+      expect(useAutomationStore.getState().realms["1"]).toBeUndefined();
+    });
+
+    it("resetRealm clears custom percentages and resets preset to smart", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, { resourceToResource: 30 });
+      useAutomationStore.getState().resetRealm("1");
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.presetId).toBe("smart");
+      expect(realm.customPercentages).toEqual({});
+      expect(realm.lastExecution).toBeUndefined();
+      expect(realm.lastStatus).toBeUndefined();
+    });
+
+    it("resetAll empties realms and clears nextRunTimestamp", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setNextRunTimestamp(1234);
+      useAutomationStore.getState().resetAll();
+      const state = useAutomationStore.getState();
+      expect(state.realms).toEqual({});
+      expect(state.nextRunTimestamp).toBeNull();
+    });
+  });
+
+  describe("recordExecution / recordStatus", () => {
+    it("attaches a lastExecution summary without mutating percentages", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setResourcePercentages("1", ResourcesIds.Wood, { resourceToResource: 15 });
+      useAutomationStore.getState().recordExecution("1", {
+        executedAt: 111,
+        resourceToResource: [],
+        laborToResource: [],
+        consumptionByResource: {},
+        outputsByResource: {},
+        skipped: [],
+      });
+      const realm = useAutomationStore.getState().realms["1"];
+      expect(realm.lastExecution?.executedAt).toBe(111);
+      expect(realm.customPercentages[ResourcesIds.Wood].resourceToResource).toBe(15);
+    });
+
+    it("attaches lastStatus with its consecutiveFailures", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().recordStatus("1", {
+        status: "failed",
+        message: "nope",
+        attemptedAt: 42,
+        consecutiveFailures: 2,
+      });
+      expect(useAutomationStore.getState().realms["1"].lastStatus?.consecutiveFailures).toBe(2);
+    });
+
+    it("no-ops when the realm does not exist", () => {
+      useAutomationStore.getState().recordExecution("nope", {
+        executedAt: 1,
+        resourceToResource: [],
+        laborToResource: [],
+        consumptionByResource: {},
+        outputsByResource: {},
+        skipped: [],
+      });
+      expect(useAutomationStore.getState().realms["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("pruneForGame", () => {
+    it("clears realms and nextRunTimestamp when gameId changes", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.getState().setNextRunTimestamp(999);
+      useAutomationStore.setState({ gameId: "old-game" });
+      useAutomationStore.getState().pruneForGame("new-game");
+      const state = useAutomationStore.getState();
+      expect(state.realms).toEqual({});
+      expect(state.nextRunTimestamp).toBeNull();
+      expect(state.gameId).toBe("new-game");
+    });
+
+    it("no-ops when the gameId matches", () => {
+      useAutomationStore.getState().upsertRealm("1");
+      useAutomationStore.setState({ gameId: "same-game" });
+      useAutomationStore.getState().pruneForGame("same-game");
+      expect(useAutomationStore.getState().realms["1"]).toBeDefined();
+    });
+  });
+
+  describe("getRealmConfig", () => {
+    it("returns the realm config when present", () => {
+      useAutomationStore.getState().upsertRealm("1", { realmName: "Alpha" });
+      expect(useAutomationStore.getState().getRealmConfig("1")?.realmName).toBe("Alpha");
+    });
+
+    it("returns undefined for an unknown realm", () => {
+      expect(useAutomationStore.getState().getRealmConfig("nope")).toBeUndefined();
+    });
+  });
+
+  describe("DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES", () => {
+    it("defaults to 0 resource, 5 labor so new configs don't over-commit", () => {
+      expect(DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES).toEqual({ resourceToResource: 0, laborToResource: 5 });
+    });
+  });
+});

--- a/client/apps/game/src/hooks/store/use-automation-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-automation-store.test.ts
@@ -90,7 +90,9 @@ describe("useAutomationStore", () => {
     });
 
     it("normalizes unknown preset ids to smart when creating", () => {
-      useAutomationStore.getState().upsertRealm("1", { presetId: "bogus" as unknown as RealmAutomationConfig["presetId"] });
+      useAutomationStore
+        .getState()
+        .upsertRealm("1", { presetId: "bogus" as unknown as RealmAutomationConfig["presetId"] });
       expect(useAutomationStore.getState().realms["1"].presetId).toBe("smart");
     });
   });

--- a/client/apps/game/src/hooks/store/use-exploration-automation-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-exploration-automation-store.test.ts
@@ -1,0 +1,380 @@
+// @vitest-environment node
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MemoryStorage {
+  private data = new Map<string, string>();
+  getItem(key: string) {
+    return this.data.has(key) ? (this.data.get(key) as string) : null;
+  }
+  setItem(key: string, value: string) {
+    this.data.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.data.delete(key);
+  }
+  clear() {
+    this.data.clear();
+  }
+  key(i: number) {
+    return Array.from(this.data.keys())[i] ?? null;
+  }
+  get length() {
+    return this.data.size;
+  }
+}
+(globalThis as unknown as { localStorage: Storage }).localStorage = new MemoryStorage() as unknown as Storage;
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  configManager: {
+    getSeasonConfig: () => ({ startSettlingAt: 1, startMainAt: 2, endAt: 3 }),
+  },
+}));
+
+import {
+  DEFAULT_SCOPE_RADIUS,
+  DEFAULT_STRATEGY_ID,
+  EXPLORATION_AUTOMATION_INTERVAL_MS,
+  useExplorationAutomationStore,
+} from "./use-exploration-automation-store";
+
+const FROZEN_NOW = 1_700_000_000_000;
+const FROZEN_GAME_ID = "1-2-3";
+
+beforeAll(() => {
+  vi.spyOn(Date, "now").mockReturnValue(FROZEN_NOW);
+});
+
+const resetStore = () => {
+  useExplorationAutomationStore.setState({ entries: {} });
+};
+
+describe("useExplorationAutomationStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  describe("add", () => {
+    it("creates an active entry with default strategy and scheduled nextRunAt", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "42",
+        active: true,
+        scopeRadius: 10,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      const entry = useExplorationAutomationStore.getState().entries[id];
+      expect(entry.active).toBe(true);
+      expect(entry.explorerId).toBe("42");
+      expect(entry.gameId).toBe(FROZEN_GAME_ID);
+      expect(entry.scopeRadius).toBe(10);
+      expect(entry.strategyId).toBe(DEFAULT_STRATEGY_ID);
+      expect(entry.createdAt).toBe(FROZEN_NOW);
+      expect(entry.nextRunAt).toBe(FROZEN_NOW + EXPLORATION_AUTOMATION_INTERVAL_MS);
+    });
+
+    it("defaults active to true when omitted", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "42",
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      } as Parameters<ReturnType<typeof useExplorationAutomationStore.getState>["add"]>[0]);
+      expect(useExplorationAutomationStore.getState().entries[id].active).toBe(true);
+    });
+
+    it("leaves nextRunAt null when created inactive", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "42",
+        active: false,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBeNull();
+    });
+
+    it("normalizes scopeRadius: rounds and enforces min of 1", () => {
+      const tiny = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: 0,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      expect(useExplorationAutomationStore.getState().entries[tiny].scopeRadius).toBe(1);
+
+      const fractional = useExplorationAutomationStore.getState().add({
+        explorerId: "2",
+        active: true,
+        scopeRadius: 7.6,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      expect(useExplorationAutomationStore.getState().entries[fractional].scopeRadius).toBe(8);
+    });
+
+    it("falls back to DEFAULT_SCOPE_RADIUS when scopeRadius is not finite", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: Number.NaN,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      expect(useExplorationAutomationStore.getState().entries[id].scopeRadius).toBe(DEFAULT_SCOPE_RADIUS);
+    });
+
+    it("generates a unique id per entry", () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 10; i++) {
+        ids.add(
+          useExplorationAutomationStore.getState().add({
+            explorerId: String(i),
+            active: true,
+            scopeRadius: DEFAULT_SCOPE_RADIUS,
+            strategyId: DEFAULT_STRATEGY_ID,
+          }),
+        );
+      }
+      expect(ids.size).toBe(10);
+    });
+  });
+
+  describe("update", () => {
+    const seed = () =>
+      useExplorationAutomationStore.getState().add({
+        explorerId: "42",
+        active: true,
+        scopeRadius: 10,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+
+    it("patches scopeRadius and re-normalizes it", () => {
+      const id = seed();
+      useExplorationAutomationStore.getState().update(id, { scopeRadius: 0.2 });
+      expect(useExplorationAutomationStore.getState().entries[id].scopeRadius).toBe(1);
+    });
+
+    it("patches strategyId without touching other fields", () => {
+      const id = seed();
+      useExplorationAutomationStore
+        .getState()
+        .update(id, { strategyId: "custom-strategy" as unknown as typeof DEFAULT_STRATEGY_ID });
+      const entry = useExplorationAutomationStore.getState().entries[id];
+      expect(entry.strategyId).toBe("custom-strategy");
+      expect(entry.explorerId).toBe("42");
+    });
+
+    it("normalizes nextRunAt through the timestamp helper", () => {
+      const id = seed();
+      useExplorationAutomationStore.getState().update(id, { nextRunAt: "not-a-number" as unknown as number });
+      // Invalid input falls back to prev nextRunAt, which was the scheduled timestamp.
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBe(
+        FROZEN_NOW + EXPLORATION_AUTOMATION_INTERVAL_MS,
+      );
+    });
+
+    it("treats a null nextRunAt patch as 'no change' (nullish-coalesce falls through to prev)", () => {
+      const id = seed();
+      const prev = useExplorationAutomationStore.getState().entries[id].nextRunAt;
+      useExplorationAutomationStore.getState().update(id, { nextRunAt: null });
+      // Callers that need to clear nextRunAt must use toggleActive(id, false) instead.
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBe(prev);
+    });
+
+    it("no-ops when the entry does not exist", () => {
+      useExplorationAutomationStore.getState().update("nope", { scopeRadius: 5 });
+      expect(useExplorationAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("toggleActive", () => {
+    it("pauses an active entry but keeps the previous nextRunAt", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      const beforePause = useExplorationAutomationStore.getState().entries[id].nextRunAt;
+      useExplorationAutomationStore.getState().toggleActive(id);
+      const entry = useExplorationAutomationStore.getState().entries[id];
+      expect(entry.active).toBe(false);
+      expect(entry.nextRunAt).toBe(beforePause);
+    });
+
+    it("resuming preserves a still-future nextRunAt", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: false,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      const future = FROZEN_NOW + 60_000;
+      useExplorationAutomationStore.getState().update(id, { nextRunAt: future });
+      useExplorationAutomationStore.getState().toggleActive(id, true);
+      expect(useExplorationAutomationStore.getState().entries[id].active).toBe(true);
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBe(future);
+    });
+
+    it("resuming reschedules from now when the stored nextRunAt is stale", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: false,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().update(id, { nextRunAt: FROZEN_NOW - 1_000 });
+      useExplorationAutomationStore.getState().toggleActive(id, true);
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBe(
+        FROZEN_NOW + EXPLORATION_AUTOMATION_INTERVAL_MS,
+      );
+    });
+
+    it("no-ops when the entry does not exist", () => {
+      useExplorationAutomationStore.getState().toggleActive("nope");
+      expect(useExplorationAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("scheduleNext", () => {
+    it("uses now when no base is provided", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().scheduleNext(id);
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBe(
+        FROZEN_NOW + EXPLORATION_AUTOMATION_INTERVAL_MS,
+      );
+    });
+
+    it("respects an explicit base", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().scheduleNext(id, 5_000_000);
+      expect(useExplorationAutomationStore.getState().entries[id].nextRunAt).toBe(
+        5_000_000 + EXPLORATION_AUTOMATION_INTERVAL_MS,
+      );
+    });
+
+    it("no-ops for a missing id", () => {
+      useExplorationAutomationStore.getState().scheduleNext("nope");
+      expect(useExplorationAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("runNow", () => {
+    it("forces active true and schedules nextRunAt to now", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: false,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().runNow(id);
+      const entry = useExplorationAutomationStore.getState().entries[id];
+      expect(entry.active).toBe(true);
+      expect(entry.nextRunAt).toBe(FROZEN_NOW);
+    });
+
+    it("no-ops for a missing id", () => {
+      useExplorationAutomationStore.getState().runNow("nope");
+      expect(useExplorationAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("remove", () => {
+    it("drops the entry", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().remove(id);
+      expect(useExplorationAutomationStore.getState().entries[id]).toBeUndefined();
+    });
+  });
+
+  describe("pruneForGame", () => {
+    it("drops entries from other gameIds", () => {
+      const kept = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      const stale = useExplorationAutomationStore.getState().add({
+        explorerId: "2",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+        gameId: "older-game",
+      });
+      useExplorationAutomationStore.getState().pruneForGame(FROZEN_GAME_ID);
+      expect(useExplorationAutomationStore.getState().entries[kept]).toBeDefined();
+      expect(useExplorationAutomationStore.getState().entries[stale]).toBeUndefined();
+    });
+
+    it("no-ops when every entry already matches the gameId", () => {
+      const id = useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      const before = useExplorationAutomationStore.getState().entries;
+      useExplorationAutomationStore.getState().pruneForGame(FROZEN_GAME_ID);
+      // Reference equality — no-op must avoid churning the entries map.
+      expect(useExplorationAutomationStore.getState().entries).toBe(before);
+      expect(useExplorationAutomationStore.getState().entries[id]).toBeDefined();
+    });
+  });
+
+  describe("pauseAll / resumeAll", () => {
+    it("pauseAll flips everything inactive and clears nextRunAt", () => {
+      useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().add({
+        explorerId: "2",
+        active: true,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().pauseAll();
+      Object.values(useExplorationAutomationStore.getState().entries).forEach((entry) => {
+        expect(entry.active).toBe(false);
+        expect(entry.nextRunAt).toBeNull();
+      });
+    });
+
+    it("resumeAll flips everything active and reschedules from now", () => {
+      useExplorationAutomationStore.getState().add({
+        explorerId: "1",
+        active: false,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().add({
+        explorerId: "2",
+        active: false,
+        scopeRadius: DEFAULT_SCOPE_RADIUS,
+        strategyId: DEFAULT_STRATEGY_ID,
+      });
+      useExplorationAutomationStore.getState().resumeAll();
+      Object.values(useExplorationAutomationStore.getState().entries).forEach((entry) => {
+        expect(entry.active).toBe(true);
+        expect(entry.nextRunAt).toBe(FROZEN_NOW + EXPLORATION_AUTOMATION_INTERVAL_MS);
+      });
+    });
+  });
+});

--- a/client/apps/game/src/hooks/store/use-transfer-automation-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-transfer-automation-store.test.ts
@@ -1,0 +1,372 @@
+// @vitest-environment node
+import { ResourcesIds } from "@bibliothecadao/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+class MemoryStorage {
+  private data = new Map<string, string>();
+  getItem(key: string) {
+    return this.data.has(key) ? (this.data.get(key) as string) : null;
+  }
+  setItem(key: string, value: string) {
+    this.data.set(key, String(value));
+  }
+  removeItem(key: string) {
+    this.data.delete(key);
+  }
+  clear() {
+    this.data.clear();
+  }
+  key(i: number) {
+    return Array.from(this.data.keys())[i] ?? null;
+  }
+  get length() {
+    return this.data.size;
+  }
+}
+(globalThis as unknown as { localStorage: Storage }).localStorage = new MemoryStorage() as unknown as Storage;
+
+// Freeze block time so nextRunAt math is deterministic across tests.
+const FROZEN_BLOCK_SECONDS = 1_700_000_000;
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  configManager: {
+    getSeasonConfig: () => ({
+      startSettlingAt: 10,
+      startMainAt: 20,
+      endAt: 30,
+    }),
+  },
+  getBlockTimestamp: () => ({ currentBlockTimestamp: FROZEN_BLOCK_SECONDS }),
+}));
+
+import { useTransferAutomationStore } from "./use-transfer-automation-store";
+
+const FROZEN_NOW_MS = FROZEN_BLOCK_SECONDS * 1000;
+const FROZEN_GAME_ID = "10-20-30";
+
+const resetStore = () => {
+  useTransferAutomationStore.setState({ entries: {} });
+};
+
+describe("useTransferAutomationStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  afterEach(() => {
+    resetStore();
+  });
+
+  describe("add", () => {
+    it("creates an active entry with scheduled nextRunAt and season-based gameId", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood, ResourcesIds.Coal],
+        intervalMinutes: 5,
+      });
+      const entry = useTransferAutomationStore.getState().entries[id];
+      expect(entry.active).toBe(true);
+      expect(entry.sourceEntityId).toBe("1");
+      expect(entry.destinationEntityId).toBe("2");
+      expect(entry.gameId).toBe(FROZEN_GAME_ID);
+      expect(entry.intervalMinutes).toBe(5);
+      expect(entry.createdAt).toBe(FROZEN_NOW_MS);
+      expect(entry.nextRunAt).toBe(FROZEN_NOW_MS + 5 * 60_000);
+    });
+
+    it("nextRunAt is null when created inactive", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+        active: false,
+      });
+      expect(useTransferAutomationStore.getState().entries[id].nextRunAt).toBeNull();
+      expect(useTransferAutomationStore.getState().entries[id].active).toBe(false);
+    });
+
+    it("dedupes resourceIds and filters non-numeric entries", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [
+          ResourcesIds.Wood,
+          ResourcesIds.Wood,
+          "not-a-number" as unknown as ResourcesIds,
+          ResourcesIds.Coal,
+        ],
+        intervalMinutes: 5,
+      });
+      expect(useTransferAutomationStore.getState().entries[id].resourceIds).toEqual([
+        ResourcesIds.Wood,
+        ResourcesIds.Coal,
+      ]);
+    });
+
+    it("builds resourceConfigs from resourceIds with zero amount when none provided", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood, ResourcesIds.Coal],
+        intervalMinutes: 1,
+      });
+      const configs = useTransferAutomationStore.getState().entries[id].resourceConfigs;
+      expect(configs).toEqual([
+        { resourceId: ResourcesIds.Wood, amount: 0 },
+        { resourceId: ResourcesIds.Coal, amount: 0 },
+      ]);
+    });
+
+    it("sanitizes provided resourceConfigs: drops bogus entries and floors negatives", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 1,
+        resourceConfigs: [
+          { resourceId: ResourcesIds.Wood, amount: 100 },
+          { resourceId: "junk" as unknown as ResourcesIds, amount: 10 },
+          { resourceId: ResourcesIds.Coal, amount: -5 },
+          { resourceId: ResourcesIds.Stone, amount: 7.9 },
+        ],
+      });
+      expect(useTransferAutomationStore.getState().entries[id].resourceConfigs).toEqual([
+        { resourceId: ResourcesIds.Wood, amount: 100 },
+        { resourceId: ResourcesIds.Coal, amount: 0 },
+        { resourceId: ResourcesIds.Stone, amount: 7 },
+      ]);
+    });
+
+    it("clamps intervalMinutes below 1 to 1", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 0,
+      });
+      expect(useTransferAutomationStore.getState().entries[id].intervalMinutes).toBe(1);
+      expect(useTransferAutomationStore.getState().entries[id].nextRunAt).toBe(FROZEN_NOW_MS + 60_000);
+    });
+
+    it("rounds a fractional intervalMinutes", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5.4,
+      });
+      expect(useTransferAutomationStore.getState().entries[id].intervalMinutes).toBe(5);
+    });
+
+    it("generates a unique id per entry", () => {
+      const ids = new Set<string>();
+      for (let i = 0; i < 10; i++) {
+        ids.add(
+          useTransferAutomationStore.getState().add({
+            sourceEntityId: "1",
+            destinationEntityId: "2",
+            resourceIds: [ResourcesIds.Wood],
+            intervalMinutes: 5,
+          }),
+        );
+      }
+      expect(ids.size).toBe(10);
+    });
+  });
+
+  describe("update", () => {
+    it("patches metadata and re-sanitizes resourceConfigs", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().update(id, {
+        sourceName: "Alpha",
+        destinationName: "Beta",
+        resourceConfigs: [{ resourceId: ResourcesIds.Wood, amount: 42 }],
+      });
+      const entry = useTransferAutomationStore.getState().entries[id];
+      expect(entry.sourceName).toBe("Alpha");
+      expect(entry.destinationName).toBe("Beta");
+      expect(entry.resourceConfigs).toEqual([{ resourceId: ResourcesIds.Wood, amount: 42 }]);
+    });
+
+    it("clamps a fractional intervalMinutes when updating", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().update(id, { intervalMinutes: 7.6 });
+      expect(useTransferAutomationStore.getState().entries[id].intervalMinutes).toBe(8);
+    });
+
+    it("clamps intervalMinutes below 1 when updating", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().update(id, { intervalMinutes: 0 });
+      expect(useTransferAutomationStore.getState().entries[id].intervalMinutes).toBe(1);
+    });
+
+    it("leaves existing resourceConfigs untouched when patch omits it", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+        resourceConfigs: [{ resourceId: ResourcesIds.Wood, amount: 10 }],
+      });
+      useTransferAutomationStore.getState().update(id, { sourceName: "Alpha" });
+      expect(useTransferAutomationStore.getState().entries[id].resourceConfigs).toEqual([
+        { resourceId: ResourcesIds.Wood, amount: 10 },
+      ]);
+    });
+
+    it("no-ops when the entry does not exist", () => {
+      useTransferAutomationStore.getState().update("nope", { sourceName: "x" });
+      expect(useTransferAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("remove", () => {
+    it("drops the entry but leaves others intact", () => {
+      const id1 = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      const id2 = useTransferAutomationStore.getState().add({
+        sourceEntityId: "3",
+        destinationEntityId: "4",
+        resourceIds: [ResourcesIds.Coal],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().remove(id1);
+      expect(useTransferAutomationStore.getState().entries[id1]).toBeUndefined();
+      expect(useTransferAutomationStore.getState().entries[id2]).toBeDefined();
+    });
+
+    it("no-ops when removing a missing id", () => {
+      useTransferAutomationStore.getState().remove("nope");
+      expect(useTransferAutomationStore.getState().entries).toEqual({});
+    });
+  });
+
+  describe("toggleActive", () => {
+    it("pauses an active entry and nulls nextRunAt", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().toggleActive(id);
+      const entry = useTransferAutomationStore.getState().entries[id];
+      expect(entry.active).toBe(false);
+      expect(entry.nextRunAt).toBeNull();
+    });
+
+    it("resumes an inactive entry and reschedules from now", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 7,
+        active: false,
+      });
+      useTransferAutomationStore.getState().toggleActive(id, true);
+      const entry = useTransferAutomationStore.getState().entries[id];
+      expect(entry.active).toBe(true);
+      expect(entry.nextRunAt).toBe(FROZEN_NOW_MS + 7 * 60_000);
+    });
+
+    it("respects explicit active=false when already paused", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+        active: false,
+      });
+      useTransferAutomationStore.getState().toggleActive(id, false);
+      expect(useTransferAutomationStore.getState().entries[id].active).toBe(false);
+      expect(useTransferAutomationStore.getState().entries[id].nextRunAt).toBeNull();
+    });
+
+    it("no-ops when the entry does not exist", () => {
+      useTransferAutomationStore.getState().toggleActive("nope");
+      expect(useTransferAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("scheduleNext", () => {
+    it("uses the current block time when no base is provided", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 3,
+      });
+      useTransferAutomationStore.getState().scheduleNext(id);
+      expect(useTransferAutomationStore.getState().entries[id].nextRunAt).toBe(FROZEN_NOW_MS + 3 * 60_000);
+    });
+
+    it("honours an explicit base timestamp", () => {
+      const id = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().scheduleNext(id, 9_000_000);
+      expect(useTransferAutomationStore.getState().entries[id].nextRunAt).toBe(9_000_000 + 5 * 60_000);
+    });
+
+    it("no-ops for a missing entry", () => {
+      useTransferAutomationStore.getState().scheduleNext("nope");
+      expect(useTransferAutomationStore.getState().entries["nope"]).toBeUndefined();
+    });
+  });
+
+  describe("clearAll / pruneForGame", () => {
+    it("clearAll empties all entries", () => {
+      useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      useTransferAutomationStore.getState().clearAll();
+      expect(useTransferAutomationStore.getState().entries).toEqual({});
+    });
+
+    it("pruneForGame drops entries from other gameIds", () => {
+      const keptId = useTransferAutomationStore.getState().add({
+        sourceEntityId: "1",
+        destinationEntityId: "2",
+        resourceIds: [ResourcesIds.Wood],
+        intervalMinutes: 5,
+      });
+      const staleId = useTransferAutomationStore.getState().add({
+        sourceEntityId: "3",
+        destinationEntityId: "4",
+        resourceIds: [ResourcesIds.Coal],
+        intervalMinutes: 5,
+        gameId: "some-old-game",
+      });
+      useTransferAutomationStore.getState().pruneForGame(FROZEN_GAME_ID);
+      expect(useTransferAutomationStore.getState().entries[keptId]).toBeDefined();
+      expect(useTransferAutomationStore.getState().entries[staleId]).toBeUndefined();
+    });
+  });
+});

--- a/client/apps/game/src/hooks/transfer-automation-planner.test.ts
+++ b/client/apps/game/src/hooks/transfer-automation-planner.test.ts
@@ -72,10 +72,7 @@ describe("planTransferAmounts", () => {
   });
 
   it("skips resources not present in resourceConfigs", () => {
-    const entry = makeEntry(
-      [ResourcesIds.Wood, ResourcesIds.Coal],
-      [{ resourceId: ResourcesIds.Wood, amount: 10 }],
-    );
+    const entry = makeEntry([ResourcesIds.Wood, ResourcesIds.Coal], [{ resourceId: ResourcesIds.Wood, amount: 10 }]);
     const result = planTransferAmounts(entry, () => 100);
     expect(result).toEqual([{ resourceId: ResourcesIds.Wood, humanAmount: 10 }]);
   });

--- a/client/apps/game/src/hooks/transfer-automation-planner.test.ts
+++ b/client/apps/game/src/hooks/transfer-automation-planner.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { ResourcesIds, RESOURCE_PRECISION } from "@bibliothecadao/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@bibliothecadao/eternum", () => {
+  return {
+    calculateDonkeysNeeded: vi.fn((weightKg: number) => Math.ceil(weightKg / 100)),
+    getTotalResourceWeightKg: vi.fn((rs: Array<{ resourceId: number; amount: number } | undefined>) =>
+      rs.reduce((acc, r) => acc + (r ? r.amount * 10 : 0), 0),
+    ),
+  };
+});
+
+import {
+  assessDonkeyCapacity,
+  buildSendResourcesArgs,
+  planTransferAmounts,
+  toRawUnits,
+} from "./transfer-automation-planner";
+import type { TransferAutomationEntry } from "./store/use-transfer-automation-store";
+
+const makeEntry = (
+  resourceIds: ResourcesIds[],
+  resourceConfigs?: TransferAutomationEntry["resourceConfigs"],
+): Pick<TransferAutomationEntry, "resourceIds" | "resourceConfigs"> => ({
+  resourceIds,
+  resourceConfigs,
+});
+
+describe("planTransferAmounts", () => {
+  it("returns items clamped to the current balance", () => {
+    const entry = makeEntry(
+      [ResourcesIds.Wood, ResourcesIds.Coal],
+      [
+        { resourceId: ResourcesIds.Wood, amount: 100 },
+        { resourceId: ResourcesIds.Coal, amount: 100 },
+      ],
+    );
+    const balances = new Map<ResourcesIds, number>([
+      [ResourcesIds.Wood, 40], // balance < desired -> transfer 40
+      [ResourcesIds.Coal, 200], // balance > desired -> transfer 100
+    ]);
+    const result = planTransferAmounts(entry, (rid) => balances.get(rid) ?? 0);
+    expect(result).toEqual([
+      { resourceId: ResourcesIds.Wood, humanAmount: 40 },
+      { resourceId: ResourcesIds.Coal, humanAmount: 100 },
+    ]);
+  });
+
+  it("skips resources with desired<=0 or zero balance", () => {
+    const entry = makeEntry(
+      [ResourcesIds.Wood, ResourcesIds.Coal, ResourcesIds.Stone],
+      [
+        { resourceId: ResourcesIds.Wood, amount: 0 },
+        { resourceId: ResourcesIds.Coal, amount: 10 },
+        { resourceId: ResourcesIds.Stone, amount: 10 },
+      ],
+    );
+    const balances = new Map<ResourcesIds, number>([
+      [ResourcesIds.Wood, 50],
+      [ResourcesIds.Coal, 0],
+      [ResourcesIds.Stone, 5],
+    ]);
+    const result = planTransferAmounts(entry, (rid) => balances.get(rid) ?? 0);
+    expect(result).toEqual([{ resourceId: ResourcesIds.Stone, humanAmount: 5 }]);
+  });
+
+  it("floors fractional desired amounts", () => {
+    const entry = makeEntry([ResourcesIds.Wood], [{ resourceId: ResourcesIds.Wood, amount: 7.9 }]);
+    const result = planTransferAmounts(entry, () => 100);
+    expect(result).toEqual([{ resourceId: ResourcesIds.Wood, humanAmount: 7 }]);
+  });
+
+  it("skips resources not present in resourceConfigs", () => {
+    const entry = makeEntry(
+      [ResourcesIds.Wood, ResourcesIds.Coal],
+      [{ resourceId: ResourcesIds.Wood, amount: 10 }],
+    );
+    const result = planTransferAmounts(entry, () => 100);
+    expect(result).toEqual([{ resourceId: ResourcesIds.Wood, humanAmount: 10 }]);
+  });
+
+  it("treats a non-finite balance as zero", () => {
+    const entry = makeEntry([ResourcesIds.Wood], [{ resourceId: ResourcesIds.Wood, amount: 10 }]);
+    const result = planTransferAmounts(entry, () => Number.NaN);
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty list when no configs are supplied", () => {
+    const entry = makeEntry([ResourcesIds.Wood, ResourcesIds.Coal]);
+    const result = planTransferAmounts(entry, () => 100);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("assessDonkeyCapacity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes when donkey balance meets the need", () => {
+    const list = [{ resourceId: ResourcesIds.Wood, humanAmount: 10 }];
+    // 10 * 10 = 100kg; calculateDonkeysNeeded mock -> ceil(100/100) = 1 donkey
+    const result = assessDonkeyCapacity(list, 1);
+    expect(result.ok).toBe(true);
+    expect(result.totalKg).toBe(100);
+    expect(result.neededDonkeys).toBe(1);
+  });
+
+  it("fails when donkey balance falls short", () => {
+    const list = [{ resourceId: ResourcesIds.Wood, humanAmount: 25 }];
+    // 25 * 10 = 250kg → 3 donkeys
+    const result = assessDonkeyCapacity(list, 2);
+    expect(result.ok).toBe(false);
+    expect(result.neededDonkeys).toBe(3);
+  });
+
+  it("returns 0 kg / 0 donkeys for an empty list", () => {
+    const result = assessDonkeyCapacity([], 0);
+    expect(result).toEqual({ ok: true, totalKg: 0, neededDonkeys: 0 });
+  });
+});
+
+describe("toRawUnits", () => {
+  it("scales by RESOURCE_PRECISION and floors", () => {
+    expect(toRawUnits(1)).toBe(BigInt(RESOURCE_PRECISION));
+    expect(toRawUnits(2.5)).toBe(BigInt(Math.floor(2.5 * RESOURCE_PRECISION)));
+  });
+
+  it("clamps negative amounts to 0n", () => {
+    expect(toRawUnits(-5)).toBe(0n);
+  });
+});
+
+describe("buildSendResourcesArgs", () => {
+  it("emits [resourceId, rawAmount] pairs in order", () => {
+    const args = buildSendResourcesArgs([
+      { resourceId: ResourcesIds.Wood, humanAmount: 1 },
+      { resourceId: ResourcesIds.Coal, humanAmount: 2 },
+    ]);
+    expect(args).toEqual([
+      ResourcesIds.Wood,
+      BigInt(RESOURCE_PRECISION),
+      ResourcesIds.Coal,
+      BigInt(2 * RESOURCE_PRECISION),
+    ]);
+  });
+
+  it("returns an empty array for an empty plan", () => {
+    expect(buildSendResourcesArgs([])).toEqual([]);
+  });
+});

--- a/client/apps/game/src/hooks/transfer-automation-planner.ts
+++ b/client/apps/game/src/hooks/transfer-automation-planner.ts
@@ -1,0 +1,58 @@
+import { calculateDonkeysNeeded, getTotalResourceWeightKg } from "@bibliothecadao/eternum";
+import { RESOURCE_PRECISION, ResourcesIds } from "@bibliothecadao/types";
+import type { TransferAutomationEntry } from "./store/use-transfer-automation-store";
+
+export interface PlannedTransfer {
+  resourceId: ResourcesIds;
+  humanAmount: number;
+}
+
+export const planTransferAmounts = (
+  entry: Pick<TransferAutomationEntry, "resourceIds" | "resourceConfigs">,
+  getBalanceHuman: (resourceId: ResourcesIds) => number,
+): PlannedTransfer[] => {
+  const configMap = new Map<number, number>();
+  if (entry.resourceConfigs && Array.isArray(entry.resourceConfigs)) {
+    for (const c of entry.resourceConfigs) {
+      configMap.set(c.resourceId, Math.max(0, Math.floor(c.amount ?? 0)));
+    }
+  }
+  const list: PlannedTransfer[] = [];
+  for (const rid of entry.resourceIds) {
+    const desired = Math.max(0, Math.floor(configMap.get(rid) ?? 0));
+    if (desired <= 0) continue;
+    const balHuman = getBalanceHuman(rid);
+    if (!Number.isFinite(balHuman) || balHuman <= 0) continue;
+    const amt = Math.max(0, Math.min(balHuman, desired));
+    if (amt > 0) list.push({ resourceId: rid, humanAmount: amt });
+  }
+  return list;
+};
+
+export interface DonkeyCapacityResult {
+  ok: boolean;
+  totalKg: number;
+  neededDonkeys: number;
+}
+
+export const assessDonkeyCapacity = (
+  transferList: PlannedTransfer[],
+  donkeyBalanceHuman: number,
+): DonkeyCapacityResult => {
+  const totalKg = getTotalResourceWeightKg(
+    transferList.map((t) => ({ resourceId: t.resourceId, amount: t.humanAmount })),
+  );
+  const neededDonkeys = calculateDonkeysNeeded(totalKg);
+  return { ok: donkeyBalanceHuman >= neededDonkeys, totalKg, neededDonkeys };
+};
+
+export const toRawUnits = (amountHuman: number): bigint =>
+  BigInt(Math.floor(Math.max(0, amountHuman) * RESOURCE_PRECISION));
+
+export const buildSendResourcesArgs = (transferList: PlannedTransfer[]): (bigint | number)[] => {
+  const args: (bigint | number)[] = [];
+  for (const t of transferList) {
+    args.push(t.resourceId, toRawUnits(t.humanAmount));
+  }
+  return args;
+};

--- a/client/apps/game/src/hooks/transfer-automation-planner.ts
+++ b/client/apps/game/src/hooks/transfer-automation-planner.ts
@@ -2,7 +2,7 @@ import { calculateDonkeysNeeded, getTotalResourceWeightKg } from "@bibliothecada
 import { RESOURCE_PRECISION, ResourcesIds } from "@bibliothecadao/types";
 import type { TransferAutomationEntry } from "./store/use-transfer-automation-store";
 
-export interface PlannedTransfer {
+interface PlannedTransfer {
   resourceId: ResourcesIds;
   humanAmount: number;
 }
@@ -29,7 +29,7 @@ export const planTransferAmounts = (
   return list;
 };
 
-export interface DonkeyCapacityResult {
+interface DonkeyCapacityResult {
   ok: boolean;
   totalKg: number;
   neededDonkeys: number;

--- a/client/apps/game/src/hooks/use-automation.source.test.ts
+++ b/client/apps/game/src/hooks/use-automation.source.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("useAutomation source", () => {
+  it("uses readable automation failure messages instead of stringifying structured errors", () => {
+    const source = readSource("src/hooks/use-automation.tsx");
+
+    expect(source).toContain("extractReadableErrorMessage");
+    expect(source).not.toContain("String(rawError)");
+  });
+});

--- a/client/apps/game/src/hooks/use-automation.source.test.ts
+++ b/client/apps/game/src/hooks/use-automation.source.test.ts
@@ -14,4 +14,13 @@ describe("useAutomation source", () => {
     expect(source).toContain("extractReadableErrorMessage");
     expect(source).not.toContain("String(rawError)");
   });
+
+  it("uses wall clock time for scheduling so stale chain time cannot freeze production automation", () => {
+    const source = readSource("src/hooks/use-automation.tsx");
+
+    expect(source).toContain("Use wall clock time for scheduling");
+    expect(source).toContain("const nowMs = Date.now();");
+    expect(source).toContain("if (nowMs < nextEligibleMs)");
+    expect(source).not.toContain("const blockTimestampMs = currentBlockTimestamp * 1000");
+  });
 });

--- a/client/apps/game/src/hooks/use-automation.source.test.ts
+++ b/client/apps/game/src/hooks/use-automation.source.test.ts
@@ -28,7 +28,7 @@ describe("useAutomation source", () => {
     const source = readSource("src/hooks/use-automation.tsx");
 
     expect(source).toContain("type ProcessRealmsResult = { ran: boolean; anyExecuted: boolean }");
-    expect(source).toContain("if (ran && !pruneDuringProcessingRef.current)");
+    expect(source).toContain("shouldAdvanceSchedulerBookkeeping(ran, pruneDuringProcessingRef.current)");
     expect(source).toContain("return { ran: false, anyExecuted: false }");
     expect(source).toContain("return { ran: true, anyExecuted }");
   });
@@ -46,7 +46,7 @@ describe("useAutomation source", () => {
 
     expect(source).toContain("pruneDuringProcessingRef = useRef");
     expect(source).toContain("pruneForGame(gameId)");
-    // The pruneForGame effect must reset the scheduler clock.
-    expect(source).toMatch(/pruneForGame\(gameId\);[\s\S]*lastRunTimestampRef\.current = nowMs/);
+    // The pruneForGame effect must reset the scheduler clock via the shared helper.
+    expect(source).toMatch(/pruneForGame\(gameId\);[\s\S]*computePostPassSchedulerUpdate\(nowMs\)/);
   });
 });

--- a/client/apps/game/src/hooks/use-automation.source.test.ts
+++ b/client/apps/game/src/hooks/use-automation.source.test.ts
@@ -23,4 +23,30 @@ describe("useAutomation source", () => {
     expect(source).toContain("if (nowMs < nextEligibleMs)");
     expect(source).not.toContain("const blockTimestampMs = currentBlockTimestamp * 1000");
   });
+
+  it("only advances the scheduler clock when processRealms actually ran", () => {
+    const source = readSource("src/hooks/use-automation.tsx");
+
+    expect(source).toContain("type ProcessRealmsResult = { ran: boolean; anyExecuted: boolean }");
+    expect(source).toContain("if (ran && !pruneDuringProcessingRef.current)");
+    expect(source).toContain("return { ran: false, anyExecuted: false }");
+    expect(source).toContain("return { ran: true, anyExecuted }");
+  });
+
+  it("uses the shared signature helper which hashes autoBalance and percentage values", () => {
+    const source = readSource("src/hooks/use-automation.tsx");
+
+    expect(source).toContain("computeAutomationConfigSignature");
+    // The inline signature that only hashed preset + customKeys must be gone.
+    expect(source).not.toContain("const customKeys = Object.keys(realm.customPercentages");
+  });
+
+  it("resets scheduler refs when pruneForGame runs and guards in-flight passes", () => {
+    const source = readSource("src/hooks/use-automation.tsx");
+
+    expect(source).toContain("pruneDuringProcessingRef = useRef");
+    expect(source).toContain("pruneForGame(gameId)");
+    // The pruneForGame effect must reset the scheduler clock.
+    expect(source).toMatch(/pruneForGame\(gameId\);[\s\S]*lastRunTimestampRef\.current = nowMs/);
+  });
 });

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -31,6 +31,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { Account as StarknetAccount } from "starknet";
 import { isVillageLikeStructureCategory } from "@/ui/lib/structure-capabilities";
+import { extractReadableErrorMessage } from "@/utils/error-message";
 
 const resolveResourceLabel = (resourceId: number): string => {
   const label = ResourcesIds[resourceId as ResourcesIds];
@@ -427,11 +428,14 @@ export const useAutomation = () => {
           } else {
             const rejection = result.reason;
             const rawError = rejection.error;
-            const errorMessage = rawError instanceof Error ? rawError.message : String(rawError);
+            const errorMessage = extractReadableErrorMessage(rawError, "Automation transaction failed");
             const realmConfig = rejection.realmConfig;
             const realmLabel = rejection.realmLabel;
 
-            console.error(`Automation: Failed to execute plan for ${realmLabel}`, errorMessage);
+            console.error(`Automation: Failed to execute plan for ${realmLabel}`, {
+              error: rawError,
+              message: errorMessage,
+            });
 
             if (realmConfig) {
               const prev = getRealmConfig(realmConfig.realmId);

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -9,9 +9,14 @@ import {
   type RealmResourceSnapshot,
 } from "@/ui/features/infrastructure/automation/model/automation-processor";
 import {
+  AutomationCancelledError,
+  AutomationSignerSkippedError,
   executeProductionPlansSequentially,
+  isSignerTransientError,
   type ExecutableProductionPlan,
 } from "@/ui/features/infrastructure/automation/model/automation-runner";
+import { computeAutomationConfigSignature } from "@/utils/automation-signature";
+import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import { useOwnedProductionStructureInfos } from "@/hooks/helpers/use-owned-structure-info";
 import {
   useAutomationStore,
@@ -19,7 +24,6 @@ import {
   DONKEY_DEFAULT_RESOURCE_PERCENT,
   type ResourceAutomationPercentages,
   type RealmAutomationExecutionSummary,
-  type RealmAutomationConfig,
 } from "./store/use-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { calculatePresetAllocations, getAutomationOverallocation } from "@/utils/automation-presets";
@@ -87,6 +91,8 @@ const formatCustomPercentagesLog = (percentages: Record<number, ResourceAutomati
     percentages: value,
   }));
 
+type ProcessRealmsResult = { ran: boolean; anyExecuted: boolean };
+
 export const useAutomation = () => {
   const {
     setup: {
@@ -105,7 +111,10 @@ export const useAutomation = () => {
   const pruneForGame = useAutomationStore((state) => state.pruneForGame);
   const hydrated = useAutomationStore((state) => state.hydrated);
   const processingRef = useRef(false);
-  const processRealmsRef = useRef<() => Promise<boolean>>(async () => false);
+  const processRealmsRef = useRef<() => Promise<ProcessRealmsResult>>(async () => ({
+    ran: false,
+    anyExecuted: false,
+  }));
   const setNextRunTimestampRef = useRef(setNextRunTimestamp);
   const playerStructures = useOwnedProductionStructureInfos();
   const gameEndAt = useUIStore((state) => state.gameEndAt);
@@ -122,6 +131,7 @@ export const useAutomation = () => {
   const scheduleNextCheckRef = useRef<() => void>();
   const automationTimeoutIdRef = useRef<number | null>(null);
   const syncedRealmIdsRef = useRef<Set<string>>(new Set());
+  const pruneDuringProcessingRef = useRef<boolean>(false);
 
   const stopAutomation = useCallback(() => {
     if (automationTimeoutIdRef.current !== null) {
@@ -156,6 +166,15 @@ export const useAutomation = () => {
     const season = configManager.getSeasonConfig();
     const gameId = `${season.startSettlingAt}-${season.startMainAt}-${season.endAt}`;
     pruneForGame(gameId);
+
+    const nowMs = Date.now();
+    if (processingRef.current) {
+      pruneDuringProcessingRef.current = true;
+    }
+    lastRunTimestampRef.current = nowMs;
+    automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
+    nextRunTimestampRef.current = automationEnabledAtRef.current;
+    setNextRunTimestampRef.current(nextRunTimestampRef.current);
   }, [components, pruneForGame]);
 
   useEffect(() => {
@@ -194,29 +213,29 @@ export const useAutomation = () => {
     });
   }, [hydrated, playerStructures, removeRealm, upsertRealm, mode]);
 
-  const processRealms = useCallback(async (): Promise<boolean> => {
-    if (processingRef.current) return false;
+  const processRealms = useCallback(async (): Promise<ProcessRealmsResult> => {
+    if (processingRef.current) return { ran: false, anyExecuted: false };
 
     if (isGameOver()) {
       console.log("Automation: Game has ended. Skipping automation pass.");
-      return false;
+      return { ran: false, anyExecuted: false };
     }
 
     if (!starknetSignerAccount || !starknetSignerAccount.address || starknetSignerAccount.address === "0x0") {
       console.log("Automation: Missing Starknet signer. Skipping automation pass.");
-      return false;
+      return { ran: false, anyExecuted: false };
     }
 
     if (!components) {
       console.log("Automation: Missing Dojo components. Skipping automation pass.");
-      return false;
+      return { ran: false, anyExecuted: false };
     }
 
     const realmList = Object.values(useAutomationStore.getState().realms).filter(
       (realm) => realm.entityType === "realm" || realm.entityType === "village",
     );
     if (realmList.length === 0) {
-      return false;
+      return { ran: false, anyExecuted: false };
     }
 
     processingRef.current = true;
@@ -381,12 +400,28 @@ export const useAutomation = () => {
       if (executablePlans.length > 0) {
         console.log(`[Automation] Executing ${executablePlans.length} production plans sequentially`);
 
+        let signerFaultSurfacedForTick = false;
         const results = await executeProductionPlansSequentially({
           executablePlans,
           signer: starknetSignerAccount as StarknetAccount,
           executeRealmProductionPlan: execute_realm_production_plan,
           onBeforeExecute: ({ planLogPayload }) => {
             console.log("[Automation] Executing production plan", planLogPayload);
+          },
+          isCancelled: ({ plan, realmConfig }) => {
+            if (isGameOver()) {
+              return { cancelled: true, reason: "Game has ended", scope: "pass" };
+            }
+            const accountAddress = starknetSignerAccount?.address;
+            if (!accountAddress || accountAddress === "0x0") {
+              return { cancelled: true, reason: "Signer unavailable", scope: "pass" };
+            }
+            const realmIdNum = Number(realmConfig.realmId);
+            const entityId = Number.isFinite(realmIdNum) && realmIdNum > 0 ? realmIdNum : plan.realmId;
+            if (!isEntityOwnedByAccount(components, entityId, accountAddress)) {
+              return { cancelled: true, reason: "Realm no longer owned", scope: "realm" };
+            }
+            return { cancelled: false };
           },
         });
 
@@ -428,9 +463,46 @@ export const useAutomation = () => {
           } else {
             const rejection = result.reason;
             const rawError = rejection.error;
-            const errorMessage = extractReadableErrorMessage(rawError, "Automation transaction failed");
             const realmConfig = rejection.realmConfig;
             const realmLabel = rejection.realmLabel;
+
+            if (rawError instanceof AutomationCancelledError) {
+              console.log("[Automation] Skipped realm due to cancellation", {
+                realmLabel,
+                reason: rawError.message,
+                scope: rawError.scope,
+              });
+              if (realmConfig) {
+                const prev = getRealmConfig(realmConfig.realmId);
+                recordStatus(realmConfig.realmId, {
+                  status: "skipped",
+                  message: rawError.message,
+                  attemptedAt: Date.now(),
+                  consecutiveFailures: prev?.lastStatus?.consecutiveFailures ?? 0,
+                });
+              }
+              continue;
+            }
+
+            if (rawError instanceof AutomationSignerSkippedError) {
+              console.log("[Automation] Skipped realm after signer fault earlier in pass", {
+                realmLabel,
+                reason: rawError.message,
+              });
+              if (realmConfig) {
+                const prev = getRealmConfig(realmConfig.realmId);
+                recordStatus(realmConfig.realmId, {
+                  status: "skipped",
+                  message: rawError.message,
+                  attemptedAt: Date.now(),
+                  consecutiveFailures: prev?.lastStatus?.consecutiveFailures ?? 0,
+                });
+              }
+              continue;
+            }
+
+            const errorMessage = extractReadableErrorMessage(rawError, "Automation transaction failed");
+            const isSignerFault = isSignerTransientError(rawError);
 
             console.error(`Automation: Failed to execute plan for ${realmLabel}`, {
               error: rawError,
@@ -443,11 +515,20 @@ export const useAutomation = () => {
                 status: "failed",
                 message: errorMessage,
                 attemptedAt: Date.now(),
-                consecutiveFailures: (prev?.lastStatus?.consecutiveFailures ?? 0) + 1,
+                consecutiveFailures: isSignerFault
+                  ? (prev?.lastStatus?.consecutiveFailures ?? 0)
+                  : (prev?.lastStatus?.consecutiveFailures ?? 0) + 1,
               });
             }
 
-            toast.error(`Automation failed for ${realmLabel}: ${errorMessage}`);
+            if (isSignerFault) {
+              if (!signerFaultSurfacedForTick) {
+                signerFaultSurfacedForTick = true;
+                toast.error(`Automation paused this tick: signer error — next tick will retry (${errorMessage})`);
+              }
+            } else {
+              toast.error(`Automation failed for ${realmLabel}: ${errorMessage}`);
+            }
           }
         }
       }
@@ -455,7 +536,7 @@ export const useAutomation = () => {
       processingRef.current = false;
     }
 
-    return anyExecuted;
+    return { ran: true, anyExecuted };
   }, [
     components,
     execute_realm_production_plan,
@@ -487,13 +568,18 @@ export const useAutomation = () => {
       return;
     }
 
+    let ran = false;
     try {
-      await processRealmsRef.current();
+      const result = await processRealmsRef.current();
+      ran = result.ran;
     } finally {
-      lastRunTimestampRef.current = nowMs;
-      automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
-      nextRunTimestampRef.current = automationEnabledAtRef.current;
-      setNextRunTimestampRef.current(nextRunTimestampRef.current);
+      if (ran && !pruneDuringProcessingRef.current) {
+        lastRunTimestampRef.current = nowMs;
+        automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
+        nextRunTimestampRef.current = automationEnabledAtRef.current;
+        setNextRunTimestampRef.current(nextRunTimestampRef.current);
+      }
+      pruneDuringProcessingRef.current = false;
       scheduleNextCheckRef.current?.();
     }
   }, [isGameOver, setNextRunTimestampRef, stopAutomation]);
@@ -527,33 +613,25 @@ export const useAutomation = () => {
   }, [setNextRunTimestamp]);
 
   useEffect(() => {
-    const computeSignature = (realms: Record<string, RealmAutomationConfig>) =>
-      Object.entries(realms)
-        .filter(([, realm]) => realm.entityType === "realm" || realm.entityType === "village")
-        .map(([realmId, realm]) => {
-          const customKeys = Object.keys(realm.customPercentages ?? {})
-            .toSorted()
-            .join(",");
-          const presetId = realm.presetId ?? "smart";
-          return `${realmId}:${presetId}:${customKeys}`;
-        })
-        .toSorted()
-        .join("|");
-
     const unsub = useAutomationStore.subscribe((state, prevState) => {
       if (state.realms === prevState.realms) return;
       if (isGameOver()) return;
 
-      const newSignature = computeSignature(state.realms);
+      const newSignature = computeAutomationConfigSignature(state.realms);
       if (newSignature !== realmResourcesSignatureRef.current) {
         realmResourcesSignatureRef.current = newSignature;
         const nowMs = Date.now();
-        if (nowMs >= automationEnabledAtRef.current) {
-          lastRunTimestampRef.current = nowMs;
-          automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
-          nextRunTimestampRef.current = automationEnabledAtRef.current;
-          setNextRunTimestampRef.current(nextRunTimestampRef.current);
-          void processRealmsRef.current();
+        if (nowMs >= automationEnabledAtRef.current && !processingRef.current) {
+          void (async () => {
+            const result = await processRealmsRef.current();
+            if (result.ran && !pruneDuringProcessingRef.current) {
+              lastRunTimestampRef.current = nowMs;
+              automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
+              nextRunTimestampRef.current = automationEnabledAtRef.current;
+              setNextRunTimestampRef.current(nextRunTimestampRef.current);
+            }
+            pruneDuringProcessingRef.current = false;
+          })();
         }
         scheduleNextCheckRef.current?.();
       }

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -17,6 +17,12 @@ import {
 } from "@/ui/features/infrastructure/automation/model/automation-runner";
 import { computeAutomationConfigSignature } from "@/utils/automation-signature";
 import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
+import {
+  computeNextEligibleMs,
+  computePostPassSchedulerUpdate,
+  computeScheduleDelayMs,
+  shouldAdvanceSchedulerBookkeeping,
+} from "./automation-scheduler";
 import { useOwnedProductionStructureInfos } from "@/hooks/helpers/use-owned-structure-info";
 import {
   useAutomationStore,
@@ -171,9 +177,10 @@ export const useAutomation = () => {
     if (processingRef.current) {
       pruneDuringProcessingRef.current = true;
     }
-    lastRunTimestampRef.current = nowMs;
-    automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
-    nextRunTimestampRef.current = automationEnabledAtRef.current;
+    const update = computePostPassSchedulerUpdate(nowMs);
+    lastRunTimestampRef.current = update.lastRunMs;
+    automationEnabledAtRef.current = update.automationEnabledAtMs;
+    nextRunTimestampRef.current = update.nextRunMs;
     setNextRunTimestampRef.current(nextRunTimestampRef.current);
   }, [components, pruneForGame]);
 
@@ -558,7 +565,7 @@ export const useAutomation = () => {
     }
 
     const lastRunMs = lastRunTimestampRef.current ?? nowMs;
-    const nextEligibleMs = Math.max(lastRunMs + PROCESS_INTERVAL_MS, automationEnabledAtRef.current);
+    const nextEligibleMs = computeNextEligibleMs(lastRunMs, automationEnabledAtRef.current);
 
     nextRunTimestampRef.current = nextEligibleMs;
     setNextRunTimestampRef.current(nextEligibleMs);
@@ -573,10 +580,11 @@ export const useAutomation = () => {
       const result = await processRealmsRef.current();
       ran = result.ran;
     } finally {
-      if (ran && !pruneDuringProcessingRef.current) {
-        lastRunTimestampRef.current = nowMs;
-        automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
-        nextRunTimestampRef.current = automationEnabledAtRef.current;
+      if (shouldAdvanceSchedulerBookkeeping(ran, pruneDuringProcessingRef.current)) {
+        const update = computePostPassSchedulerUpdate(nowMs);
+        lastRunTimestampRef.current = update.lastRunMs;
+        automationEnabledAtRef.current = update.automationEnabledAtMs;
+        nextRunTimestampRef.current = update.nextRunMs;
         setNextRunTimestampRef.current(nextRunTimestampRef.current);
       }
       pruneDuringProcessingRef.current = false;
@@ -592,9 +600,7 @@ export const useAutomation = () => {
     if (automationTimeoutIdRef.current !== null) {
       window.clearTimeout(automationTimeoutIdRef.current);
     }
-    const now = Date.now();
-    const nextBlockMs = (Math.floor(now / 1000) + 1) * 1000;
-    const delay = Math.max(250, nextBlockMs - now);
+    const delay = computeScheduleDelayMs(Date.now());
     automationTimeoutIdRef.current = window.setTimeout(() => {
       void runAutomationIfDue();
     }, delay);
@@ -624,10 +630,11 @@ export const useAutomation = () => {
         if (nowMs >= automationEnabledAtRef.current && !processingRef.current) {
           void (async () => {
             const result = await processRealmsRef.current();
-            if (result.ran && !pruneDuringProcessingRef.current) {
-              lastRunTimestampRef.current = nowMs;
-              automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
-              nextRunTimestampRef.current = automationEnabledAtRef.current;
+            if (shouldAdvanceSchedulerBookkeeping(result.ran, pruneDuringProcessingRef.current)) {
+              const update = computePostPassSchedulerUpdate(nowMs);
+              lastRunTimestampRef.current = update.lastRunMs;
+              automationEnabledAtRef.current = update.automationEnabledAtMs;
+              nextRunTimestampRef.current = update.nextRunMs;
               setNextRunTimestampRef.current(nextRunTimestampRef.current);
             }
             pruneDuringProcessingRef.current = false;

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -1,4 +1,5 @@
 import {
+  buildAutomationPlanSkipMessage,
   buildExecutionSummary,
   buildRealmProductionPlan,
   buildRealmResourceSnapshot,
@@ -7,6 +8,10 @@ import {
   type RealmProductionPlan,
   type RealmResourceSnapshot,
 } from "@/ui/features/infrastructure/automation/model/automation-processor";
+import {
+  executeProductionPlansSequentially,
+  type ExecutableProductionPlan,
+} from "@/ui/features/infrastructure/automation/model/automation-runner";
 import { useOwnedProductionStructureInfos } from "@/hooks/helpers/use-owned-structure-info";
 import {
   useAutomationStore,
@@ -93,7 +98,6 @@ export const useAutomation = () => {
   const setNextRunTimestamp = useAutomationStore((state) => state.setNextRunTimestamp);
   const recordExecution = useAutomationStore((state) => state.recordExecution);
   const recordStatus = useAutomationStore((state) => state.recordStatus);
-  const setRealmPreset = useAutomationStore((state) => state.setRealmPreset);
   const getRealmConfig = useAutomationStore((state) => state.getRealmConfig);
   const upsertRealm = useAutomationStore((state) => state.upsertRealm);
   const removeRealm = useAutomationStore((state) => state.removeRealm);
@@ -222,15 +226,11 @@ export const useAutomation = () => {
       const { currentDefaultTick: conservativeTick } = getConservativeBlockTimestamp();
 
       // Phase 1: Build all plans synchronously (no awaits, so no event loop yields)
-      const executablePlans: Array<{
-        plan: RealmProductionPlan;
-        realmConfig: (typeof realmList)[0];
-        realmLabel: string;
-        planLogPayload: Record<string, unknown>;
-      }> = [];
+      const executablePlans: ExecutableProductionPlan[] = [];
 
       for (const realmConfig of realmList) {
         let activeRealmConfig = realmConfig;
+        let runStatusNote: string | undefined;
         const realmIdNum = Number(activeRealmConfig.realmId);
         const realmLabel = activeRealmConfig.realmName ?? `Realm ${activeRealmConfig.realmId}`;
 
@@ -273,10 +273,12 @@ export const useAutomation = () => {
 
         if (activeRealmConfig.presetId === "custom" && activeRealmConfig.autoBalance) {
           try {
-            const resourceIdsForCheck =
-              producedResourceIds.length > 0
-                ? producedResourceIds
-                : Object.keys(activeRealmConfig.customPercentages ?? {}).map((key) => Number(key) as ResourcesIds);
+            const resourceIdsForCheck = Array.from(
+              new Set<ResourcesIds>([
+                ...producedResourceIds,
+                ...Object.keys(activeRealmConfig.customPercentages ?? {}).map((key) => Number(key) as ResourcesIds),
+              ]),
+            );
 
             const effectivePercentages: Record<number, ResourceAutomationPercentages> = {};
             const smartDefaults = calculatePresetAllocations(
@@ -300,7 +302,8 @@ export const useAutomation = () => {
             );
 
             if (resourceOver || laborOver) {
-              console.log("[Automation] Auto-switching to smart preset due to over-allocation", {
+              runStatusNote = "Custom allocation over budget; used Smart for this run";
+              console.log("[Automation] Using smart preset for this run due to over-allocation", {
                 realmId: activeRealmConfig.realmId,
                 realmName: realmLabel,
                 producedResourceIds,
@@ -308,11 +311,11 @@ export const useAutomation = () => {
                 laborOver,
               });
 
-              setRealmPreset(activeRealmConfig.realmId, "smart");
-              const refreshed = getRealmConfig(activeRealmConfig.realmId);
-              if (refreshed) {
-                activeRealmConfig = refreshed;
-              }
+              activeRealmConfig = {
+                ...activeRealmConfig,
+                presetId: "smart",
+                customPercentages: {},
+              };
             }
           } catch (error) {
             console.error("[Automation] Failed to auto-balance custom allocations", activeRealmConfig.realmId, error);
@@ -348,55 +351,43 @@ export const useAutomation = () => {
 
         if (!planHasExecutableCalls(plan)) {
           console.log("[Automation] No executable automation calls detected", planLogPayload);
+          recordExecution(activeRealmConfig.realmId, buildExecutionSummary(plan, Date.now()));
           recordStatus(activeRealmConfig.realmId, {
             status: "skipped",
-            message: "No executable calls",
+            message: [runStatusNote, buildAutomationPlanSkipMessage(plan)].filter(Boolean).join("; "),
             attemptedAt: Date.now(),
             consecutiveFailures: 0,
           });
           continue;
         }
 
-        // Collect executable plans for parallel execution
+        // Collect executable plans for isolated execution.
         executablePlans.push({
           plan,
           realmConfig: activeRealmConfig,
           realmLabel,
-          planLogPayload,
+          planLogPayload: {
+            ...planLogPayload,
+            runStatusNote,
+          },
         });
       }
 
-      // Phase 2: Execute all plans in parallel (each realm gets its own independent transaction)
+      // Phase 2: Execute all plans sequentially so isolated per-realm txs do not race the same signer nonce.
       console.log(
         `[Automation] Planning complete: ${executablePlans.length} executable out of ${realmList.length} realms`,
       );
       if (executablePlans.length > 0) {
-        console.log(`[Automation] Executing ${executablePlans.length} production plans in parallel`);
+        console.log(`[Automation] Executing ${executablePlans.length} production plans sequentially`);
 
-        const results = await Promise.allSettled(
-          executablePlans.map(async ({ plan, realmConfig, realmLabel, planLogPayload }) => {
-            try {
-              console.log("[Automation] Executing production plan", planLogPayload);
-              const callset = plan.callset;
-              await execute_realm_production_plan({
-                signer: starknetSignerAccount as StarknetAccount,
-                realm_entity_id: plan.realmId,
-                skipQueue: true,
-                resource_to_resource: callset.resourceToResource.map((item) => ({
-                  resource_id: item.resourceId,
-                  cycles: item.cycles,
-                })),
-                labor_to_resource: callset.laborToResource.map((item) => ({
-                  resource_id: item.resourceId,
-                  cycles: item.cycles,
-                })),
-              });
-              return { plan, realmConfig, realmLabel, planLogPayload };
-            } catch (error) {
-              throw { error, realmConfig, realmLabel };
-            }
-          }),
-        );
+        const results = await executeProductionPlansSequentially({
+          executablePlans,
+          signer: starknetSignerAccount as StarknetAccount,
+          executeRealmProductionPlan: execute_realm_production_plan,
+          onBeforeExecute: ({ planLogPayload }) => {
+            console.log("[Automation] Executing production plan", planLogPayload);
+          },
+        });
 
         // Phase 3: Process results
         for (const result of results) {
@@ -406,7 +397,7 @@ export const useAutomation = () => {
             recordExecution(realmConfig.realmId, summary);
             recordStatus(realmConfig.realmId, {
               status: "success",
-              message: undefined,
+              message: typeof planLogPayload.runStatusNote === "string" ? planLogPayload.runStatusNote : undefined,
               attemptedAt: Date.now(),
               consecutiveFailures: 0,
             });
@@ -434,15 +425,11 @@ export const useAutomation = () => {
               toast.success(`Automation executed for ${realmConfig.realmName ?? `Realm ${plan.realmId}`}.`);
             }
           } else {
-            const rejection = result.reason as {
-              error?: unknown;
-              realmConfig?: (typeof executablePlans)[0]["realmConfig"];
-              realmLabel?: string;
-            };
-            const rawError = rejection?.error ?? result.reason;
+            const rejection = result.reason;
+            const rawError = rejection.error;
             const errorMessage = rawError instanceof Error ? rawError.message : String(rawError);
-            const realmConfig = rejection?.realmConfig;
-            const realmLabel = rejection?.realmLabel ?? "Unknown realm";
+            const realmConfig = rejection.realmConfig;
+            const realmLabel = rejection.realmLabel;
 
             console.error(`Automation: Failed to execute plan for ${realmLabel}`, errorMessage);
 
@@ -471,7 +458,6 @@ export const useAutomation = () => {
     recordExecution,
     recordStatus,
     starknetSignerAccount,
-    setRealmPreset,
     getRealmConfig,
     isGameOver,
   ]);

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -111,14 +111,14 @@ export const useAutomation = () => {
   const gameEndAt = useUIStore((state) => state.gameEndAt);
   const mode = useGameModeConfig();
   const realmResourcesSignatureRef = useRef<string>("");
-  const initialBlockTimestampMsRef = useRef<number | null>(null);
-  if (initialBlockTimestampMsRef.current === null) {
-    initialBlockTimestampMsRef.current = getBlockTimestamp().currentBlockTimestamp * 1000;
+  const initialAutomationTimestampMsRef = useRef<number | null>(null);
+  if (initialAutomationTimestampMsRef.current === null) {
+    initialAutomationTimestampMsRef.current = Date.now();
   }
-  const initialBlockTimestampMs = initialBlockTimestampMsRef.current!;
-  const automationEnabledAtRef = useRef<number>(initialBlockTimestampMs + PROCESS_INTERVAL_MS);
-  const lastRunBlockTimestampRef = useRef<number>(initialBlockTimestampMs);
-  const nextRunBlockTimestampRef = useRef<number>(automationEnabledAtRef.current);
+  const initialAutomationTimestampMs = initialAutomationTimestampMsRef.current!;
+  const automationEnabledAtRef = useRef<number>(initialAutomationTimestampMs + PROCESS_INTERVAL_MS);
+  const lastRunTimestampRef = useRef<number>(initialAutomationTimestampMs);
+  const nextRunTimestampRef = useRef<number>(automationEnabledAtRef.current);
   const scheduleNextCheckRef = useRef<() => void>();
   const automationTimeoutIdRef = useRef<number | null>(null);
   const syncedRealmIdsRef = useRef<Set<string>>(new Set());
@@ -468,20 +468,21 @@ export const useAutomation = () => {
 
   const runAutomationIfDue = useCallback(async () => {
     const { currentBlockTimestamp } = getBlockTimestamp();
-    const blockTimestampMs = currentBlockTimestamp * 1000;
+    // Use wall clock time for scheduling so stale chain time cannot freeze automation.
+    const nowMs = Date.now();
 
     if (isGameOver(currentBlockTimestamp)) {
       stopAutomation();
       return;
     }
 
-    const lastRunMs = lastRunBlockTimestampRef.current ?? blockTimestampMs;
+    const lastRunMs = lastRunTimestampRef.current ?? nowMs;
     const nextEligibleMs = Math.max(lastRunMs + PROCESS_INTERVAL_MS, automationEnabledAtRef.current);
 
-    nextRunBlockTimestampRef.current = nextEligibleMs;
+    nextRunTimestampRef.current = nextEligibleMs;
     setNextRunTimestampRef.current(nextEligibleMs);
 
-    if (blockTimestampMs < nextEligibleMs) {
+    if (nowMs < nextEligibleMs) {
       scheduleNextCheckRef.current?.();
       return;
     }
@@ -489,10 +490,10 @@ export const useAutomation = () => {
     try {
       await processRealmsRef.current();
     } finally {
-      lastRunBlockTimestampRef.current = blockTimestampMs;
-      automationEnabledAtRef.current = blockTimestampMs + PROCESS_INTERVAL_MS;
-      nextRunBlockTimestampRef.current = automationEnabledAtRef.current;
-      setNextRunTimestampRef.current(nextRunBlockTimestampRef.current);
+      lastRunTimestampRef.current = nowMs;
+      automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
+      nextRunTimestampRef.current = automationEnabledAtRef.current;
+      setNextRunTimestampRef.current(nextRunTimestampRef.current);
       scheduleNextCheckRef.current?.();
     }
   }, [isGameOver, setNextRunTimestampRef, stopAutomation]);
@@ -546,12 +547,12 @@ export const useAutomation = () => {
       const newSignature = computeSignature(state.realms);
       if (newSignature !== realmResourcesSignatureRef.current) {
         realmResourcesSignatureRef.current = newSignature;
-        const currentBlockMs = getBlockTimestamp().currentBlockTimestamp * 1000;
-        if (currentBlockMs >= automationEnabledAtRef.current) {
-          lastRunBlockTimestampRef.current = currentBlockMs;
-          automationEnabledAtRef.current = currentBlockMs + PROCESS_INTERVAL_MS;
-          nextRunBlockTimestampRef.current = automationEnabledAtRef.current;
-          setNextRunTimestampRef.current(nextRunBlockTimestampRef.current);
+        const nowMs = Date.now();
+        if (nowMs >= automationEnabledAtRef.current) {
+          lastRunTimestampRef.current = nowMs;
+          automationEnabledAtRef.current = nowMs + PROCESS_INTERVAL_MS;
+          nextRunTimestampRef.current = automationEnabledAtRef.current;
+          setNextRunTimestampRef.current(nextRunTimestampRef.current);
           void processRealmsRef.current();
         }
         scheduleNextCheckRef.current?.();
@@ -570,7 +571,7 @@ export const useAutomation = () => {
       };
     }
 
-    setNextRunTimestampRef.current(nextRunBlockTimestampRef.current);
+    setNextRunTimestampRef.current(nextRunTimestampRef.current);
     scheduleNextCheck();
     return () => {
       if (automationTimeoutIdRef.current !== null) {

--- a/client/apps/game/src/hooks/use-exploration-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-exploration-automation-runner.ts
@@ -1,4 +1,3 @@
-import type { ActionPath } from "@bibliothecadao/eternum";
 import {
   ActionPaths,
   ActionType,
@@ -25,6 +24,12 @@ import {
   useExplorationAutomationStore,
 } from "@/hooks/store/use-exploration-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import {
+  computeEffectiveStaminaCost,
+  filterFreshExplorationPaths,
+  selectDueEntries,
+  shouldRepeatExplore,
+} from "./exploration-automation-planner";
 
 const isExplorerOwnedByAccount = (
   components: any,
@@ -45,9 +50,6 @@ const isExplorerOwnedByAccount = (
 
 const REPEAT_EXPLORE_DELAY_MS = 3_000;
 const FAST_CACHE_TTL_MS = 15_000;
-
-const getPathStaminaCost = (path: { staminaCost?: number }[]): number =>
-  path.reduce((total, step) => total + (step.staminaCost ?? 0), 0);
 
 type SnapshotCache = {
   snapshot: ExplorationMapSnapshot;
@@ -74,12 +76,6 @@ export const useExplorationAutomationRunner = () => {
   const processRef = useRef<() => Promise<void>>(async () => {});
   const timeoutIdRef = useRef<number | null>(null);
   const snapshotCacheRef = useRef<Map<string, SnapshotCache>>(new Map());
-
-  const normalizeNextRunAt = useCallback((value: unknown): number | null => {
-    if (value === null || value === undefined) return null;
-    const numeric = typeof value === "number" ? value : Number(value);
-    return Number.isFinite(numeric) ? numeric : null;
-  }, []);
 
   const activeEntries = useMemo(() => Object.values(entries).filter((e) => e.active), [entries]);
   const activeEntriesRef = useRef(activeEntries);
@@ -195,11 +191,7 @@ export const useExplorationAutomationRunner = () => {
 
       // Use wall clock time for scheduling (matches store and UI expectations)
       const nowMs = Date.now();
-      const due = activeEntriesRef.current.filter((entry) => {
-        const nextRunAt = normalizeNextRunAt(entry.nextRunAt);
-        if (nextRunAt === null) return true;
-        return nextRunAt <= nowMs;
-      });
+      const due = selectDueEntries(activeEntriesRef.current, nowMs);
 
       if (!due.length) {
         scheduleNextCheck();
@@ -283,14 +275,9 @@ export const useExplorationAutomationRunner = () => {
             let actionPathMap = actionPaths.getPaths();
 
             if (useFastCache && cached) {
-              const filtered = new Map<string, ActionPath[]>();
-              actionPathMap.forEach((path, key) => {
-                if (ActionPaths.getActionType(path) !== ActionType.Explore) return;
-                const endHex = path[path.length - 1]?.hex;
-                if (!endHex) return;
-                const normalized = new Position({ x: endHex.col, y: endHex.row }).getNormalized();
-                if (cached.recentlyExplored.has(`${normalized.x},${normalized.y}`)) return;
-                filtered.set(key, path);
+              const filtered = filterFreshExplorationPaths(actionPathMap, cached.recentlyExplored, (hex) => {
+                const normalized = new Position({ x: hex.col, y: hex.row }).getNormalized();
+                return { x: normalized.x, y: normalized.y };
               });
 
               if (filtered.size === 0) {
@@ -349,11 +336,9 @@ export const useExplorationAutomationRunner = () => {
               currentArmiesTick,
             );
 
-            const pathStaminaCost = getPathStaminaCost(selection.path);
-            const effectiveCost =
-              pathStaminaCost > 0 || actionType !== ActionType.Explore ? pathStaminaCost : exploreStaminaCost;
+            const effectiveCost = computeEffectiveStaminaCost(selection.path, actionType, exploreStaminaCost);
             const remainingStamina = Math.max(0, Number(currentStamina.amount) - effectiveCost);
-            const shouldRepeat = actionType === ActionType.Explore && remainingStamina >= exploreStaminaCost;
+            const shouldRepeat = shouldRepeatExplore(actionType, remainingStamina, exploreStaminaCost);
             const repeatAt = nowMs + REPEAT_EXPLORE_DELAY_MS;
 
             if (shouldRepeat) {
@@ -400,7 +385,6 @@ export const useExplorationAutomationRunner = () => {
     isSeasonOver,
     network?.contractComponents,
     network?.toriiClient,
-    normalizeNextRunAt,
     scheduleNext,
     scheduleNextCheck,
     stopAutomation,

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.ts
@@ -14,11 +14,7 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { canTransferMilitaryInventoryBetweenStructureIds } from "@/ui/lib/structure-capabilities";
 import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import { useTransferAutomationStore } from "./store/use-transfer-automation-store";
-import {
-  assessDonkeyCapacity,
-  buildSendResourcesArgs,
-  planTransferAmounts,
-} from "./transfer-automation-planner";
+import { assessDonkeyCapacity, buildSendResourcesArgs, planTransferAmounts } from "./transfer-automation-planner";
 
 export const useTransferAutomationRunner = () => {
   const {

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.ts
@@ -7,41 +7,17 @@ import {
   configManager,
   getBlockTimestamp,
   getConservativeBlockTimestamp,
-  getEntityIdFromKeys,
   getTotalResourceWeightKg,
   isMilitaryResource,
   ResourceManager,
 } from "@bibliothecadao/eternum";
-import { ClientComponents, ResourcesIds, RESOURCE_PRECISION } from "@bibliothecadao/types";
-import { getComponentValue } from "@dojoengine/recs";
+import { ResourcesIds, RESOURCE_PRECISION } from "@bibliothecadao/types";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { canTransferMilitaryInventoryBetweenStructureIds } from "@/ui/lib/structure-capabilities";
+import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import { useTransferAutomationStore } from "./store/use-transfer-automation-store";
 
 const toRaw = (amountHuman: number) => BigInt(Math.floor(amountHuman * RESOURCE_PRECISION));
-
-const normalizeOwnerValue = (owner: unknown): string | null => {
-  if (typeof owner === "string") return owner.trim().toLowerCase();
-  if (typeof owner === "bigint") return `0x${owner.toString(16)}`;
-  if (typeof owner === "number" && Number.isFinite(owner)) return `0x${BigInt(owner).toString(16)}`;
-  return null;
-};
-
-const isEntityOwnedByAccount = (
-  components: ClientComponents | null | undefined,
-  entityId: number,
-  accountAddress: string | undefined,
-): boolean => {
-  if (!components || !entityId || !accountAddress) return false;
-  try {
-    const structure = getComponentValue(components.Structure, getEntityIdFromKeys([BigInt(entityId)]));
-    const owner = normalizeOwnerValue(structure?.owner);
-    const accountOwner = normalizeOwnerValue(accountAddress);
-    return Boolean(owner && accountOwner && owner === accountOwner);
-  } catch {
-    return false;
-  }
-};
 
 export const useTransferAutomationRunner = () => {
   const {

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.ts
@@ -3,11 +3,9 @@ import { toast } from "sonner";
 import { useDojo } from "@bibliothecadao/react";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import {
-  calculateDonkeysNeeded,
   configManager,
   getBlockTimestamp,
   getConservativeBlockTimestamp,
-  getTotalResourceWeightKg,
   isMilitaryResource,
   ResourceManager,
 } from "@bibliothecadao/eternum";
@@ -16,8 +14,11 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { canTransferMilitaryInventoryBetweenStructureIds } from "@/ui/lib/structure-capabilities";
 import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import { useTransferAutomationStore } from "./store/use-transfer-automation-store";
-
-const toRaw = (amountHuman: number) => BigInt(Math.floor(amountHuman * RESOURCE_PRECISION));
+import {
+  assessDonkeyCapacity,
+  buildSendResourcesArgs,
+  planTransferAmounts,
+} from "./transfer-automation-planner";
 
 export const useTransferAutomationRunner = () => {
   const {
@@ -174,43 +175,24 @@ export const useTransferAutomationRunner = () => {
             const donkeyBalRaw = rm.balanceWithProduction(conservativeTick, ResourcesIds.Donkey).balance ?? 0n;
             const donkeyBalHuman = Number(donkeyBalRaw) / RESOURCE_PRECISION;
 
-            // compute human amounts per resource based on per-resource configs (fallback to legacy fields)
-            const transferList: { resourceId: ResourcesIds; humanAmount: number }[] = [];
-            const configMap = new Map<number, number>();
-            if (entry.resourceConfigs && Array.isArray(entry.resourceConfigs)) {
-              for (const c of entry.resourceConfigs) {
-                configMap.set(c.resourceId, Math.max(0, Math.floor(c.amount ?? 0)));
-              }
-            }
-            for (const rid of entry.resourceIds) {
-              const desired = Math.max(0, Math.floor(configMap.get(rid) ?? 0));
-              if (desired <= 0) continue;
+            const transferList = planTransferAmounts(entry, (rid) => {
               const balRaw = rm.balanceWithProduction(conservativeTick, rid).balance ?? 0n;
-              const balHuman = Number(balRaw) / RESOURCE_PRECISION;
-              const amt = Math.max(0, Math.min(balHuman, desired));
-              if (amt > 0) transferList.push({ resourceId: rid, humanAmount: amt });
-            }
+              return Number(balRaw) / RESOURCE_PRECISION;
+            });
 
             if (transferList.length === 0) {
               scheduleNext(entry.id, nowMs);
               continue;
             }
 
-            // donkey capacity check
-            const totalKg = getTotalResourceWeightKg(
-              transferList.map((t) => ({ resourceId: t.resourceId, amount: t.humanAmount })),
-            );
-            const neededDonkeys = calculateDonkeysNeeded(totalKg);
-            if (donkeyBalHuman < neededDonkeys) {
+            const capacity = assessDonkeyCapacity(transferList, donkeyBalHuman);
+            if (!capacity.ok) {
               toast.error("Scheduled transfer blocked: insufficient donkeys at source.");
               scheduleNext(entry.id, nowMs);
               continue;
             }
 
-            const resources: (bigint | number)[] = [];
-            for (const t of transferList) {
-              resources.push(t.resourceId, toRaw(t.humanAmount));
-            }
+            const resources = buildSendResourcesArgs(transferList);
 
             await systemCalls.send_resources_multiple({
               signer: account,

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -204,6 +204,36 @@ describe("buildRealmProductionPlan", () => {
     expect(plan.callset.resourceToResource).toEqual([{ resourceId: ResourcesIds.Knight, cycles: 1 }]);
   });
 
+  it("ignores stale custom resource keys when planning smart allocations", () => {
+    const snapshot = makeSnapshot([ResourcesIds.Knight], {
+      [ResourcesIds.Wheat]: 100,
+      [ResourcesIds.Copper]: 100,
+      [ResourcesIds.Essence]: 100,
+      [ResourcesIds.Knight]: 100,
+    });
+
+    const baselinePlan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(),
+      snapshot,
+    });
+    const planWithStaleCustomKeys = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "smart" },
+        {
+          [ResourcesIds.KnightT2]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot,
+    });
+
+    expect(planWithStaleCustomKeys.evaluatedResourceIds).toEqual(baselinePlan.evaluatedResourceIds);
+    expect(planWithStaleCustomKeys.callset.resourceToResource).toEqual(baselinePlan.callset.resourceToResource);
+    expect(planWithStaleCustomKeys.skipped).not.toContainEqual({
+      resourceId: ResourcesIds.KnightT2,
+      reason: "No active production building",
+    });
+  });
+
   it("does not allow the smart minimum cycle when any input cannot fund one cycle inside budget", () => {
     const plan = buildRealmProductionPlan({
       realmConfig: makeRealmConfig(),

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -173,7 +173,7 @@ describe("buildRealmProductionPlan", () => {
     ]);
   });
 
-  it("does not spend same-pass T1 output as T2 input", () => {
+  it("feeds same-pass T1 output into T2 consumption so deep chains execute in one tick", () => {
     const plan = buildRealmProductionPlan({
       realmConfig: makeRealmConfig(),
       snapshot: makeSnapshot([ResourcesIds.Knight, ResourcesIds.KnightT2], {
@@ -184,12 +184,132 @@ describe("buildRealmProductionPlan", () => {
       }),
     });
 
-    expect(plan.callset.resourceToResource.map((call) => call.resourceId)).toContain(ResourcesIds.Knight);
-    expect(plan.callset.resourceToResource.map((call) => call.resourceId)).not.toContain(ResourcesIds.KnightT2);
-    expect(plan.skipped).toContainEqual({
-      resourceId: ResourcesIds.KnightT2,
-      reason: "Insufficient complex recipe inputs",
+    const callResourceIds = plan.callset.resourceToResource.map((call) => call.resourceId);
+    expect(callResourceIds).toContain(ResourcesIds.Knight);
+    expect(callResourceIds).toContain(ResourcesIds.KnightT2);
+
+    const t1Cycles = plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
+    const t2Cycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.KnightT2)?.cycles ?? 0;
+    expect(t1Cycles).toBeGreaterThan(0);
+    expect(t2Cycles).toBeGreaterThan(0);
+    expect(t2Cycles).toBeLessThanOrEqual(t1Cycles);
+  });
+
+  it("skips T2 when there is no snapshot Knight balance and T1 produces nothing (recipe undeployable)", () => {
+    configManagerMock.complexSystemResourceInputs[ResourcesIds.Knight] = [
+      { resource: ResourcesIds.Wheat, amount: 1 },
+      { resource: ResourcesIds.Copper, amount: 1 },
+    ];
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(),
+      snapshot: makeSnapshot([ResourcesIds.Knight, ResourcesIds.KnightT2], {
+        [ResourcesIds.Wheat]: 0,
+        [ResourcesIds.Copper]: 0,
+        [ResourcesIds.Essence]: 500,
+        [ResourcesIds.Knight]: 0,
+      }),
     });
+
+    const callResourceIds = plan.callset.resourceToResource.map((call) => call.resourceId);
+    expect(callResourceIds).not.toContain(ResourcesIds.Knight);
+    expect(callResourceIds).not.toContain(ResourcesIds.KnightT2);
+  });
+
+  it("does not let same-pass output of one recipe leak into an unrelated recipe's budget", () => {
+    configureComplexRecipe(
+      ResourcesIds.Wood,
+      [
+        { resource: ResourcesIds.Wheat, amount: 1 },
+        { resource: ResourcesIds.Copper, amount: 1 },
+      ],
+      10,
+    );
+
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [ResourcesIds.Wood]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([ResourcesIds.Wood], {
+        [ResourcesIds.Wheat]: 100,
+        [ResourcesIds.Copper]: 100,
+      }),
+    });
+
+    expect(plan.outputsByResource[ResourcesIds.Wood]).toBeGreaterThan(0);
+    expect(plan.consumptionByResource[ResourcesIds.Wood]).toBeUndefined();
+  });
+
+  it("executes a three-tier chain (Ore -> Iron -> Steel) in a single pass", () => {
+    const Ore = ResourcesIds.Stone;
+    const Iron = ResourcesIds.Coal;
+    const Steel = ResourcesIds.Ironwood;
+
+    configureComplexRecipe(Ore, [{ resource: ResourcesIds.Wheat, amount: 1 }], 10);
+    configureComplexRecipe(Iron, [{ resource: Ore, amount: 1 }], 5);
+    configureComplexRecipe(Steel, [{ resource: Iron, amount: 1 }], 2);
+
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [Ore]: { resourceToResource: 50, laborToResource: 0 },
+          [Iron]: { resourceToResource: 50, laborToResource: 0 },
+          [Steel]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([Ore, Iron, Steel], {
+        [ResourcesIds.Wheat]: 1000,
+        [Ore]: 0,
+        [Iron]: 0,
+        [Steel]: 0,
+      }),
+    });
+
+    const callOrder = plan.callset.resourceToResource.map((call) => call.resourceId);
+    expect(callOrder.indexOf(Ore)).toBeLessThan(callOrder.indexOf(Iron));
+    expect(callOrder.indexOf(Iron)).toBeLessThan(callOrder.indexOf(Steel));
+
+    const oreCycles = plan.callset.resourceToResource.find((call) => call.resourceId === Ore)?.cycles ?? 0;
+    const ironCycles = plan.callset.resourceToResource.find((call) => call.resourceId === Iron)?.cycles ?? 0;
+    const steelCycles = plan.callset.resourceToResource.find((call) => call.resourceId === Steel)?.cycles ?? 0;
+    expect(oreCycles).toBeGreaterThan(0);
+    expect(ironCycles).toBeGreaterThan(0);
+    expect(steelCycles).toBeGreaterThan(0);
+  });
+
+  it("falls back to numeric order and warns when recipe config introduces a cycle", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      configureComplexRecipe(ResourcesIds.Wood, [{ resource: ResourcesIds.Stone, amount: 1 }], 1);
+      configureComplexRecipe(ResourcesIds.Stone, [{ resource: ResourcesIds.Wood, amount: 1 }], 1);
+
+      const plan = buildRealmProductionPlan({
+        realmConfig: makeRealmConfig(
+          { presetId: "custom" },
+          {
+            [ResourcesIds.Wood]: { resourceToResource: 50, laborToResource: 0 },
+            [ResourcesIds.Stone]: { resourceToResource: 50, laborToResource: 0 },
+          },
+        ),
+        snapshot: makeSnapshot([ResourcesIds.Wood, ResourcesIds.Stone], {
+          [ResourcesIds.Wood]: 100,
+          [ResourcesIds.Stone]: 100,
+        }),
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("dependency cycle"),
+        expect.objectContaining({ missing: expect.any(Array) }),
+      );
+      expect(plan.evaluatedResourceIds).toContain(ResourcesIds.Wood);
+      expect(plan.evaluatedResourceIds).toContain(ResourcesIds.Stone);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("allows one smart troop cycle when percentage math floors to zero but one cycle is affordable", () => {

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -188,7 +188,8 @@ describe("buildRealmProductionPlan", () => {
     expect(callResourceIds).toContain(ResourcesIds.Knight);
     expect(callResourceIds).toContain(ResourcesIds.KnightT2);
 
-    const t1Cycles = plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
+    const t1Cycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
     const t2Cycles =
       plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.KnightT2)?.cycles ?? 0;
     expect(t1Cycles).toBeGreaterThan(0);

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import {
+  buildAutomationSkipMessage,
+  buildRealmProductionPlan,
+  type RealmResourceSnapshot,
+} from "./automation-processor";
+import type { RealmAutomationConfig, ResourceAutomationPercentages } from "@/hooks/store/use-automation-store";
+
+const { configManagerMock } = vi.hoisted(() => ({
+  configManagerMock: {
+    complexSystemResourceInputs: {} as Record<number, Array<{ resource: number; amount: number }>>,
+    complexSystemResourceOutput: {} as Record<number, { resource: number; amount: number }>,
+    simpleSystemResourceInputs: {} as Record<number, Array<{ resource: number; amount: number }>>,
+    simpleSystemResourceOutput: {} as Record<number, { resource: number; amount: number }>,
+    getLaborConfig: vi.fn(),
+    getSeasonConfig: vi.fn(() => ({ startSettlingAt: 1, startMainAt: 2, endAt: 3 })),
+  },
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  configManager: configManagerMock,
+  divideByPrecision: (value: number) => value,
+  ResourceManager: class ResourceManager {},
+}));
+
+const TROOP_INPUTS = [ResourcesIds.Wheat, ResourcesIds.Copper, ResourcesIds.Essence];
+
+const makeRealmConfig = (
+  overrides: Partial<RealmAutomationConfig> = {},
+  customPercentages: Record<number, ResourceAutomationPercentages> = {},
+): RealmAutomationConfig => ({
+  realmId: "777",
+  realmName: "Test Realm",
+  entityType: "realm",
+  presetId: "smart",
+  autoBalance: true,
+  customPercentages,
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+const makeSnapshot = (
+  activeResources: ResourcesIds[],
+  balances: Partial<Record<ResourcesIds, number>>,
+): RealmResourceSnapshot => {
+  const snapshot: RealmResourceSnapshot = new Map();
+
+  const trackedResources = new Set<ResourcesIds>([...activeResources, ...TROOP_INPUTS]);
+  Object.keys(balances).forEach((resourceId) => trackedResources.add(Number(resourceId) as ResourcesIds));
+
+  trackedResources.forEach((resourceId) => {
+    snapshot.set(resourceId, {
+      resourceId,
+      balanceHuman: balances[resourceId] ?? 0,
+      hasActiveProduction: activeResources.includes(resourceId),
+      productionPerSecond: activeResources.includes(resourceId) ? 1 : 0,
+    });
+  });
+
+  return snapshot;
+};
+
+const configureComplexRecipe = (
+  resourceId: ResourcesIds,
+  inputs: Array<{ resource: ResourcesIds; amount: number }>,
+  outputAmount = 1,
+) => {
+  configManagerMock.complexSystemResourceInputs[resourceId] = inputs;
+  configManagerMock.complexSystemResourceOutput[resourceId] = {
+    resource: resourceId,
+    amount: outputAmount,
+  };
+};
+
+const configureTroopRecipes = () => {
+  configureComplexRecipe(ResourcesIds.Knight, [
+    { resource: ResourcesIds.Wheat, amount: 1 },
+    { resource: ResourcesIds.Copper, amount: 1 },
+  ]);
+  configureComplexRecipe(ResourcesIds.Crossbowman, [
+    { resource: ResourcesIds.Wheat, amount: 1 },
+    { resource: ResourcesIds.Copper, amount: 1 },
+  ]);
+  configureComplexRecipe(ResourcesIds.Paladin, [
+    { resource: ResourcesIds.Wheat, amount: 1 },
+    { resource: ResourcesIds.Copper, amount: 1 },
+  ]);
+  configureComplexRecipe(ResourcesIds.KnightT2, [
+    { resource: ResourcesIds.Wheat, amount: 1 },
+    { resource: ResourcesIds.Knight, amount: 1 },
+    { resource: ResourcesIds.Essence, amount: 1 },
+  ]);
+  configureComplexRecipe(ResourcesIds.CrossbowmanT2, [
+    { resource: ResourcesIds.Wheat, amount: 1 },
+    { resource: ResourcesIds.Crossbowman, amount: 1 },
+    { resource: ResourcesIds.Essence, amount: 1 },
+  ]);
+  configureComplexRecipe(ResourcesIds.PaladinT2, [
+    { resource: ResourcesIds.Wheat, amount: 1 },
+    { resource: ResourcesIds.Paladin, amount: 1 },
+    { resource: ResourcesIds.Essence, amount: 1 },
+  ]);
+};
+
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  configManagerMock.complexSystemResourceInputs = {};
+  configManagerMock.complexSystemResourceOutput = {};
+  configManagerMock.simpleSystemResourceInputs = {};
+  configManagerMock.simpleSystemResourceOutput = {};
+  configManagerMock.getLaborConfig.mockImplementation((resourceId: ResourcesIds) => ({
+    inputResources: configManagerMock.simpleSystemResourceInputs[resourceId] ?? [],
+    resourceOutputPerInputResources: configManagerMock.simpleSystemResourceOutput[resourceId]?.amount ?? 0,
+  }));
+  configureTroopRecipes();
+});
+
+afterEach(() => {
+  consoleLogSpy.mockRestore();
+});
+
+describe("buildRealmProductionPlan", () => {
+  it("evaluates custom inactive resources for diagnostics without executing them", () => {
+    configureComplexRecipe(ResourcesIds.Wood, [{ resource: ResourcesIds.Wheat, amount: 1 }]);
+
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [ResourcesIds.KnightT2]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([ResourcesIds.Wood], {
+        [ResourcesIds.Wheat]: 100,
+        [ResourcesIds.Knight]: 100,
+        [ResourcesIds.Essence]: 100,
+      }),
+    });
+
+    expect(plan.evaluatedResourceIds).toContain(ResourcesIds.KnightT2);
+    expect(plan.callset.resourceToResource.map((call) => call.resourceId)).not.toContain(ResourcesIds.KnightT2);
+    expect(plan.skipped).toContainEqual({
+      resourceId: ResourcesIds.KnightT2,
+      reason: "No active production building",
+    });
+  });
+
+  it("plans all T1 troops before T2 troops so lower-tier dependencies get first claim", () => {
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(),
+      snapshot: makeSnapshot(
+        [ResourcesIds.Knight, ResourcesIds.KnightT2, ResourcesIds.Crossbowman, ResourcesIds.CrossbowmanT2],
+        {
+          [ResourcesIds.Wheat]: 500,
+          [ResourcesIds.Copper]: 500,
+          [ResourcesIds.Essence]: 500,
+          [ResourcesIds.Knight]: 500,
+          [ResourcesIds.Crossbowman]: 500,
+        },
+      ),
+    });
+
+    expect(plan.callset.resourceToResource.map((call) => call.resourceId)).toEqual([
+      ResourcesIds.Knight,
+      ResourcesIds.Crossbowman,
+      ResourcesIds.KnightT2,
+      ResourcesIds.CrossbowmanT2,
+    ]);
+  });
+
+  it("does not spend same-pass T1 output as T2 input", () => {
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(),
+      snapshot: makeSnapshot([ResourcesIds.Knight, ResourcesIds.KnightT2], {
+        [ResourcesIds.Wheat]: 500,
+        [ResourcesIds.Copper]: 500,
+        [ResourcesIds.Essence]: 500,
+        [ResourcesIds.Knight]: 0,
+      }),
+    });
+
+    expect(plan.callset.resourceToResource.map((call) => call.resourceId)).toContain(ResourcesIds.Knight);
+    expect(plan.callset.resourceToResource.map((call) => call.resourceId)).not.toContain(ResourcesIds.KnightT2);
+    expect(plan.skipped).toContainEqual({
+      resourceId: ResourcesIds.KnightT2,
+      reason: "Insufficient complex recipe inputs",
+    });
+  });
+
+  it("allows one smart troop cycle when percentage math floors to zero but one cycle is affordable", () => {
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(),
+      snapshot: makeSnapshot([ResourcesIds.Knight], {
+        [ResourcesIds.Wheat]: 2,
+        [ResourcesIds.Copper]: 2,
+      }),
+    });
+
+    expect(plan.callset.resourceToResource).toEqual([{ resourceId: ResourcesIds.Knight, cycles: 1 }]);
+  });
+
+  it("does not allow the smart minimum cycle when any input cannot fund one cycle inside budget", () => {
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(),
+      snapshot: makeSnapshot([ResourcesIds.Knight], {
+        [ResourcesIds.Wheat]: 2,
+        [ResourcesIds.Copper]: 1,
+      }),
+    });
+
+    expect(plan.callset.resourceToResource).toEqual([]);
+    expect(plan.skipped).toContainEqual({
+      resourceId: ResourcesIds.Knight,
+      reason: "Insufficient complex recipe inputs",
+    });
+  });
+
+  it("keeps T2 labor allocations skipped when no labor recipe exists", () => {
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [ResourcesIds.KnightT2]: { resourceToResource: 0, laborToResource: 20 },
+        },
+      ),
+      snapshot: makeSnapshot([ResourcesIds.KnightT2], {
+        [ResourcesIds.Wheat]: 100,
+        [ResourcesIds.Knight]: 100,
+        [ResourcesIds.Essence]: 100,
+      }),
+    });
+
+    expect(plan.callset.laborToResource).toEqual([]);
+    expect(plan.skipped).toContainEqual({
+      resourceId: ResourcesIds.KnightT2,
+      reason: "Missing labor recipe configuration",
+    });
+  });
+});
+
+describe("buildAutomationSkipMessage", () => {
+  it("describes inactive production buildings with the resource name", () => {
+    expect(
+      buildAutomationSkipMessage({
+        resourceId: ResourcesIds.PaladinT2,
+        reason: "No active production building",
+      }),
+    ).toBe("PaladinT2 has no active production building");
+  });
+
+  it("describes troop input waits with the resource name", () => {
+    expect(
+      buildAutomationSkipMessage({
+        resourceId: ResourcesIds.KnightT2,
+        reason: "Insufficient complex recipe inputs",
+      }),
+    ).toBe("KnightT2 waiting for recipe inputs");
+  });
+});

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -265,9 +265,11 @@ export const buildRealmProductionPlan = ({
     }
   });
 
-  const configuredCustomIds = Object.keys(realmConfig.customPercentages ?? {}).map(
-    (key) => Number(key) as ResourcesIds,
-  );
+  const presetId = realmConfig.presetId ?? "smart";
+  const configuredCustomIds =
+    presetId === "custom"
+      ? Object.keys(realmConfig.customPercentages ?? {}).map((key) => Number(key) as ResourcesIds)
+      : [];
   const resourceIdsToEvaluate = buildResourceIdsToEvaluate(producedResourceIds, configuredCustomIds);
 
   if (resourceIdsToEvaluate.length === 0) {
@@ -285,7 +287,6 @@ export const buildRealmProductionPlan = ({
     };
   }
 
-  const presetId = realmConfig.presetId ?? "smart";
   const smartDefaults = calculatePresetAllocations(resourceIdsToEvaluate, "smart", entityType);
   const presetAllocations =
     presetId === "smart" || presetId === "idle"

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -115,6 +115,86 @@ const compareAutomationResources = (left: ResourcesIds, right: ResourcesIds): nu
 const isResourceActiveInSnapshot = (snapshot: RealmResourceSnapshot, resourceId: ResourcesIds): boolean =>
   snapshot.get(resourceId)?.hasActiveProduction === true;
 
+type AutomationEntityType = RealmAutomationConfig["entityType"];
+
+export const buildResourceDependencyOrder = (
+  resourceIds: ResourcesIds[],
+  entityType: AutomationEntityType,
+): ResourcesIds[] => {
+  if (!resourceIds.length) return [];
+
+  const idSet = new Set<ResourcesIds>(resourceIds);
+  const dependsOn = new Map<ResourcesIds, Set<ResourcesIds>>();
+  const dependents = new Map<ResourcesIds, Set<ResourcesIds>>();
+
+  for (const resourceId of resourceIds) {
+    dependsOn.set(resourceId, new Set());
+    dependents.set(resourceId, new Set());
+  }
+
+  const addEdge = (dependent: ResourcesIds, input: ResourcesIds) => {
+    if (dependent === input) return;
+    if (!idSet.has(input)) return;
+    dependsOn.get(dependent)!.add(input);
+    dependents.get(input)!.add(dependent);
+  };
+
+  const collectInputs = (resourceId: ResourcesIds): ResourcesIds[] => {
+    const complexInputs = configManager.complexSystemResourceInputs[resourceId] ?? [];
+    const laborConfig = configManager.getLaborConfig?.(resourceId);
+    const laborInputs = laborConfig?.inputResources ?? [];
+    const aggregated: ResourcesIds[] = [];
+    for (const input of complexInputs) {
+      if (!isAutomationResourceBlocked(input.resource, entityType, "input")) {
+        aggregated.push(input.resource);
+      }
+    }
+    for (const input of laborInputs) {
+      if (!isAutomationResourceBlocked(input.resource, entityType, "input")) {
+        aggregated.push(input.resource);
+      }
+    }
+    return aggregated;
+  };
+
+  for (const resourceId of resourceIds) {
+    for (const input of collectInputs(resourceId)) {
+      addEdge(resourceId, input);
+    }
+  }
+
+  const insertSorted = (bucket: ResourcesIds[], value: ResourcesIds) => {
+    const idx = bucket.findIndex((other) => compareAutomationResources(value, other) < 0);
+    if (idx === -1) bucket.push(value);
+    else bucket.splice(idx, 0, value);
+  };
+
+  const ready: ResourcesIds[] = [];
+  for (const [resourceId, deps] of dependsOn) {
+    if (deps.size === 0) insertSorted(ready, resourceId);
+  }
+
+  const order: ResourcesIds[] = [];
+  while (ready.length) {
+    const current = ready.shift()!;
+    order.push(current);
+    const downstream = Array.from(dependents.get(current) ?? []).sort(compareAutomationResources);
+    for (const dependent of downstream) {
+      const deps = dependsOn.get(dependent)!;
+      deps.delete(current);
+      if (deps.size === 0) insertSorted(ready, dependent);
+    }
+  }
+
+  if (order.length !== resourceIds.length) {
+    const missing = resourceIds.filter((id) => !order.includes(id));
+    console.warn("[Automation] Resource dependency cycle detected; falling back to numeric order", { missing });
+    return [...resourceIds].sort(compareAutomationResources);
+  }
+
+  return order;
+};
+
 const buildResourceIdsToEvaluate = (
   producedResourceIds: ResourcesIds[],
   configuredCustomIds: ResourcesIds[],
@@ -300,9 +380,11 @@ export const buildRealmProductionPlan = ({
     return { ...DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES };
   };
 
-  const resourceDefinitions = resourceIdsToEvaluate
-    .filter((resourceId) => !isAutomationResourceBlocked(resourceId, entityType))
-    .toSorted(compareAutomationResources)
+  const filteredResourceIds = resourceIdsToEvaluate.filter(
+    (resourceId) => !isAutomationResourceBlocked(resourceId, entityType),
+  );
+  const orderedResourceIds = buildResourceDependencyOrder(filteredResourceIds, entityType);
+  const resourceDefinitions = orderedResourceIds
     .map((resourceId) => {
       const customPercentages = realmConfig.customPercentages?.[resourceId];
       const presetPercentages = presetAllocations.get(resourceId);
@@ -402,6 +484,17 @@ export const buildRealmProductionPlan = ({
     return true;
   };
 
+  const creditSamePassOutput = (resourceId: ResourcesIds, produced: number) => {
+    if (!Number.isFinite(produced) || produced <= 0) return;
+    const prevTotal = totalAvailable.get(resourceId) ?? 0;
+    const newTotal = prevTotal + produced;
+    totalAvailable.set(resourceId, newTotal);
+
+    const consumedSoFar = consumptionByResource[resourceId] ?? 0;
+    const maxConsumable = Math.floor((newTotal * MAX_RESOURCE_ALLOCATION_PERCENT) / 100);
+    availableBudget.set(resourceId, Math.max(0, maxConsumable - consumedSoFar));
+  };
+
   const getTotal = (resourceId: ResourcesIds) => totalAvailable.get(resourceId) ?? 0;
   const getBudget = (resourceId: ResourcesIds) => availableBudget.get(resourceId) ?? 0;
 
@@ -496,6 +589,7 @@ export const buildRealmProductionPlan = ({
           } else {
             const produced = outputPerCycle * maxCycles;
             addToRecord(outputsByResource, resourceId, produced);
+            creditSamePassOutput(resourceId, produced);
             planCallset.resourceToResource.push({ resourceId, cycles: maxCycles });
             resourceExecutions.push({
               resourceId,
@@ -638,6 +732,7 @@ export const buildRealmProductionPlan = ({
           } else {
             const produced = outputPerCycle * maxCycles;
             addToRecord(outputsByResource, resourceId, produced);
+            creditSamePassOutput(resourceId, produced);
             planCallset.laborToResource.push({ resourceId, cycles: maxCycles });
             laborExecutions.push({
               resourceId,

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -117,7 +117,7 @@ const isResourceActiveInSnapshot = (snapshot: RealmResourceSnapshot, resourceId:
 
 type AutomationEntityType = RealmAutomationConfig["entityType"];
 
-export const buildResourceDependencyOrder = (
+const buildResourceDependencyOrder = (
   resourceIds: ResourcesIds[],
   entityType: AutomationEntityType,
 ): ResourcesIds[] => {
@@ -384,25 +384,24 @@ export const buildRealmProductionPlan = ({
     (resourceId) => !isAutomationResourceBlocked(resourceId, entityType),
   );
   const orderedResourceIds = buildResourceDependencyOrder(filteredResourceIds, entityType);
-  const resourceDefinitions = orderedResourceIds
-    .map((resourceId) => {
-      const customPercentages = realmConfig.customPercentages?.[resourceId];
-      const presetPercentages = presetAllocations.get(resourceId);
-      const smartPercentages = smartDefaults.get(resourceId) ?? baselinePercentages(resourceId);
-      const hasActiveProduction = isResourceActiveInSnapshot(snapshot, resourceId);
+  const resourceDefinitions = orderedResourceIds.map((resourceId) => {
+    const customPercentages = realmConfig.customPercentages?.[resourceId];
+    const presetPercentages = presetAllocations.get(resourceId);
+    const smartPercentages = smartDefaults.get(resourceId) ?? baselinePercentages(resourceId);
+    const hasActiveProduction = isResourceActiveInSnapshot(snapshot, resourceId);
 
-      const source =
-        presetId === "custom"
-          ? (customPercentages ?? smartPercentages)
-          : (presetPercentages ?? { resourceToResource: 0, laborToResource: 0 });
+    const source =
+      presetId === "custom"
+        ? (customPercentages ?? smartPercentages)
+        : (presetPercentages ?? { resourceToResource: 0, laborToResource: 0 });
 
-      const percentages: ResourceAutomationPercentages = {
-        resourceToResource: clampPercent(source.resourceToResource),
-        laborToResource: resourceId === ResourcesIds.Donkey ? 0 : clampPercent(source.laborToResource ?? 0),
-      };
+    const percentages: ResourceAutomationPercentages = {
+      resourceToResource: clampPercent(source.resourceToResource),
+      laborToResource: resourceId === ResourcesIds.Donkey ? 0 : clampPercent(source.laborToResource ?? 0),
+    };
 
-      return { resourceId, percentages, hasActiveProduction };
-    });
+    return { resourceId, percentages, hasActiveProduction };
+  });
 
   const skipped: RealmAutomationExecutionSummary["skipped"] = [];
   const resourcesToTrack = new Set<ResourcesIds>();

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -52,6 +52,8 @@ interface BuildRealmProductionPlanArgs {
   snapshot: RealmResourceSnapshot;
 }
 
+type AutomationSkipEntry = RealmAutomationExecutionSummary["skipped"][number];
+
 const ZERO_PLAN: RealmProductionPlan = {
   realmId: 0,
   realmKey: "",
@@ -83,6 +85,107 @@ const clampPercent = (value: number): number => {
 const DEFAULT_PLAN_CALLSET: RealmProductionCallset = {
   resourceToResource: [],
   laborToResource: [],
+};
+
+const TROOP_PLANNING_ORDER = new Map<ResourcesIds, number>([
+  [ResourcesIds.Knight, 1],
+  [ResourcesIds.Crossbowman, 2],
+  [ResourcesIds.Paladin, 3],
+  [ResourcesIds.KnightT2, 4],
+  [ResourcesIds.CrossbowmanT2, 5],
+  [ResourcesIds.PaladinT2, 6],
+  [ResourcesIds.KnightT3, 7],
+  [ResourcesIds.CrossbowmanT3, 8],
+  [ResourcesIds.PaladinT3, 9],
+]);
+
+const isTroopResource = (resourceId: ResourcesIds): boolean => TROOP_PLANNING_ORDER.has(resourceId);
+
+const compareAutomationResources = (left: ResourcesIds, right: ResourcesIds): number => {
+  const leftTroopOrder = TROOP_PLANNING_ORDER.get(left);
+  const rightTroopOrder = TROOP_PLANNING_ORDER.get(right);
+
+  if (leftTroopOrder !== undefined && rightTroopOrder !== undefined) {
+    return leftTroopOrder - rightTroopOrder;
+  }
+
+  return left - right;
+};
+
+const isResourceActiveInSnapshot = (snapshot: RealmResourceSnapshot, resourceId: ResourcesIds): boolean =>
+  snapshot.get(resourceId)?.hasActiveProduction === true;
+
+const buildResourceIdsToEvaluate = (
+  producedResourceIds: ResourcesIds[],
+  configuredCustomIds: ResourcesIds[],
+): ResourcesIds[] => Array.from(new Set<ResourcesIds>([...producedResourceIds, ...configuredCustomIds]));
+
+const canFundOneCycle = (
+  recipeInputs: Array<{ resource: ResourcesIds; amount: number }>,
+  getTotal: (resourceId: ResourcesIds) => number,
+  getBudget: (resourceId: ResourcesIds) => number,
+): boolean => {
+  const requiredInputs = recipeInputs.filter((input) => input.amount > 0);
+  if (!requiredInputs.length) return false;
+
+  return requiredInputs.every((input) => getTotal(input.resource) > 0 && getBudget(input.resource) >= input.amount);
+};
+
+const shouldUseSmartMinimumTroopCycle = ({
+  presetId,
+  resourceId,
+  resourceToResource,
+  recipeInputs,
+  getTotal,
+  getBudget,
+}: {
+  presetId: string;
+  resourceId: ResourcesIds;
+  resourceToResource: number;
+  recipeInputs: Array<{ resource: ResourcesIds; amount: number }>;
+  getTotal: (resourceId: ResourcesIds) => number;
+  getBudget: (resourceId: ResourcesIds) => number;
+}): boolean => {
+  if (presetId !== "smart") return false;
+  if (!isTroopResource(resourceId)) return false;
+  if (resourceToResource <= 0) return false;
+  return canFundOneCycle(recipeInputs, getTotal, getBudget);
+};
+
+const resolveResourceLabel = (resourceId: ResourcesIds): string => {
+  const label = ResourcesIds[resourceId];
+  return typeof label === "string" ? label : `Resource ${resourceId}`;
+};
+
+export const buildAutomationSkipMessage = (skip: AutomationSkipEntry): string => {
+  const resource = resolveResourceLabel(skip.resourceId);
+
+  switch (skip.reason) {
+    case "No active production building":
+      return `${resource} has no active production building`;
+    case "Insufficient complex recipe inputs":
+      return `${resource} waiting for recipe inputs`;
+    case "Missing complex recipe configuration":
+      return `${resource} missing resource recipe`;
+    case "Resource budget exhausted for complex recipe":
+      return `${resource} resource budget exhausted`;
+    case "Missing labor recipe configuration":
+      return `${resource} missing labor recipe`;
+    case "Insufficient labor recipe inputs":
+      return `${resource} waiting for labor inputs`;
+    case "Resource budget exhausted for labor recipe":
+      return `${resource} labor budget exhausted`;
+    default:
+      return `${resource}: ${skip.reason}`;
+  }
+};
+
+export const buildAutomationPlanSkipMessage = (plan: RealmProductionPlan): string => {
+  const firstSkip = plan.skipped[0];
+  if (!firstSkip) return "No executable calls";
+
+  const suffix = plan.skipped.length > 1 ? ` (+${plan.skipped.length - 1} more)` : "";
+  return `${buildAutomationSkipMessage(firstSkip)}${suffix}`;
 };
 
 interface BuildRealmResourceSnapshotArgs {
@@ -165,14 +268,9 @@ export const buildRealmProductionPlan = ({
   const configuredCustomIds = Object.keys(realmConfig.customPercentages ?? {}).map(
     (key) => Number(key) as ResourcesIds,
   );
-  const resourceIdsToProcess = new Set<ResourcesIds>(producedResourceIds);
+  const resourceIdsToEvaluate = buildResourceIdsToEvaluate(producedResourceIds, configuredCustomIds);
 
-  // Reliability fallback: if snapshot misses active production, keep configured custom resources in scope.
-  if (resourceIdsToProcess.size === 0) {
-    configuredCustomIds.forEach((resourceId) => resourceIdsToProcess.add(resourceId));
-  }
-
-  if (resourceIdsToProcess.size === 0) {
+  if (resourceIdsToEvaluate.length === 0) {
     return {
       realmId: realmIdNumber,
       realmKey: realmConfig.realmId,
@@ -188,10 +286,10 @@ export const buildRealmProductionPlan = ({
   }
 
   const presetId = realmConfig.presetId ?? "smart";
-  const smartDefaults = calculatePresetAllocations(Array.from(resourceIdsToProcess), "smart", entityType);
+  const smartDefaults = calculatePresetAllocations(resourceIdsToEvaluate, "smart", entityType);
   const presetAllocations =
     presetId === "smart" || presetId === "idle"
-      ? calculatePresetAllocations(Array.from(resourceIdsToProcess), presetId, entityType)
+      ? calculatePresetAllocations(resourceIdsToEvaluate, presetId, entityType)
       : new Map<number, ResourceAutomationPercentages>();
 
   const baselinePercentages = (resourceId: ResourcesIds): ResourceAutomationPercentages => {
@@ -201,13 +299,14 @@ export const buildRealmProductionPlan = ({
     return { ...DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES };
   };
 
-  const resourceDefinitions = Array.from(resourceIdsToProcess)
+  const resourceDefinitions = resourceIdsToEvaluate
     .filter((resourceId) => !isAutomationResourceBlocked(resourceId, entityType))
-    .toSorted((a, b) => a - b)
+    .toSorted(compareAutomationResources)
     .map((resourceId) => {
       const customPercentages = realmConfig.customPercentages?.[resourceId];
       const presetPercentages = presetAllocations.get(resourceId);
       const smartPercentages = smartDefaults.get(resourceId) ?? baselinePercentages(resourceId);
+      const hasActiveProduction = isResourceActiveInSnapshot(snapshot, resourceId);
 
       const source =
         presetId === "custom"
@@ -219,15 +318,25 @@ export const buildRealmProductionPlan = ({
         laborToResource: resourceId === ResourcesIds.Donkey ? 0 : clampPercent(source.laborToResource ?? 0),
       };
 
-      return { resourceId, percentages };
+      return { resourceId, percentages, hasActiveProduction };
     });
 
+  const skipped: RealmAutomationExecutionSummary["skipped"] = [];
   const resourcesToTrack = new Set<ResourcesIds>();
   for (const definition of resourceDefinitions) {
     const {
       resourceId,
       percentages: { resourceToResource, laborToResource },
+      hasActiveProduction,
     } = definition;
+
+    if (!hasActiveProduction) {
+      skipped.push({
+        resourceId,
+        reason: "No active production building",
+      });
+      continue;
+    }
 
     const hasActivity = ensurePositiveNumber(resourceToResource) || ensurePositiveNumber(laborToResource);
 
@@ -279,7 +388,6 @@ export const buildRealmProductionPlan = ({
   };
   const resourceExecutions: RealmAutomationExecutionSummary["resourceToResource"] = [];
   const laborExecutions: RealmAutomationExecutionSummary["laborToResource"] = [];
-  const skipped: RealmAutomationExecutionSummary["skipped"] = [];
 
   const reserveAmount = (resourceId: ResourcesIds, amount: number) => {
     if (!Number.isFinite(amount) || amount <= 0) return false;
@@ -300,7 +408,12 @@ export const buildRealmProductionPlan = ({
     const {
       resourceId,
       percentages: { resourceToResource, laborToResource },
+      hasActiveProduction,
     } = definition;
+
+    if (!hasActiveProduction) {
+      continue;
+    }
 
     const hasConfig = ensurePositiveNumber(resourceToResource) || ensurePositiveNumber(laborToResource);
     if (!hasConfig) {
@@ -339,6 +452,20 @@ export const buildRealmProductionPlan = ({
           const permitted = Math.min(desired, budget);
           const cyclesForInput = Math.floor(permitted / input.amount);
           maxCycles = Math.min(maxCycles, cyclesForInput);
+        }
+
+        if (
+          (!Number.isFinite(maxCycles) || maxCycles <= 0) &&
+          shouldUseSmartMinimumTroopCycle({
+            presetId,
+            resourceId,
+            resourceToResource,
+            recipeInputs,
+            getTotal,
+            getBudget,
+          })
+        ) {
+          maxCycles = 1;
         }
 
         if (!Number.isFinite(maxCycles) || maxCycles <= 0) {

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.test.ts
@@ -1,7 +1,14 @@
 // @vitest-environment node
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ResourcesIds } from "@bibliothecadao/types";
-import { executeProductionPlansSequentially, type ExecutableProductionPlan } from "./automation-runner";
+import {
+  AutomationCancelledError,
+  AutomationSignerSkippedError,
+  AutomationTimeoutError,
+  executeProductionPlansSequentially,
+  isSignerTransientError,
+  type ExecutableProductionPlan,
+} from "./automation-runner";
 import type { RealmProductionPlan } from "./automation-processor";
 import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
 import type { ExecuteRealmProductionPlanProps } from "@bibliothecadao/types";
@@ -41,13 +48,136 @@ const makeExecutablePlan = (realmId: number): ExecutableProductionPlan => ({
 });
 
 describe("executeProductionPlansSequentially", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("times out a stuck realm tx and continues to the next realm", async () => {
+    const callOrder: number[] = [];
+    const executeRealmProductionPlan = vi.fn(async ({ realm_entity_id }: ExecuteRealmProductionPlanProps) => {
+      const realmId = Number(realm_entity_id);
+      callOrder.push(realmId);
+      if (realmId === 1) {
+        return new Promise(() => {});
+      }
+    });
+
+    const resultsPromise = executeProductionPlansSequentially({
+      executablePlans: [makeExecutablePlan(1), makeExecutablePlan(2)],
+      signer: { address: "0xabc" } as ExecuteRealmProductionPlanProps["signer"],
+      executeRealmProductionPlan,
+      timeoutMs: 50,
+    });
+
+    await vi.advanceTimersByTimeAsync(51);
+    const results = await resultsPromise;
+
+    expect(callOrder).toEqual([1, 2]);
+    expect(results).toHaveLength(2);
+    expect(results[0].status).toBe("rejected");
+    if (results[0].status === "rejected") {
+      expect(results[0].reason.error).toBeInstanceOf(AutomationTimeoutError);
+    }
+    expect(results[1].status).toBe("fulfilled");
+  });
+
+  it("skips a realm when isCancelled returns realm scope and continues the rest", async () => {
+    vi.useRealTimers();
+    const executed: number[] = [];
+    const executeRealmProductionPlan = vi.fn(async ({ realm_entity_id }: ExecuteRealmProductionPlanProps) => {
+      executed.push(Number(realm_entity_id));
+    });
+
+    const results = await executeProductionPlansSequentially({
+      executablePlans: [makeExecutablePlan(1), makeExecutablePlan(2), makeExecutablePlan(3)],
+      signer: { address: "0xabc" } as ExecuteRealmProductionPlanProps["signer"],
+      executeRealmProductionPlan,
+      isCancelled: ({ plan }) =>
+        plan.realmId === 2
+          ? { cancelled: true, reason: "Realm no longer owned", scope: "realm" }
+          : { cancelled: false },
+    });
+
+    expect(executed).toEqual([1, 3]);
+    expect(results.map((r) => r.status)).toEqual(["fulfilled", "rejected", "fulfilled"]);
+    const skipped = results[1];
+    if (skipped.status === "rejected") {
+      expect(skipped.reason.error).toBeInstanceOf(AutomationCancelledError);
+      expect((skipped.reason.error as AutomationCancelledError).scope).toBe("realm");
+    }
+  });
+
+  it("aborts remaining realms when isCancelled returns pass scope", async () => {
+    vi.useRealTimers();
+    const executed: number[] = [];
+    const executeRealmProductionPlan = vi.fn(async ({ realm_entity_id }: ExecuteRealmProductionPlanProps) => {
+      executed.push(Number(realm_entity_id));
+    });
+
+    let passed = 0;
+    const results = await executeProductionPlansSequentially({
+      executablePlans: [makeExecutablePlan(1), makeExecutablePlan(2), makeExecutablePlan(3)],
+      signer: { address: "0xabc" } as ExecuteRealmProductionPlanProps["signer"],
+      executeRealmProductionPlan,
+      isCancelled: () => {
+        passed += 1;
+        return passed === 2 ? { cancelled: true, reason: "Game has ended", scope: "pass" } : { cancelled: false };
+      },
+    });
+
+    expect(executed).toEqual([1]);
+    expect(results.map((r) => r.status)).toEqual(["fulfilled", "rejected", "rejected"]);
+    results.slice(1).forEach((entry) => {
+      if (entry.status === "rejected") {
+        expect(entry.reason.error).toBeInstanceOf(AutomationCancelledError);
+      }
+    });
+  });
+
+  it("short-circuits tail realms with AutomationSignerSkippedError when a signer-transient error fires", async () => {
+    vi.useRealTimers();
+    const executed: number[] = [];
+    const executeRealmProductionPlan = vi.fn(async ({ realm_entity_id }: ExecuteRealmProductionPlanProps) => {
+      const realmId = Number(realm_entity_id);
+      executed.push(realmId);
+      if (realmId === 1) throw new Error("StarknetError: Invalid transaction nonce");
+    });
+
+    const results = await executeProductionPlansSequentially({
+      executablePlans: [makeExecutablePlan(1), makeExecutablePlan(2), makeExecutablePlan(3)],
+      signer: { address: "0xabc" } as ExecuteRealmProductionPlanProps["signer"],
+      executeRealmProductionPlan,
+    });
+
+    expect(executed).toEqual([1]);
+    expect(results.map((r) => r.status)).toEqual(["rejected", "rejected", "rejected"]);
+    expect((results[0] as { reason: { error: unknown } }).reason.error).toBeInstanceOf(Error);
+    expect((results[1] as { reason: { error: unknown } }).reason.error).toBeInstanceOf(AutomationSignerSkippedError);
+    expect((results[2] as { reason: { error: unknown } }).reason.error).toBeInstanceOf(AutomationSignerSkippedError);
+  });
+
+  it("recognises common signer-transient error payloads", () => {
+    expect(isSignerTransientError(new Error("nonce too low"))).toBe(true);
+    expect(isSignerTransientError(new Error("StarknetError: Invalid transaction nonce"))).toBe(true);
+    expect(isSignerTransientError({ message: "account validation failed" })).toBe(true);
+    expect(isSignerTransientError({ cause: { message: "insufficient fee" } })).toBe(true);
+    expect(isSignerTransientError(new Error("some unrelated error"))).toBe(false);
+    expect(isSignerTransientError(new AutomationTimeoutError(1000))).toBe(false);
+    expect(isSignerTransientError(new AutomationCancelledError("x"))).toBe(false);
+  });
+
   it("executes production plans sequentially and continues after a failed realm", async () => {
+    vi.useRealTimers();
     const callOrder: number[] = [];
     const executeRealmProductionPlan = vi.fn(async ({ realm_entity_id }: ExecuteRealmProductionPlanProps) => {
       const realmId = Number(realm_entity_id);
       callOrder.push(realmId);
       if (realmId === 2) {
-        throw new Error("nonce too low");
+        throw new Error("recipe validation failed");
       }
     });
 

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import { executeProductionPlansSequentially, type ExecutableProductionPlan } from "./automation-runner";
+import type { RealmProductionPlan } from "./automation-processor";
+import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
+import type { ExecuteRealmProductionPlanProps } from "@bibliothecadao/types";
+
+const makePlan = (realmId: number): RealmProductionPlan => ({
+  realmId,
+  realmKey: String(realmId),
+  realmName: `Realm ${realmId}`,
+  callset: {
+    resourceToResource: [{ resourceId: ResourcesIds.Knight, cycles: 1 }],
+    laborToResource: [],
+  },
+  consumptionByResource: {},
+  outputsByResource: { [ResourcesIds.Knight]: 1 },
+  resourceExecutions: [],
+  laborExecutions: [],
+  skipped: [],
+  evaluatedResourceIds: [ResourcesIds.Knight],
+});
+
+const makeRealmConfig = (realmId: number): RealmAutomationConfig => ({
+  realmId: String(realmId),
+  realmName: `Realm ${realmId}`,
+  entityType: "realm",
+  presetId: "smart",
+  autoBalance: true,
+  customPercentages: {},
+  createdAt: 1,
+  updatedAt: 1,
+});
+
+const makeExecutablePlan = (realmId: number): ExecutableProductionPlan => ({
+  plan: makePlan(realmId),
+  realmConfig: makeRealmConfig(realmId),
+  realmLabel: `Realm ${realmId}`,
+  planLogPayload: {},
+});
+
+describe("executeProductionPlansSequentially", () => {
+  it("executes production plans sequentially and continues after a failed realm", async () => {
+    const callOrder: number[] = [];
+    const executeRealmProductionPlan = vi.fn(async ({ realm_entity_id }: ExecuteRealmProductionPlanProps) => {
+      const realmId = Number(realm_entity_id);
+      callOrder.push(realmId);
+      if (realmId === 2) {
+        throw new Error("nonce too low");
+      }
+    });
+
+    const results = await executeProductionPlansSequentially({
+      executablePlans: [makeExecutablePlan(1), makeExecutablePlan(2), makeExecutablePlan(3)],
+      signer: { address: "0xabc" } as ExecuteRealmProductionPlanProps["signer"],
+      executeRealmProductionPlan,
+    });
+
+    expect(callOrder).toEqual([1, 2, 3]);
+    expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected", "fulfilled"]);
+    expect(executeRealmProductionPlan).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ realm_entity_id: 1, skipQueue: true }),
+    );
+    expect(executeRealmProductionPlan).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ realm_entity_id: 2, skipQueue: true }),
+    );
+    expect(executeRealmProductionPlan).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ realm_entity_id: 3, skipQueue: true }),
+    );
+  });
+});

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
@@ -2,7 +2,7 @@ import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
 import type { ExecuteRealmProductionPlanProps } from "@bibliothecadao/types";
 import type { RealmProductionPlan } from "./automation-processor";
 
-export const REALM_EXECUTION_TIMEOUT_MS = 30_000;
+const REALM_EXECUTION_TIMEOUT_MS = 30_000;
 
 export class AutomationTimeoutError extends Error {
   constructor(timeoutMs: number) {
@@ -62,9 +62,7 @@ export const isSignerTransientError = (error: unknown): boolean => {
   return false;
 };
 
-export type AutomationCancellation =
-  | { cancelled: false }
-  | { cancelled: true; reason: string; scope?: "pass" | "realm" };
+type AutomationCancellation = { cancelled: false } | { cancelled: true; reason: string; scope?: "pass" | "realm" };
 
 export interface ExecutableProductionPlan {
   plan: RealmProductionPlan;

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
@@ -1,0 +1,77 @@
+import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
+import type { ExecuteRealmProductionPlanProps } from "@bibliothecadao/types";
+import type { RealmProductionPlan } from "./automation-processor";
+
+export interface ExecutableProductionPlan {
+  plan: RealmProductionPlan;
+  realmConfig: RealmAutomationConfig;
+  realmLabel: string;
+  planLogPayload: Record<string, unknown>;
+}
+
+interface ExecuteRealmProductionPlanArgs extends ExecuteRealmProductionPlanProps {
+  skipQueue: true;
+  resource_to_resource: Array<{ resource_id: number; cycles: number }>;
+  labor_to_resource: Array<{ resource_id: number; cycles: number }>;
+}
+
+type ExecuteRealmProductionPlan = (args: ExecuteRealmProductionPlanProps) => Promise<unknown>;
+
+type ProductionPlanExecutionResult =
+  | { status: "fulfilled"; value: ExecutableProductionPlan }
+  | {
+      status: "rejected";
+      reason: {
+        error: unknown;
+        realmConfig: RealmAutomationConfig;
+        realmLabel: string;
+      };
+    };
+
+export const executeProductionPlansSequentially = async ({
+  executablePlans,
+  signer,
+  executeRealmProductionPlan,
+  onBeforeExecute,
+}: {
+  executablePlans: ExecutableProductionPlan[];
+  signer: ExecuteRealmProductionPlanProps["signer"];
+  executeRealmProductionPlan: ExecuteRealmProductionPlan;
+  onBeforeExecute?: (executablePlan: ExecutableProductionPlan) => void;
+}): Promise<ProductionPlanExecutionResult[]> => {
+  const results: ProductionPlanExecutionResult[] = [];
+
+  for (const executablePlan of executablePlans) {
+    const { plan, realmConfig, realmLabel } = executablePlan;
+
+    try {
+      onBeforeExecute?.(executablePlan);
+      const callset = plan.callset;
+      await executeRealmProductionPlan({
+        signer,
+        realm_entity_id: plan.realmId,
+        skipQueue: true,
+        resource_to_resource: callset.resourceToResource.map((item) => ({
+          resource_id: item.resourceId,
+          cycles: item.cycles,
+        })),
+        labor_to_resource: callset.laborToResource.map((item) => ({
+          resource_id: item.resourceId,
+          cycles: item.cycles,
+        })),
+      });
+      results.push({ status: "fulfilled", value: executablePlan });
+    } catch (error) {
+      results.push({
+        status: "rejected",
+        reason: {
+          error,
+          realmConfig,
+          realmLabel,
+        },
+      });
+    }
+  }
+
+  return results;
+};

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
@@ -9,12 +9,6 @@ export interface ExecutableProductionPlan {
   planLogPayload: Record<string, unknown>;
 }
 
-interface ExecuteRealmProductionPlanArgs extends ExecuteRealmProductionPlanProps {
-  skipQueue: true;
-  resource_to_resource: Array<{ resource_id: number; cycles: number }>;
-  labor_to_resource: Array<{ resource_id: number; cycles: number }>;
-}
-
 type ExecuteRealmProductionPlan = (args: ExecuteRealmProductionPlanProps) => Promise<unknown>;
 
 type ProductionPlanExecutionResult =

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-runner.ts
@@ -2,6 +2,70 @@ import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
 import type { ExecuteRealmProductionPlanProps } from "@bibliothecadao/types";
 import type { RealmProductionPlan } from "./automation-processor";
 
+export const REALM_EXECUTION_TIMEOUT_MS = 30_000;
+
+export class AutomationTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Realm execution timed out after ${Math.round(timeoutMs / 1000)}s`);
+    this.name = "AutomationTimeoutError";
+  }
+}
+
+export class AutomationCancelledError extends Error {
+  readonly scope: "pass" | "realm";
+  constructor(reason: string, scope: "pass" | "realm" = "realm") {
+    super(reason);
+    this.name = "AutomationCancelledError";
+    this.scope = scope;
+  }
+}
+
+export class AutomationSignerSkippedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "AutomationSignerSkipped";
+  }
+}
+
+const SIGNER_TRANSIENT_PATTERN =
+  /nonce|invalid transaction nonce|account validation failed|account balance|duplicate transaction|insufficient (?:max )?fee/i;
+
+export const isSignerTransientError = (error: unknown): boolean => {
+  if (!error) return false;
+  if (error instanceof AutomationTimeoutError) return false;
+  if (error instanceof AutomationCancelledError) return false;
+  if (error instanceof AutomationSignerSkippedError) return false;
+
+  const visited = new Set<unknown>();
+  const stack: unknown[] = [error];
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || visited.has(current)) continue;
+    visited.add(current);
+
+    if (typeof current === "string") {
+      if (SIGNER_TRANSIENT_PATTERN.test(current)) return true;
+      continue;
+    }
+    if (typeof current !== "object") continue;
+
+    const record = current as Record<string, unknown>;
+    const candidateFields = ["message", "reason", "data", "revert_error"];
+    for (const field of candidateFields) {
+      const value = record[field];
+      if (typeof value === "string" && SIGNER_TRANSIENT_PATTERN.test(value)) return true;
+      if (value && (typeof value === "object" || typeof value === "string")) stack.push(value);
+    }
+    if (record.cause) stack.push(record.cause);
+  }
+
+  return false;
+};
+
+export type AutomationCancellation =
+  | { cancelled: false }
+  | { cancelled: true; reason: string; scope?: "pass" | "realm" };
+
 export interface ExecutableProductionPlan {
   plan: RealmProductionPlan;
   realmConfig: RealmAutomationConfig;
@@ -22,38 +86,100 @@ type ProductionPlanExecutionResult =
       };
     };
 
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new AutomationTimeoutError(timeoutMs)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+};
+
 export const executeProductionPlansSequentially = async ({
   executablePlans,
   signer,
   executeRealmProductionPlan,
   onBeforeExecute,
+  timeoutMs = REALM_EXECUTION_TIMEOUT_MS,
+  isCancelled,
 }: {
   executablePlans: ExecutableProductionPlan[];
   signer: ExecuteRealmProductionPlanProps["signer"];
   executeRealmProductionPlan: ExecuteRealmProductionPlan;
   onBeforeExecute?: (executablePlan: ExecutableProductionPlan) => void;
+  timeoutMs?: number;
+  isCancelled?: (executablePlan: ExecutableProductionPlan) => AutomationCancellation;
 }): Promise<ProductionPlanExecutionResult[]> => {
   const results: ProductionPlanExecutionResult[] = [];
+  let passAborted: { reason: string } | null = null;
+  let signerAborted: { reason: string } | null = null;
 
   for (const executablePlan of executablePlans) {
     const { plan, realmConfig, realmLabel } = executablePlan;
 
+    if (signerAborted) {
+      results.push({
+        status: "rejected",
+        reason: {
+          error: new AutomationSignerSkippedError(signerAborted.reason),
+          realmConfig,
+          realmLabel,
+        },
+      });
+      continue;
+    }
+
+    if (passAborted) {
+      results.push({
+        status: "rejected",
+        reason: {
+          error: new AutomationCancelledError(passAborted.reason, "pass"),
+          realmConfig,
+          realmLabel,
+        },
+      });
+      continue;
+    }
+
+    const cancellation = isCancelled?.(executablePlan);
+    if (cancellation?.cancelled) {
+      const scope = cancellation.scope ?? "realm";
+      if (scope === "pass") passAborted = { reason: cancellation.reason };
+      results.push({
+        status: "rejected",
+        reason: {
+          error: new AutomationCancelledError(cancellation.reason, scope),
+          realmConfig,
+          realmLabel,
+        },
+      });
+      continue;
+    }
+
     try {
       onBeforeExecute?.(executablePlan);
       const callset = plan.callset;
-      await executeRealmProductionPlan({
-        signer,
-        realm_entity_id: plan.realmId,
-        skipQueue: true,
-        resource_to_resource: callset.resourceToResource.map((item) => ({
-          resource_id: item.resourceId,
-          cycles: item.cycles,
-        })),
-        labor_to_resource: callset.laborToResource.map((item) => ({
-          resource_id: item.resourceId,
-          cycles: item.cycles,
-        })),
-      });
+      await withTimeout(
+        executeRealmProductionPlan({
+          signer,
+          realm_entity_id: plan.realmId,
+          skipQueue: true,
+          resource_to_resource: callset.resourceToResource.map((item) => ({
+            resource_id: item.resourceId,
+            cycles: item.cycles,
+          })),
+          labor_to_resource: callset.laborToResource.map((item) => ({
+            resource_id: item.resourceId,
+            cycles: item.cycles,
+          })),
+        }),
+        timeoutMs,
+      );
       results.push({ status: "fulfilled", value: executablePlan });
     } catch (error) {
       results.push({
@@ -64,6 +190,11 @@ export const executeProductionPlansSequentially = async ({
           realmLabel,
         },
       });
+      if (isSignerTransientError(error)) {
+        signerAborted = {
+          reason: "Skipped: signer error earlier in pass — next tick will retry",
+        };
+      }
     }
   }
 

--- a/client/apps/game/src/ui/features/infrastructure/automation/production-automation-dashboard.source.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/production-automation-dashboard.source.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("ProductionAutomationDashboard source", () => {
+  it("derives visible skip details from the current status instead of stale execution history", () => {
+    const source = readSource("src/ui/features/infrastructure/automation/production-automation-dashboard.tsx");
+
+    expect(source).toContain("realm.lastStatus?.message");
+    expect(source).not.toContain("realm.lastExecution?.skipped");
+  });
+});

--- a/client/apps/game/src/ui/features/infrastructure/automation/production-automation-dashboard.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/production-automation-dashboard.tsx
@@ -1,4 +1,4 @@
-import { useAutomationStore } from "@/hooks/store/use-automation-store";
+import { useAutomationStore, type RealmAutomationConfig } from "@/hooks/store/use-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { OSWindow, productionAutomation } from "@/ui/features/world";
@@ -10,7 +10,10 @@ import {
   getRealmStatusLabel,
   timeAgo,
 } from "@/utils/automation-status";
-import { PROCESS_INTERVAL_MS } from "@/ui/features/infrastructure/automation/model/automation-processor";
+import {
+  buildAutomationSkipMessage,
+  PROCESS_INTERVAL_MS,
+} from "@/ui/features/infrastructure/automation/model/automation-processor";
 import { Bot } from "lucide-react";
 import { memo, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -45,6 +48,9 @@ const getStatusDotBg = (statusStr?: string): string => {
       return "bg-gold/50";
   }
 };
+
+const getVisibleSkipMessages = (realm: RealmAutomationConfig): string[] =>
+  (realm.lastExecution?.skipped ?? []).slice(0, 2).map(buildAutomationSkipMessage);
 
 interface ProductionAutomationContentProps {
   compact?: boolean;
@@ -138,6 +144,7 @@ const ProductionAutomationContent = ({ compact = false }: ProductionAutomationCo
           {list.map((realm) => {
             const severity = getFailureSeverity(realm.lastStatus);
             const isCritical = severity === "critical";
+            const skipMessages = getVisibleSkipMessages(realm);
 
             return (
               <div
@@ -198,6 +205,12 @@ const ProductionAutomationContent = ({ compact = false }: ProductionAutomationCo
                     <span className="text-[10px] text-red-400">
                       {realm.lastStatus.consecutiveFailures} consecutive failures: {realm.lastStatus.message}
                     </span>
+                  </div>
+                )}
+
+                {realm.lastStatus?.status === "skipped" && skipMessages.length > 0 && (
+                  <div className="mt-1.5 rounded border border-amber-500/30 bg-amber-500/5 px-2 py-1">
+                    <span className="text-[10px] text-amber-300">{skipMessages.join("; ")}</span>
                   </div>
                 )}
               </div>

--- a/client/apps/game/src/ui/features/infrastructure/automation/production-automation-dashboard.tsx
+++ b/client/apps/game/src/ui/features/infrastructure/automation/production-automation-dashboard.tsx
@@ -10,10 +10,7 @@ import {
   getRealmStatusLabel,
   timeAgo,
 } from "@/utils/automation-status";
-import {
-  buildAutomationSkipMessage,
-  PROCESS_INTERVAL_MS,
-} from "@/ui/features/infrastructure/automation/model/automation-processor";
+import { PROCESS_INTERVAL_MS } from "@/ui/features/infrastructure/automation/model/automation-processor";
 import { Bot } from "lucide-react";
 import { memo, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
@@ -50,7 +47,7 @@ const getStatusDotBg = (statusStr?: string): string => {
 };
 
 const getVisibleSkipMessages = (realm: RealmAutomationConfig): string[] =>
-  (realm.lastExecution?.skipped ?? []).slice(0, 2).map(buildAutomationSkipMessage);
+  realm.lastStatus?.status === "skipped" && realm.lastStatus.message ? [realm.lastStatus.message] : [];
 
 interface ProductionAutomationContentProps {
   compact?: boolean;

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-16",
+    title: "Automation Skip Reasons",
+    description:
+      "Production automation now shows why a realm was skipped, making inactive buildings, missing inputs, and budget limits easier to diagnose.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-15",
     title: "Blitz Settlement Handoff Fix",
     description:

--- a/client/apps/game/src/utils/automation-presets.test.ts
+++ b/client/apps/game/src/utils/automation-presets.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import { configManager } from "@bibliothecadao/eternum";
+import {
+  calculatePresetAllocations,
+  getAutomationOverallocation,
+  inferRealmPreset,
+  REALM_PRESETS,
+} from "./automation-presets";
+
+const snapshotInputs = () => ({
+  complex: { ...configManager.complexSystemResourceInputs },
+  simple: { ...configManager.simpleSystemResourceInputs },
+});
+
+describe("calculatePresetAllocations", () => {
+  it("returns an empty map when no resources are provided", () => {
+    expect(calculatePresetAllocations([], "smart", "realm").size).toBe(0);
+  });
+
+  it("idle preset zeros every resource", () => {
+    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Coal], "idle", "realm");
+    expect(result.get(ResourcesIds.Wood)).toEqual({ resourceToResource: 0, laborToResource: 0 });
+    expect(result.get(ResourcesIds.Coal)).toEqual({ resourceToResource: 0, laborToResource: 0 });
+  });
+
+  it("custom preset returns an empty map (caller resolves stored values)", () => {
+    const result = calculatePresetAllocations([ResourcesIds.Wood], "custom", "realm");
+    expect(result.size).toBe(0);
+  });
+
+  it("smart with incomplete T1 uses labor slider at 5%", () => {
+    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Copper], "smart", "realm");
+    expect(result.get(ResourcesIds.Wood)).toEqual({ resourceToResource: 0, laborToResource: 5 });
+    expect(result.get(ResourcesIds.Copper)).toEqual({ resourceToResource: 0, laborToResource: 5 });
+  });
+
+  it("smart with complete T1 and no higher tiers uses 30% resource slider", () => {
+    const result = calculatePresetAllocations(
+      [ResourcesIds.Wood, ResourcesIds.Copper, ResourcesIds.Coal],
+      "smart",
+      "realm",
+    );
+    expect(result.get(ResourcesIds.Wood)).toEqual({ resourceToResource: 30, laborToResource: 0 });
+    expect(result.get(ResourcesIds.Copper)).toEqual({ resourceToResource: 30, laborToResource: 0 });
+    expect(result.get(ResourcesIds.Coal)).toEqual({ resourceToResource: 30, laborToResource: 0 });
+  });
+
+  it("smart with complete T1 and an army downshifts T1 to 20/20/30", () => {
+    const result = calculatePresetAllocations(
+      [ResourcesIds.Wood, ResourcesIds.Copper, ResourcesIds.Coal, ResourcesIds.Knight],
+      "smart",
+      "realm",
+    );
+    expect(result.get(ResourcesIds.Wood)).toEqual({ resourceToResource: 20, laborToResource: 0 });
+    expect(result.get(ResourcesIds.Coal)).toEqual({ resourceToResource: 20, laborToResource: 0 });
+    expect(result.get(ResourcesIds.Copper)).toEqual({ resourceToResource: 30, laborToResource: 0 });
+    // Army T1 alone (no higher tiers) gets 30/20/10 sequentially; here only Knight is present → 30%.
+    expect(result.get(ResourcesIds.Knight)).toEqual({ resourceToResource: 30, laborToResource: 0 });
+  });
+
+  it("smart weights army T3 highest and drops T1 to 10/5/3 when T3 present", () => {
+    const result = calculatePresetAllocations(
+      [
+        ResourcesIds.Wood,
+        ResourcesIds.Copper,
+        ResourcesIds.Coal,
+        ResourcesIds.Knight,
+        ResourcesIds.KnightT3,
+      ],
+      "smart",
+      "realm",
+    );
+    expect(result.get(ResourcesIds.KnightT3)?.resourceToResource).toBe(50);
+    expect(result.get(ResourcesIds.Knight)?.resourceToResource).toBe(10);
+  });
+
+  it("smart filters blocked output resources (Wheat, Labor)", () => {
+    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Wheat, ResourcesIds.Labor], "smart", "realm");
+    expect(result.has(ResourcesIds.Wheat)).toBe(false);
+    expect(result.has(ResourcesIds.Labor)).toBe(false);
+    expect(result.has(ResourcesIds.Wood)).toBe(true);
+  });
+
+  it("smart forces Donkey laborToResource to 0", () => {
+    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Donkey], "smart", "realm");
+    expect(result.get(ResourcesIds.Donkey)).toEqual({ resourceToResource: 0, laborToResource: 0 });
+  });
+
+  it("smart includes resources without a tier weighting as zero entries", () => {
+    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Donkey, ResourcesIds.Fish], "smart", "realm");
+    // Fish is not in any tier; must still be present and zeroed.
+    expect(result.get(ResourcesIds.Fish)).toEqual({ resourceToResource: 0, laborToResource: 0 });
+  });
+
+  it("smart dedupes repeated resource ids", () => {
+    const result = calculatePresetAllocations(
+      [ResourcesIds.Wood, ResourcesIds.Wood, ResourcesIds.Copper, ResourcesIds.Copper, ResourcesIds.Coal],
+      "smart",
+      "realm",
+    );
+    expect(result.size).toBe(3);
+  });
+});
+
+describe("getAutomationOverallocation", () => {
+  let snapshot: ReturnType<typeof snapshotInputs>;
+
+  beforeEach(() => {
+    snapshot = snapshotInputs();
+    // Set up a tiny synthetic recipe table: Knight (complex) needs Wood+Coal.
+    configManager.complexSystemResourceInputs[ResourcesIds.Knight] = [
+      { resource: ResourcesIds.Wood, amount: 1 },
+      { resource: ResourcesIds.Coal, amount: 1 },
+    ];
+    configManager.complexSystemResourceInputs[ResourcesIds.Crossbowman] = [
+      { resource: ResourcesIds.Wood, amount: 1 },
+    ];
+    configManager.simpleSystemResourceInputs[ResourcesIds.Knight] = [
+      { resource: ResourcesIds.Copper, amount: 1 },
+    ];
+  });
+
+  afterEach(() => {
+    configManager.complexSystemResourceInputs = snapshot.complex;
+    configManager.simpleSystemResourceInputs = snapshot.simple;
+  });
+
+  it("returns all false when no percentages are set", () => {
+    expect(getAutomationOverallocation(undefined, "realm")).toEqual({ resourceOver: false, laborOver: false });
+    expect(getAutomationOverallocation({}, "realm")).toEqual({ resourceOver: false, laborOver: false });
+  });
+
+  it("flags resourceOver when the combined resource-slider draw on an input exceeds MAX", () => {
+    // Knight r2r=50, Crossbowman r2r=50 both draw from Wood → 100% total > 90%.
+    const result = getAutomationOverallocation(
+      {
+        [ResourcesIds.Knight]: { resourceToResource: 50, laborToResource: 0 },
+        [ResourcesIds.Crossbowman]: { resourceToResource: 50, laborToResource: 0 },
+      },
+      "realm",
+    );
+    expect(result.resourceOver).toBe(true);
+    expect(result.laborOver).toBe(false);
+  });
+
+  it("does not flag when per-input totals stay within MAX", () => {
+    const result = getAutomationOverallocation(
+      {
+        [ResourcesIds.Knight]: { resourceToResource: 30, laborToResource: 0 },
+        [ResourcesIds.Crossbowman]: { resourceToResource: 30, laborToResource: 0 },
+      },
+      "realm",
+    );
+    expect(result).toEqual({ resourceOver: false, laborOver: false });
+  });
+
+  it("flags laborOver separately from resourceOver", () => {
+    const result = getAutomationOverallocation(
+      {
+        [ResourcesIds.Knight]: { resourceToResource: 0, laborToResource: 95 },
+      },
+      "realm",
+    );
+    expect(result.laborOver).toBe(true);
+    expect(result.resourceOver).toBe(false);
+  });
+
+  it("skips blocked output resources (does not count Wheat/Labor as a consumer)", () => {
+    const result = getAutomationOverallocation(
+      {
+        [ResourcesIds.Wheat]: { resourceToResource: 95, laborToResource: 0 },
+        [ResourcesIds.Labor]: { resourceToResource: 95, laborToResource: 0 },
+      },
+      "realm",
+    );
+    expect(result).toEqual({ resourceOver: false, laborOver: false });
+  });
+});
+
+describe("inferRealmPreset", () => {
+  it("defaults to smart when no automation config is present", () => {
+    expect(inferRealmPreset(undefined)).toBe("smart");
+  });
+
+  it("returns the stored presetId when set", () => {
+    expect(
+      inferRealmPreset({
+        realmId: "1",
+        entityType: "realm",
+        presetId: "idle",
+        autoBalance: false,
+        customPercentages: {},
+        createdAt: 1,
+        updatedAt: 1,
+      }),
+    ).toBe("idle");
+  });
+});
+
+describe("REALM_PRESETS", () => {
+  it("exposes smart, custom, and idle entries with labels", () => {
+    const ids = REALM_PRESETS.map((p) => p.id);
+    expect(ids).toEqual(["smart", "custom", "idle"]);
+    REALM_PRESETS.forEach((p) => expect(p.label.length).toBeGreaterThan(0));
+  });
+});

--- a/client/apps/game/src/utils/automation-presets.test.ts
+++ b/client/apps/game/src/utils/automation-presets.test.ts
@@ -62,13 +62,7 @@ describe("calculatePresetAllocations", () => {
 
   it("smart weights army T3 highest and drops T1 to 10/5/3 when T3 present", () => {
     const result = calculatePresetAllocations(
-      [
-        ResourcesIds.Wood,
-        ResourcesIds.Copper,
-        ResourcesIds.Coal,
-        ResourcesIds.Knight,
-        ResourcesIds.KnightT3,
-      ],
+      [ResourcesIds.Wood, ResourcesIds.Copper, ResourcesIds.Coal, ResourcesIds.Knight, ResourcesIds.KnightT3],
       "smart",
       "realm",
     );
@@ -77,7 +71,11 @@ describe("calculatePresetAllocations", () => {
   });
 
   it("smart filters blocked output resources (Wheat, Labor)", () => {
-    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Wheat, ResourcesIds.Labor], "smart", "realm");
+    const result = calculatePresetAllocations(
+      [ResourcesIds.Wood, ResourcesIds.Wheat, ResourcesIds.Labor],
+      "smart",
+      "realm",
+    );
     expect(result.has(ResourcesIds.Wheat)).toBe(false);
     expect(result.has(ResourcesIds.Labor)).toBe(false);
     expect(result.has(ResourcesIds.Wood)).toBe(true);
@@ -89,7 +87,11 @@ describe("calculatePresetAllocations", () => {
   });
 
   it("smart includes resources without a tier weighting as zero entries", () => {
-    const result = calculatePresetAllocations([ResourcesIds.Wood, ResourcesIds.Donkey, ResourcesIds.Fish], "smart", "realm");
+    const result = calculatePresetAllocations(
+      [ResourcesIds.Wood, ResourcesIds.Donkey, ResourcesIds.Fish],
+      "smart",
+      "realm",
+    );
     // Fish is not in any tier; must still be present and zeroed.
     expect(result.get(ResourcesIds.Fish)).toEqual({ resourceToResource: 0, laborToResource: 0 });
   });
@@ -114,12 +116,8 @@ describe("getAutomationOverallocation", () => {
       { resource: ResourcesIds.Wood, amount: 1 },
       { resource: ResourcesIds.Coal, amount: 1 },
     ];
-    configManager.complexSystemResourceInputs[ResourcesIds.Crossbowman] = [
-      { resource: ResourcesIds.Wood, amount: 1 },
-    ];
-    configManager.simpleSystemResourceInputs[ResourcesIds.Knight] = [
-      { resource: ResourcesIds.Copper, amount: 1 },
-    ];
+    configManager.complexSystemResourceInputs[ResourcesIds.Crossbowman] = [{ resource: ResourcesIds.Wood, amount: 1 }];
+    configManager.simpleSystemResourceInputs[ResourcesIds.Knight] = [{ resource: ResourcesIds.Copper, amount: 1 }];
   });
 
   afterEach(() => {

--- a/client/apps/game/src/utils/automation-signature.test.ts
+++ b/client/apps/game/src/utils/automation-signature.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
+import { computeAutomationConfigSignature } from "./automation-signature";
+
+const baseRealm = (overrides: Partial<RealmAutomationConfig>): RealmAutomationConfig => ({
+  realmId: "1",
+  realmName: "Realm 1",
+  entityType: "realm",
+  presetId: "smart",
+  autoBalance: false,
+  customPercentages: {},
+  createdAt: 1,
+  updatedAt: 1,
+  ...overrides,
+});
+
+describe("computeAutomationConfigSignature", () => {
+  it("changes when autoBalance toggles", () => {
+    const off = computeAutomationConfigSignature({ "1": baseRealm({ autoBalance: false }) });
+    const on = computeAutomationConfigSignature({ "1": baseRealm({ autoBalance: true }) });
+    expect(off).not.toEqual(on);
+  });
+
+  it("changes when a percentage value changes", () => {
+    const a = computeAutomationConfigSignature({
+      "1": baseRealm({
+        presetId: "custom",
+        customPercentages: {
+          [ResourcesIds.Knight]: { resourceToResource: 10, laborToResource: 0 },
+        },
+      }),
+    });
+    const b = computeAutomationConfigSignature({
+      "1": baseRealm({
+        presetId: "custom",
+        customPercentages: {
+          [ResourcesIds.Knight]: { resourceToResource: 15, laborToResource: 0 },
+        },
+      }),
+    });
+    expect(a).not.toEqual(b);
+  });
+
+  it("is stable across insertion order of percentages", () => {
+    const a = computeAutomationConfigSignature({
+      "1": baseRealm({
+        presetId: "custom",
+        customPercentages: {
+          [ResourcesIds.Knight]: { resourceToResource: 10, laborToResource: 5 },
+          [ResourcesIds.Crossbowman]: { resourceToResource: 20, laborToResource: 0 },
+        },
+      }),
+    });
+    const b = computeAutomationConfigSignature({
+      "1": baseRealm({
+        presetId: "custom",
+        customPercentages: {
+          [ResourcesIds.Crossbowman]: { resourceToResource: 20, laborToResource: 0 },
+          [ResourcesIds.Knight]: { resourceToResource: 10, laborToResource: 5 },
+        },
+      }),
+    });
+    expect(a).toEqual(b);
+  });
+
+  it("changes when preset changes", () => {
+    const smart = computeAutomationConfigSignature({ "1": baseRealm({ presetId: "smart" }) });
+    const idle = computeAutomationConfigSignature({ "1": baseRealm({ presetId: "idle" }) });
+    expect(smart).not.toEqual(idle);
+  });
+
+  it("does not include non-managed entities", () => {
+    const managedOnly = computeAutomationConfigSignature({ "1": baseRealm({}) });
+    const withExtra = computeAutomationConfigSignature({
+      "1": baseRealm({}),
+      // @ts-expect-error simulate a non-managed entityType slipping in
+      "2": baseRealm({ realmId: "2", entityType: "bank" }),
+    });
+    expect(managedOnly).toEqual(withExtra);
+  });
+});

--- a/client/apps/game/src/utils/automation-signature.ts
+++ b/client/apps/game/src/utils/automation-signature.ts
@@ -1,0 +1,28 @@
+import type { RealmAutomationConfig, ResourceAutomationPercentages } from "@/hooks/store/use-automation-store";
+
+const isManagedEntity = (realm: RealmAutomationConfig) =>
+  realm.entityType === "realm" || realm.entityType === "village";
+
+const encodePercentages = (percentages: Record<number, ResourceAutomationPercentages> | undefined): string => {
+  if (!percentages) return "";
+  return Object.entries(percentages)
+    .toSorted(([a], [b]) => Number(a) - Number(b))
+    .map(([resourceId, value]) => {
+      const r2r = Number.isFinite(value?.resourceToResource) ? value!.resourceToResource : 0;
+      const l2r = Number.isFinite(value?.laborToResource) ? value!.laborToResource : 0;
+      return `${resourceId}:${r2r}:${l2r}`;
+    })
+    .join(",");
+};
+
+export const computeAutomationConfigSignature = (realms: Record<string, RealmAutomationConfig>): string =>
+  Object.entries(realms)
+    .filter(([, realm]) => isManagedEntity(realm))
+    .map(([realmId, realm]) => {
+      const presetId = realm.presetId ?? "smart";
+      const balance = realm.autoBalance ? "A" : "a";
+      const percentages = encodePercentages(realm.customPercentages);
+      return `${realmId}:${presetId}:${balance}:${percentages}`;
+    })
+    .toSorted()
+    .join("|");

--- a/client/apps/game/src/utils/entity-ownership.test.ts
+++ b/client/apps/game/src/utils/entity-ownership.test.ts
@@ -16,9 +16,10 @@ vi.mock("@bibliothecadao/eternum", () => ({
 import { isEntityOwnedByAccount } from "./entity-ownership";
 
 type FakeStructure = { owner: unknown };
-const makeComponents = (structures: Record<string, FakeStructure>) => ({
-  Structure: new Map<string, FakeStructure>(Object.entries(structures)),
-}) as unknown as Parameters<typeof isEntityOwnedByAccount>[0];
+const makeComponents = (structures: Record<string, FakeStructure>) =>
+  ({
+    Structure: new Map<string, FakeStructure>(Object.entries(structures)),
+  }) as unknown as Parameters<typeof isEntityOwnedByAccount>[0];
 
 describe("isEntityOwnedByAccount", () => {
   it("returns true when the structure owner matches the account address (case-insensitive, trimmed)", () => {

--- a/client/apps/game/src/utils/entity-ownership.test.ts
+++ b/client/apps/game/src/utils/entity-ownership.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@dojoengine/recs", () => ({
+  getComponentValue: (component: unknown, entity: unknown) => {
+    if (component instanceof Map) return component.get(entity);
+    return undefined;
+  },
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  getEntityIdFromKeys: (keys: bigint[]) => keys.map((k) => k.toString()).join(":"),
+}));
+
+// Imported after mocks to ensure they take effect.
+import { isEntityOwnedByAccount } from "./entity-ownership";
+
+type FakeStructure = { owner: unknown };
+const makeComponents = (structures: Record<string, FakeStructure>) => ({
+  Structure: new Map<string, FakeStructure>(Object.entries(structures)),
+}) as unknown as Parameters<typeof isEntityOwnedByAccount>[0];
+
+describe("isEntityOwnedByAccount", () => {
+  it("returns true when the structure owner matches the account address (case-insensitive, trimmed)", () => {
+    const components = makeComponents({ "1": { owner: "0xABC" } });
+    expect(isEntityOwnedByAccount(components, 1, "  0xabc  ")).toBe(true);
+  });
+
+  it("returns false when the structure has a different owner", () => {
+    const components = makeComponents({ "1": { owner: "0xdef" } });
+    expect(isEntityOwnedByAccount(components, 1, "0xabc")).toBe(false);
+  });
+
+  it("normalizes bigint owner values to hex", () => {
+    const components = makeComponents({ "1": { owner: BigInt("0xabc") } });
+    expect(isEntityOwnedByAccount(components, 1, "0xabc")).toBe(true);
+  });
+
+  it("normalizes finite number owner values to hex", () => {
+    const components = makeComponents({ "1": { owner: 0xabc } });
+    expect(isEntityOwnedByAccount(components, 1, "0xabc")).toBe(true);
+  });
+
+  it("returns false when the structure is missing", () => {
+    const components = makeComponents({});
+    expect(isEntityOwnedByAccount(components, 1, "0xabc")).toBe(false);
+  });
+
+  it("returns false when the structure has no owner field", () => {
+    const components = makeComponents({ "1": { owner: undefined } });
+    expect(isEntityOwnedByAccount(components, 1, "0xabc")).toBe(false);
+  });
+
+  it("returns false when components is null or undefined", () => {
+    expect(isEntityOwnedByAccount(null, 1, "0xabc")).toBe(false);
+    expect(isEntityOwnedByAccount(undefined, 1, "0xabc")).toBe(false);
+  });
+
+  it("returns false when accountAddress is missing", () => {
+    const components = makeComponents({ "1": { owner: "0xabc" } });
+    expect(isEntityOwnedByAccount(components, 1, undefined)).toBe(false);
+  });
+
+  it("returns false when entityId is 0 or NaN", () => {
+    const components = makeComponents({ "0": { owner: "0xabc" } });
+    expect(isEntityOwnedByAccount(components, 0, "0xabc")).toBe(false);
+    expect(isEntityOwnedByAccount(components, Number.NaN, "0xabc")).toBe(false);
+  });
+
+  it("returns false when the owner type is unsupported (e.g. plain object)", () => {
+    const components = makeComponents({ "1": { owner: { address: "0xabc" } } });
+    expect(isEntityOwnedByAccount(components, 1, "0xabc")).toBe(false);
+  });
+
+  it("returns false if getComponentValue throws (e.g. bad BigInt conversion)", () => {
+    const components = { Structure: new Map() } as unknown as Parameters<typeof isEntityOwnedByAccount>[0];
+    // Passing a non-integer forces BigInt to throw.
+    expect(isEntityOwnedByAccount(components, 1.5, "0xabc")).toBe(false);
+  });
+});

--- a/client/apps/game/src/utils/entity-ownership.ts
+++ b/client/apps/game/src/utils/entity-ownership.ts
@@ -1,0 +1,26 @@
+import { getEntityIdFromKeys } from "@bibliothecadao/eternum";
+import { ClientComponents } from "@bibliothecadao/types";
+import { getComponentValue } from "@dojoengine/recs";
+
+const normalizeOwnerValue = (owner: unknown): string | null => {
+  if (typeof owner === "string") return owner.trim().toLowerCase();
+  if (typeof owner === "bigint") return `0x${owner.toString(16)}`;
+  if (typeof owner === "number" && Number.isFinite(owner)) return `0x${BigInt(owner).toString(16)}`;
+  return null;
+};
+
+export const isEntityOwnedByAccount = (
+  components: ClientComponents | null | undefined,
+  entityId: number,
+  accountAddress: string | undefined,
+): boolean => {
+  if (!components || !entityId || !accountAddress) return false;
+  try {
+    const structure = getComponentValue(components.Structure, getEntityIdFromKeys([BigInt(entityId)]));
+    const owner = normalizeOwnerValue(structure?.owner);
+    const accountOwner = normalizeOwnerValue(accountAddress);
+    return Boolean(owner && accountOwner && owner === accountOwner);
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- serialize per-realm production automation transactions to avoid same-signer nonce races
- update production planning so custom inactive resources are diagnosed, troop dependencies are ordered, and Smart can run one affordable troop cycle
- surface concrete skip reasons in the production automation dashboard

## Verification
- PATH="/Users/os/Library/pnpm:$PATH" pnpm --dir client/apps/game test -- automation-processor automation-runner
- PATH="/Users/os/Library/pnpm:$PATH" pnpm --dir client/apps/game typecheck
- PATH="/Users/os/Library/pnpm:$PATH" pnpm run format
- PATH="/Users/os/Library/pnpm:$PATH" pnpm run knip