### PR TITLE
Add rolling Blitz rotation cadence

### DIFF
--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -239,6 +239,7 @@ jobs:
             singleRealmMode: "GAME_LAUNCH_SINGLE_REALM_MODE",
             twoPlayerMode: "GAME_LAUNCH_TWO_PLAYER_MODE",
             durationSeconds: "GAME_LAUNCH_DURATION_SECONDS",
+            weeklyCadence: "GAME_LAUNCH_WEEKLY_CADENCE_JSON",
             mapConfigOverrides: "GAME_LAUNCH_MAP_CONFIG_OVERRIDES_JSON",
             blitzRegistrationOverrides: "GAME_LAUNCH_BLITZ_REGISTRATION_OVERRIDES_JSON",
             cartridgeApiBase: "GAME_LAUNCH_CARTRIDGE_API_BASE",
@@ -332,6 +333,7 @@ jobs:
             append_optional_arg "${args_name}" --single-realm-mode "${GAME_LAUNCH_SINGLE_REALM_MODE:-}"
             append_optional_arg "${args_name}" --two-player-mode "${GAME_LAUNCH_TWO_PLAYER_MODE:-}"
             append_optional_arg "${args_name}" --duration-seconds "${GAME_LAUNCH_DURATION_SECONDS:-}"
+            append_optional_arg "${args_name}" --weekly-cadence-json "${GAME_LAUNCH_WEEKLY_CADENCE_JSON:-}"
             append_optional_arg "${args_name}" --cartridge-api-base "${GAME_LAUNCH_CARTRIDGE_API_BASE:-}"
             append_optional_arg "${args_name}" --torii-namespaces "${GAME_LAUNCH_TORII_NAMESPACES:-}"
             append_optional_arg "${args_name}" --vrf-provider-address "${GAME_LAUNCH_VRF_PROVIDER_ADDRESS:-}"
@@ -374,18 +376,19 @@ jobs:
               --series-games-json "${GAME_LAUNCH_SERIES_GAMES_JSON}"
             )
           elif [ "${GAME_LAUNCH_KIND}" = "rotation" ]; then
-            if [ -z "${GAME_LAUNCH_ROTATION_NAME}" ] || [ -z "${GAME_LAUNCH_FIRST_GAME_START_TIME}" ] || [ -z "${GAME_LAUNCH_GAME_INTERVAL_MINUTES}" ] || [ -z "${GAME_LAUNCH_MAX_GAMES}" ] || [ -z "${GAME_LAUNCH_EVALUATION_INTERVAL_MINUTES}" ]; then
-              echo "Rotation launches require rotation_name, first_game_start_time, game_interval_minutes, max_games, and evaluation_interval_minutes" >&2
+            if [ -z "${GAME_LAUNCH_ROTATION_NAME}" ] || [ -z "${GAME_LAUNCH_FIRST_GAME_START_TIME}" ] || [ -z "${GAME_LAUNCH_MAX_GAMES}" ] || [ -z "${GAME_LAUNCH_EVALUATION_INTERVAL_MINUTES}" ] || { [ -z "${GAME_LAUNCH_GAME_INTERVAL_MINUTES}" ] && [ -z "${GAME_LAUNCH_WEEKLY_CADENCE_JSON:-}" ]; }; then
+              echo "Rotation launches require rotation_name, first_game_start_time, max_games, evaluation_interval_minutes, and either game_interval_minutes or weekly_cadence_json" >&2
               exit 1
             fi
 
             args+=(
               --rotation-name "${GAME_LAUNCH_ROTATION_NAME}"
               --first-game-start-time "${GAME_LAUNCH_FIRST_GAME_START_TIME}"
-              --game-interval-minutes "${GAME_LAUNCH_GAME_INTERVAL_MINUTES}"
               --max-games "${GAME_LAUNCH_MAX_GAMES}"
               --evaluation-interval-minutes "${GAME_LAUNCH_EVALUATION_INTERVAL_MINUTES}"
             )
+
+            append_optional_arg args --game-interval-minutes "${GAME_LAUNCH_GAME_INTERVAL_MINUTES}"
 
             if [ -n "${GAME_LAUNCH_ADVANCE_WINDOW_GAMES}" ]; then
               args+=(--advance-window-games "${GAME_LAUNCH_ADVANCE_WINDOW_GAMES}")
@@ -432,11 +435,12 @@ jobs:
               --environment "${GAME_LAUNCH_ENVIRONMENT}"
               --rotation-name "${GAME_LAUNCH_ROTATION_NAME}"
               --first-game-start-time "${GAME_LAUNCH_FIRST_GAME_START_TIME}"
-              --game-interval-minutes "${GAME_LAUNCH_GAME_INTERVAL_MINUTES}"
               --max-games "${GAME_LAUNCH_MAX_GAMES}"
               --evaluation-interval-minutes "${GAME_LAUNCH_EVALUATION_INTERVAL_MINUTES}"
               --launch-step "${GAME_LAUNCH_STEP}"
             )
+
+            append_optional_arg run_store_args --game-interval-minutes "${GAME_LAUNCH_GAME_INTERVAL_MINUTES}"
 
             if [ -n "${GAME_LAUNCH_ADVANCE_WINDOW_GAMES}" ]; then
               run_store_args+=(--advance-window-games "${GAME_LAUNCH_ADVANCE_WINDOW_GAMES}")

--- a/client/apps/game/src/ui/features/factory-v2/api/factory-run-mapper.test.ts
+++ b/client/apps/game/src/ui/features/factory-v2/api/factory-run-mapper.test.ts
@@ -336,4 +336,22 @@ describe("mapFactoryWorkerRun", () => {
       firstGameStartTimeIso: "2026-03-18T12:00:00.000Z",
     });
   });
+
+  it("maps weekly cadence metadata for rotation runs", () => {
+    const baseRecord = buildRotationRunRecord();
+    const run = mapFactoryWorkerRun(
+      buildRotationRunRecord({
+        summary: {
+          ...baseRecord.summary,
+          gameIntervalMinutes: 0,
+          weeklyCadence: [{ gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" }],
+        },
+      }),
+    );
+
+    expect(run.rotation).toMatchObject({
+      gameIntervalMinutes: 0,
+      weeklyCadence: [{ gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" }],
+    });
+  });
 });

--- a/client/apps/game/src/ui/features/factory-v2/api/factory-run-mapper.ts
+++ b/client/apps/game/src/ui/features/factory-v2/api/factory-run-mapper.ts
@@ -364,6 +364,7 @@ function mapFactoryRotationState(record: FactoryWorkerRotationRunRecord): Factor
     createdGameCount: record.summary.games.length,
     queuedGameCount: record.summary.games.filter((game) => game.startTime * 1000 > Date.now()).length,
     gameIntervalMinutes: record.summary.gameIntervalMinutes,
+    ...(record.summary.weeklyCadence?.length ? { weeklyCadence: record.summary.weeklyCadence } : {}),
     firstGameStartTimeIso: record.summary.firstGameStartTimeIso,
   };
 }

--- a/client/apps/game/src/ui/features/factory-v2/api/factory-worker.ts
+++ b/client/apps/game/src/ui/features/factory-v2/api/factory-worker.ts
@@ -268,6 +268,11 @@ export interface FactoryWorkerRotationRunRecord extends FactoryWorkerBaseRunReco
     maxGames: number;
     advanceWindowGames: number;
     evaluationIntervalMinutes: number;
+    weeklyCadence?: Array<{
+      gameNamePrefix: string;
+      weekday: string;
+      utcTime: string;
+    }>;
     rpcUrl: string;
     factoryAddress: string;
     autoRetryEnabled: boolean;

