### PR TITLE
fix(game): keep Blitz Play on settlement flow

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-handoff.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-handoff.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { resolveGameEntryModalPhase, resolveBlitzSettlementPhase } from "./game-entry-phase";
@@ -56,13 +58,22 @@ const resolvePhaseFromSnapshot = ({
     checksComplete: true,
     needsHyperstructureInit: false,
     needsSettlement: status.needsSettlement,
+    canPlay: status.canPlay,
     isBlitzSettlementUnlocked: isSettlementUnlocked,
   });
 };
 
 describe("resolveBlitzSettlementPhase", () => {
   it("maps settled players to ready", () => {
-    expect(resolveBlitzSettlementPhase({ needsSettlement: false, isSettlementUnlocked: false })).toBe("ready");
+    expect(resolveBlitzSettlementPhase({ canPlay: true, isSettlementUnlocked: false })).toBe("ready");
+  });
+
+  it("routes unfinished players to settlement when unlocked", () => {
+    expect(resolveBlitzSettlementPhase({ canPlay: false, isSettlementUnlocked: true })).toBe("settlement");
+  });
+
+  it("holds unfinished players in settlement-waiting before unlock", () => {
+    expect(resolveBlitzSettlementPhase({ canPlay: false, isSettlementUnlocked: false })).toBe("settlement-waiting");
   });
 });
 
@@ -87,6 +98,28 @@ describe("blitz entry handoff", () => {
         isSettlementUnlocked: true,
       }),
     ).toBe("settlement");
