### PR TITLE
perf(game): memoize player-structure subscription clauses (#4649)

### DIFF
--- a/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
+++ b/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
@@ -76,6 +76,40 @@ export const usePlayerStructureSync = () => {
     [playerStructures],
   );
 
+  // Stable content-based key; changes only when owned structures or their positions change,
+  // so downstream memos + the subscription useEffect do not churn on every render.
+  const clauseKey = useMemo(
+    () =>
+      `${structureEntityIds.join(",")}|${structurePositions.map((p) => `${p.col},${p.row}`).join(";")}`,
+    [structureEntityIds, structurePositions],
+  );
+
+  const structureClauses = useMemo(
+    () =>
+      structureEntityIds.map((id) => ({
+        Keys: {
+          keys: [id.toString()],
+          pattern_matching: "VariableLen" as PatternMatching,
+          models: PLAYER_STRUCTURE_MODELS,
+        },
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clauseKey captures structureEntityIds content
+    [clauseKey],
+  );
+
+  const buildingClauses = useMemo(
+    () =>
+      structurePositions.map((pos) => ({
+        Keys: {
+          keys: [pos.col.toString(), pos.row.toString()],
+          pattern_matching: "VariableLen" as PatternMatching,
+          models: ["s1_eternum-Building"],
+        },
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- clauseKey captures structurePositions content
+    [clauseKey],
+  );
+
   const accountAddress = useAccountStore().account?.address;
   const toriiComponents = contractComponents as unknown as Parameters<typeof getStructuresDataFromTorii>[1];
   const structureEntityIdsRef = useRef<ReadonlySet<number>>(new Set());
@@ -229,22 +263,6 @@ export const usePlayerStructureSync = () => {
 
       if (!accountAddress || !toriiClient) return;
 
-      const structureClauses = structureEntityIds.map((id) => ({
-        Keys: {
-          keys: [id.toString()],
-          pattern_matching: "VariableLen" as PatternMatching,
-          models: PLAYER_STRUCTURE_MODELS,
-        },
-      }));
-
-      const buildingClauses = structurePositions.map((pos) => ({
-        Keys: {
-          keys: [pos.col.toString(), pos.row.toString()],
-          pattern_matching: "VariableLen" as PatternMatching,
-          models: ["s1_eternum-Building"],
-        },
-      }));
-
       const ownerStructureClause = MemberClause("s1_eternum-Structure", "owner", "Eq", {
         type: "ContractAddress",
         value: padHexAddressTo66(accountAddress),
@@ -268,5 +286,7 @@ export const usePlayerStructureSync = () => {
         subscriptionRef.current = null;
       }
     };
-  }, [structureEntityIds, structurePositions, accountAddress, toriiClient, setup]);
+    // clauseKey is the stable content-based dep; structureClauses/buildingClauses track it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [clauseKey, accountAddress, toriiClient, setup]);
 };

--- a/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
+++ b/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
@@ -79,8 +79,7 @@ export const usePlayerStructureSync = () => {
   // Stable content-based key; changes only when owned structures or their positions change,
   // so downstream memos + the subscription useEffect do not churn on every render.
   const clauseKey = useMemo(
-    () =>
-      `${structureEntityIds.join(",")}|${structurePositions.map((p) => `${p.col},${p.row}`).join(";")}`,
+    () => `${structureEntityIds.join(",")}|${structurePositions.map((p) => `${p.col},${p.row}`).join(";")}`,
     [structureEntityIds, structurePositions],
   );
 


### PR DESCRIPTION
Closes #4649 (tracked in the meta #4671 Wave B).

## Summary
- Hoist `structureClauses` / `buildingClauses` out of the subscription `useEffect` and memoize them against a content-stable `clauseKey` string.
- Swap the `useEffect` dep array from `[structureEntityIds, structurePositions, ...]` (new array refs every render) to `[clauseKey, ...]` so `syncEntitiesDebounced` only tears down + re-establishes the Torii `SubscribeEntities` when an owned structure is added/removed or moves — not on every re-render.

## Why
`usePlayerStructureSync` was churning a fresh subscription on nearly every render: `playerStructures` is a live store selector, so `structureEntityIds` / `structurePositions` got new array identities each pass, the effect deps changed, the old sub was cancelled and a new one opened. That cost Torii CPU, wasted network, and occasionally opened a race window where a new sub raced its own cancel.

With the content key, idle sessions go from many subs/sec to one per ownership/position delta.

## Smoke test requirements

Manual (must do before merging):
- [ ] Boot game to Ready on a populated account with ≥1 realm. Confirm realms, resources, and buildings appear and stay present.
- [ ] Stay idle on the map for ~30 seconds. Add a temporary `console.count('player-sub-setup')` inside the effect body (or check Torii server gRPC logs if available): count should stay at 1 across the idle window. Pre-fix it climbs each render.
- [ ] Transfer / mint a structure to the account. The new structure should appear in the realm list and its buildings should sync within the usual window (one new SubscribeEntities expected).
- [ ] Switch accounts (disconnect + reconnect with a different controller). Subscription should rebuild exactly once for the new account.
- [ ] Watch the browser devtools network panel: no new WS frames for `SubscribeEntities` during passive map idling.

Automated:
- [x] `pnpm --filter eternum-game-client typecheck` clean.
- [x] `pnpm --filter eternum-game-client exec eslint src/hooks/helpers/use-player-structure-sync.ts` clean.
- [x] `player-structure-sync-utils.test.ts` still green (unrelated logic, sanity check only).

## Risk
Low. The memo key captures every input that changes clause contents (`structureEntityIds`, `structurePositions`). `accountAddress`, `toriiClient`, `setup` remain in the dep array and are stable across renders. No behavior change on ownership / position delta — just fewer redundant subscription resets.