--- a/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
+++ b/client/apps/game/src/ui/features/factory-v2/components/factory-v2-watch-workspace.tsx
@@ -877,7 +877,7 @@ const FactoryV2RotationScheduleCard = ({ run }: { run: FactoryRun }) => {
           value={`${run.rotation.createdGameCount} of ${run.rotation.maxGames}`}
         />
         <FactoryV2RotationMetric label="Queued ahead" value={`${run.rotation.queuedGameCount} games`} />
-        <FactoryV2RotationMetric label="Game interval" value={`Every ${run.rotation.gameIntervalMinutes} minutes`} />
+        <FactoryV2RotationMetric label="Cadence" value={resolveRotationCadenceLabel(run)} />
         <FactoryV2RotationMetric
           label="Next evaluation"
           value={
@@ -890,6 +890,15 @@ const FactoryV2RotationScheduleCard = ({ run }: { run: FactoryRun }) => {
     </div>
   );
 };
+
+function resolveRotationCadenceLabel(run: FactoryRun) {
+  const weeklySlotCount = run.rotation?.weeklyCadence?.length ?? 0;
+  if (weeklySlotCount > 0) {
+    return `${weeklySlotCount} weekly slots`;
+  }
+
+  return `Every ${run.rotation?.gameIntervalMinutes ?? 0} minutes`;
+}
 
 const FactoryV2RotationMetric = ({ label, value }: { label: string; value: string }) => (
   <div className="rounded-[18px] border border-gold/10 bg-black/20 px-3 py-3 text-center">

--- a/client/apps/game/src/ui/features/factory-v2/types.ts
+++ b/client/apps/game/src/ui/features/factory-v2/types.ts
@@ -191,6 +191,12 @@ export interface FactoryRotationEvaluationState {
   lastNudgedAt: string | null;
 }
 
+export interface FactoryRotationWeeklyCadenceEntry {
+  gameNamePrefix: string;
+  weekday: string;
+  utcTime: string;
+}
+
 export interface FactoryRotationRunState {
   rotationName: string;
   maxGames: number;
@@ -198,6 +204,7 @@ export interface FactoryRotationRunState {
   createdGameCount: number;
   queuedGameCount: number;
   gameIntervalMinutes: number;
+  weeklyCadence?: FactoryRotationWeeklyCadenceEntry[];
   firstGameStartTimeIso: string;
 }
 

--- a/client/apps/game/src/ui/features/factory-v2/types.ts
+++ b/client/apps/game/src/ui/features/factory-v2/types.ts
@@ -191,7 +191,7 @@ export interface FactoryRotationEvaluationState {
   lastNudgedAt: string | null;
 }
 
-export interface FactoryRotationWeeklyCadenceEntry {
+interface FactoryRotationWeeklyCadenceEntry {
   gameNamePrefix: string;
   weekday: string;
   utcTime: string;

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-20",
+    title: "Rolling Blitz Cadence",
+    description:
+      "Factory rotations now support weekly cadence details and weekend buy-in overrides, making long-running Blitz schedules easier to monitor as future games stay queued.",
+    type: "improvement",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-20",
     title: "Blitz Settlement Sync",
     description:
       "Blitz settlement now waits for the requested settled realm count before advancing, so fresh entries no longer get stuck on finalizing when the index briefly returns an empty snapshot.",

--- a/config/deployer/clean/README.md
+++ b/config/deployer/clean/README.md
@@ -28,7 +28,10 @@ Required inputs:
 - `--start-time`: unix seconds, unix milliseconds, or ISO-8601
 
 When `--config-path` is present, the YAML file can provide those required fields instead. The file uses the clean
-deployer request shape, so weekly schedules should be modeled as `launchKind: series` with an explicit `games:` list.
+deployer request shape, so finite weekly schedules can be modeled as `launchKind: series` with an explicit `games:`
+list. Rolling weekly schedules should use `launchKind: rotation` with `weeklyCadence:` entries so the worker keeps the
+advance window filled until the rotation is cancelled. A weekly cadence entry can include `blitzRegistrationOverrides`
+when a slot needs a different buy-in from the parent/default Blitz registration config.
 
 Optional env or flags:
 
@@ -164,6 +167,15 @@ schedules should be dispatched like:
 launch_kind = series
 environment = slot.blitz
 config_path = config/deployer/clean/examples/blitz-weekly-series.yaml
+launch_step = full
+```
+
+The committed rolling Blitz cadence should be dispatched as:
+
+```text
+launch_kind = rotation
+environment = slot.blitz
+config_path = config/deployer/clean/examples/blitz-rotation.yaml
 launch_step = full
 ```
 

--- a/config/deployer/clean/README.md
+++ b/config/deployer/clean/README.md
@@ -174,7 +174,7 @@ The committed rolling Blitz cadence should be dispatched as:
 
 ```text
 launch_kind = rotation
-environment = slot.blitz
+environment = mainnet.blitz
 config_path = config/deployer/clean/examples/blitz-rotation.yaml
 launch_step = full
 ```

--- a/config/deployer/clean/cli/launch-config-file.ts
+++ b/config/deployer/clean/cli/launch-config-file.ts
@@ -286,6 +286,7 @@ function buildRotationLaunchConfigArgs(record: LaunchConfigRecord, configPath: s
     "evaluation-interval-minutes",
     resolveOptionalNumberValue(record, ["evaluationIntervalMinutes", "evaluation_interval_minutes"]),
   );
+  setOptionalJsonArg(args, "weekly-cadence-json", resolveValue(record, ["weeklyCadence", "weekly_cadence"]));
   applySharedLaunchArgs(record, args);
   setOptionalJsonArg(args, "target-game-names-json", resolveValue(record, ["targetGameNames", "target_game_names"]));
   setOptionalBooleanArg(
@@ -343,6 +344,7 @@ function applyConfigOwnedTargetArgs(mergedArgs: CliArgs, configArgs: CliArgs): v
       delete mergedArgs["max-games"];
       delete mergedArgs["advance-window-games"];
       delete mergedArgs["evaluation-interval-minutes"];
+      delete mergedArgs["weekly-cadence-json"];
       return;
     case "rotation":
       mergedArgs["rotation-name"] = configArgs["rotation-name"];
@@ -353,6 +355,9 @@ function applyConfigOwnedTargetArgs(mergedArgs: CliArgs, configArgs: CliArgs): v
         mergedArgs["advance-window-games"] = configArgs["advance-window-games"];
       }
       mergedArgs["evaluation-interval-minutes"] = configArgs["evaluation-interval-minutes"];
+      if (configArgs["weekly-cadence-json"]) {
+        mergedArgs["weekly-cadence-json"] = configArgs["weekly-cadence-json"];
+      }
       delete mergedArgs.game;
       delete mergedArgs["start-time"];
       delete mergedArgs["series-name"];
@@ -375,6 +380,7 @@ function applyConfigOwnedTargetArgs(mergedArgs: CliArgs, configArgs: CliArgs): v
       delete mergedArgs["max-games"];
       delete mergedArgs["advance-window-games"];
       delete mergedArgs["evaluation-interval-minutes"];
+      delete mergedArgs["weekly-cadence-json"];
       return;
   }
 }

--- a/config/deployer/clean/cli/launch-request.ts
+++ b/config/deployer/clean/cli/launch-request.ts
@@ -13,6 +13,7 @@ import type {
   LaunchGameStepId,
   LaunchRotationRequest,
   LaunchRotationStepId,
+  LaunchRotationWeeklyCadenceEntry,
   LaunchSeriesRequest,
   LaunchSeriesStepId,
   LaunchTargetKind,
@@ -278,6 +279,100 @@ function resolveTargetGameNamesJson(args: Args): string[] | undefined {
   return normalizedGameNames;
 }
 
+const WEEKLY_CADENCE_WEEKDAYS = new Set<LaunchRotationWeeklyCadenceEntry["weekday"]>([
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+]);
+
+function resolveWeeklyCadenceJson(args: Args): LaunchRotationWeeklyCadenceEntry[] | undefined {
+  const rawValue = resolveOptionalArg(args, "weekly-cadence-json", ["GAME_LAUNCH_WEEKLY_CADENCE_JSON"]);
+
+  if (!rawValue) {
+    return undefined;
+  }
+
+  let parsedValue: unknown;
+
+  try {
+    parsedValue = JSON.parse(rawValue);
+  } catch {
+    throw new Error("weekly cadence JSON must be valid JSON");
+  }
+
+  if (!Array.isArray(parsedValue) || parsedValue.length === 0) {
+    throw new Error("weekly cadence JSON must be a non-empty array");
+  }
+
+  return parsedValue.map((entry, index) => normalizeWeeklyCadenceEntry(entry, index));
+}
+
+function normalizeWeeklyCadenceEntry(entry: unknown, index: number): LaunchRotationWeeklyCadenceEntry {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(`weekly cadence JSON entry ${index + 1} must be an object`);
+  }
+
+  const record = entry as Record<string, unknown>;
+  const gameNamePrefix = normalizeWeeklyCadenceString(record.gameNamePrefix, "gameNamePrefix", index);
+  const weekday = normalizeWeeklyCadenceWeekday(record.weekday, index);
+  const utcTime = normalizeWeeklyCadenceTime(record.utcTime, index);
+  const blitzRegistrationOverrides = normalizeWeeklyCadenceRegistrationOverrides(
+    record.blitzRegistrationOverrides,
+    index,
+  );
+
+  return {
+    gameNamePrefix,
+    weekday,
+    utcTime,
+    ...(blitzRegistrationOverrides ? { blitzRegistrationOverrides } : {}),
+  };
+}
+
+function normalizeWeeklyCadenceString(value: unknown, label: string, index: number): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`weekly cadence JSON entry ${index + 1} requires a non-empty ${label}`);
+  }
+
+  return value.trim();
+}
+
+function normalizeWeeklyCadenceWeekday(value: unknown, index: number): LaunchRotationWeeklyCadenceEntry["weekday"] {
+  const weekday = normalizeWeeklyCadenceString(value, "weekday", index).toLowerCase();
+  if (!WEEKLY_CADENCE_WEEKDAYS.has(weekday as LaunchRotationWeeklyCadenceEntry["weekday"])) {
+    throw new Error(`weekly cadence JSON entry ${index + 1} has an unsupported weekday`);
+  }
+
+  return weekday as LaunchRotationWeeklyCadenceEntry["weekday"];
+}
+
+function normalizeWeeklyCadenceTime(value: unknown, index: number): string {
+  const utcTime = normalizeWeeklyCadenceString(value, "utcTime", index);
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(utcTime);
+  if (!match) {
+    throw new Error(`weekly cadence JSON entry ${index + 1} utcTime must be HH:MM in UTC`);
+  }
+
+  return utcTime;
+}
+
+function normalizeWeeklyCadenceRegistrationOverrides(value: unknown, index: number) {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`weekly cadence JSON entry ${index + 1} blitzRegistrationOverrides must be an object`);
+  }
+
+  validateBlitzRegistrationOverrideEntries(value as Record<string, unknown>);
+  return value as LaunchRotationWeeklyCadenceEntry["blitzRegistrationOverrides"];
+}
+
 function requireSeriesLaunchArgs(args: Args): {
   environmentId: LaunchSeriesRequest["environmentId"];
   seriesName: string;
@@ -305,6 +400,7 @@ function requireRotationLaunchArgs(args: Args): {
   maxGames: number;
   advanceWindowGames?: number;
   evaluationIntervalMinutes: number;
+  weeklyCadence?: LaunchRotationWeeklyCadenceEntry[];
 } {
   const environmentId = args.environment;
   const rotationName = resolveOptionalArg(args, "rotation-name", ["GAME_LAUNCH_ROTATION_NAME"]);
@@ -322,17 +418,18 @@ function requireRotationLaunchArgs(args: Args): {
     resolveOptionalArg(args, "evaluation-interval-minutes", ["GAME_LAUNCH_EVALUATION_INTERVAL_MINUTES"]),
     "evaluation interval minutes",
   );
+  const weeklyCadence = resolveWeeklyCadenceJson(args);
 
   if (
     !environmentId ||
     !rotationName ||
     !firstGameStartTime ||
-    gameIntervalMinutes === undefined ||
+    (gameIntervalMinutes === undefined && !weeklyCadence) ||
     maxGames === undefined ||
     evaluationIntervalMinutes === undefined
   ) {
     throw new Error(
-      "--environment, --rotation-name, --first-game-start-time, --game-interval-minutes, --max-games, and --evaluation-interval-minutes are required for rotation launches",
+      "--environment, --rotation-name, --first-game-start-time, --max-games, and --evaluation-interval-minutes are required for rotation launches, plus either --game-interval-minutes or --weekly-cadence-json",
     );
   }
 
@@ -340,10 +437,11 @@ function requireRotationLaunchArgs(args: Args): {
     environmentId: environmentId as LaunchRotationRequest["environmentId"],
     rotationName,
     firstGameStartTime,
-    gameIntervalMinutes,
+    gameIntervalMinutes: gameIntervalMinutes ?? 0,
     maxGames,
     advanceWindowGames,
     evaluationIntervalMinutes,
+    weeklyCadence,
   };
 }
 
@@ -448,6 +546,7 @@ export function buildLaunchRotationRequest(args: Args): LaunchRotationRequest {
     gameIntervalMinutes: requiredArgs.gameIntervalMinutes,
     maxGames: requiredArgs.maxGames,
     advanceWindowGames: requiredArgs.advanceWindowGames,
+    weeklyCadence: requiredArgs.weeklyCadence,
     targetGameNames: resolveTargetGameNamesJson(resolvedArgs),
     evaluationIntervalMinutes: requiredArgs.evaluationIntervalMinutes,
     ...resolveSharedLaunchRequestOptions(resolvedArgs),

--- a/config/deployer/clean/cli/launch-run-store.ts
+++ b/config/deployer/clean/cli/launch-run-store.ts
@@ -47,7 +47,7 @@ function usage(): void {
       "  --series-name <series-name> --series-games-json <json-array>",
       "",
       "Rotation launch:",
-      "  --rotation-name <rotation-name> --first-game-start-time <unix|iso> --game-interval-minutes <n> --max-games <n> --evaluation-interval-minutes <n>",
+      "  --rotation-name <rotation-name> --first-game-start-time <unix|iso> --max-games <n> --evaluation-interval-minutes <n> (--game-interval-minutes <n> or --weekly-cadence-json <json-array>)",
       "",
       "Required for step events:",
       "  --step <single-game-step-id|series-step-id>",
@@ -228,7 +228,7 @@ main().catch((error: unknown) => {
     message.includes("--environment, --game, and --start-time are required") ||
     message.includes("--environment and --series-name are required for series launches") ||
     message.includes(
-      "--environment, --rotation-name, --first-game-start-time, --game-interval-minutes, --max-games, and --evaluation-interval-minutes are required for rotation launches",
+      "--environment, --rotation-name, --first-game-start-time, --max-games, and --evaluation-interval-minutes are required for rotation launches",
     ) ||
     message.includes("--series-games-json is required for series launches") ||
     message.includes('Unsupported run-store event "') ||

--- a/config/deployer/clean/cli/launch-step.ts
+++ b/config/deployer/clean/cli/launch-step.ts
@@ -37,7 +37,7 @@ function usage(): void {
       "  --series-name <series-name> --series-games-json <json-array>",
       "",
       "Rotation launch:",
-      "  --rotation-name <rotation-name> --first-game-start-time <unix|iso> --game-interval-minutes <n> --max-games <n> --evaluation-interval-minutes <n>",
+      "  --rotation-name <rotation-name> --first-game-start-time <unix|iso> --max-games <n> --evaluation-interval-minutes <n> (--game-interval-minutes <n> or --weekly-cadence-json <json-array>)",
       "",
       "Optional env or flags:",
       "  GAME_LAUNCH_CONFIG_PATH / --config-path",
@@ -59,6 +59,7 @@ function usage(): void {
       "  DURATION_SECONDS=<integer> / --duration-seconds <integer>",
       "  MAP_CONFIG_OVERRIDES_JSON=<json> / --map-config-overrides-json <json>",
       "  BLITZ_REGISTRATION_OVERRIDES_JSON=<json> / --blitz-registration-overrides-json <json>",
+      "  GAME_LAUNCH_WEEKLY_CADENCE_JSON=<json> / --weekly-cadence-json <json>",
       "  --auto-retry-enabled <true|false>",
       "  --auto-retry-interval-minutes <number>",
       "  --mode <batched|sequential>",
@@ -160,7 +161,7 @@ main().catch((error: unknown) => {
     message.includes("--environment, --game, and --start-time are required") ||
     message.includes("--environment and --series-name are required for series launches") ||
     message.includes(
-      "--environment, --rotation-name, --first-game-start-time, --game-interval-minutes, --max-games, and --evaluation-interval-minutes are required for rotation launches",
+      "--environment, --rotation-name, --first-game-start-time, --max-games, and --evaluation-interval-minutes are required for rotation launches",
     ) ||
     message.includes("--series-games-json is required for series launches") ||
     message.includes('Unsupported launch step "') ||

--- a/config/deployer/clean/cli/launch-workflow-env.ts
+++ b/config/deployer/clean/cli/launch-workflow-env.ts
@@ -31,6 +31,9 @@ function buildReplayableLaunchOptions(request: LaunchRequest): Record<string, un
   assignOptionalLaunchOption(launchOptions, "singleRealmMode", request.singleRealmMode);
   assignOptionalLaunchOption(launchOptions, "twoPlayerMode", request.twoPlayerMode);
   assignOptionalLaunchOption(launchOptions, "durationSeconds", request.durationSeconds);
+  if (request.launchKind === "rotation") {
+    assignOptionalLaunchOption(launchOptions, "weeklyCadence", request.weeklyCadence);
+  }
   assignOptionalLaunchOption(launchOptions, "mapConfigOverrides", request.mapConfigOverrides);
   assignOptionalLaunchOption(launchOptions, "blitzRegistrationOverrides", request.blitzRegistrationOverrides);
   assignOptionalLaunchOption(launchOptions, "cartridgeApiBase", request.cartridgeApiBase);
@@ -140,6 +143,10 @@ function assignRotationWorkflowEnvironment(
   environment.GAME_LAUNCH_MAX_GAMES = String(request.maxGames);
   environment.GAME_LAUNCH_EVALUATION_INTERVAL_MINUTES = String(request.evaluationIntervalMinutes);
   environment.GAME_LAUNCH_AUTO_RETRY_ENABLED = request.autoRetryEnabled === false ? "false" : "true";
+
+  if (request.weeklyCadence?.length) {
+    environment.GAME_LAUNCH_WEEKLY_CADENCE_JSON = JSON.stringify(request.weeklyCadence);
+  }
 
   if (request.advanceWindowGames !== undefined) {
     environment.GAME_LAUNCH_ADVANCE_WINDOW_GAMES = String(request.advanceWindowGames);

--- a/config/deployer/clean/examples/blitz-rotation.yaml
+++ b/config/deployer/clean/examples/blitz-rotation.yaml
@@ -1,5 +1,5 @@
 launchKind: rotation
-environmentId: slot.blitz
+environmentId: mainnet.blitz
 rotationName: blitz-rotation
 firstGameStartTime: 2026-04-20T01:00:00Z
 maxGames: 5200

--- a/config/deployer/clean/examples/blitz-rotation.yaml
+++ b/config/deployer/clean/examples/blitz-rotation.yaml
@@ -1,0 +1,72 @@
+launchKind: rotation
+environmentId: slot.blitz
+rotationName: blitz-rotation
+firstGameStartTime: 2026-04-20T01:00:00Z
+maxGames: 5200
+advanceWindowGames: 5
+evaluationIntervalMinutes: 15
+autoRetryEnabled: true
+autoRetryIntervalMinutes: 15
+durationSeconds: 3600
+
+weeklyCadence:
+  - gameNamePrefix: na-gladiator
+    weekday: monday
+    utcTime: "01:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: apac-gladiator
+    weekday: tuesday
+    utcTime: "11:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: na-gladiator
+    weekday: wednesday
+    utcTime: "02:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: eu-gladiator
+    weekday: wednesday
+    utcTime: "19:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: apac-gladiator
+    weekday: thursday
+    utcTime: "10:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: na-gladiator
+    weekday: friday
+    utcTime: "01:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: eu-gladiator
+    weekday: friday
+    utcTime: "18:00"
+    blitzRegistrationOverrides:
+      fee_amount: "500000000000000000000"
+  - gameNamePrefix: apac-gladiator
+    weekday: saturday
+    utcTime: "12:00"
+    blitzRegistrationOverrides:
+      fee_amount: "1000000000000000000000"
+  - gameNamePrefix: eu-gladiator
+    weekday: saturday
+    utcTime: "20:00"
+    blitzRegistrationOverrides:
+      fee_amount: "1000000000000000000000"
+  - gameNamePrefix: na-gladiator
+    weekday: sunday
+    utcTime: "03:00"
+    blitzRegistrationOverrides:
+      fee_amount: "1000000000000000000000"
+  - gameNamePrefix: apac-gladiator
+    weekday: sunday
+    utcTime: "11:00"
+    blitzRegistrationOverrides:
+      fee_amount: "1000000000000000000000"
+  - gameNamePrefix: eu-gladiator
+    weekday: sunday
+    utcTime: "19:00"
+    blitzRegistrationOverrides:
+      fee_amount: "1000000000000000000000"

--- a/config/deployer/clean/launch/rotation-summary.ts
+++ b/config/deployer/clean/launch/rotation-summary.ts
@@ -146,7 +146,9 @@ function buildWeeklyCadenceGameName(gameNamePrefix: string, startTime: number): 
   const day = String(date.getUTCDate()).padStart(2, "0");
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
   const year = String(date.getUTCFullYear()).slice(-2);
-  return `${toRotationSlug(gameNamePrefix) || "rotation"}-${day}-${month}-${year}`;
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${toRotationSlug(gameNamePrefix) || "rotation"}-${day}-${month}-${year}-${hour}${minute}`;
 }
 
 function toRotationSlug(value: string): string {

--- a/config/deployer/clean/launch/rotation-summary.ts
+++ b/config/deployer/clean/launch/rotation-summary.ts
@@ -4,6 +4,7 @@ import { readFactorySeriesState } from "../factory/series";
 import type {
   LaunchRotationRequest,
   LaunchRotationSummary,
+  LaunchRotationWeeklyCadenceEntry,
   RotationLaunchStepId,
   SeriesLaunchGameStepState,
   SeriesLaunchGameSummary,
@@ -14,6 +15,22 @@ import { parseStartTime, toIsoUtc } from "./time";
 
 export const DEFAULT_ROTATION_AUTO_RETRY_INTERVAL_MINUTES = 15;
 export const DEFAULT_ROTATION_ADVANCE_WINDOW_GAMES = 5;
+const WEEKLY_CADENCE_PERIOD_SECONDS = 7 * 24 * 60 * 60;
+const WEEKDAY_OFFSET_DAYS: Record<LaunchRotationWeeklyCadenceEntry["weekday"], number> = {
+  monday: 0,
+  tuesday: 1,
+  wednesday: 2,
+  thursday: 3,
+  friday: 4,
+  saturday: 5,
+  sunday: 6,
+};
+
+interface PlannedRotationGame {
+  startTime: number;
+  gameNamePrefix?: string;
+  blitzRegistrationOverrides?: LaunchRotationWeeklyCadenceEntry["blitzRegistrationOverrides"];
+}
 
 export function resolveDefaultRotationRetryIntervalMinutes(request: LaunchRotationRequest): number {
   return request.autoRetryIntervalMinutes ?? DEFAULT_ROTATION_AUTO_RETRY_INTERVAL_MINUTES;
@@ -28,7 +45,12 @@ export function validateRotationLaunchRequest(request: LaunchRotationRequest): v
     throw new Error("Rotation name is required");
   }
 
-  validateRotationPositiveInteger(request.gameIntervalMinutes, "game interval minutes");
+  if (hasWeeklyCadence(request)) {
+    validateWeeklyCadence(request.weeklyCadence);
+  } else {
+    validateRotationPositiveInteger(request.gameIntervalMinutes, "game interval minutes");
+  }
+
   validateRotationPositiveInteger(request.maxGames, "max games");
   validateRotationPositiveInteger(request.evaluationIntervalMinutes, "evaluation interval minutes");
   validateRotationPositiveInteger(resolveRotationAdvanceWindowGames(request), "advance window games");
@@ -46,6 +68,40 @@ function validateRotationPositiveInteger(value: number, label: string): void {
   }
 }
 
+function hasWeeklyCadence(request: Pick<LaunchRotationRequest, "weeklyCadence">): boolean {
+  return Boolean(request.weeklyCadence?.length);
+}
+
+function validateWeeklyCadence(weeklyCadence: LaunchRotationWeeklyCadenceEntry[] | undefined): void {
+  if (!weeklyCadence?.length) {
+    throw new Error("weekly cadence must include at least one entry");
+  }
+
+  const scheduledOffsets = new Set<number>();
+  for (const entry of weeklyCadence) {
+    validateWeeklyCadenceEntry(entry);
+    const scheduledOffset = resolveWeeklyCadenceOffsetSeconds(entry);
+    if (scheduledOffsets.has(scheduledOffset)) {
+      throw new Error(`weekly cadence contains more than one game at ${entry.weekday} ${entry.utcTime} UTC`);
+    }
+    scheduledOffsets.add(scheduledOffset);
+  }
+}
+
+function validateWeeklyCadenceEntry(entry: LaunchRotationWeeklyCadenceEntry): void {
+  if (!entry.gameNamePrefix.trim()) {
+    throw new Error("weekly cadence gameNamePrefix must be a non-empty string");
+  }
+
+  if (!(entry.weekday in WEEKDAY_OFFSET_DAYS)) {
+    throw new Error(`weekly cadence weekday "${entry.weekday}" is not supported`);
+  }
+
+  if (!/^([01]\d|2[0-3]):([0-5]\d)$/.test(entry.utcTime)) {
+    throw new Error(`weekly cadence utcTime "${entry.utcTime}" must be HH:MM in UTC`);
+  }
+}
+
 function buildInitialRotationGameStepStates(stepIds: RotationLaunchStepId[]): SeriesLaunchGameStepState[] {
   return stepIds.map((stepId) => ({
     id: stepId,
@@ -60,12 +116,15 @@ function buildRotationGameSummary(
   startTime: number,
   stepIds: RotationLaunchStepId[],
   defaultDurationSeconds: number | undefined,
+  gameName?: string,
+  blitzRegistrationOverrides?: LaunchRotationWeeklyCadenceEntry["blitzRegistrationOverrides"],
 ): SeriesLaunchGameSummary {
   return {
-    gameName: buildRotationGameName(rotationName, seriesGameNumber),
+    gameName: gameName ?? buildRotationGameName(rotationName, seriesGameNumber),
     startTime,
     startTimeIso: toIsoUtc(startTime),
     durationSeconds: defaultDurationSeconds,
+    ...(blitzRegistrationOverrides ? { blitzRegistrationOverrides } : {}),
     seriesGameNumber,
     currentStepId: null,
     latestEvent: "Waiting to run",
@@ -77,13 +136,25 @@ function buildRotationGameSummary(
 }
 
 function buildRotationGameName(rotationName: string, seriesGameNumber: number): string {
-  const slug = rotationName
+  const slug = toRotationSlug(rotationName);
+
+  return `${slug || "rotation"}-${String(seriesGameNumber).padStart(2, "0")}`;
+}
+
+function buildWeeklyCadenceGameName(gameNamePrefix: string, startTime: number): string {
+  const date = new Date(startTime * 1000);
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const year = String(date.getUTCFullYear()).slice(-2);
+  return `${toRotationSlug(gameNamePrefix) || "rotation"}-${day}-${month}-${year}`;
+}
+
+function toRotationSlug(value: string): string {
+  return value
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-
-  return `${slug || "rotation"}-${String(seriesGameNumber).padStart(2, "0")}`;
 }
 
 export function buildInitialRotationLaunchSummary(request: LaunchRotationRequest): LaunchRotationSummary {
@@ -102,6 +173,7 @@ export function buildInitialRotationLaunchSummary(request: LaunchRotationRequest
     maxGames: request.maxGames,
     advanceWindowGames: resolveRotationAdvanceWindowGames(request),
     evaluationIntervalMinutes: request.evaluationIntervalMinutes,
+    weeklyCadence: request.weeklyCadence,
     rpcUrl: request.rpcUrl || environment.rpcUrl,
     factoryAddress: request.factoryAddress || environment.factoryAddress || "",
     autoRetryEnabled: request.autoRetryEnabled ?? true,
@@ -125,6 +197,7 @@ function applyRotationRequestSettings(
     autoRetryIntervalMinutes: resolveDefaultRotationRetryIntervalMinutes(request),
     dryRun: request.dryRun === true,
     configMode: request.executionMode || summary.configMode,
+    weeklyCadence: request.weeklyCadence ?? summary.weeklyCadence,
   };
 }
 
@@ -188,20 +261,84 @@ async function assignRotationGameNumbers(
   };
 }
 
-function resolveNextRotationStartTime(summary: LaunchRotationSummary, nowSeconds: number): number {
+function resolveNextFixedRotationStartTime(summary: LaunchRotationSummary, afterSeconds: number): number {
   const lastPlannedStartTime = summary.games.at(-1)?.startTime;
-  if (lastPlannedStartTime) {
+  if (lastPlannedStartTime && afterSeconds <= lastPlannedStartTime) {
     return lastPlannedStartTime + summary.gameIntervalMinutes * 60;
   }
 
-  if (summary.firstGameStartTime >= nowSeconds) {
+  if (summary.firstGameStartTime > afterSeconds) {
     return summary.firstGameStartTime;
   }
 
   const intervalSeconds = summary.gameIntervalMinutes * 60;
-  const elapsedSeconds = nowSeconds - summary.firstGameStartTime;
+  const elapsedSeconds = afterSeconds - summary.firstGameStartTime;
   const skippedIntervals = Math.floor(elapsedSeconds / intervalSeconds) + 1;
   return summary.firstGameStartTime + skippedIntervals * intervalSeconds;
+}
+
+function resolveNextWeeklyCadenceGame(summary: LaunchRotationSummary, afterSeconds: number): PlannedRotationGame {
+  const cadence = resolveSortedWeeklyCadence(summary);
+  const weekStartSeconds = resolveCadenceWeekStartSeconds(summary.firstGameStartTime);
+  const searchStartSeconds = Math.max(afterSeconds + 1, summary.firstGameStartTime);
+  const firstWeekIndex = Math.max(
+    0,
+    Math.floor((searchStartSeconds - weekStartSeconds) / WEEKLY_CADENCE_PERIOD_SECONDS),
+  );
+
+  for (let weekIndex = firstWeekIndex; weekIndex <= firstWeekIndex + 1; weekIndex += 1) {
+    for (const entry of cadence) {
+      const startTime = weekStartSeconds + weekIndex * WEEKLY_CADENCE_PERIOD_SECONDS + entry.offsetSeconds;
+      if (startTime >= summary.firstGameStartTime && startTime > afterSeconds) {
+        return {
+          startTime,
+          gameNamePrefix: entry.gameNamePrefix,
+          blitzRegistrationOverrides: entry.blitzRegistrationOverrides,
+        };
+      }
+    }
+  }
+
+  throw new Error(`Unable to resolve the next weekly rotation game for ${summary.rotationName}`);
+}
+
+function resolveNextRotationGame(summary: LaunchRotationSummary, afterSeconds: number): PlannedRotationGame {
+  if (summary.weeklyCadence?.length) {
+    return resolveNextWeeklyCadenceGame(summary, afterSeconds);
+  }
+
+  return {
+    startTime: resolveNextFixedRotationStartTime(summary, afterSeconds),
+  };
+}
+
+function resolveSortedWeeklyCadence(summary: LaunchRotationSummary) {
+  if (!summary.weeklyCadence?.length) {
+    throw new Error("weekly cadence must include at least one entry");
+  }
+
+  return summary.weeklyCadence
+    .map((entry) => ({
+      ...entry,
+      offsetSeconds: resolveWeeklyCadenceOffsetSeconds(entry),
+    }))
+    .sort(
+      (left, right) =>
+        left.offsetSeconds - right.offsetSeconds || left.gameNamePrefix.localeCompare(right.gameNamePrefix),
+    );
+}
+
+function resolveWeeklyCadenceOffsetSeconds(entry: LaunchRotationWeeklyCadenceEntry): number {
+  const [hour = "0", minute = "0"] = entry.utcTime.split(":");
+  return (WEEKDAY_OFFSET_DAYS[entry.weekday] * 24 * 60 + Number(hour) * 60 + Number(minute)) * 60;
+}
+
+function resolveCadenceWeekStartSeconds(firstGameStartTime: number): number {
+  const date = new Date(firstGameStartTime * 1000);
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
+  return Math.floor(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - daysSinceMonday, 0, 0, 0) / 1000,
+  );
 }
 
 function resolveRotationGamesToAdd(summary: LaunchRotationSummary, nowSeconds: number): number {
@@ -230,14 +367,22 @@ export function reconcileRotationLaunchSummary(
   const stepIds = resolveSeriesLaunchStepIds(request.environmentId);
   const nextGames = [...summary.games];
   let nextGameNumber = Math.max(0, ...nextGames.map((game) => game.seriesGameNumber));
-  let nextStartTime = resolveNextRotationStartTime(summary, nowSeconds);
+  let nextGame = resolveNextRotationGame(summary, nextGames.at(-1)?.startTime ?? nowSeconds);
 
   for (let index = 0; index < gamesToAdd; index += 1) {
     nextGameNumber += 1;
     nextGames.push(
-      buildRotationGameSummary(summary.rotationName, nextGameNumber, nextStartTime, stepIds, request.durationSeconds),
+      buildRotationGameSummary(
+        summary.rotationName,
+        nextGameNumber,
+        nextGame.startTime,
+        stepIds,
+        request.durationSeconds,
+        nextGame.gameNamePrefix ? buildWeeklyCadenceGameName(nextGame.gameNamePrefix, nextGame.startTime) : undefined,
+        nextGame.blitzRegistrationOverrides,
+      ),
     );
-    nextStartTime += summary.gameIntervalMinutes * 60;
+    nextGame = resolveNextRotationGame(summary, nextGame.startTime);
   }
 
   return applyRotationRequestSettings(

--- a/config/deployer/clean/launch/series-like-runner.ts
+++ b/config/deployer/clean/launch/series-like-runner.ts
@@ -145,7 +145,7 @@ function buildSeriesLikeGameRequest(
     twoPlayerMode: request.twoPlayerMode,
     durationSeconds: request.durationSeconds,
     mapConfigOverrides: request.mapConfigOverrides,
-    blitzRegistrationOverrides: request.blitzRegistrationOverrides,
+    blitzRegistrationOverrides: game.blitzRegistrationOverrides ?? request.blitzRegistrationOverrides,
     cartridgeApiBase: request.cartridgeApiBase,
     toriiNamespaces: request.toriiNamespaces,
     vrfProviderAddress: request.vrfProviderAddress,

--- a/config/deployer/clean/run-store/cloudflare-worker.js
+++ b/config/deployer/clean/run-store/cloudflare-worker.js
@@ -340,6 +340,7 @@ async function handleCreateFactoryRotationRun(request, env) {
     maxGames: body.maxGames,
     advanceWindowGames: body.advanceWindowGames,
     evaluationIntervalMinutes: body.evaluationIntervalMinutes,
+    weeklyCadence: body.weeklyCadence,
     devModeOn: body.devModeOn,
     singleRealmMode: body.singleRealmMode,
     twoPlayerMode: body.twoPlayerMode,
@@ -1135,7 +1136,13 @@ function validateCreateFactoryRotationRunBody(body) {
   validateWorkflowRef(body.workflowRef);
   validateMapConfigOverrides(body.mapConfigOverrides);
   validateBlitzRegistrationOverrides(body.blitzRegistrationOverrides);
-  validatePositiveNumber(body.gameIntervalMinutes, "gameIntervalMinutes");
+
+  if (hasWeeklyCadence(body)) {
+    validateWeeklyCadence(body.weeklyCadence);
+  } else {
+    validatePositiveNumber(body.gameIntervalMinutes, "gameIntervalMinutes");
+  }
+
   validatePositiveNumber(body.maxGames, "maxGames");
   validatePositiveNumber(body.evaluationIntervalMinutes, "evaluationIntervalMinutes");
 
@@ -1153,6 +1160,42 @@ function validateCreateFactoryRotationRunBody(body) {
   if (body.autoRetryIntervalMinutes !== undefined) {
     validatePositiveNumber(body.autoRetryIntervalMinutes, "autoRetryIntervalMinutes");
   }
+}
+
+const WEEKLY_CADENCE_WEEKDAYS = new Set(["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]);
+
+function hasWeeklyCadence(body) {
+  return Array.isArray(body.weeklyCadence) && body.weeklyCadence.length > 0;
+}
+
+function validateWeeklyCadence(weeklyCadence) {
+  if (!Array.isArray(weeklyCadence) || weeklyCadence.length === 0) {
+    throw new HttpError(400, "weeklyCadence must be a non-empty array");
+  }
+
+  for (const [index, entry] of weeklyCadence.entries()) {
+    validateWeeklyCadenceEntry(entry, index);
+  }
+}
+
+function validateWeeklyCadenceEntry(entry, index) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new HttpError(400, `weeklyCadence entry ${index + 1} must be an object`);
+  }
+
+  if (typeof entry.gameNamePrefix !== "string" || !entry.gameNamePrefix.trim()) {
+    throw new HttpError(400, `weeklyCadence entry ${index + 1} requires gameNamePrefix`);
+  }
+
+  if (typeof entry.weekday !== "string" || !WEEKLY_CADENCE_WEEKDAYS.has(entry.weekday.toLowerCase())) {
+    throw new HttpError(400, `weeklyCadence entry ${index + 1} has an unsupported weekday`);
+  }
+
+  if (typeof entry.utcTime !== "string" || !/^([01]\d|2[0-3]):([0-5]\d)$/.test(entry.utcTime)) {
+    throw new HttpError(400, `weeklyCadence entry ${index + 1} utcTime must be HH:MM in UTC`);
+  }
+
+  validateBlitzRegistrationOverrides(entry.blitzRegistrationOverrides);
 }
 
 function validateContinueFactoryRunBody(body) {
@@ -1432,6 +1475,7 @@ function buildContinueRotationWorkflowRequest(route, run, inputRecord, launchSte
     maxGames: rawRequest.maxGames,
     advanceWindowGames: rawRequest.advanceWindowGames,
     evaluationIntervalMinutes: rawRequest.evaluationIntervalMinutes,
+    weeklyCadence: rawRequest.weeklyCadence,
     rpcUrl: rawRequest.rpcUrl,
     factoryAddress: rawRequest.factoryAddress,
     devModeOn: rawRequest.devModeOn,
@@ -3033,6 +3077,7 @@ function buildReplayableLaunchOptions(request) {
   assignOptionalLaunchOption(launchOptions, "singleRealmMode", request.singleRealmMode);
   assignOptionalLaunchOption(launchOptions, "twoPlayerMode", request.twoPlayerMode);
   assignOptionalLaunchOption(launchOptions, "durationSeconds", request.durationSeconds);
+  assignOptionalLaunchOption(launchOptions, "weeklyCadence", request.weeklyCadence);
   assignOptionalLaunchOption(launchOptions, "mapConfigOverrides", request.mapConfigOverrides);
   assignOptionalLaunchOption(launchOptions, "blitzRegistrationOverrides", request.blitzRegistrationOverrides);
   assignOptionalLaunchOption(launchOptions, "cartridgeApiBase", request.cartridgeApiBase);

--- a/config/deployer/clean/run-store/cloudflare-worker.js
+++ b/config/deployer/clean/run-store/cloudflare-worker.js
@@ -1173,9 +1173,19 @@ function validateWeeklyCadence(weeklyCadence) {
     throw new HttpError(400, "weeklyCadence must be a non-empty array");
   }
 
+  const scheduledOffsets = new Set();
   for (const [index, entry] of weeklyCadence.entries()) {
     validateWeeklyCadenceEntry(entry, index);
+    const scheduledOffset = resolveWeeklyCadenceOffsetKey(entry);
+    if (scheduledOffsets.has(scheduledOffset)) {
+      throw new HttpError(400, `weeklyCadence contains more than one game at ${entry.weekday} ${entry.utcTime} UTC`);
+    }
+    scheduledOffsets.add(scheduledOffset);
   }
+}
+
+function resolveWeeklyCadenceOffsetKey(entry) {
+  return `${entry.weekday.toLowerCase()}-${entry.utcTime}`;
 }
 
 function validateWeeklyCadenceEntry(entry, index) {

--- a/config/deployer/clean/run-store/persisted-launch-request.ts
+++ b/config/deployer/clean/run-store/persisted-launch-request.ts
@@ -190,6 +190,7 @@ export function buildPersistedRotationLaunchRequest(
     gameIntervalMinutes: summary.gameIntervalMinutes,
     maxGames: summary.maxGames,
     advanceWindowGames: summary.advanceWindowGames,
+    weeklyCadence: summary.weeklyCadence,
     targetGameNames: undefined,
     evaluationIntervalMinutes: summary.evaluationIntervalMinutes,
     autoRetryEnabled: summary.autoRetryEnabled,

--- a/config/deployer/clean/tests/cloudflare-worker.test.ts
+++ b/config/deployer/clean/tests/cloudflare-worker.test.ts
@@ -250,6 +250,40 @@ describe("factory worker map config overrides", () => {
     ]);
   });
 
+  test("rejects duplicate weekly cadence slots before dispatching the workflow", async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url: String(url), init });
+      throw new Error(`Unexpected fetch call: ${String(url)}`);
+    };
+
+    const response = await worker.fetch(
+      new Request("https://worker.example/api/factory/rotation-runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          environment: "slot.blitz",
+          rotationName: "blitz-rotation",
+          firstGameStartTime: "2026-04-20T01:00:00Z",
+          maxGames: 5200,
+          advanceWindowGames: 5,
+          evaluationIntervalMinutes: 15,
+          weeklyCadence: [
+            { gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" },
+            { gameNamePrefix: "eu-gladiator", weekday: "monday", utcTime: "01:00" },
+          ],
+        }),
+      }),
+      buildWorkerEnv(),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "weeklyCadence contains more than one game at monday 01:00 UTC",
+    });
+    expect(fetchCalls).toHaveLength(0);
+  });
+
   test("reuses stored map config overrides during continue", async () => {
     const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
     globalThis.fetch = async (url, init) => {

--- a/config/deployer/clean/tests/cloudflare-worker.test.ts
+++ b/config/deployer/clean/tests/cloudflare-worker.test.ts
@@ -189,6 +189,67 @@ describe("factory worker map config overrides", () => {
     expect(dispatchBody.inputs.auto_retry_interval_minutes).toBe("15");
   });
 
+  test("dispatches weekly cadence rotations without a fixed game interval", async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    globalThis.fetch = async (url, init) => {
+      fetchCalls.push({ url: String(url), init });
+
+      if (String(url).includes("/contents/runs/slot/blitz/rotations/blitz-rotation.json")) {
+        return new Response("{}", { status: 404 });
+      }
+
+      if (String(url).includes("/actions/workflows/game-launch.yml/dispatches")) {
+        return new Response(null, { status: 204 });
+      }
+
+      throw new Error(`Unexpected fetch call: ${String(url)}`);
+    };
+
+    const response = await worker.fetch(
+      new Request("https://worker.example/api/factory/rotation-runs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          environment: "slot.blitz",
+          rotationName: "blitz-rotation",
+          firstGameStartTime: "2026-04-20T01:00:00Z",
+          maxGames: 5200,
+          advanceWindowGames: 5,
+          evaluationIntervalMinutes: 15,
+          weeklyCadence: [
+            {
+              gameNamePrefix: "na-gladiator",
+              weekday: "monday",
+              utcTime: "01:00",
+              blitzRegistrationOverrides: {
+                fee_amount: "500000000000000000000",
+              },
+            },
+          ],
+        }),
+      }),
+      buildWorkerEnv(),
+    );
+
+    const dispatchCall = fetchCalls.find((call) => call.url.includes("/actions/workflows/game-launch.yml/dispatches"));
+    const dispatchBody = JSON.parse(String(dispatchCall?.init?.body));
+    const launchOptions = parseLaunchOptionsInput(dispatchBody);
+
+    expect(response.status).toBe(202);
+    expect(dispatchBody.inputs.launch_kind).toBe("rotation");
+    expect(dispatchBody.inputs.game_interval_minutes).toBeUndefined();
+    expect(launchOptions.weeklyCadence).toEqual([
+      {
+        gameNamePrefix: "na-gladiator",
+        weekday: "monday",
+        utcTime: "01:00",
+        blitzRegistrationOverrides: {
+          fee_amount: "500000000000000000000",
+        },
+      },
+    ]);
+  });
+
   test("reuses stored map config overrides during continue", async () => {
     const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
     globalThis.fetch = async (url, init) => {

--- a/config/deployer/clean/tests/launch-request.test.ts
+++ b/config/deployer/clean/tests/launch-request.test.ts
@@ -167,6 +167,121 @@ games:
     });
   });
 
+  test("loads the committed blitz rotation as a rolling weekly cadence", () => {
+    const request = buildLaunchRotationRequest({
+      "config-path": "config/deployer/clean/examples/blitz-rotation.yaml",
+    });
+
+    expect(request).toMatchObject({
+      launchKind: "rotation",
+      environmentId: "slot.blitz",
+      rotationName: "blitz-rotation",
+      firstGameStartTime: "2026-04-20T01:00:00Z",
+      gameIntervalMinutes: 0,
+      maxGames: 5200,
+      advanceWindowGames: 5,
+      evaluationIntervalMinutes: 15,
+      durationSeconds: 3600,
+      autoRetryEnabled: true,
+      autoRetryIntervalMinutes: 15,
+      weeklyCadence: [
+        { gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" },
+        { gameNamePrefix: "apac-gladiator", weekday: "tuesday", utcTime: "11:00" },
+        { gameNamePrefix: "na-gladiator", weekday: "wednesday", utcTime: "02:00" },
+        { gameNamePrefix: "eu-gladiator", weekday: "wednesday", utcTime: "19:00" },
+        { gameNamePrefix: "apac-gladiator", weekday: "thursday", utcTime: "10:00" },
+        { gameNamePrefix: "na-gladiator", weekday: "friday", utcTime: "01:00" },
+        { gameNamePrefix: "eu-gladiator", weekday: "friday", utcTime: "18:00" },
+        { gameNamePrefix: "apac-gladiator", weekday: "saturday", utcTime: "12:00" },
+        { gameNamePrefix: "eu-gladiator", weekday: "saturday", utcTime: "20:00" },
+        { gameNamePrefix: "na-gladiator", weekday: "sunday", utcTime: "03:00" },
+        { gameNamePrefix: "apac-gladiator", weekday: "sunday", utcTime: "11:00" },
+        { gameNamePrefix: "eu-gladiator", weekday: "sunday", utcTime: "19:00" },
+      ],
+    });
+    expect(
+      request.weeklyCadence?.map((entry) => ({
+        gameNamePrefix: entry.gameNamePrefix,
+        weekday: entry.weekday,
+        utcTime: entry.utcTime,
+        feeAmount: entry.blitzRegistrationOverrides?.fee_amount,
+      })),
+    ).toEqual([
+      {
+        gameNamePrefix: "na-gladiator",
+        weekday: "monday",
+        utcTime: "01:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "apac-gladiator",
+        weekday: "tuesday",
+        utcTime: "11:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "na-gladiator",
+        weekday: "wednesday",
+        utcTime: "02:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "eu-gladiator",
+        weekday: "wednesday",
+        utcTime: "19:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "apac-gladiator",
+        weekday: "thursday",
+        utcTime: "10:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "na-gladiator",
+        weekday: "friday",
+        utcTime: "01:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "eu-gladiator",
+        weekday: "friday",
+        utcTime: "18:00",
+        feeAmount: "500000000000000000000",
+      },
+      {
+        gameNamePrefix: "apac-gladiator",
+        weekday: "saturday",
+        utcTime: "12:00",
+        feeAmount: "1000000000000000000000",
+      },
+      {
+        gameNamePrefix: "eu-gladiator",
+        weekday: "saturday",
+        utcTime: "20:00",
+        feeAmount: "1000000000000000000000",
+      },
+      {
+        gameNamePrefix: "na-gladiator",
+        weekday: "sunday",
+        utcTime: "03:00",
+        feeAmount: "1000000000000000000000",
+      },
+      {
+        gameNamePrefix: "apac-gladiator",
+        weekday: "sunday",
+        utcTime: "11:00",
+        feeAmount: "1000000000000000000000",
+      },
+      {
+        gameNamePrefix: "eu-gladiator",
+        weekday: "sunday",
+        utcTime: "19:00",
+        feeAmount: "1000000000000000000000",
+      },
+    ]);
+  });
+
   test("lets explicit CLI overrides win over YAML shared launch options", () => {
     const configPath = writeLaunchConfig(`
 launchKind: series

--- a/config/deployer/clean/tests/launch-request.test.ts
+++ b/config/deployer/clean/tests/launch-request.test.ts
@@ -174,7 +174,7 @@ games:
 
     expect(request).toMatchObject({
       launchKind: "rotation",
-      environmentId: "slot.blitz",
+      environmentId: "mainnet.blitz",
       rotationName: "blitz-rotation",
       firstGameStartTime: "2026-04-20T01:00:00Z",
       gameIntervalMinutes: 0,

--- a/config/deployer/clean/tests/launch-workflow-env.test.ts
+++ b/config/deployer/clean/tests/launch-workflow-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildLaunchWorkflowEnvironment } from "../cli/launch-workflow-env";
-import type { LaunchSeriesRequest } from "../types";
+import type { LaunchRotationRequest, LaunchSeriesRequest } from "../types";
 
 function buildSeriesRequest(overrides: Partial<LaunchSeriesRequest> = {}): LaunchSeriesRequest {
   return {
@@ -13,6 +13,22 @@ function buildSeriesRequest(overrides: Partial<LaunchSeriesRequest> = {}): Launc
     autoRetryIntervalMinutes: 15,
     workflowFile: "factory-torii-deployer.yml",
     ref: "feature/yaml-schedule",
+    ...overrides,
+  };
+}
+
+function buildRotationRequest(overrides: Partial<LaunchRotationRequest> = {}): LaunchRotationRequest {
+  return {
+    launchKind: "rotation",
+    environmentId: "slot.blitz",
+    rotationName: "blitz-rotation",
+    firstGameStartTime: "2026-04-20T01:00:00Z",
+    gameIntervalMinutes: 0,
+    maxGames: 5200,
+    advanceWindowGames: 5,
+    evaluationIntervalMinutes: 15,
+    durationSeconds: 3600,
+    weeklyCadence: [{ gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" }],
     ...overrides,
   };
 }
@@ -45,6 +61,18 @@ describe("launch workflow env", () => {
     expect(JSON.parse(environment.GAME_LAUNCH_OPTIONS_JSON)).toMatchObject({
       workflowFile: "factory-torii-deployer.yml",
       ref: "feature/yaml-schedule",
+    });
+  });
+
+  test("exports rotation weekly cadence for workflow replay", () => {
+    const environment = buildLaunchWorkflowEnvironment(buildRotationRequest());
+
+    expect(environment.GAME_LAUNCH_WEEKLY_CADENCE_JSON).toBe(
+      '[{"gameNamePrefix":"na-gladiator","weekday":"monday","utcTime":"01:00"}]',
+    );
+    expect(JSON.parse(environment.GAME_LAUNCH_OPTIONS_JSON)).toMatchObject({
+      durationSeconds: 3600,
+      weeklyCadence: [{ gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" }],
     });
   });
 });

--- a/config/deployer/clean/tests/rotation-summary.test.ts
+++ b/config/deployer/clean/tests/rotation-summary.test.ts
@@ -5,7 +5,7 @@ import type { LaunchRotationRequest } from "../types";
 function buildWeeklyRotationRequest(overrides: Partial<LaunchRotationRequest> = {}): LaunchRotationRequest {
   return {
     launchKind: "rotation",
-    environmentId: "slot.blitz",
+    environmentId: "mainnet.blitz",
     rotationName: "blitz-rotation",
     firstGameStartTime: "2026-04-20T01:00:00Z",
     gameIntervalMinutes: 0,

--- a/config/deployer/clean/tests/rotation-summary.test.ts
+++ b/config/deployer/clean/tests/rotation-summary.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import { buildInitialRotationLaunchSummary, reconcileRotationLaunchSummary } from "../launch/rotation-summary";
+import type { LaunchRotationRequest } from "../types";
+
+function buildWeeklyRotationRequest(overrides: Partial<LaunchRotationRequest> = {}): LaunchRotationRequest {
+  return {
+    launchKind: "rotation",
+    environmentId: "slot.blitz",
+    rotationName: "blitz-rotation",
+    firstGameStartTime: "2026-04-20T01:00:00Z",
+    gameIntervalMinutes: 0,
+    maxGames: 5200,
+    advanceWindowGames: 5,
+    evaluationIntervalMinutes: 15,
+    durationSeconds: 3600,
+    autoRetryEnabled: true,
+    autoRetryIntervalMinutes: 15,
+    weeklyCadence: [
+      { gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" },
+      { gameNamePrefix: "apac-gladiator", weekday: "tuesday", utcTime: "11:00" },
+      { gameNamePrefix: "na-gladiator", weekday: "wednesday", utcTime: "02:00" },
+      { gameNamePrefix: "eu-gladiator", weekday: "wednesday", utcTime: "19:00" },
+      { gameNamePrefix: "apac-gladiator", weekday: "thursday", utcTime: "10:00" },
+      { gameNamePrefix: "na-gladiator", weekday: "friday", utcTime: "01:00" },
+      { gameNamePrefix: "eu-gladiator", weekday: "friday", utcTime: "18:00" },
+      { gameNamePrefix: "apac-gladiator", weekday: "saturday", utcTime: "12:00" },
+      { gameNamePrefix: "eu-gladiator", weekday: "saturday", utcTime: "20:00" },
+      { gameNamePrefix: "na-gladiator", weekday: "sunday", utcTime: "03:00" },
+      { gameNamePrefix: "apac-gladiator", weekday: "sunday", utcTime: "11:00" },
+      { gameNamePrefix: "eu-gladiator", weekday: "sunday", utcTime: "19:00" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("rotation launch summary", () => {
+  test("keeps a rolling weekly cadence filled from the next future slot", () => {
+    const request = buildWeeklyRotationRequest();
+    const summary = reconcileRotationLaunchSummary(
+      request,
+      buildInitialRotationLaunchSummary(request),
+      Date.parse("2026-04-20T07:00:00Z"),
+    );
+
+    expect(summary.games.map((game) => [game.gameName, game.startTimeIso])).toEqual([
+      ["apac-gladiator-21-04-26", "2026-04-21T11:00:00.000Z"],
+      ["na-gladiator-22-04-26", "2026-04-22T02:00:00.000Z"],
+      ["eu-gladiator-22-04-26", "2026-04-22T19:00:00.000Z"],
+      ["apac-gladiator-23-04-26", "2026-04-23T10:00:00.000Z"],
+      ["na-gladiator-24-04-26", "2026-04-24T01:00:00.000Z"],
+    ]);
+  });
+
+  test("continues a weekly cadence into the next week", () => {
+    const request = buildWeeklyRotationRequest({ advanceWindowGames: 1 });
+    const initialSummary = reconcileRotationLaunchSummary(
+      request,
+      {
+        ...buildInitialRotationLaunchSummary(request),
+        games: [
+          {
+            gameName: "eu-gladiator-26-04-26",
+            startTime: Math.floor(Date.parse("2026-04-26T19:00:00Z") / 1000),
+            startTimeIso: "2026-04-26T19:00:00.000Z",
+            durationSeconds: 3600,
+            seriesGameNumber: 12,
+            currentStepId: null,
+            latestEvent: "Waiting to run",
+            status: "pending",
+            configSteps: [],
+            steps: [],
+            artifacts: {},
+          },
+        ],
+      },
+      Date.parse("2026-04-26T20:00:00Z"),
+    );
+
+    expect(initialSummary.games.at(-1)).toMatchObject({
+      gameName: "na-gladiator-27-04-26",
+      startTimeIso: "2026-04-27T01:00:00.000Z",
+      seriesGameNumber: 13,
+    });
+  });
+
+  test("applies weekly cadence registration overrides to generated games", () => {
+    const request = buildWeeklyRotationRequest({
+      advanceWindowGames: 1,
+      weeklyCadence: [
+        {
+          gameNamePrefix: "weekend-gladiator",
+          weekday: "saturday",
+          utcTime: "12:00",
+          blitzRegistrationOverrides: {
+            fee_amount: "1000000000000000000000",
+          },
+        },
+      ],
+    });
+    const summary = reconcileRotationLaunchSummary(
+      request,
+      buildInitialRotationLaunchSummary(request),
+      Date.parse("2026-04-20T07:00:00Z"),
+    );
+
+    expect(summary.games[0]).toMatchObject({
+      gameName: "weekend-gladiator-25-04-26",
+      blitzRegistrationOverrides: {
+        fee_amount: "1000000000000000000000",
+      },
+    });
+  });
+});

--- a/config/deployer/clean/tests/rotation-summary.test.ts
+++ b/config/deployer/clean/tests/rotation-summary.test.ts
@@ -43,11 +43,11 @@ describe("rotation launch summary", () => {
     );
 
     expect(summary.games.map((game) => [game.gameName, game.startTimeIso])).toEqual([
-      ["apac-gladiator-21-04-26", "2026-04-21T11:00:00.000Z"],
-      ["na-gladiator-22-04-26", "2026-04-22T02:00:00.000Z"],
-      ["eu-gladiator-22-04-26", "2026-04-22T19:00:00.000Z"],
-      ["apac-gladiator-23-04-26", "2026-04-23T10:00:00.000Z"],
-      ["na-gladiator-24-04-26", "2026-04-24T01:00:00.000Z"],
+      ["apac-gladiator-21-04-26-1100", "2026-04-21T11:00:00.000Z"],
+      ["na-gladiator-22-04-26-0200", "2026-04-22T02:00:00.000Z"],
+      ["eu-gladiator-22-04-26-1900", "2026-04-22T19:00:00.000Z"],
+      ["apac-gladiator-23-04-26-1000", "2026-04-23T10:00:00.000Z"],
+      ["na-gladiator-24-04-26-0100", "2026-04-24T01:00:00.000Z"],
     ]);
   });
 
@@ -77,7 +77,7 @@ describe("rotation launch summary", () => {
     );
 
     expect(initialSummary.games.at(-1)).toMatchObject({
-      gameName: "na-gladiator-27-04-26",
+      gameName: "na-gladiator-27-04-26-0100",
       startTimeIso: "2026-04-27T01:00:00.000Z",
       seriesGameNumber: 13,
     });
@@ -104,10 +104,31 @@ describe("rotation launch summary", () => {
     );
 
     expect(summary.games[0]).toMatchObject({
-      gameName: "weekend-gladiator-25-04-26",
+      gameName: "weekend-gladiator-25-04-26-1200",
       blitzRegistrationOverrides: {
         fee_amount: "1000000000000000000000",
       },
     });
+  });
+
+  test("keeps same-day cadence game names unique per slot", () => {
+    const request = buildWeeklyRotationRequest({
+      advanceWindowGames: 2,
+      weeklyCadence: [
+        { gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "01:00" },
+        { gameNamePrefix: "na-gladiator", weekday: "monday", utcTime: "03:00" },
+      ],
+    });
+
+    const summary = reconcileRotationLaunchSummary(
+      request,
+      buildInitialRotationLaunchSummary(request),
+      Date.parse("2026-04-20T00:30:00Z"),
+    );
+
+    expect(summary.games.map((game) => game.gameName)).toEqual([
+      "na-gladiator-20-04-26-0100",
+      "na-gladiator-20-04-26-0300",
+    ]);
   });
 });

--- a/config/deployer/clean/tests/series-like-runner.fail-fast.test.ts
+++ b/config/deployer/clean/tests/series-like-runner.fail-fast.test.ts
@@ -17,6 +17,11 @@ mock.module("../launch/runner", () => ({
   runLaunchStep: runLaunchStepMock,
 }));
 
+mock.module("../launch/grouped-role-grants", () => ({
+  grantLootChestRolesForSeriesLikeGames: mock(async () => undefined),
+  grantVillagePassRolesForSeriesLikeGames: mock(async () => undefined),
+}));
+
 const { runGroupedSeriesLikeGameStep } = await import("../launch/series-like-runner");
 const { buildInitialSeriesLaunchSummary } = await import("../launch/series-summary");
 
@@ -55,6 +60,47 @@ describe("grouped series-like runner fail-fast behavior", () => {
     expect(persistedSummary?.games[1]?.status).toBe("pending");
     expect(persistedSummary?.games[1]?.currentStepId).toBeNull();
     expect(persistedSummary?.games[1]?.steps.find((step) => step.id === "create-worlds")?.status).toBe("pending");
+  });
+
+  test("passes child registration overrides into grouped game launches", async () => {
+    const request = buildSeriesRequest({
+      games: [
+        { gameName: "weekday-gladiator", startTime: "2099-01-01T06:00:00Z" },
+        { gameName: "weekend-gladiator", startTime: "2099-01-02T06:00:00Z" },
+      ],
+      blitzRegistrationOverrides: {
+        fee_amount: "500000000000000000000",
+      },
+    });
+    const initialSummary = buildInitialSeriesLaunchSummary(request);
+    const summary = {
+      ...initialSummary,
+      seriesCreated: true,
+      games: [
+        initialSummary.games[0],
+        {
+          ...initialSummary.games[1],
+          blitzRegistrationOverrides: {
+            fee_amount: "1000000000000000000000",
+          },
+        },
+      ],
+    };
+
+    await runGroupedSeriesLikeGameStep({
+      request,
+      summary,
+      stepId: "create-worlds",
+      persistSummary: (next) => next,
+    });
+
+    expect(runLaunchStepMock).toHaveBeenCalledTimes(2);
+    expect(runLaunchStepMock.mock.calls[0]?.[0].blitzRegistrationOverrides).toEqual({
+      fee_amount: "500000000000000000000",
+    });
+    expect(runLaunchStepMock.mock.calls[1]?.[0].blitzRegistrationOverrides).toEqual({
+      fee_amount: "1000000000000000000000",
+    });
   });
 });
 

--- a/config/deployer/clean/types.ts
+++ b/config/deployer/clean/types.ts
@@ -11,6 +11,7 @@ export type DeploymentEnvironmentId = "slot.blitz" | "slot.eternum" | "mainnet.b
 export type ExecutionMode = "batched" | "sequential";
 export type LaunchTargetKind = "game" | "series" | "rotation";
 export type LaunchStepStatus = "pending" | "running" | "succeeded" | "failed";
+export type LaunchRotationWeekday = "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday";
 export type LaunchGameStepId =
   | "create-world"
   | "wait-for-factory-index"
@@ -249,6 +250,7 @@ export interface LaunchRotationRequest {
   advanceWindowGames?: number;
   targetGameNames?: string[];
   evaluationIntervalMinutes: number;
+  weeklyCadence?: LaunchRotationWeeklyCadenceEntry[];
   rpcUrl?: string;
   factoryAddress?: string;
   accountAddress?: string;
@@ -281,6 +283,13 @@ export interface LaunchRotationRequest {
 
 export interface LaunchRotationStepRequest extends LaunchRotationRequest {
   stepId: RotationLaunchStepId;
+}
+
+export interface LaunchRotationWeeklyCadenceEntry {
+  gameNamePrefix: string;
+  weekday: LaunchRotationWeekday;
+  utcTime: string;
+  blitzRegistrationOverrides?: FactoryBlitzRegistrationOverrides;
 }
 
 export interface LaunchGameSummary {
@@ -370,6 +379,7 @@ export interface SeriesLaunchGameSummary {
   startTime: number;
   startTimeIso: string;
   durationSeconds?: number;
+  blitzRegistrationOverrides?: FactoryBlitzRegistrationOverrides;
   seriesGameNumber: number;
   currentStepId: SeriesLaunchStepId | null;
   latestEvent: string;
@@ -408,6 +418,7 @@ export interface LaunchRotationSummary {
   maxGames: number;
   advanceWindowGames: number;
   evaluationIntervalMinutes: number;
+  weeklyCadence?: LaunchRotationWeeklyCadenceEntry[];
   rpcUrl: string;
   factoryAddress: string;
   autoRetryEnabled: boolean;


### PR DESCRIPTION
Adds a rolling `slot.blitz` rotation config for the Blitz timetable, including weekday 500 buy-ins and weekend 1000 buy-ins from the provided CSV.

Extends the clean deployer, workflow env, run-store replay, and Factory UI mapping to carry weekly cadence entries and per-slot Blitz registration overrides.

Adds coverage for cadence parsing, planning, worker dispatch, child launch overrides, and Factory UI mapping.

Verification: focused `bun test` suites and `git diff --check` passed; `pnpm run format` and `pnpm run knip` are blocked locally by missing `prettier`/`@eslint/js` plus Node 20.9.0 below the repo's >=20.19.0 requirement.