### PR TITLE
fix(game): stop realm automation over-sizing (remove same-pass credit)

### DIFF
--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -173,7 +173,7 @@ describe("buildRealmProductionPlan", () => {
     ]);
   });
 
-  it("feeds same-pass T1 output into T2 consumption so deep chains execute in one tick", () => {
+  it("does not let T1 same-pass output fund T2 when pre-existing T1 balance is zero", () => {
     const plan = buildRealmProductionPlan({
       realmConfig: makeRealmConfig(),
       snapshot: makeSnapshot([ResourcesIds.Knight, ResourcesIds.KnightT2], {
@@ -186,15 +186,39 @@ describe("buildRealmProductionPlan", () => {
 
     const callResourceIds = plan.callset.resourceToResource.map((call) => call.resourceId);
     expect(callResourceIds).toContain(ResourcesIds.Knight);
-    expect(callResourceIds).toContain(ResourcesIds.KnightT2);
+    expect(callResourceIds).not.toContain(ResourcesIds.KnightT2);
 
     const t1Cycles =
       plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
+    expect(t1Cycles).toBeGreaterThan(0);
+  });
+
+  it("sizes T2 cycles from pre-existing T1 balance only, ignoring same-pass T1 output", () => {
+    // Use custom preset with 100% percentages so the T2 cycle cap is clearly bounded by Knight balance
+    // and not by any preset-specific allocation math.
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [ResourcesIds.Knight]: { resourceToResource: 10, laborToResource: 0 },
+          [ResourcesIds.KnightT2]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([ResourcesIds.Knight, ResourcesIds.KnightT2], {
+        [ResourcesIds.Wheat]: 10_000,
+        [ResourcesIds.Copper]: 10_000,
+        [ResourcesIds.Essence]: 10_000,
+        [ResourcesIds.Knight]: 100,
+      }),
+    });
+
     const t2Cycles =
       plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.KnightT2)?.cycles ?? 0;
-    expect(t1Cycles).toBeGreaterThan(0);
+
+    // KnightT2 consumes 1 Knight per cycle. Real Knight balance is 100, MAX_RESOURCE_ALLOCATION_PERCENT = 90%,
+    // so the binding cap is 90. Same-pass Knight output must NOT raise this ceiling.
     expect(t2Cycles).toBeGreaterThan(0);
-    expect(t2Cycles).toBeLessThanOrEqual(t1Cycles);
+    expect(t2Cycles).toBeLessThanOrEqual(90);
   });
 
   it("skips T2 when there is no snapshot Knight balance and T1 produces nothing (recipe undeployable)", () => {
@@ -244,7 +268,7 @@ describe("buildRealmProductionPlan", () => {
     expect(plan.consumptionByResource[ResourcesIds.Wood]).toBeUndefined();
   });
 
-  it("executes a three-tier chain (Ore -> Iron -> Steel) in a single pass", () => {
+  it("primes a three-tier chain (Ore -> Iron -> Steel) tier-by-tier across passes, not all in one pass", () => {
     const Ore = ResourcesIds.Stone;
     const Iron = ResourcesIds.Coal;
     const Steel = ResourcesIds.Ironwood;
@@ -270,16 +294,58 @@ describe("buildRealmProductionPlan", () => {
       }),
     });
 
+    // Topological order is preserved even when downstream tiers cannot run — evaluation order is observable via ordering of evaluatedResourceIds.
+    expect(plan.evaluatedResourceIds.indexOf(Ore)).toBeLessThan(plan.evaluatedResourceIds.indexOf(Iron));
+    expect(plan.evaluatedResourceIds.indexOf(Iron)).toBeLessThan(plan.evaluatedResourceIds.indexOf(Steel));
+
     const callOrder = plan.callset.resourceToResource.map((call) => call.resourceId);
-    expect(callOrder.indexOf(Ore)).toBeLessThan(callOrder.indexOf(Iron));
-    expect(callOrder.indexOf(Iron)).toBeLessThan(callOrder.indexOf(Steel));
+    // Only Ore has a spendable input (Wheat). Iron and Steel cannot execute this pass because
+    // their upstream output goes to `output_amount_left` on chain and only materializes
+    // into spendable balance over future ticks.
+    expect(callOrder).toEqual([Ore]);
 
     const oreCycles = plan.callset.resourceToResource.find((call) => call.resourceId === Ore)?.cycles ?? 0;
-    const ironCycles = plan.callset.resourceToResource.find((call) => call.resourceId === Iron)?.cycles ?? 0;
-    const steelCycles = plan.callset.resourceToResource.find((call) => call.resourceId === Steel)?.cycles ?? 0;
     expect(oreCycles).toBeGreaterThan(0);
-    expect(ironCycles).toBeGreaterThan(0);
-    expect(steelCycles).toBeGreaterThan(0);
+  });
+
+  it("regression: downstream COAL consumption is bounded by real COAL balance, ignoring same-pass output (COAL chain bug)", () => {
+    // Reproduces the on-chain failure: "Insufficient Balance: COAL (id: 209, balance: 463) < 1279".
+    // Upstream recipe that produces COAL must NOT inflate the downstream COAL-consuming budget.
+    const CoalProducer = ResourcesIds.Stone; // stand-in for a recipe whose output is COAL
+    const CoalConsumer = ResourcesIds.Ironwood; // stand-in for a recipe that consumes COAL
+
+    // CoalProducer: consumes Wheat, outputs COAL (10 per cycle).
+    configManagerMock.complexSystemResourceInputs[CoalProducer] = [{ resource: ResourcesIds.Wheat, amount: 1 }];
+    configManagerMock.complexSystemResourceOutput[CoalProducer] = {
+      resource: ResourcesIds.Coal,
+      amount: 10,
+    };
+
+    // CoalConsumer: consumes COAL (1 per cycle), outputs itself.
+    configureComplexRecipe(CoalConsumer, [{ resource: ResourcesIds.Coal, amount: 1 }], 2);
+
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [CoalProducer]: { resourceToResource: 50, laborToResource: 0 },
+          [CoalConsumer]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([CoalProducer, CoalConsumer], {
+        [ResourcesIds.Wheat]: 10_000, // plenty of upstream input
+        [ResourcesIds.Coal]: 463, // low pre-existing COAL balance
+      }),
+    });
+
+    const consumerCycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === CoalConsumer)?.cycles ?? 0;
+    const coalConsumed = plan.consumptionByResource[ResourcesIds.Coal] ?? 0;
+
+    // CoalConsumer needs 1 COAL per cycle; with 90% cap and 463 balance, max cycles = floor(463 * 0.9) = 416.
+    // Without the fix, same-pass credit from CoalProducer would push this far higher (contract reverts on chain).
+    expect(consumerCycles).toBeLessThanOrEqual(416);
+    expect(coalConsumed).toBeLessThanOrEqual(416);
   });
 
   it("falls back to numeric order and warns when recipe config introduces a cycle", () => {

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -483,17 +483,6 @@ export const buildRealmProductionPlan = ({
     return true;
   };
 
-  const creditSamePassOutput = (resourceId: ResourcesIds, produced: number) => {
-    if (!Number.isFinite(produced) || produced <= 0) return;
-    const prevTotal = totalAvailable.get(resourceId) ?? 0;
-    const newTotal = prevTotal + produced;
-    totalAvailable.set(resourceId, newTotal);
-
-    const consumedSoFar = consumptionByResource[resourceId] ?? 0;
-    const maxConsumable = Math.floor((newTotal * MAX_RESOURCE_ALLOCATION_PERCENT) / 100);
-    availableBudget.set(resourceId, Math.max(0, maxConsumable - consumedSoFar));
-  };
-
   const getTotal = (resourceId: ResourcesIds) => totalAvailable.get(resourceId) ?? 0;
   const getBudget = (resourceId: ResourcesIds) => availableBudget.get(resourceId) ?? 0;
 
@@ -588,7 +577,6 @@ export const buildRealmProductionPlan = ({
           } else {
             const produced = outputPerCycle * maxCycles;
             addToRecord(outputsByResource, resourceId, produced);
-            creditSamePassOutput(resourceId, produced);
             planCallset.resourceToResource.push({ resourceId, cycles: maxCycles });
             resourceExecutions.push({
               resourceId,
@@ -731,7 +719,6 @@ export const buildRealmProductionPlan = ({
           } else {
             const produced = outputPerCycle * maxCycles;
             addToRecord(outputsByResource, resourceId, produced);
-            creditSamePassOutput(resourceId, produced);
             planCallset.laborToResource.push({ resourceId, cycles: maxCycles });
             laborExecutions.push({
               resourceId,


### PR DESCRIPTION
## Summary

Realm automation was failing on chain with `Insufficient Balance` (e.g. COAL balance 463B vs 1.28T requested). Commit 09d2084868 added `creditSamePassOutput`, which fed an upstream recipe's output back into downstream recipes' budgets within the same multicall. On chain, `burn_*_for_resource_production` routes output to `production.output_amount_left`, and `retrieve` only harvests elapsed-tick production — within a single block elapsed = 0, so downstream steps see the old balance and revert. This PR removes the same-pass credit; multi-tier chains now prime tier-by-tier across passes (reverting to pre-Apr-17 behavior) while `buildResourceDependencyOrder` and `outputsByResource` reporting are preserved.

## Test plan

- [x] `pnpm exec vitest run` on processor + runner tests: 21/21 pass
- [x] Broader automation scope (processor, runner, presets, signature, store): 72/72 pass
- [x] Added COAL regression test mirroring the reported failure shape
- [x] Inverted the T1→T2 and Ore→Iron→Steel "single-pass chain" tests to match contract reality
- [ ] Manual smoke test on dev realm: enable a labor-produces-COAL + complex-consumes-COAL config and confirm no `Insufficient Balance` reverts