### PR TITLE
fix(game): continue partial mainnet settlement when coords indexing is unavailable

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
@@ -250,6 +250,25 @@ describe("buildSettlementExecutionPlan", () => {
     expect(plan.missingAssignmentRegistration).toBe(false);
   });
 
+  it("continues partial mainnet settlement when coords indexing is unavailable", () => {
+    const plan = buildSettlementExecutionPlan({
+      isMainnet: true,
+      singleRealmMode: false,
+      snapshot: snapshot({
+        registered: false,
+        onceRegistered: true,
+        coordsCount: 0,
+        settledCount: 1,
+      }),
+    });
+
+    expect(plan.targetSettleCount).toBe(3);
+    expect(plan.shouldAssignAndSettle).toBe(false);
+    expect(plan.initialSettleCount).toBe(0);
+    expect(plan.extraSettleCalls).toBe(2);
+    expect(plan.missingAssignmentRegistration).toBe(false);
+  });
+
   it("plans single-call non-mainnet multi-realm settlement", () => {
     const plan = buildSettlementExecutionPlan({
       isMainnet: false,

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
@@ -157,6 +157,16 @@ export type SettlementExecutionPlan = {
   missingAssignmentRegistration: boolean;
 };
 
+const shouldContinueSettlementWithoutAssignment = ({
+  registered,
+  settledCount,
+  targetSettleCount,
+}: {
+  registered: boolean;
+  settledCount: number;
+  targetSettleCount: number;
+}): boolean => settledCount > 0 && settledCount < targetSettleCount && !registered;
+
 export const buildSettlementExecutionPlan = ({
   isMainnet,
   singleRealmMode,
@@ -169,6 +179,7 @@ export const buildSettlementExecutionPlan = ({
   const targetSettleCount = getExpectedSettlementCount(singleRealmMode);
   const settledCount = Math.max(0, snapshot.settledCount);
   const coordsCount = Math.max(0, snapshot.coordsCount);
+  const remainingToTarget = Math.max(0, targetSettleCount - settledCount);
 
   if (settledCount >= targetSettleCount) {
     return {
@@ -180,8 +191,17 @@ export const buildSettlementExecutionPlan = ({
     };
   }
 
+  if (shouldContinueSettlementWithoutAssignment({ registered: snapshot.registered, settledCount, targetSettleCount })) {
+    return {
+      targetSettleCount,
+      shouldAssignAndSettle: false,
+      initialSettleCount: 0,
+      extraSettleCalls: remainingToTarget,
+      missingAssignmentRegistration: false,
+    };
+  }
+
   if (coordsCount > 0) {
-    const remainingToTarget = Math.max(0, targetSettleCount - settledCount);
     return {
       targetSettleCount,
       shouldAssignAndSettle: false,


### PR DESCRIPTION
## Summary
- When a mainnet player has already settled at least one realm but is no longer `registered` (e.g. coords indexing is unavailable), `buildSettlementExecutionPlan` previously fell through to the assign-and-settle path, which could double-assign or stall progress.
- Adds an explicit `shouldContinueSettlementWithoutAssignment` branch that finishes the remaining settle calls without re-running assignment, and a unit test covering `coordsCount: 0` + `settledCount: 1` on mainnet.

## Test plan
- [ ] `pnpm --filter @bibliothecadao/game test game-entry-settlement.utils`