### PR TITLE
fix(game): read Torii boolean columns in blitz settlement snapshot

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -58,6 +58,7 @@ import {
   deriveSettlementPhaseViewModel,
   deriveSettlementStatus,
   hasReachedSettlementTarget,
+  parseSnapshotRegistrationRow,
   type SettleStage,
   type SettlementSnapshot,
 } from "./game-entry-settlement.utils";
@@ -502,8 +503,8 @@ const mapVillagePassDistributorTransferError = (error: unknown): string => {
 
 type DirectSettlementSnapshotRow = {
   coords?: unknown;
-  once_registered?: boolean | null;
-  registered?: boolean | null;
+  once_registered?: unknown;
+  registered?: unknown;
   structure_ids?: unknown;
 };
 
@@ -3842,10 +3843,12 @@ export const GameEntryModal = ({
     const playerRegister = registerRows[0] ?? null;
     const settleFinish = settleFinishRows[0] ?? null;
 
+    const { registered, onceRegistered } = parseSnapshotRegistrationRow(playerRegister);
+
     return applyDashboardRegistrationHint({
       snapshot: {
-        registered: playerRegister?.registered === true,
-        onceRegistered: playerRegister?.once_registered === true,
+        registered,
+        onceRegistered,
         hasSettledStructure: playerStructures.length > 0,
         coordsCount: parseSpanLength(settleFinish?.coords),
         settledCount: parseSpanLength(settleFinish?.structure_ids),

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
@@ -9,6 +9,7 @@ import {
   deriveSettlementStatus,
   getExpectedSettlementCount,
   hasReachedSettlementTarget,
+  parseSnapshotRegistrationRow,
   type SettlementSnapshot,
 } from "./game-entry-settlement.utils";
 
@@ -315,5 +316,38 @@ describe("buildSettlementExecutionPlan", () => {
 
     expect(plan.shouldAssignAndSettle).toBe(true);
     expect(plan.missingAssignmentRegistration).toBe(true);
+  });
+});
+
+describe("parseSnapshotRegistrationRow", () => {
+  it("returns false for null / undefined rows", () => {
+    expect(parseSnapshotRegistrationRow(null)).toEqual({ registered: false, onceRegistered: false });
+    expect(parseSnapshotRegistrationRow(undefined)).toEqual({ registered: false, onceRegistered: false });
+    expect(parseSnapshotRegistrationRow({})).toEqual({ registered: false, onceRegistered: false });
+  });
+
+  it("accepts native booleans", () => {
+    expect(parseSnapshotRegistrationRow({ registered: true, once_registered: false })).toEqual({
+      registered: true,
+      onceRegistered: false,
+    });
+  });
+
+  it("accepts numeric 1/0 from Torii SQL", () => {
+    expect(parseSnapshotRegistrationRow({ registered: 1, once_registered: 0 })).toEqual({
+      registered: true,
+      onceRegistered: false,
+    });
+    expect(parseSnapshotRegistrationRow({ registered: 0, once_registered: 1 })).toEqual({
+      registered: false,
+      onceRegistered: true,
+    });
+  });
+
+  it('accepts string "1"/"0" from Torii SQL', () => {
+    expect(parseSnapshotRegistrationRow({ registered: "0", once_registered: "1" })).toEqual({
+      registered: false,
+      onceRegistered: true,
+    });
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
@@ -1,3 +1,5 @@
+import { parseMaybeBooleanFlag } from "@/config/game-modes/resolved-mode";
+
 export type SettlementSnapshot = {
   registered: boolean;
   onceRegistered: boolean;
@@ -5,6 +7,15 @@ export type SettlementSnapshot = {
   coordsCount: number;
   settledCount: number;
 };
+
+// Torii SQL returns boolean columns as numeric (0/1) or string ("0"/"1"), so
+// strict `=== true` on the raw row mis-reads genuine registrations as false.
+export const parseSnapshotRegistrationRow = (
+  row: { registered?: unknown; once_registered?: unknown } | null | undefined,
+): { registered: boolean; onceRegistered: boolean } => ({
+  registered: parseMaybeBooleanFlag(row?.registered) === true,
+  onceRegistered: parseMaybeBooleanFlag(row?.once_registered) === true,
+});
 
 const hasIndexedSettlementProgress = (snapshot: SettlementSnapshot): boolean =>
   snapshot.hasSettledStructure || snapshot.coordsCount > 0 || snapshot.settledCount > 0;


### PR DESCRIPTION
## Symptom
Registered Blitz player clicks **Start Settlement** on a world where the dashboard card shows "Registered" and hits:

> Settlement failed. Please try again.
> Cannot assign realm positions because the player is no longer in registered state.

## Root cause
Torii SQL returns boolean columns as numeric (\`0\`/\`1\`) or string (\`"0"\`/\`"1"\`), not native JS booleans. \`readSettlementSnapshot\` in \`game-entry-modal.tsx\` was comparing with strict \`=== true\`:

\`\`\`ts
registered: playerRegister?.registered === true,
onceRegistered: playerRegister?.once_registered === true,
\`\`\`

So a row with \`registered: 1\` was read as \`{registered: false, onceRegistered: false}\`. \`buildSettlementExecutionPlan\` then flagged \`missingAssignmentRegistration\` and \`runBlitzSettlementFlow\` threw.

The dashboard card shows "Registered" correctly because it reads the same column via \`parseMaybeBooleanFlag\` in \`use-world-availability.ts\`. Two code paths, one truthy-aware, one not — hence the UI/flow disagreement.

## Fix
- Add \`parseSnapshotRegistrationRow\` helper in \`game-entry-settlement.utils.ts\` that routes the row fields through \`parseMaybeBooleanFlag\`, matching the dashboard path.
- Loosen \`DirectSettlementSnapshotRow.registered\` / \`once_registered\` types to \`unknown\` — they always were.
- Unit tests covering native \`true\`, numeric \`1\`/\`0\`, string \`"1"\`/\`"0"\`, and null/missing-row variants.

## Smoke test requirements
- [ ] Reproduce pre-fix locally by mocking the register SQL row to \`{registered: 1, once_registered: 1}\` (or point a dev build at a world where you have already registered) and click Start Settlement — must succeed instead of throwing.
- [ ] Clean-player path: brand new wallet that has never registered on this world → Start Settlement still throws (\`missingAssignmentRegistration\` still catches truly-unregistered players).
- [ ] Dashboard "Registered" badge + Start Settlement must now agree on a real registered wallet on a live Blitz world.
- [ ] Resume mid-settlement after the initial \`assign_realm_positions\` lands (row has \`registered: 0, once_registered: 1\`) — must still reach Play without re-throwing.

## Automated
- [x] \`pnpm --filter eternum-game-client exec vitest run src/ui/features/landing/components/game-entry-settlement.utils.test.ts\` — 25 green (4 new).
- [x] \`pnpm --filter eternum-game-client typecheck\` — clean.
- [x] \`eslint\` + \`prettier --check\` clean on touched files.

## Risk
Low. Existing call sites already expect a boolean-valued \`SettlementSnapshot\`. The helper only widens how the *raw* row is coerced; downstream logic is unchanged.