### PR TITLE
Add Torii sync readiness signal

### DIFF
--- a/client/apps/game/src/dojo/sync.test.ts
+++ b/client/apps/game/src/dojo/sync.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { setEntitiesMock } = vi.hoisted(() => ({
+  setEntitiesMock: vi.fn(),
+}));
+
+vi.mock("@dojoengine/state", () => ({
+  setEntities: setEntitiesMock,
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  MAP_DATA_REFRESH_INTERVAL: 1_000,
+  MapDataStore: {
+    getInstance: vi.fn(() => ({
+      refresh: vi.fn(),
+    })),
+  },
+  recordArmyMovementLatencyPhase: vi.fn(),
+  tileOptToTile: vi.fn(),
+}));
+
+vi.mock("@/hooks/store/use-account-store", () => ({
+  useAccountStore: {
+    getState: vi.fn(() => ({ account: null })),
+  },
+}));
+
+vi.mock("@/hooks/store/use-connection-store", () => ({
+  useConnectionStore: {
+    getState: vi.fn(() => ({ recordGlobalUpdate: vi.fn() })),
+  },
+}));
+
+vi.mock("@/services/api", () => ({
+  sqlApi: {
+    fetchFirstStructure: vi.fn(),
+    fetchPlayerStructures: vi.fn(),
+  },
+}));
+
+vi.mock("./queries", () => ({
+  getAddressNamesFromTorii: vi.fn(),
+  getBankStructuresFromTorii: vi.fn(),
+  getConfigFromTorii: vi.fn(),
+  getGuildsFromTorii: vi.fn(),
+  getStructuresDataFromTorii: vi.fn(),
+}));
+
+vi.mock("../../env", () => ({
+  env: {
+    VITE_PUBLIC_TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS: 8_000,
+  },
+}));
+
+vi.mock("./sync-initial-selection", () => ({
+  resolveInitialStructureSelection: vi.fn(() => ({ selectedStructure: null, spectator: false })),
+}));
+
+vi.mock("./sync-utils", () => ({
+  isDeletionPayload: vi.fn(
+    (entity: { models?: Record<string, unknown> }) => Object.keys(entity.models ?? {}).length === 0,
+  ),
+}));
+
+vi.mock("./torii-stream-manager", () => ({
+  buildModelKeysClause: vi.fn(() => ({ mocked: "global-stream-clause" })),
+}));
+
+import { syncEntitiesDebounced } from "./sync";
+
+type ToriiEntityStub = {
+  hashed_keys: string;
+  models: Record<string, unknown>;
+};
+
+type EntityUpdatedCallback = (entity: ToriiEntityStub) => void;
+
+function createSyncHarness() {
+  let onEntityUpdated: EntityUpdatedCallback | null = null;
+  const cancelEntitySubscription = vi.fn();
+  const cancelEventSubscription = vi.fn();
+
+  const client = {
+    onEntityUpdated: vi.fn(async (_clause, callback: EntityUpdatedCallback) => {
+      onEntityUpdated = callback;
+      return { cancel: cancelEntitySubscription };
+    }),
+    onEventMessageUpdated: vi.fn(async () => ({ cancel: cancelEventSubscription })),
+  };
+
+  const setup = {
+    network: {
+      world: {
+        components: {},
+        deleteEntity: vi.fn(),
+      },
+    },
+  };
+
+  const emitEntityUpdate = (entity: ToriiEntityStub) => {
+    if (!onEntityUpdated) {
+      throw new Error("entity subscription was not created");
+    }
+    onEntityUpdated(entity);
+  };
+
+  return {
+    cancelEntitySubscription,
+    cancelEventSubscription,
+    client,
+    emitEntityUpdate,
+    setup,
+  };
+}
+
+describe("syncEntitiesDebounced", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("resolves ready after the first entity update is written to RECS", async () => {
+    vi.useFakeTimers();
+    const harness = createSyncHarness();
+    const subscription = await syncEntitiesDebounced(harness.client as any, harness.setup as any, null, false);
+    let readyResolved = false;
+
+    subscription.ready.then(() => {
+      readyResolved = true;
+    });
+
+    harness.emitEntityUpdate({
+      hashed_keys: "entity-1",
+      models: {
+        "s1_eternum-Structure": { entity_id: 1 },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(199);
+    expect(readyResolved).toBe(false);
+    expect(setEntitiesMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await subscription.ready;
+
+    expect(readyResolved).toBe(true);
+    expect(setEntitiesMock).toHaveBeenCalledWith(
+      [
+        {
+          hashed_keys: "entity-1",
+          models: {
+            "s1_eternum-Structure": { entity_id: 1 },
+          },
+        },
+      ],
+      harness.setup.network.world.components,
+      false,
+    );
+  });
+
+  it("rejects ready when canceled before the first entity update is written", async () => {
+    vi.useFakeTimers();
+    const harness = createSyncHarness();
+    const subscription = await syncEntitiesDebounced(harness.client as any, harness.setup as any, null, false);
+    const readyRejection = expect(subscription.ready).rejects.toThrow(/cancel/i);
+
+    subscription.cancel();
+
+    await readyRejection;
+    expect(harness.cancelEntitySubscription).toHaveBeenCalledTimes(1);
+    expect(harness.cancelEventSubscription).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -153,15 +153,123 @@ const GLOBAL_STREAM_CLAUSE = buildModelKeysClause(GLOBAL_STREAM_MODELS);
 type BatchPayload = { upserts: ToriiEntity[]; deletions: string[] };
 
 interface QueueProcessor {
-  queueUpdate: (entityId: string, data: ToriiEntity, origin?: "entity" | "event") => void;
+  queueUpdate: (entityId: string, data: ToriiEntity, origin?: "entity" | "event") => Promise<void>;
   dispose: () => void;
 }
+
+interface SyncEntitiesSubscription {
+  cancel: () => void;
+  ready: Promise<void>;
+}
+
+interface SyncReadinessController {
+  ready: Promise<void>;
+  trackInitialEntityWrite: (writeComplete: Promise<void>) => void;
+  markSubscriptionsReady: () => void;
+  cancel: () => void;
+}
+
+interface WriteCompletionTracker {
+  track: (entityId: string) => Promise<void>;
+  resolveBatch: (batch: BatchPayload) => void;
+  resolveAll: () => void;
+}
+
+type QueuedUpdate = { entityId: string; data: ToriiEntity; resolve: () => void };
+
+const createSyncReadinessController = (): SyncReadinessController => {
+  let firstEntityUpdateReceived = false;
+  let subscriptionsReady = false;
+  let pendingInitialEntityWrites = 0;
+  let settled = false;
+
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  ready.catch(() => undefined);
+
+  const resolveWhenInitialEntitiesAreApplied = () => {
+    if (settled || !firstEntityUpdateReceived || !subscriptionsReady || pendingInitialEntityWrites > 0) {
+      return;
+    }
+
+    settled = true;
+    resolveReady();
+  };
+
+  return {
+    ready,
+    trackInitialEntityWrite: (writeComplete: Promise<void>) => {
+      firstEntityUpdateReceived = true;
+      pendingInitialEntityWrites += 1;
+      writeComplete.then(
+        () => {
+          pendingInitialEntityWrites -= 1;
+          resolveWhenInitialEntitiesAreApplied();
+        },
+        () => {
+          pendingInitialEntityWrites -= 1;
+          resolveWhenInitialEntitiesAreApplied();
+        },
+      );
+    },
+    markSubscriptionsReady: () => {
+      subscriptionsReady = true;
+      resolveWhenInitialEntitiesAreApplied();
+    },
+    cancel: () => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      rejectReady(new Error("syncEntitiesDebounced canceled before ready"));
+    },
+  };
+};
+
+const createWriteCompletionTracker = (): WriteCompletionTracker => {
+  const pendingWriteResolvers = new Map<string, Array<() => void>>();
+
+  const resolveEntityWrites = (entityId: string) => {
+    const resolvers = pendingWriteResolvers.get(entityId);
+    if (!resolvers) {
+      return;
+    }
+
+    resolvers.forEach((resolve) => resolve());
+    pendingWriteResolvers.delete(entityId);
+  };
+
+  return {
+    track: (entityId: string) =>
+      new Promise<void>((resolve) => {
+        const resolvers = pendingWriteResolvers.get(entityId) ?? [];
+        resolvers.push(resolve);
+        pendingWriteResolvers.set(entityId, resolvers);
+      }),
+    resolveBatch: (batch: BatchPayload) => {
+      const appliedEntityIds = new Set([...batch.deletions, ...batch.upserts.map((entity) => entity.hashed_keys)]);
+      appliedEntityIds.forEach(resolveEntityWrites);
+    },
+    resolveAll: () => {
+      pendingWriteResolvers.forEach((resolvers) => {
+        resolvers.forEach((resolve) => resolve());
+      });
+      pendingWriteResolvers.clear();
+    },
+  };
+};
 
 const createMainThreadQueueProcessor = (
   applyBatch: (batch: BatchPayload) => void,
   logging: boolean,
 ): QueueProcessor => {
-  const updateQueue: Array<{ entityId: string; data: ToriiEntity }> = [];
+  const updateQueue: QueuedUpdate[] = [];
   let isProcessing = false;
   let pendingTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -229,6 +337,8 @@ const createMainThreadQueueProcessor = (
       }
     }
 
+    itemsToProcess.forEach(({ resolve }) => resolve());
+
     isProcessing = false;
     if (updateQueue.length > 0) {
       pendingTimeoutId = setTimeout(processNextInQueue, 0);
@@ -237,17 +347,21 @@ const createMainThreadQueueProcessor = (
 
   return {
     queueUpdate: (entityId: string, data: ToriiEntity) => {
-      updateQueue.push({ entityId, data });
+      const writeComplete = new Promise<void>((resolve) => {
+        updateQueue.push({ entityId, data, resolve });
+      });
       if (!isProcessing) {
         if (pendingTimeoutId !== null) clearTimeout(pendingTimeoutId);
         pendingTimeoutId = setTimeout(processNextInQueue, 200);
       }
+      return writeComplete;
     },
     dispose: () => {
       if (pendingTimeoutId !== null) {
         clearTimeout(pendingTimeoutId);
         pendingTimeoutId = null;
       }
+      updateQueue.forEach(({ resolve }) => resolve());
       updateQueue.length = 0;
     },
   };
@@ -262,10 +376,14 @@ const createWorkerQueueProcessor = (
   }
 
   try {
+    const writeCompletion = createWriteCompletionTracker();
+
     const manager = new ToriiSyncWorkerManager({
       logging,
       onBatch: (batch) => {
-        applyBatch({ upserts: batch.upserts, deletions: batch.deletions });
+        const syncBatch = { upserts: batch.upserts, deletions: batch.deletions };
+        applyBatch(syncBatch);
+        writeCompletion.resolveBatch(syncBatch);
       },
       onError: (message, error) => {
         console.error("[sync-worker] error", message, error);
@@ -279,9 +397,16 @@ const createWorkerQueueProcessor = (
 
     return {
       queueUpdate: (_entityId: string, data: ToriiEntity, origin?: "entity" | "event") => {
-        manager.enqueue(data, origin ?? "entity");
+        const writeComplete = writeCompletion.track(data.hashed_keys);
+        if (!manager.enqueue(data, origin ?? "entity")) {
+          writeCompletion.resolveAll();
+        }
+        return writeComplete;
       },
-      dispose: () => manager.dispose(),
+      dispose: () => {
+        writeCompletion.resolveAll();
+        manager.dispose();
+      },
     };
   } catch (error) {
     console.error("[sync-worker] failed to initialize", error);
@@ -296,7 +421,7 @@ export const syncEntitiesDebounced = async (
   logging = true,
   onUpdate?: () => void,
   options?: SyncEntitiesSubscriptionOptions,
-) => {
+): Promise<SyncEntitiesSubscription> => {
   if (logging) console.log("Starting syncEntities");
 
   const {
@@ -328,13 +453,16 @@ export const syncEntitiesDebounced = async (
 
   const queueProcessor =
     createWorkerQueueProcessor(applyBatch, logging) ?? createMainThreadQueueProcessor(applyBatch, logging);
+  const readiness = createSyncReadinessController();
 
   const queueUpdate = (data: ToriiEntity, origin: "entity" | "event") => {
     try {
-      queueProcessor.queueUpdate(data.hashed_keys, data, origin);
+      const writeComplete = queueProcessor.queueUpdate(data.hashed_keys, data, origin);
       onUpdate?.();
+      return writeComplete;
     } catch (error) {
       console.error("Error queuing entity update:", error);
+      return Promise.resolve();
     }
   };
 
@@ -344,7 +472,7 @@ export const syncEntitiesDebounced = async (
         client.onEntityUpdated(entityKeyClause, (data: ToriiEntity) => {
           if (logging) console.log("Entity updated", data);
           recordTileOptStreamTrace(data);
-          queueUpdate(data, "entity");
+          readiness.trackInitialEntityWrite(queueUpdate(data, "entity"));
         }),
       createEventSubscription: () =>
         client.onEventMessageUpdated(entityKeyClause, (data: ToriiEntity) => {
@@ -355,10 +483,14 @@ export const syncEntitiesDebounced = async (
       onSubscriptionSetupTimeout: options?.onSubscriptionSetupTimeout,
     });
 
+    readiness.markSubscriptionsReady();
+
     return {
+      ready: readiness.ready,
       cancel: () => {
         subscriptions.cancel();
         queueProcessor.dispose();
+        readiness.cancel();
       },
     };
   } catch (error) {

--- a/client/apps/game/src/dojo/torii-stream-manager.test.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.test.ts
@@ -30,6 +30,16 @@ function deferred<T>() {
   return { promise, resolve, reject };
 }
 
+type SyncSubscriptionStub = {
+  cancel: () => void;
+  ready: Promise<void>;
+};
+
+const syncSubscription = (cancel: () => void): SyncSubscriptionStub => ({
+  cancel,
+  ready: Promise.resolve(),
+});
+
 const descriptor = (minCol: number): BoundsDescriptor => ({
   minCol,
   maxCol: minCol + 10,
@@ -42,7 +52,7 @@ describe("ToriiStreamManager", () => {
   it("reports skipped outcome when switching to an unchanged signature", async () => {
     const syncMock = vi.mocked(syncEntitiesDebounced);
     const cancel = vi.fn();
-    syncMock.mockImplementation(async () => ({ cancel }));
+    syncMock.mockImplementation(async () => syncSubscription(cancel));
 
     const manager = new ToriiStreamManager({
       client: {} as any,
@@ -60,8 +70,8 @@ describe("ToriiStreamManager", () => {
 
   it("keeps the newest bounds subscription active when switches race", async () => {
     const syncMock = vi.mocked(syncEntitiesDebounced);
-    const firstSwitch = deferred<{ cancel: () => void }>();
-    const secondSwitch = deferred<{ cancel: () => void }>();
+    const firstSwitch = deferred<SyncSubscriptionStub>();
+    const secondSwitch = deferred<SyncSubscriptionStub>();
 
     const cancelFirst = vi.fn();
     const cancelSecond = vi.fn();
@@ -80,10 +90,10 @@ describe("ToriiStreamManager", () => {
     const pendingSecond = manager.switchBounds(descriptor(24));
 
     // Resolve second first to simulate out-of-order completion.
-    secondSwitch.resolve({ cancel: cancelSecond });
+    secondSwitch.resolve(syncSubscription(cancelSecond));
     await Promise.resolve();
 
-    firstSwitch.resolve({ cancel: cancelFirst });
+    firstSwitch.resolve(syncSubscription(cancelFirst));
 
     const [firstResult, secondResult] = await Promise.all([pendingFirst, pendingSecond]);
 
@@ -97,9 +107,9 @@ describe("ToriiStreamManager", () => {
 
   it("drops stale middle switch during A->B->A bounds churn", async () => {
     const syncMock = vi.mocked(syncEntitiesDebounced);
-    const firstSwitch = deferred<{ cancel: () => void }>();
-    const secondSwitch = deferred<{ cancel: () => void }>();
-    const thirdSwitch = deferred<{ cancel: () => void }>();
+    const firstSwitch = deferred<SyncSubscriptionStub>();
+    const secondSwitch = deferred<SyncSubscriptionStub>();
+    const thirdSwitch = deferred<SyncSubscriptionStub>();
 
     const cancelFirst = vi.fn();
     const cancelSecond = vi.fn();
@@ -120,9 +130,9 @@ describe("ToriiStreamManager", () => {
     const pendingB = manager.switchBounds(descriptor(24));
     const pendingA2 = manager.switchBounds(descriptor(0));
 
-    firstSwitch.resolve({ cancel: cancelFirst });
-    secondSwitch.resolve({ cancel: cancelSecond });
-    thirdSwitch.resolve({ cancel: cancelThird });
+    firstSwitch.resolve(syncSubscription(cancelFirst));
+    secondSwitch.resolve(syncSubscription(cancelSecond));
+    thirdSwitch.resolve(syncSubscription(cancelThird));
 
     const [resultA1, resultB, resultA2] = await Promise.all([pendingA1, pendingB, pendingA2]);
 
@@ -157,7 +167,7 @@ describe("ToriiStreamManager", () => {
     const syncMock = vi.mocked(syncEntitiesDebounced);
     const cancelRecovered = vi.fn();
 
-    syncMock.mockRejectedValueOnce(new Error("timeout:25")).mockResolvedValueOnce({ cancel: cancelRecovered });
+    syncMock.mockRejectedValueOnce(new Error("timeout:25")).mockResolvedValueOnce(syncSubscription(cancelRecovered));
 
     const manager = new ToriiStreamManager({
       client: {} as any,


### PR DESCRIPTION
## Summary
Adds a `ready` promise to `syncEntitiesDebounced` so callers can wait for the entity subscription to be live and the first entity write to reach RECS.
Tracks write completion for both main-thread and worker-backed sync queues, and rejects readiness if the subscription is canceled first.
Updates stream-manager test stubs and adds focused sync readiness tests.

## Verification
- pnpm run format
- pnpm run knip
- pnpm --dir client/apps/game test src/dojo/sync.test.ts src/dojo/torii-stream-manager.test.ts

Fixes #4654