### PR TITLE
fix(game): prevent 'Unable to Start' flash on Play

### DIFF
--- a/client/apps/game/src/hooks/use-world-availability.bulk-gating.test.ts
+++ b/client/apps/game/src/hooks/use-world-availability.bulk-gating.test.ts
@@ -76,4 +76,45 @@ describe("useWorldsAvailability bulk gating", () => {
 
     expect(queries[0]?.enabled).toBe(true);
   });
+
+  it("reports loading while the bulk query is still pending, even though per-world queries are disabled", () => {
+    reactQueryMocks.useQuery.mockReturnValue({
+      data: undefined,
+      isPending: true,
+    });
+    reactQueryMocks.useQueries.mockImplementation(() => [
+      {
+        data: undefined,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    ]);
+
+    const result = useWorldsAvailability([{ name: "alpha", chain: "mainnet" }], true, null);
+
+    expect(result.isAnyLoading).toBe(true);
+    expect(result.allSettled).toBe(false);
+    expect(result.results.get("mainnet:alpha")?.isLoading).toBe(true);
+  });
+
+  it("reports loading while per-world queries have no data yet (disabled but not errored)", () => {
+    reactQueryMocks.useQuery.mockReturnValue({
+      data: {},
+      isPending: false,
+    });
+    reactQueryMocks.useQueries.mockImplementation(() => [
+      {
+        data: undefined,
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      },
+    ]);
+
+    const result = useWorldsAvailability([{ name: "alpha", chain: "mainnet" }], true, null);
+
+    expect(result.isAnyLoading).toBe(true);
+    expect(result.allSettled).toBe(false);
+  });
 });

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -549,13 +549,15 @@ export const useWorldsAvailability = (worlds: WorldRef[], enabled = true, player
       chain: world.chain,
       isAvailable: query.data?.isAvailable ?? false,
       meta: query.data?.meta ?? null,
-      isLoading: query.isLoading,
+      isLoading: isBulkAvailabilityPending || query.isLoading || (query.data === undefined && query.error == null),
       error: query.error as Error | null,
     });
   });
 
-  const isAnyLoading = queries.some((q) => q.isLoading);
-  const allSettled = queries.every((q) => !q.isLoading);
+  const isAnyLoading =
+    isBulkAvailabilityPending ||
+    queries.some((q) => q.isLoading || (q.data === undefined && q.error == null));
+  const allSettled = !isBulkAvailabilityPending && queries.every((q) => q.data !== undefined || q.error != null);
 
   return {
     results,

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -555,8 +555,7 @@ export const useWorldsAvailability = (worlds: WorldRef[], enabled = true, player
   });
 
   const isAnyLoading =
-    isBulkAvailabilityPending ||
-    queries.some((q) => q.isLoading || (q.data === undefined && q.error == null));
+    isBulkAvailabilityPending || queries.some((q) => q.isLoading || (q.data === undefined && q.error == null));
   const allSettled = !isBulkAvailabilityPending && queries.every((q) => q.data !== undefined || q.error != null);
 
   return {


### PR DESCRIPTION
## Summary
- Fix race in `useWorldsAvailability` that caused a brief 'Unable to Start' flash when clicking Play.
- While `useBulkAvailability` was still pending, per-world queries were `enabled: false`, so RQ v5 reported `isLoading: false` on them. `isAnyLoading` was then `false` even though we had no data. The game-entry modal's `resolveGameEntryBlockingError` saw `isCheckingWorldAvailability=false` + `isAvailable=false` (the `?? false` default) and returned 'The selected world is currently unavailable.', flipping the phase to `error` for one tick.
- Treat bulk-pending and 'no data yet, no error' as loading in both the per-world `isLoading` and the aggregate `isAnyLoading` / `allSettled`.

## Test plan
- [ ] Open the landing page and click Play — verify no 'Unable to Start' flash before the modal resolves.
- [ ] Reload with a cold cache and repeat.
- [ ] Run `pnpm --filter eternum-game-client test -- use-world-availability` (added two regression tests in `use-world-availability.bulk-gating.test.ts`).