### PR TITLE
Fix Blitz settlement sync target

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.settlement-wait.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.settlement-wait.source.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Game entry settlement target polling", () => {
+  it("waits for the requested settled realm count instead of accepting empty indexed snapshots", () => {
+    const source = readSource("src/ui/features/landing/components/game-entry-modal.tsx");
+
+    expect(source).toContain("hasReachedSettlementTarget(status, targetSettleCount)");
+    expect(source).not.toContain("status.remainingToSettle === 0");
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -3883,7 +3883,7 @@ export const GameEntryModal = ({
         if (snapshot) {
           latestSnapshot = snapshot;
           const status = syncSettlementStateFromSnapshot(snapshot);
-          if (status.settledCount >= targetSettleCount || status.remainingToSettle === 0) {
+          if (hasReachedSettlementTarget(status, targetSettleCount)) {
             return snapshot;
           }
         }

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-20",
+    title: "Blitz Settlement Sync",
+    description:
+      "Blitz settlement now waits for the requested settled realm count before advancing, so fresh entries no longer get stuck on finalizing when the index briefly returns an empty snapshot.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-20",
     title: "Faster Game Lists",
     description:
       "Landing game lists now load from a shared world summary, reducing startup requests while keeping registration, rewards, and review actions available.",


### PR DESCRIPTION
## Summary
- Fix Blitz settlement polling so it waits for the requested settled realm count instead of accepting empty indexed snapshots.
- Add a regression source test for the polling guard.
- Add the landing latest-features entry for the Blitz settlement sync fix.

## Verification
- pnpm --dir client/apps/game test -- game-entry-modal.settlement-wait.source.test.ts game-entry-settlement.utils.test.ts game-entry-blitz-settlement-flow.test.ts
- pnpm run format
- pnpm run knip