### PR TITLE
fix(worldmap): set mesh.boundingSphere for InstancedMesh culling

### DIFF
--- a/client/apps/game/src/three/managers/instanced-biome.tsx
+++ b/client/apps/game/src/three/managers/instanced-biome.tsx
@@ -338,6 +338,15 @@ export default class InstancedModel {
   private applyWorldBounds(mesh: THREE.InstancedMesh) {
     if (this.worldBounds) {
       mesh.frustumCulled = true;
+      // three.js frustum-culls InstancedMesh against mesh.boundingSphere
+      // (its own, not geometry's). Writing only to geometry.* is a no-op
+      // for culling and left the mesh sphere stuck at the identity-matrix
+      // sphere computed on first render — biomes were being culled when
+      // the camera moved to a different chunk.
+      mesh.boundingSphere = mesh.boundingSphere ?? new THREE.Sphere();
+      mesh.boundingSphere.copy(this.worldBounds.sphere);
+      mesh.boundingBox = mesh.boundingBox ?? new THREE.Box3();
+      mesh.boundingBox.copy(this.worldBounds.box);
       const geometry = mesh.geometry;
       geometry.boundingSphere = geometry.boundingSphere ?? new THREE.Sphere();
       geometry.boundingSphere.copy(this.worldBounds.sphere);
@@ -345,6 +354,8 @@ export default class InstancedModel {
       geometry.boundingBox.copy(this.worldBounds.box);
     } else {
       mesh.frustumCulled = false;
+      mesh.boundingSphere = null;
+      mesh.boundingBox = null;
     }
     if (typeof window !== "undefined" && (window as unknown as { __WORLDMAP_BIOME_BOUNDS_DEBUG?: boolean }).__WORLDMAP_BIOME_BOUNDS_DEBUG) {
       const ms = (mesh as unknown as { boundingSphere: THREE.Sphere | null }).boundingSphere;

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -634,6 +634,14 @@ export default class InstancedModel {
   private applyWorldBounds(mesh: InstancedMesh) {
     if (this.worldBounds) {
       mesh.frustumCulled = true;
+      // three.js frustum-culls InstancedMesh against mesh.boundingSphere
+      // (its own, not geometry's). Geometry-only writes were a no-op for
+      // culling and left the mesh sphere stale after instance matrices
+      // moved to a new chunk.
+      mesh.boundingSphere = mesh.boundingSphere ?? new Sphere();
+      mesh.boundingSphere.copy(this.worldBounds.sphere);
+      mesh.boundingBox = mesh.boundingBox ?? new Box3();
+      mesh.boundingBox.copy(this.worldBounds.box);
       const geometry = mesh.geometry;
       geometry.boundingSphere = geometry.boundingSphere ?? new Sphere();
       geometry.boundingSphere.copy(this.worldBounds.sphere);
@@ -641,6 +649,8 @@ export default class InstancedModel {
       geometry.boundingBox.copy(this.worldBounds.box);
     } else {
       mesh.frustumCulled = false;
+      mesh.boundingSphere = null;
+      mesh.boundingBox = null;
     }
   }
 


### PR DESCRIPTION
## Summary

Fix for the hard-refresh chunk-disappearance bug. **Stacked on #4677** (debug logs), rebase onto `next` once that lands.

three.js frustum-culls `InstancedMesh` against **`mesh.boundingSphere`** (its own), not `geometry.boundingSphere`. The existing `applyWorldBounds` in `InstancedBiome` and `InstancedModel` was writing only to `geometry.*` — a no-op for culling. The mesh's own sphere was stuck at whatever three.js computed on first render, which on hard refresh was `{center:[0,0,0], radius:-1}` (the `makeEmpty()` sentinel it gets when `count=0`).

As soon as the camera moved to a chunk that didn't include the origin, `Frustum.intersectsSphere` returned false for every InstancedMesh and the biomes vanished.

## Smoking gun

From devtools after enabling the debug logs from #4677 — Tundra biome during a chunk transition:

```
[biome-bounds] applyWorldBounds {
  biome: "Tundra", count: 17, meshCount: 17,
  meshBSphere:  { c: [0, 0, 0], r: -1 },              ← stale empty sphere
  geoBSphere:   { c: [...], r: 61.29 },               ← set by applyWorldBounds
  worldBoundsSphere: { c: [...], r: 61.29 },          ← what we passed in
}
```

`meshBSphere.radius = -1` is `Sphere.makeEmpty()` — three.js's empty-sphere sentinel. `geometry.boundingSphere` is correct but three.js doesn't read it for `InstancedMesh` frustum culling.

## The fix

In `applyWorldBounds` (both `instanced-biome.tsx` and `instanced-model.tsx`):

- Write `this.worldBounds` to **`mesh.boundingSphere`** and **`mesh.boundingBox`** (what three.js actually uses for InstancedMesh culling).
- Keep the existing `geometry.*` writes in case any consumer inspects them.
- When `worldBounds` is cleared, null `mesh.boundingSphere` / `mesh.boundingBox` so three.js recomputes from matrices next render.

No changes to `needsUpdate()` / `setMatricesAndCount()` — they're correct once `applyWorldBounds` targets the right field. Source-inspection tests (`instanced-{biome,model}.bounds-authority.test.ts`) that pin the worldBounds short-circuit pattern still pass.

## Debug logs retained

The `window.__WORLDMAP_BIOME_BOUNDS_DEBUG` logs from #4677 are left in place so we can re-verify after the fix lands. Once confirmed green in prod, a follow-up will strip them.

## Test plan

- [ ] Typecheck passes locally (one pre-existing environment error unrelated to this change)
- [ ] Hard-refresh into `/play?...` on a live world
- [ ] Pan across multiple chunk boundaries — biomes stay visible, no offset appearance
- [ ] Enable `window.__WORLDMAP_BIOME_BOUNDS_DEBUG = true` and confirm `meshBSphere.c` now tracks `worldBoundsSphere.c` and `radius` is a positive number (not -1)
- [ ] Verify structures / army models still render (same fix applies to InstancedModel)

## Related

- PR #4677 — debug logging (stack base)
- Issue: chunks offset and biomes disappear on hard-refresh worldmap load