+  });
+
+  it("routes unregistered new players (no dashboard hint) into the settle flow, not ready", () => {
+    expect(
+      resolvePhaseFromSnapshot({
+        snapshot: snapshot(),
+        entryIntent: "play",
+        hasDashboardRegistrationEntry: false,
+        isSettlementUnlocked: true,
+      }),
+    ).toBe("settlement");
+  });
+
+  it("holds unregistered new players (no dashboard hint) in settlement-waiting before unlock", () => {
+    expect(
+      resolvePhaseFromSnapshot({
+        snapshot: snapshot(),
+        entryIntent: "play",
+        hasDashboardRegistrationEntry: false,
+        isSettlementUnlocked: false,
+      }),
+    ).toBe("settlement-waiting");
   });
 
   it("keeps settled entries ready", () => {

--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it, vi } from "vitest";
 
 import { runBlitzSettlementFlow } from "./game-entry-blitz-settlement-flow";

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -888,6 +888,7 @@ const SettlementPhase = ({
   isSettling,
   onSettle,
   onEnterGame,
+  errorMessage,
 }: {
   stage: SettleStage;
   assignedCount: number;
@@ -895,6 +896,7 @@ const SettlementPhase = ({
   isSettling: boolean;
   onSettle: () => void;
   onEnterGame: () => void;
+  errorMessage: string | null;
 }) => {
   const viewModel = deriveSettlementPhaseViewModel({
     stage,
@@ -1035,7 +1037,10 @@ const SettlementPhase = ({
       )}
 
       {viewModel.showError && (
-        <p className="text-xs text-red-300 text-center mt-2">Settlement failed. Please try again.</p>
+        <div className="mt-2 text-center">
+          <p className="text-xs text-red-300">Settlement failed. Please try again.</p>
+          {errorMessage && <p className="mt-1 text-[10px] text-red-300/70 break-words">{errorMessage}</p>}
+        </div>
       )}
     </div>
   );
@@ -3031,10 +3036,12 @@ export const GameEntryModal = ({
 
   // Settlement state
   const [settleStage, setSettleStage] = useState<SettleStage>("idle");
+  const [settleErrorMessage, setSettleErrorMessage] = useState<string | null>(null);
   const [isSettling, setIsSettling] = useState(false);
   const [assignedRealmCount, setAssignedRealmCount] = useState(0);
   const [settledRealmCount, setSettledRealmCount] = useState(0);
   const [needsSettlement, setNeedsSettlement] = useState(false);
+  const [canPlay, setCanPlay] = useState(false);
   const [pendingSettlementVerificationTargetCount, setPendingSettlementVerificationTargetCount] = useState<
     number | null
   >(null);
@@ -3495,6 +3502,7 @@ export const GameEntryModal = ({
   const resetBootstrapDependentState = useCallback(() => {
     setPreflightError(null);
     setNeedsSettlement(false);
+    setCanPlay(false);
     setSettlementCheckComplete(false);
     setSettleStage("idle");
     setIsSettling(false);
@@ -3708,6 +3716,7 @@ export const GameEntryModal = ({
       checksComplete,
       needsHyperstructureInit,
       needsSettlement,
+      canPlay,
       isBlitzSettlementUnlocked: blitzSettlementAvailability.isUnlocked,
     });
 
@@ -3722,6 +3731,7 @@ export const GameEntryModal = ({
       hyperstructureCheckComplete,
       needsHyperstructureInit,
       needsSettlement,
+      canPlay,
       isBlitzSettlementUnlocked: blitzSettlementAvailability.isUnlocked,
       worldMode,
       startSettlingAt: worldMeta?.startSettlingAt,
@@ -3768,6 +3778,7 @@ export const GameEntryModal = ({
     hyperstructureCheckComplete,
     needsHyperstructureInit,
     needsSettlement,
+    canPlay,
     blitzSettlementAvailability.isUnlocked,
     isEternumMode,
     isLoadingEternumPrereqs,
@@ -3864,9 +3875,10 @@ export const GameEntryModal = ({
       setAssignedRealmCount(status.assignedCount);
       setSettledRealmCount(status.settledCount);
       setNeedsSettlement(status.needsSettlement);
+      setCanPlay(status.canPlay);
       return status;
     },
-    [setAssignedRealmCount, setSettledRealmCount, setNeedsSettlement],
+    [setAssignedRealmCount, setSettledRealmCount, setNeedsSettlement, setCanPlay],
   );
 
   const waitForSettlementTarget = useCallback(
@@ -4095,6 +4107,7 @@ export const GameEntryModal = ({
 
     if (isEternumMode) {
       setNeedsSettlement(false);
+      setCanPlay(true);
       setSettlementCheckComplete(true);
       return;
     }
@@ -4106,6 +4119,7 @@ export const GameEntryModal = ({
 
     if (isSpectateMode || (isForgeMode && isBlitzMode)) {
       setNeedsSettlement(false);
+      setCanPlay(true);
       setSettlementCheckComplete(true);
       return;
     }
@@ -4114,6 +4128,7 @@ export const GameEntryModal = ({
       try {
         if (!account?.address) {
           setNeedsSettlement(false);
+          setCanPlay(false);
           setSettlementCheckComplete(true);
           return;
         }
@@ -4121,15 +4136,17 @@ export const GameEntryModal = ({
         const snapshot = await readSettlementSnapshot();
         if (!snapshot) {
           setNeedsSettlement(false);
+          setCanPlay(false);
           setSettlementCheckComplete(true);
           return;
         }
-        const status = syncSettlementStateFromSnapshot(snapshot);
+        syncSettlementStateFromSnapshot(snapshot);
 
         setSettlementCheckComplete(true);
       } catch (error) {
         setPreflightError(error instanceof Error ? error : new Error("Failed to check settlement status."));
         setNeedsSettlement(false);
+        setCanPlay(false);
         setSettlementCheckComplete(true);
       }
     };
@@ -4854,9 +4871,10 @@ export const GameEntryModal = ({
 
   const finalizeFailedBlitzSettlement = useCallback(
     (error: Error) => {
-      debugLog(worldName, "Settlement failed:", error);
+      console.error("[GameEntryModal] Settlement failed", { worldName, error });
       clearBlitzSettlementVerification();
       setSettleStage("error");
+      setSettleErrorMessage(error.message);
       if (autoSettleEnabled && autoSettleEntryKey) {
         markFailed(autoSettleEntryKey, error.message);
       }
@@ -4942,13 +4960,17 @@ export const GameEntryModal = ({
     if (!account) return;
 
     setIsSettling(true);
+    setSettleErrorMessage(null);
     if (autoSettleEnabled && autoSettleEntryKey) {
       markSettling(autoSettleEntryKey, Date.now());
     }
 
     try {
+      if (!worldMeta) {
+        throw new Error("World configuration is still loading. Please wait a moment and try again.");
+      }
       const isMainnet = env.VITE_PUBLIC_CHAIN === "mainnet";
-      const singleRealmMode = worldMeta?.singleRealmMode ?? false;
+      const singleRealmMode = worldMeta.singleRealmMode;
       const blitzRealmSystemsAddress = resolveWorldSystemAddress("blitz_realm_systems");
       const signer = account as unknown as Account;
       const vrfProviderAddress = env.VITE_PUBLIC_VRF_PROVIDER_ADDRESS;
@@ -5004,7 +5026,7 @@ export const GameEntryModal = ({
     markSettling,
     submitAssignedRealmSettlement,
     submitRemainingRealmSettlement,
-    worldMeta?.singleRealmMode,
+    worldMeta,
     worldName,
     readSettlementSnapshot,
     resolveWorldSystemAddress,
@@ -5402,6 +5424,7 @@ export const GameEntryModal = ({
                   isSettling={isSettling}
                   onSettle={handleSettle}
                   onEnterGame={handleEnterGame}
+                  errorMessage={settleErrorMessage}
                 />
               </motion.div>
             )}

--- a/client/apps/game/src/ui/features/landing/components/game-entry-phase.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-phase.test.ts
@@ -41,6 +41,7 @@ describe("game entry phase resolution", () => {
       checksComplete: true,
       needsHyperstructureInit: false,
       needsSettlement: false,
+      canPlay: false,
       isBlitzSettlementUnlocked: false,
     });
 
@@ -70,6 +71,7 @@ describe("game entry phase resolution", () => {
       checksComplete: true,
       needsHyperstructureInit: false,
       needsSettlement: true,
+      canPlay: false,
       isBlitzSettlementUnlocked: false,
     });
 
@@ -99,9 +101,100 @@ describe("game entry phase resolution", () => {
       checksComplete: true,
       needsHyperstructureInit: false,
       needsSettlement: true,
+      canPlay: false,
       isBlitzSettlementUnlocked: true,
     });
 
     expect(phase).toBe("settlement");
+  });
+
+  it("keeps unregistered new blitz players out of the game before settlement unlocks", () => {
+    const phase = resolveGameEntryModalPhase({
+      bootstrapStatus: "ready",
+      hasPhaseError: false,
+      isForgeMode: false,
+      isBlitzMode: true,
+      isSpectateMode: false,
+      worldMode: "blitz",
+      isCheckingWorldAvailability: false,
+      hasWorldMeta: true,
+      isEternumMode: false,
+      isLoadingEternumPrereqs: false,
+      hasVillageRevealResult: false,
+      unifiedSettlementPlannerEnabled: false,
+      hasSettledRealm: false,
+      entryIntent: "play",
+      seasonSettlementComplete: false,
+      eternumSettlementMode: "realm",
+      hasVillagePass: false,
+      hasSeasonPass: false,
+      checksComplete: true,
+      needsHyperstructureInit: false,
+      needsSettlement: false,
+      canPlay: false,
+      isBlitzSettlementUnlocked: false,
+    });
+
+    expect(phase).toBe("settlement-waiting");
+  });
+
+  it("routes unregistered new blitz players into the settle flow once settlement unlocks", () => {
+    const phase = resolveGameEntryModalPhase({
+      bootstrapStatus: "ready",
+      hasPhaseError: false,
+      isForgeMode: false,
+      isBlitzMode: true,
+      isSpectateMode: false,
+      worldMode: "blitz",
+      isCheckingWorldAvailability: false,
+      hasWorldMeta: true,
+      isEternumMode: false,
+      isLoadingEternumPrereqs: false,
+      hasVillageRevealResult: false,
+      unifiedSettlementPlannerEnabled: false,
+      hasSettledRealm: false,
+      entryIntent: "play",
+      seasonSettlementComplete: false,
+      eternumSettlementMode: "realm",
+      hasVillagePass: false,
+      hasSeasonPass: false,
+      checksComplete: true,
+      needsHyperstructureInit: false,
+      needsSettlement: false,
+      canPlay: false,
+      isBlitzSettlementUnlocked: true,
+    });
+
+    expect(phase).toBe("settlement");
+  });
+
+  it("auto-enters blitz players once settlement is provably complete", () => {
+    const phase = resolveGameEntryModalPhase({
+      bootstrapStatus: "ready",
+      hasPhaseError: false,
+      isForgeMode: false,
+      isBlitzMode: true,
+      isSpectateMode: false,
+      worldMode: "blitz",
+      isCheckingWorldAvailability: false,
+      hasWorldMeta: true,
+      isEternumMode: false,
+      isLoadingEternumPrereqs: false,
+      hasVillageRevealResult: false,
+      unifiedSettlementPlannerEnabled: false,
+      hasSettledRealm: false,
+      entryIntent: "play",
+      seasonSettlementComplete: false,
+      eternumSettlementMode: "realm",
+      hasVillagePass: false,
+      hasSeasonPass: false,
+      checksComplete: true,
+      needsHyperstructureInit: false,
+      needsSettlement: false,
+      canPlay: true,
+      isBlitzSettlementUnlocked: true,
+    });
+
+    expect(phase).toBe("ready");
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-entry-phase.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-phase.ts
@@ -45,17 +45,18 @@ interface ResolveGameEntryModalPhaseInput {
   checksComplete: boolean;
   needsHyperstructureInit: boolean;
   needsSettlement: boolean;
+  canPlay: boolean;
   isBlitzSettlementUnlocked: boolean;
 }
 
 export const resolveBlitzSettlementPhase = ({
-  needsSettlement,
+  canPlay,
   isSettlementUnlocked,
 }: {
-  needsSettlement: boolean;
+  canPlay: boolean;
   isSettlementUnlocked: boolean;
 }): Extract<GameEntryModalPhase, "ready" | "settlement" | "settlement-waiting"> => {
-  if (!needsSettlement) {
+  if (canPlay) {
     return "ready";
   }
 
@@ -110,6 +111,7 @@ export const resolveGameEntryModalPhase = ({
   checksComplete,
   needsHyperstructureInit,
   needsSettlement,
+  canPlay,
   isBlitzSettlementUnlocked,
 }: ResolveGameEntryModalPhaseInput): GameEntryModalPhase => {
   if (isForgeMode && isBlitzMode) {
@@ -166,7 +168,7 @@ export const resolveGameEntryModalPhase = ({
 
   if (isBlitzMode) {
     return resolveBlitzSettlementPhase({
-      needsSettlement,
+      canPlay,
       isSettlementUnlocked: isBlitzSettlementUnlocked,
     });
   }

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -272,5 +274,27 @@ describe("buildSettlementExecutionPlan", () => {
     expect(plan.targetSettleCount).toBe(1);
     expect(plan.initialSettleCount).toBe(1);
     expect(plan.extraSettleCalls).toBe(0);
+  });
+
+  it("does not preempt the settle call for onceRegistered players who have no coords yet", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: false,
+      singleRealmMode: true,
+      snapshot: snapshot({ registered: false, onceRegistered: true }),
+    });
+
+    expect(plan.shouldAssignAndSettle).toBe(true);
+    expect(plan.missingAssignmentRegistration).toBe(false);
+  });
+
+  it("still blocks truly unregistered players from the assign+settle path", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: false,
+      singleRealmMode: true,
+      snapshot: snapshot({ registered: false, onceRegistered: false }),
+    });
+
+    expect(plan.shouldAssignAndSettle).toBe(true);
+    expect(plan.missingAssignmentRegistration).toBe(true);
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
@@ -199,6 +199,6 @@ export const buildSettlementExecutionPlan = ({
     shouldAssignAndSettle: true,
     initialSettleCount,
     extraSettleCalls,
-    missingAssignmentRegistration: !snapshot.registered,
+    missingAssignmentRegistration: !snapshot.registered && !snapshot.onceRegistered,
   };
 };


### PR DESCRIPTION
## Summary

This is the narrow replacement for the larger `next` -> `main` PR. It only brings over the Blitz Play-button settlement fix.

- route Blitz phase readiness through `canPlay` instead of `needsSettlement`, so unregistered or not-yet-settled players do not skip into the game
- keep once-registered players eligible for the settlement execution plan
- surface settlement failure messages instead of hiding the real error
- require loaded world config before submitting settlement

## Files

- `client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx`
- `client/apps/game/src/ui/features/landing/components/game-entry-phase.ts`
- `client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts`
- focused regression tests for the above

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run format`
- `pnpm --dir client/apps/game test src/ui/features/landing/components/game-entry-phase.test.ts src/ui/features/landing/components/game-entry-settlement.utils.test.ts src/ui/features/landing/components/game-entry-blitz-handoff.test.ts src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts`
- `pnpm run knip`

## Non-goals

- No renderer/worldmap changes
- No `next` branch rollup
- No unrelated feature-feed or stamina changes
