### PR TITLE
perf(game): ship Wave A quick wins from #4671

### DIFF
--- a/client/apps/game/src/dojo/queries.ts
+++ b/client/apps/game/src/dojo/queries.ts
@@ -45,11 +45,7 @@ const markConfigCacheFresh = () => {
   }
 };
 
-/**
- * Clear the cached "config already fetched this session" marker. Surfaces as a
- * module export so a debug action can force a blocking revalidation on next boot.
- */
-export const clearConfigFetchCache = () => {
+const clearConfigFetchCache = () => {
   if (!hasSessionStorage()) return;
   try {
     window.sessionStorage.removeItem(getConfigCacheKey());

--- a/client/apps/game/src/dojo/queries.ts
+++ b/client/apps/game/src/dojo/queries.ts
@@ -7,12 +7,56 @@ import { getEntities } from "@dojoengine/state";
 import { PatternMatching, ToriiClient } from "@dojoengine/torii-client";
 import { Clause, LogicalOperator } from "@dojoengine/torii-wasm";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { env } from "../../env";
 import {
   debouncedGetBuildingsFromTorii,
   debouncedGetEntitiesFromTorii,
   debouncedGetOwnedArmiesFromTorii,
 } from "./debounced-queries";
 import { EVENT_QUERY_LIMIT } from "./sync";
+
+const CONFIG_FETCH_CACHE_PREFIX = "eternum:config-fetched";
+
+const getConfigCacheKey = () => `${CONFIG_FETCH_CACHE_PREFIX}:${env.VITE_PUBLIC_CHAIN}:${env.VITE_PUBLIC_TORII}`;
+
+const hasSessionStorage = () => {
+  try {
+    return typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+  } catch {
+    return false;
+  }
+};
+
+const hasFreshConfigCache = () => {
+  if (!hasSessionStorage()) return false;
+  try {
+    return window.sessionStorage.getItem(getConfigCacheKey()) !== null;
+  } catch {
+    return false;
+  }
+};
+
+const markConfigCacheFresh = () => {
+  if (!hasSessionStorage()) return;
+  try {
+    window.sessionStorage.setItem(getConfigCacheKey(), Date.now().toString());
+  } catch {
+    /* storage quota / disabled — ignore */
+  }
+};
+
+/**
+ * Clear the cached "config already fetched this session" marker. Surfaces as a
+ * module export so a debug action can force a blocking revalidation on next boot.
+ */
+export const clearConfigFetchCache = () => {
+  if (!hasSessionStorage()) return;
+  try {
+    window.sessionStorage.removeItem(getConfigCacheKey());
+  } catch {
+    /* ignore */
+  }
+};
 
 const isValidId = (id: unknown): id is ID => typeof id === "number" && Number.isFinite(id);
 const hasValidPosition = (position: HexPosition | undefined): position is HexPosition =>
@@ -208,15 +252,34 @@ export const getConfigFromTorii = async <S extends Schema>(
       },
     },
   ];
-  return getEntities(
-    client,
-    { Composite: { operator: "Or", clauses: configClauses } },
-    components,
-    [],
-    configModels,
-    EVENT_QUERY_LIMIT,
-    false,
-  );
+
+  const fetchConfig = () =>
+    getEntities(
+      client,
+      { Composite: { operator: "Or", clauses: configClauses } },
+      components,
+      [],
+      configModels,
+      EVENT_QUERY_LIMIT,
+      false,
+    );
+
+  // Per issue #4653: config data is static within a chain/world deployment and
+  // most config models are also covered by GLOBAL_STREAM_CLAUSE's initial state
+  // flush. On reloads within the same tab session, skip blocking on the fetch —
+  // fire it in the background so RECS still revalidates. Clear the marker on
+  // failure so the next boot falls back to a blocking fetch.
+  if (hasFreshConfigCache()) {
+    fetchConfig().catch((error) => {
+      console.warn("[torii] Background config revalidation failed", error);
+      clearConfigFetchCache();
+    });
+    return;
+  }
+
+  const result = await fetchConfig();
+  markConfigCacheFresh();
+  return result;
 };
 
 export const getAddressNamesFromTorii = async <S extends Schema>(

--- a/client/apps/game/src/dojo/queries.ts
+++ b/client/apps/game/src/dojo/queries.ts
@@ -369,12 +369,6 @@ export const getEntitiesFromTorii = async <S extends Schema>(
   entityIDs: ID[],
   entityModels: string[],
 ) => {
-  // Debug: Track what's calling this function repeatedly
-  if (import.meta.env.DEV) {
-    console.log(`[getEntitiesFromTorii] Called with ${entityIDs.length} entities, models:`, entityModels);
-    console.trace("[getEntitiesFromTorii] Call stack:");
-  }
-
   const validEntityIDs = entityIDs.filter((id) => {
     const valid = isValidId(id);
 

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -490,15 +490,20 @@ export const initialSync = async (
     updateProgress(25);
   }
 
-  await getConfigFromTorii(setup.network.toriiClient, setup.network.contractComponents as any);
-
-  updateProgress(50);
-
-  await getAddressNamesFromTorii(setup.network.toriiClient, setup.network.contractComponents as any);
-  updateProgress(75);
-
-  await getGuildsFromTorii(setup.network.toriiClient, setup.network.contractComponents as any);
-  updateProgress(90);
+  // Config, AddressNames and Guilds write to disjoint components with no
+  // ordering constraints, so run them concurrently. updateProgress keeps the
+  // highest value, so individual checkpoints are safe in any order.
+  await Promise.all([
+    runTimedTask("config query", 50, async () => {
+      await getConfigFromTorii(setup.network.toriiClient, setup.network.contractComponents as any);
+    }),
+    runTimedTask("address names query", 75, async () => {
+      await getAddressNamesFromTorii(setup.network.toriiClient, setup.network.contractComponents as any);
+    }),
+    runTimedTask("guilds query", 90, async () => {
+      await getGuildsFromTorii(setup.network.toriiClient, setup.network.contractComponents as any);
+    }),
+  ]);
 
   await MapDataStore.getInstance(MAP_DATA_REFRESH_INTERVAL, sqlApi).refresh();
 

--- a/client/apps/game/src/hooks/store/use-sync-store.ts
+++ b/client/apps/game/src/hooks/store/use-sync-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 
 export enum Subscription {
   Market = "market",
@@ -37,3 +38,20 @@ const createSyncStoreSlice = (
 export const useSyncStore = create<SyncStore>((set) => ({
   ...createSyncStoreSlice(set),
 }));
+
+/**
+ * Shallow-equality variant of {@link useSyncStore} for consumers that need
+ * multiple fields in a single subscription. Prevents re-renders from unrelated
+ * store updates (e.g. ~10 Hz initialSyncProgress ticks) when the selected
+ * object's field values are unchanged.
+ *
+ * Single-field selectors should keep using `useSyncStore` directly — primitive
+ * equality is already cheap and correct.
+ *
+ * @example
+ *   const { initialSyncProgress, subscriptions } = useSyncStoreShallow(
+ *     (s) => ({ initialSyncProgress: s.initialSyncProgress, subscriptions: s.subscriptions }),
+ *   );
+ */
+export const useSyncStoreShallow = <T>(selector: (state: SyncStore) => T): T =>
+  useSyncStore(useShallow(selector));

--- a/client/apps/game/src/hooks/store/use-sync-store.ts
+++ b/client/apps/game/src/hooks/store/use-sync-store.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { useShallow } from "zustand/react/shallow";
 
 export enum Subscription {
   Market = "market",
@@ -38,20 +37,3 @@ const createSyncStoreSlice = (
 export const useSyncStore = create<SyncStore>((set) => ({
   ...createSyncStoreSlice(set),
 }));
-
-/**
- * Shallow-equality variant of {@link useSyncStore} for consumers that need
- * multiple fields in a single subscription. Prevents re-renders from unrelated
- * store updates (e.g. ~10 Hz initialSyncProgress ticks) when the selected
- * object's field values are unchanged.
- *
- * Single-field selectors should keep using `useSyncStore` directly — primitive
- * equality is already cheap and correct.
- *
- * @example
- *   const { initialSyncProgress, subscriptions } = useSyncStoreShallow(
- *     (s) => ({ initialSyncProgress: s.initialSyncProgress, subscriptions: s.subscriptions }),
- *   );
- */
-export const useSyncStoreShallow = <T>(selector: (state: SyncStore) => T): T =>
-  useSyncStore(useShallow(selector));

--- a/packages/torii/src/queries/sql/api.ts
+++ b/packages/torii/src/queries/sql/api.ts
@@ -103,6 +103,15 @@ const buildCacheUrl = (baseUrl: string, path: string): URL => {
   return new URL(`${trimmed}${normalizedPath}`);
 };
 
+// Short-lived dedupe + TTL for fetchStructuresByOwner. Callers mount concurrently
+// during boot (use-player-structure-sync + others) and re-query the same owner
+// within a few hundred ms. gRPC subscription reconciles any staleness within a block.
+const STRUCTURES_BY_OWNER_TTL_MS = 500;
+const structuresByOwnerCache = new Map<
+  string,
+  { promise: Promise<StructureLocation[]>; expiresAt: number }
+>();
+
 export class SqlApi {
   constructor(
     private readonly baseUrl: string,
@@ -174,12 +183,36 @@ export class SqlApi {
   /**
    * Fetch structures by owner from the SQL database.
    * SQL queries always return arrays.
+   *
+   * Concurrent calls for the same owner share a single in-flight request, and
+   * repeats within {@link STRUCTURES_BY_OWNER_TTL_MS} reuse the resolved result.
    */
   async fetchStructuresByOwner(owner: string): Promise<StructureLocation[]> {
+    const cacheKey = `${this.baseUrl}|${owner}`;
+    const cached = structuresByOwnerCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.promise;
+    }
+
     const formattedOwner = formatAddressForQuery(owner);
     const query = STRUCTURE_QUERIES.STRUCTURES_BY_OWNER.replace("{owner}", formattedOwner);
     const url = buildApiUrl(this.baseUrl, query);
-    return await fetchWithErrorHandling<StructureLocation>(url, "Failed to fetch structures by owner");
+    const promise = fetchWithErrorHandling<StructureLocation>(url, "Failed to fetch structures by owner");
+
+    // Evict on rejection so the next caller retries instead of inheriting the error.
+    promise.catch(() => {
+      const current = structuresByOwnerCache.get(cacheKey);
+      if (current?.promise === promise) {
+        structuresByOwnerCache.delete(cacheKey);
+      }
+    });
+
+    structuresByOwnerCache.set(cacheKey, {
+      promise,
+      expiresAt: Date.now() + STRUCTURES_BY_OWNER_TTL_MS,
+    });
+
+    return promise;
   }
 
   /**


### PR DESCRIPTION
## Summary

Ships Wave A "quick wins" from the game load performance backlog (#4671) — low-risk, independent patches that shave time off boot or remove foot-guns on the critical path.

| Issue | Change |
| --- | --- |
| Closes #4647 | Delete unconditional `console.log` + `console.trace` from `getEntitiesFromTorii` hot path (fired per-batch in dev, thousands of times during initialSync). |
| Closes #4648 | Run `Config`, `AddressNames` and `Guilds` fetches in `Promise.all` inside `initialSync`. They write to disjoint components and have no ordering dependency, so the slowest drives wall time instead of the sum. **Expected 500–1000ms saved in `bootstrap-completed` milestone.** |
| Closes #4651 | In-flight promise dedupe + 500ms TTL cache on `SqlApi.fetchStructuresByOwner`. Concurrent consumers share one SQL round-trip per owner; reloads within the TTL skip the request. gRPC subscription reconciles any staleness within a block. |
| Closes #4653 | Skip blocking on `getConfigFromTorii` on same-tab reloads. Keyed on `VITE_PUBLIC_CHAIN` + `VITE_PUBLIC_TORII`; on a hit the fetch still fires in background so RECS revalidates. Marker clears on failure so next boot falls back to a blocking fetch. |
| n/a (re #4660) | Verified: **no current `useSyncStore` consumer selects a multi-field object**, so the problem described in #4660 does not exist today. Every call site is a primitive/function single-field selector or a non-reactive `.getState()` read. Leaving #4660 open so the audit line can be re-evaluated once a real multi-field consumer lands. |

Each active fix is its own commit so they bisect cleanly.

## Test plan

- [ ] `pnpm build:packages && pnpm --dir client/apps/game build` succeeds.
- [ ] Boot against a populated world, record `boot_react_mount_start` → `bootstrap-completed` before/after; expect ≥500ms reduction on warm reload.
- [ ] DevTools Network on fresh boot: one `/sql` call for `fetchStructuresByOwner` even with multiple consumers mounted; reloads within 500ms add zero calls.
- [ ] Reload same tab: `getConfigFromTorii` fires in background (not blocking path); RECS config components stay populated via `GLOBAL_STREAM_CLAUSE` initial state flush. Hard-refresh (new tab) still triggers blocking fetch.
- [ ] Existing `sync.test.ts` and related suites pass.
- [ ] `pnpm knip` and `pnpm prettier --check` pass on touched files.