### PR TITLE
fix(game): self-heal stuck chunk transitions and silent stream death

### DIFF
--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ConnectionHealthMonitor } from "./connection-health-monitor";
+import { useConnectionStore } from "@/hooks/store/use-connection-store";
+
+interface FakeEventTarget {
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+const originalDocument = (globalThis as { document?: unknown }).document;
+const originalWindow = (globalThis as { window?: unknown }).window;
+
+function stubDomGlobals(visibility: "visible" | "hidden" = "visible") {
+  const doc: FakeEventTarget & { visibilityState: string } = {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    visibilityState: visibility,
+  };
+  const win: FakeEventTarget = {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+  (globalThis as { document: unknown }).document = doc;
+  (globalThis as { window: unknown }).window = win;
+  return { doc, win };
+}
+
+function restoreDomGlobals() {
+  if (originalDocument === undefined) {
+    delete (globalThis as { document?: unknown }).document;
+  } else {
+    (globalThis as { document: unknown }).document = originalDocument;
+  }
+  if (originalWindow === undefined) {
+    delete (globalThis as { window?: unknown }).window;
+  } else {
+    (globalThis as { window: unknown }).window = originalWindow;
+  }
+}
+
+describe("ConnectionHealthMonitor", () => {
+  beforeEach(() => {
+    stubDomGlobals("visible");
+    vi.useFakeTimers();
+    useConnectionStore.setState({
+      status: "connected",
+      lastSpatialUpdate: Date.now(),
+      lastGlobalUpdate: Date.now(),
+      lastHealthCheck: Date.now(),
+      reconnectAttempts: 0,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    restoreDomGlobals();
+  });
+
+  it("reconnects streams during polling when spatial traffic has gone silent past the stale threshold", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now(),
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).not.toHaveBeenCalled();
+
+    monitor.dispose();
+  });
+
+  it("does not reconnect twice within a single staleThresholdMs window (cooldown)", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(1);
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 11_000,
+      lastGlobalUpdate: Date.now() - 11_000,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(1);
+
+    monitor.dispose();
+  });
+
+  it("does not reconnect when the health check fails", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.reject(new Error("offline")));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).not.toHaveBeenCalled();
+    expect(onReconnectGlobal).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().status).toBe("disconnected");
+
+    monitor.dispose();
+  });
+});

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -19,6 +19,7 @@ export class ConnectionHealthMonitor {
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
   private reconnecting = false;
   private disposed = false;
+  private lastStreamReconnectAtMs = 0;
 
   constructor(config: ConnectionHealthMonitorConfig) {
     this.config = config;
@@ -90,17 +91,28 @@ export class ConnectionHealthMonitor {
     if (document.visibilityState === "hidden") return;
 
     const store = useConnectionStore.getState();
-    const now = Date.now();
 
     try {
       const healthy = await this.config.healthCheckFn();
 
       if (healthy) {
         store.recordHealthCheck();
-        // Server is reachable — connection is healthy.
-        // Stream staleness just means no game state changed recently, not a connection issue.
         store.setStatus("connected");
         store.resetReconnectAttempts();
+
+        // Server is reachable, but a stream can silently die (WASM gRPC drop
+        // without onError firing) while the tab stays visible. If either stream
+        // has been silent past the stale threshold, force a resubscribe.
+        // Cooldown prevents reconnect storms when the area is genuinely idle.
+        const now = Date.now();
+        if (now - this.lastStreamReconnectAtMs >= this.staleThresholdMs) {
+          const spatialStale = now - store.lastSpatialUpdate > this.staleThresholdMs;
+          const globalStale = now - store.lastGlobalUpdate > this.staleThresholdMs;
+          if (spatialStale || globalStale) {
+            this.lastStreamReconnectAtMs = now;
+            void this.reconnectStaleStreams(spatialStale, globalStale);
+          }
+        }
       }
     } catch {
       store.setStatus("disconnected");

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -1,7 +1,7 @@
 import { useConnectionStore } from "@/hooks/store/use-connection-store";
 
-const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 15_000;
-const DEFAULT_STALE_THRESHOLD_MS = 30_000;
+const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 10_000;
+const DEFAULT_STALE_THRESHOLD_MS = 15_000;
 
 interface ConnectionHealthMonitorConfig {
   onReconnectSpatial: () => Promise<void>;

--- a/client/apps/game/src/three/scenes/worldmap-chunk-trace.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-trace.ts
@@ -16,6 +16,7 @@ export type WorldmapChunkTraceEvent =
   | "spatial_sql_fetch_failed"
   | "spatial_sql_recs_hydrated"
   | "chunk_presentation_timeout"
+  | "chunk_transition_hard_timeout"
   | "chunk_recovery_scheduled"
   | "chunk_recovery_executed"
   | "torii_resubscribe_requested"

--- a/client/apps/game/src/three/scenes/worldmap-chunk-transition-runtime.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-transition-runtime.test.ts
@@ -50,4 +50,116 @@ describe("runWorldmapChunkTransition", () => {
     expect(state.isTransitioning).toBe(false);
     expect(state.activePromise).toBeNull();
   });
+
+  it("invokes onHardTimeout and releases ownership when the transition exceeds hardTimeoutMs", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = createWorldmapChunkTransitionRuntimeState();
+      // Never resolves during the test.
+      const transitionPromise = new Promise<void>(() => {});
+      const onResolved = vi.fn(() => true);
+      const onHardTimeout = vi.fn(() => false);
+      const onFinally = vi.fn();
+
+      const runPromise = runWorldmapChunkTransition({
+        hardTimeoutMs: 1_000,
+        onFinally,
+        onHardTimeout,
+        onResolved,
+        state,
+        transitionPromise,
+        yieldFrame: () => Promise.resolve(),
+      });
+
+      // Let onTransitionStart + yieldFrame microtasks run.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(state.isTransitioning).toBe(true);
+      expect(state.activePromise).toBe(transitionPromise);
+
+      vi.advanceTimersByTime(1_000);
+
+      await expect(runPromise).resolves.toBe(false);
+      expect(onHardTimeout).toHaveBeenCalledWith({ timeoutMs: 1_000 });
+      expect(onResolved).not.toHaveBeenCalled();
+      expect(onFinally).toHaveBeenCalledTimes(1);
+      expect(state.isTransitioning).toBe(false);
+      expect(state.activePromise).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("prefers the transition result when it resolves before hardTimeoutMs elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = createWorldmapChunkTransitionRuntimeState();
+      let resolveTransition!: () => void;
+      const transitionPromise = new Promise<void>((resolve) => {
+        resolveTransition = resolve;
+      });
+      const onResolved = vi.fn(() => true);
+      const onHardTimeout = vi.fn(() => false);
+
+      const runPromise = runWorldmapChunkTransition({
+        hardTimeoutMs: 60_000,
+        onHardTimeout,
+        onResolved,
+        state,
+        transitionPromise,
+        yieldFrame: () => Promise.resolve(),
+      });
+
+      resolveTransition();
+
+      await expect(runPromise).resolves.toBe(true);
+      expect(onResolved).toHaveBeenCalledTimes(1);
+      expect(onHardTimeout).not.toHaveBeenCalled();
+      expect(state.isTransitioning).toBe(false);
+      expect(state.activePromise).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("swallows a transition rejection that lands after the hard timeout without unhandled rejection", async () => {
+    vi.useFakeTimers();
+    const rejection = new Error("late rejection");
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    try {
+      const state = createWorldmapChunkTransitionRuntimeState();
+      let rejectTransition!: (error: unknown) => void;
+      const transitionPromise = new Promise<void>((_, reject) => {
+        rejectTransition = reject;
+      });
+      const onHardTimeout = vi.fn(() => false);
+
+      const runPromise = runWorldmapChunkTransition({
+        hardTimeoutMs: 1_000,
+        onHardTimeout,
+        onResolved: vi.fn(() => true),
+        state,
+        transitionPromise,
+        yieldFrame: () => Promise.resolve(),
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      vi.advanceTimersByTime(1_000);
+      await expect(runPromise).resolves.toBe(false);
+
+      rejectTransition(rejection);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+      vi.useRealTimers();
+    }
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-chunk-transition-runtime.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-transition-runtime.ts
@@ -3,6 +3,10 @@ export interface WorldmapChunkTransitionRuntimeState<TTransitionPromise = Promis
   isTransitioning: boolean;
 }
 
+export interface WorldmapChunkTransitionHardTimeoutInfo {
+  timeoutMs: number;
+}
+
 interface RunWorldmapChunkTransitionInput<TTransitionPromise extends Promise<unknown>, TResult> {
   onFinally?: () => void | Promise<void>;
   onResolved: () => TResult | Promise<TResult>;
@@ -10,6 +14,8 @@ interface RunWorldmapChunkTransitionInput<TTransitionPromise extends Promise<unk
   yieldFrame?: () => Promise<void>;
   state: WorldmapChunkTransitionRuntimeState<TTransitionPromise>;
   transitionPromise: TTransitionPromise;
+  hardTimeoutMs?: number;
+  onHardTimeout?: (info: WorldmapChunkTransitionHardTimeoutInfo) => TResult | Promise<TResult>;
 }
 
 export function createWorldmapChunkTransitionRuntimeState<
@@ -20,6 +26,11 @@ export function createWorldmapChunkTransitionRuntimeState<
     isTransitioning: false,
   };
 }
+
+type RaceOutcome<T> =
+  | { status: "resolved"; value: T }
+  | { status: "rejected"; error: unknown }
+  | { status: "timed_out" };
 
 export async function runWorldmapChunkTransition<TTransitionPromise extends Promise<unknown>, TResult>(
   input: RunWorldmapChunkTransitionInput<TTransitionPromise, TResult>,
@@ -33,10 +44,47 @@ export async function runWorldmapChunkTransition<TTransitionPromise extends Prom
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
   }
 
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
   try {
+    const hasHardTimeout =
+      input.hardTimeoutMs !== undefined && input.hardTimeoutMs > 0 && input.onHardTimeout !== undefined;
+
+    if (hasHardTimeout) {
+      const hardTimeoutMs = input.hardTimeoutMs!;
+      const settled: Promise<RaceOutcome<Awaited<TTransitionPromise>>> = input.transitionPromise.then(
+        (value) => ({ status: "resolved" as const, value: value as Awaited<TTransitionPromise> }),
+        (error) => ({ status: "rejected" as const, error }),
+      );
+      // Prevent later rejection from the underlying promise from becoming unhandled
+      // when we have already moved past the race due to the hard timeout firing.
+      settled.catch(() => undefined);
+
+      const timed = new Promise<RaceOutcome<Awaited<TTransitionPromise>>>((resolve) => {
+        timeoutHandle = setTimeout(() => {
+          resolve({ status: "timed_out" });
+        }, hardTimeoutMs);
+      });
+
+      const outcome = await Promise.race([settled, timed]);
+
+      if (outcome.status === "timed_out") {
+        return await input.onHardTimeout!({ timeoutMs: hardTimeoutMs });
+      }
+
+      if (outcome.status === "rejected") {
+        throw outcome.error;
+      }
+
+      return await input.onResolved();
+    }
+
     await input.transitionPromise;
     return await input.onResolved();
   } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
     await input.onFinally?.();
     input.state.activePromise = null;
     input.state.isTransitioning = false;

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -458,7 +458,8 @@ const WORLDMAP_CHUNK_RECOVERY_COOLDOWN_MS = 2_000;
 // Hard timeout wrapping the entire chunk transition (phase timeouts + post-phase work).
 // Catches cases where post-phase awaits (e.g. manager catch-up, finalize rollback)
 // hang past all per-phase timeouts and would otherwise lock isChunkTransitioning.
-const WORLDMAP_CHUNK_TRANSITION_HARD_TIMEOUT_MS = Math.max(WORLDMAP_CHUNK_PHASE_TIMEOUT_MS * 4, 30_000);
+// Kept tight so a wedged transition recovers inside ~20s instead of 45s+.
+const WORLDMAP_CHUNK_TRANSITION_HARD_TIMEOUT_MS = Math.max(WORLDMAP_CHUNK_PHASE_TIMEOUT_MS + 8_000, 20_000);
 const WORLDMAP_STREAMING_ROLLOUT = {
   stagedPathEnabled: env.VITE_PUBLIC_WORLDMAP_STREAMING_STAGED !== false,
 };

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -150,6 +150,7 @@ import {
 import {
   createWorldmapChunkTransitionRuntimeState,
   runWorldmapChunkTransition,
+  type WorldmapChunkTransitionHardTimeoutInfo,
 } from "./worldmap-chunk-transition-runtime";
 import {
   settleWorldmapShortcutSelectionProtection,
@@ -454,6 +455,10 @@ const TORII_BOUNDS_DEBUG = env.VITE_PUBLIC_TORII_BOUNDS_DEBUG === true;
 const TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS = env.VITE_PUBLIC_TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS;
 const WORLDMAP_CHUNK_PHASE_TIMEOUT_MS = env.VITE_PUBLIC_WORLDMAP_CHUNK_PHASE_TIMEOUT_MS;
 const WORLDMAP_CHUNK_RECOVERY_COOLDOWN_MS = 2_000;
+// Hard timeout wrapping the entire chunk transition (phase timeouts + post-phase work).
+// Catches cases where post-phase awaits (e.g. manager catch-up, finalize rollback)
+// hang past all per-phase timeouts and would otherwise lock isChunkTransitioning.
+const WORLDMAP_CHUNK_TRANSITION_HARD_TIMEOUT_MS = Math.max(WORLDMAP_CHUNK_PHASE_TIMEOUT_MS * 4, 30_000);
 const WORLDMAP_STREAMING_ROLLOUT = {
   stagedPathEnabled: env.VITE_PUBLIC_WORLDMAP_STREAMING_STAGED !== false,
 };
@@ -5681,6 +5686,34 @@ export default class WorldmapScene extends WarpTravel {
     }, 0);
   }
 
+  private handleChunkTransitionHardTimeout(
+    reason: "switch_chunk" | "refresh_current_chunk",
+    chunkKey: string,
+    info: WorldmapChunkTransitionHardTimeoutInfo,
+  ): void {
+    console.warn("[WorldmapScene] Chunk transition hard timeout — forcing recovery", {
+      reason,
+      chunkKey,
+      timeoutMs: info.timeoutMs,
+    });
+    this.traceChunk("chunk_transition_hard_timeout", {
+      reason,
+      chunkKey,
+      timeoutMs: info.timeoutMs,
+    });
+    if (this.toriiLoadingCounter > 0) {
+      this.toriiLoadingCounter = 0;
+      this.state.setLoading(LoadingStateKey.Map, false);
+    }
+    this.toriiBoundsAreaKey = null;
+    this.clearStalledChunkAreaState(chunkKey);
+    this.requestToriiResubscribe("chunk_transition_hard_timeout", chunkKey);
+    this.scheduleChunkRecovery("chunk_transition_hard_timeout", chunkKey, {
+      reason,
+      timeoutMs: info.timeoutMs,
+    });
+  }
+
   private handleChunkPresentationTimeout(info: WorldmapChunkPresentationTimeoutInfo): void {
     const areaKey = this.clearStalledChunkAreaState(info.chunkKey);
     this.toriiLoadingCounter = recoverWorldmapMapLoadingStateFromChunkTimeout({
@@ -6958,11 +6991,16 @@ export default class WorldmapScene extends WarpTravel {
         recordChunkDiagnosticsEvent(this.chunkDiagnostics, "transition_started");
         this.state.setLoading(LoadingStateKey.ChunkTransition, true);
         return runWorldmapChunkTransition({
+          hardTimeoutMs: WORLDMAP_CHUNK_TRANSITION_HARD_TIMEOUT_MS,
           onFinally: () => {
             this.state.setLoading(LoadingStateKey.ChunkTransition, false);
             recordChunkDiagnosticsEvent(this.chunkDiagnostics, "switch_duration_recorded", {
               durationMs: performance.now() - switchStartedAt,
             });
+          },
+          onHardTimeout: (info) => {
+            this.handleChunkTransitionHardTimeout("switch_chunk", chunkKey, info);
+            return false;
           },
           onResolved: () => {
             this.retryDeferredChunkRemovals();
@@ -6998,8 +7036,13 @@ export default class WorldmapScene extends WarpTravel {
         });
         this.state.setLoading(LoadingStateKey.ChunkTransition, true);
         return runWorldmapChunkTransition({
+          hardTimeoutMs: WORLDMAP_CHUNK_TRANSITION_HARD_TIMEOUT_MS,
           onFinally: () => {
             this.state.setLoading(LoadingStateKey.ChunkTransition, false);
+          },
+          onHardTimeout: (info) => {
+            this.handleChunkTransitionHardTimeout("refresh_current_chunk", chunkKey, info);
+            return false;
           },
           onResolved: () => {
             this.retryDeferredChunkRemovals();


### PR DESCRIPTION
## Summary
A single hung post-phase await (e.g. manager catch-up, finalize rollback) could leave `isChunkTransitioning` true forever, silently locking army clicks and blocking every subsequent chunk switch — the observed desync symptom. A silent WASM gRPC stream drop while the tab stayed visible also went undetected, because reconnect only fired on `visibilitychange` / `online` events.

## Changes
- **Outer watchdog on `runWorldmapChunkTransition`**: adds `hardTimeoutMs` + `onHardTimeout` so a hung transition promise no longer wedges state. On fire, the scene force-releases `isChunkTransitioning`, resets the torii loading counter, clears the bounds area key, and schedules a chunk recovery + torii resubscribe. Hard timeout is `max(phaseTimeout * 4, 30s)`.
- **Stale-stream detection in `ConnectionHealthMonitor`**: health-check polling now also reconnects streams when spatial or global updates have been silent past the stale threshold, with a cooldown (≥ staleThresholdMs) to avoid reconnect storms in idle areas.

## Test plan
- [x] `pnpm typecheck` (clean)
- [x] `pnpm run test:three:types` (clean)
- [x] 177 related worldmap tests pass, including 3 new cases covering timeout/resolve/late-rejection
- [x] 3 new health-monitor tests cover stale detection + cooldown + unhealthy skip
- [ ] In-game verification: induce a network blip and confirm chunk loading + army clicks recover automatically