### PR TITLE
chore: format Torii structure-owner cache declaration

### DIFF
--- a/packages/torii/src/queries/sql/api.ts
+++ b/packages/torii/src/queries/sql/api.ts
@@ -107,10 +107,7 @@ const buildCacheUrl = (baseUrl: string, path: string): URL => {
 // during boot (use-player-structure-sync + others) and re-query the same owner
 // within a few hundred ms. gRPC subscription reconciles any staleness within a block.
 const STRUCTURES_BY_OWNER_TTL_MS = 500;
-const structuresByOwnerCache = new Map<
-  string,
-  { promise: Promise<StructureLocation[]>; expiresAt: number }
->();
+const structuresByOwnerCache = new Map<string, { promise: Promise<StructureLocation[]>; expiresAt: number }>();
 
 export class SqlApi {
   constructor(


### PR DESCRIPTION
## Summary
Formats the `structuresByOwnerCache` declaration in `packages/torii/src/queries/sql/api.ts` onto Prettier's single-line generic form.

## Verification
- `pnpm run format`
- `pnpm run knip`

Both checks passed; both emitted local Node engine warnings because this shell uses Node v20.9.0 and the repo asks for >=20.19.0.