### PR TITLE
debug(worldmap): log biome InstancedMesh bounding sphere drift

### DIFF
--- a/client/apps/game/src/three/managers/instanced-biome.tsx
+++ b/client/apps/game/src/three/managers/instanced-biome.tsx
@@ -338,6 +338,15 @@ export default class InstancedModel {
   private applyWorldBounds(mesh: THREE.InstancedMesh) {
     if (this.worldBounds) {
       mesh.frustumCulled = true;
+      // three.js frustum-culls InstancedMesh against mesh.boundingSphere
+      // (its own, not geometry's). Writing only to geometry.* is a no-op
+      // for culling and left the mesh sphere stuck at the identity-matrix
+      // sphere computed on first render — biomes were being culled when
+      // the camera moved to a different chunk.
+      mesh.boundingSphere = mesh.boundingSphere ?? new THREE.Sphere();
+      mesh.boundingSphere.copy(this.worldBounds.sphere);
+      mesh.boundingBox = mesh.boundingBox ?? new THREE.Box3();
+      mesh.boundingBox.copy(this.worldBounds.box);
       const geometry = mesh.geometry;
       geometry.boundingSphere = geometry.boundingSphere ?? new THREE.Sphere();
       geometry.boundingSphere.copy(this.worldBounds.sphere);
@@ -345,6 +354,8 @@ export default class InstancedModel {
       geometry.boundingBox.copy(this.worldBounds.box);
     } else {
       mesh.frustumCulled = false;
+      mesh.boundingSphere = null;
+      mesh.boundingBox = null;
     }
     if (typeof window !== "undefined" && (window as unknown as { __WORLDMAP_BIOME_BOUNDS_DEBUG?: boolean }).__WORLDMAP_BIOME_BOUNDS_DEBUG) {
       const ms = (mesh as unknown as { boundingSphere: THREE.Sphere | null }).boundingSphere;

--- a/client/apps/game/src/three/managers/instanced-biome.tsx
+++ b/client/apps/game/src/three/managers/instanced-biome.tsx
@@ -271,6 +271,22 @@ export default class InstancedModel {
       }
     });
     this.count = resolvedCount;
+    if (typeof window !== "undefined" && (window as unknown as { __WORLDMAP_BIOME_BOUNDS_DEBUG?: boolean }).__WORLDMAP_BIOME_BOUNDS_DEBUG) {
+      const probe = this.instancedMeshes[0];
+      if (probe) {
+        const ms = (probe as unknown as { boundingSphere: THREE.Sphere | null }).boundingSphere;
+        const gs = probe.geometry.boundingSphere;
+        console.log("[biome-bounds] setMatricesAndCount", {
+          biome: this.biomeName,
+          count: this.count,
+          meshBSphere: ms ? { c: ms.center.toArray(), r: ms.radius } : null,
+          geoBSphere: gs ? { c: gs.center.toArray(), r: gs.radius } : null,
+          worldBoundsSphere: this.worldBounds
+            ? { c: this.worldBounds.sphere.center.toArray(), r: this.worldBounds.sphere.radius }
+            : null,
+        });
+      }
+    }
   }
 
   setMatrixAt(index: number, matrix: THREE.Matrix4) {
@@ -330,6 +346,20 @@ export default class InstancedModel {
     } else {
       mesh.frustumCulled = false;
     }
+    if (typeof window !== "undefined" && (window as unknown as { __WORLDMAP_BIOME_BOUNDS_DEBUG?: boolean }).__WORLDMAP_BIOME_BOUNDS_DEBUG) {
+      const ms = (mesh as unknown as { boundingSphere: THREE.Sphere | null }).boundingSphere;
+      const gs = mesh.geometry.boundingSphere;
+      console.log("[biome-bounds] applyWorldBounds", {
+        biome: this.biomeName,
+        count: this.count,
+        meshCount: mesh.count,
+        meshBSphere: ms ? { c: ms.center.toArray(), r: ms.radius } : null,
+        geoBSphere: gs ? { c: gs.center.toArray(), r: gs.radius } : null,
+        worldBoundsSphere: this.worldBounds
+          ? { c: this.worldBounds.sphere.center.toArray(), r: this.worldBounds.sphere.radius }
+          : null,
+      });
+    }
   }
 
   public setWorldBounds(bounds?: { box: THREE.Box3; sphere: THREE.Sphere }) {
@@ -340,6 +370,20 @@ export default class InstancedModel {
         }
       : undefined;
     this.instancedMeshes.forEach((mesh) => this.applyWorldBounds(mesh));
+    if (typeof window !== "undefined" && (window as unknown as { __WORLDMAP_BIOME_BOUNDS_DEBUG?: boolean }).__WORLDMAP_BIOME_BOUNDS_DEBUG) {
+      const probe = this.instancedMeshes[0];
+      if (probe) {
+        const ms = (probe as unknown as { boundingSphere: THREE.Sphere | null }).boundingSphere;
+        console.log("[biome-bounds] setWorldBounds:after", {
+          biome: this.biomeName,
+          count: this.count,
+          meshBSphere: ms ? { c: ms.center.toArray(), r: ms.radius } : null,
+          worldBoundsSphere: this.worldBounds
+            ? { c: this.worldBounds.sphere.center.toArray(), r: this.worldBounds.sphere.radius }
+            : null,
+        });
+      }
+    }
   }
 
   clone() {

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -634,6 +634,14 @@ export default class InstancedModel {
   private applyWorldBounds(mesh: InstancedMesh) {
     if (this.worldBounds) {
       mesh.frustumCulled = true;
+      // three.js frustum-culls InstancedMesh against mesh.boundingSphere
+      // (its own, not geometry's). Geometry-only writes were a no-op for
+      // culling and left the mesh sphere stale after instance matrices
+      // moved to a new chunk.
+      mesh.boundingSphere = mesh.boundingSphere ?? new Sphere();
+      mesh.boundingSphere.copy(this.worldBounds.sphere);
+      mesh.boundingBox = mesh.boundingBox ?? new Box3();
+      mesh.boundingBox.copy(this.worldBounds.box);
       const geometry = mesh.geometry;
       geometry.boundingSphere = geometry.boundingSphere ?? new Sphere();
       geometry.boundingSphere.copy(this.worldBounds.sphere);
@@ -641,6 +649,8 @@ export default class InstancedModel {
       geometry.boundingBox.copy(this.worldBounds.box);
     } else {
       mesh.frustumCulled = false;
+      mesh.boundingSphere = null;
+      mesh.boundingBox = null;
     }
   }
 


### PR DESCRIPTION
## Summary

Adds opt-in logging to `InstancedBiome` to help diagnose a hard-refresh bug on the worldmap where chunks appear offset and biomes disappear as the player moves between chunks.

## Hypothesis being tested

three.js frustum-culls `InstancedMesh` against **`mesh.boundingSphere`** (the mesh's own), not `geometry.boundingSphere`. But the existing `InstancedBiome.applyWorldBounds` writes only to `geometry.boundingSphere`, and:

- `setMatricesAndCount` does not call `needsUpdate()` or `computeBoundingSphere()` after replacing matrices
- `needsUpdate()` only refreshes `mesh.boundingSphere` when `worldBounds` is undefined — on the worldmap it is always set, so the compute branch never runs

The suspicion: `mesh.boundingSphere` gets computed **once** by three.js on the first render (when instance matrices are still identity) and is never refreshed. After a chunk transition, the cached sphere no longer intersects the camera frustum and the whole biome mesh is culled.

## How to enable

In devtools after a hard refresh:

```js
window.__WORLDMAP_BIOME_BOUNDS_DEBUG = true
```

Three log lines fire:

- `[biome-bounds] setMatricesAndCount` — captures drift right after matrices change
- `[biome-bounds] applyWorldBounds` — per `setWorldBounds` call, per mesh
- `[biome-bounds] setWorldBounds:after` — confirms flipping `worldBounds` does not refresh `mesh.boundingSphere`

Each log contains `meshBSphere` (what three.js uses for culling), `geoBSphere` (what `applyWorldBounds` writes), and `worldBoundsSphere` (what we *think* we set), plus biome name and count.

## Expected pattern if the hypothesis holds

`meshBSphere.center` stays pinned near `(0,0,0)` across chunk transitions while `worldBoundsSphere.center` and `geoBSphere.center` follow the camera to the new chunk.

## Scope

Instrumentation only — default off, zero cost when the flag is not set. The fix (call `computeBoundingSphere` from `needsUpdate` / `setMatricesAndCount` even when `worldBounds` is set) will land in a follow-up PR once this log output confirms the theory in a live environment.

## Test plan

- [ ] Hard-refresh into `/play?...`, open devtools console
- [ ] Set `window.__WORLDMAP_BIOME_BOUNDS_DEBUG = true`
- [ ] Pan across a chunk boundary, observe `[biome-bounds] setMatricesAndCount` lines
- [ ] Confirm `meshBSphere.center` does not track `worldBoundsSphere.center`
- [ ] Verify with the flag unset that no logs fire (production behavior unchanged)