### PR TITLE
fix(game): allocate shared automation inputs proportionally

### DIFF
--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -437,6 +437,78 @@ describe("buildRealmProductionPlan", () => {
     });
   });
 
+  it("splits a shared input's 90% budget proportionally so late-ordered consumers aren't starved", () => {
+    // Reproduces the user-reported troop-starvation bug: when raw resources and a troop
+    // share Wheat as input and aggregate allocation > 90%, sequential first-come reservation
+    // leaves the last consumer with crumbs. Proportional allocation must give each consumer
+    // its scaled share of the cap.
+    configureComplexRecipe(ResourcesIds.Wood, [{ resource: ResourcesIds.Wheat, amount: 1 }], 1);
+    configureComplexRecipe(ResourcesIds.Coal, [{ resource: ResourcesIds.Wheat, amount: 1 }], 1);
+    // Knight's troop recipe is already configured: needs 1 Wheat + 1 Copper per cycle, output 1.
+
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [ResourcesIds.Wood]: { resourceToResource: 40, laborToResource: 0 },
+          [ResourcesIds.Coal]: { resourceToResource: 40, laborToResource: 0 },
+          [ResourcesIds.Knight]: { resourceToResource: 50, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([ResourcesIds.Wood, ResourcesIds.Coal, ResourcesIds.Knight], {
+        [ResourcesIds.Wheat]: 1000,
+        [ResourcesIds.Copper]: 10_000,
+      }),
+    });
+
+    // Total Wheat demand = 40 + 40 + 50 = 130%. Cap = 90%. Scale ≈ 90/130 ≈ 0.6923.
+    // Knight scaled demand ≈ 50% * 0.6923 * 1000 ≈ 346 Wheat → 346 cycles.
+    const knightCycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
+    const woodCycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Wood)?.cycles ?? 0;
+    const coalCycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Coal)?.cycles ?? 0;
+
+    // Sequential-first-come would give Knight ~0-100 cycles after Wood/Coal drain the budget.
+    // Proportional allocation gives every consumer their scaled share simultaneously.
+    expect(knightCycles).toBeGreaterThan(300);
+    expect(woodCycles).toBeGreaterThan(250);
+    expect(coalCycles).toBeGreaterThan(250);
+
+    // Total Wheat consumed must never exceed the 90% cap.
+    const totalWheat = plan.consumptionByResource[ResourcesIds.Wheat] ?? 0;
+    expect(totalWheat).toBeLessThanOrEqual(900);
+  });
+
+  it("does not scale when aggregate demand fits inside the 90% cap", () => {
+    // Regression: if demand <= 90%, every consumer gets its full unscaled desired share.
+    configureComplexRecipe(ResourcesIds.Wood, [{ resource: ResourcesIds.Wheat, amount: 1 }], 1);
+
+    const plan = buildRealmProductionPlan({
+      realmConfig: makeRealmConfig(
+        { presetId: "custom" },
+        {
+          [ResourcesIds.Wood]: { resourceToResource: 30, laborToResource: 0 },
+          [ResourcesIds.Knight]: { resourceToResource: 30, laborToResource: 0 },
+        },
+      ),
+      snapshot: makeSnapshot([ResourcesIds.Wood, ResourcesIds.Knight], {
+        [ResourcesIds.Wheat]: 1000,
+        [ResourcesIds.Copper]: 10_000,
+      }),
+    });
+
+    // Total Wheat demand = 60%. No scaling. Each gets floor(1000 * 30 / 100) = 300.
+    const knightCycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
+    const woodCycles =
+      plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Wood)?.cycles ?? 0;
+
+    expect(knightCycles).toBe(300);
+    expect(woodCycles).toBe(300);
+  });
+
   it("keeps T2 labor allocations skipped when no labor recipe exists", () => {
     const plan = buildRealmProductionPlan({
       realmConfig: makeRealmConfig(

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -464,6 +464,43 @@ export const buildRealmProductionPlan = ({
     availableBudget.set(resourceId, Math.max(0, maxConsumable));
   });
 
+  // Pre-allocate shared-input budget proportionally. Without this, consumers processed
+  // first drain the 90% cap and later consumers (especially troops under the cycle-fallback
+  // numeric ordering) get crumbs. Each input's scale factor caps every consumer's
+  // requested share so total reservations fit within the budget.
+  const totalDemandByInput = new Map<ResourcesIds, number>();
+  const addDemand = (inputId: ResourcesIds, percent: number) => {
+    if (!(percent > 0)) return;
+    totalDemandByInput.set(inputId, (totalDemandByInput.get(inputId) ?? 0) + percent);
+  };
+  for (const definition of resourceDefinitions) {
+    if (!definition.hasActiveProduction) continue;
+    const { resourceId, percentages } = definition;
+    if (percentages.resourceToResource > 0) {
+      const inputs = configManager.complexSystemResourceInputs[resourceId] ?? [];
+      for (const input of inputs) {
+        if (input.amount <= 0) continue;
+        if (isAutomationResourceBlocked(input.resource, entityType, "input")) continue;
+        addDemand(input.resource, percentages.resourceToResource);
+      }
+    }
+    if (percentages.laborToResource > 0) {
+      const laborConfig = configManager.getLaborConfig?.(resourceId);
+      const inputs = laborConfig?.inputResources ?? [];
+      for (const input of inputs) {
+        if (input.amount <= 0) continue;
+        if (isAutomationResourceBlocked(input.resource, entityType, "input")) continue;
+        addDemand(input.resource, percentages.laborToResource);
+      }
+    }
+  }
+  const scaleFactorByInput = new Map<ResourcesIds, number>();
+  totalDemandByInput.forEach((demand, inputId) => {
+    const scale = demand > MAX_RESOURCE_ALLOCATION_PERCENT ? MAX_RESOURCE_ALLOCATION_PERCENT / demand : 1;
+    scaleFactorByInput.set(inputId, scale);
+  });
+  const getInputShareScale = (inputId: ResourcesIds) => scaleFactorByInput.get(inputId) ?? 1;
+
   const planCallset: RealmProductionCallset = {
     resourceToResource: [],
     laborToResource: [],
@@ -526,7 +563,7 @@ export const buildRealmProductionPlan = ({
             break;
           }
 
-          const desired = Math.floor((total * resourceToResource) / 100);
+          const desired = Math.floor((total * resourceToResource * getInputShareScale(input.resource)) / 100);
           if (desired <= 0) {
             maxCycles = 0;
             break;
@@ -642,7 +679,7 @@ export const buildRealmProductionPlan = ({
             break;
           }
 
-          const desired = Math.floor((total * laborToResource) / 100);
+          const desired = Math.floor((total * laborToResource * getInputShareScale(input.resource)) / 100);
           if (desired <= 0) {
             laborDebug.push({
               inputResource: input.resource,


### PR DESCRIPTION
## Summary
- Automation's sequential first-come reservation let early consumers drain the 90% input budget, starving troops (e.g. Paladin getting ~100 cycles instead of its 30% share) under the cycle-fallback numeric ordering.
- `buildRealmProductionPlan` now pre-computes each shared input's aggregate demand; when demand exceeds the cap, every consumer's desired share is scaled so reservations fit the budget regardless of processing order.
- Behavior is unchanged when aggregate demand ≤ 90%.

## Test plan
- [x] `automation-processor.test.ts` — new proportional-scaling test (fails before fix, passes after) and a no-scaling regression test
- [x] `pnpm vitest run automation-processor.test.ts automation-runner.test.ts automation-presets.test.ts` — 43/43 pass
- [ ] Manual: in-game smart preset on a realm with T1 raw + army + higher tiers; confirm troops are now produced near their allocated share and no Insufficient Balance reverts from over-allocation