### PR TITLE
feat(worldmap): optimistic local army movement on tx confirm

### DIFF
--- a/client/apps/game/src/three/WORLDMAP_OPTIMISTIC_MOVE_PRD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_OPTIMISTIC_MOVE_PRD_TDD.md
@@ -1,0 +1,293 @@
+# Worldmap Optimistic Movement Resolution PRD / TDD
+
+## Status
+
+- Status: Proposed for implementation
+- Scope: `client/apps/game/src/three/scenes/worldmap.tsx`
+- Scope: movement timing for local armies
+- Related: `WORLDMAP_ARMY_MOVEMENT_HANDOFF_PRD_TDD.md` (prior fix that split cache sync from visual handoff)
+
+## Problem Statement
+
+After the handoff fix, local army movement now presents correctly but still waits on the Torii indexer before the
+animation starts. The sequence is:
+
+1. user initiates move
+2. transaction submits
+3. transaction confirms on chain
+4. Torii indexes the new `TileOpt` row (hundreds of ms to several seconds)
+5. world update listener delivers `onTileUpdate`
+6. `ArmyManager.onTileUpdate(...)` calls `moveArmy(...)`
+7. the animation finally starts and the pending gate releases
+
+The wait between 3 and 4-5 is wasted time. At confirmation time the client already knows:
+
+- the tx hash (via `pendingArmyMovementTxMap`)
+- the selected entity id
+- the exact destination hex (`actionPath[last].hex`)
+- the rest of the owner and troop fields (via `ArmyManager.getArmy(entityId)`)
+
+So the visual move can start as soon as the provider emits `transactionComplete` rather than waiting for the indexer
+round-trip. The indexer update, when it eventually arrives, should converge to a no-op because the army will already be
+at the authoritative destination.
+
+## Findings From The Trace
+
+### Stable facts
+
+1. Submit path
+   - `onArmyMovement(...)` at `scenes/worldmap.tsx:2373` captures `actionPath`, the destination hex, creates travel FX,
+     creates arrival ghost, installs lifecycle, marks pending.
+   - `armyActionManager.moveArmy(...)` returns a promise; on success we map `txHash -> entityId` in
+     `pendingArmyMovementTxMap` at `scenes/worldmap.tsx:2541`.
+
+2. Tx confirmation path
+   - `bindTransactionFailureLifecycle(...)` at `scenes/worldmap.tsx:1062` wires `transactionComplete` to
+     `handleTransactionComplete(...)` at `scenes/worldmap.tsx:1063`.
+   - Today this handler only records a `tx_confirmed` latency phase at `scenes/worldmap.tsx:1074`. It does **not**
+     resolve the move.
+
+3. Indexer path
+   - `registerArmyWorldUpdateSubscriptions(...)` at `scenes/worldmap.tsx:1230` handles `onTileUpdate`, calling
+     `updateArmyHexes(update)` and `await this.armyManager.onTileUpdate(update)`.
+   - `ArmyManager.onTileUpdate(...)` at `managers/army-manager.ts:622` calls `this.moveArmy(entityId, newPosition)` when
+     the army is already tracked.
+   - `ArmyManager.moveArmy(...)` at `managers/army-manager.ts:1790` early-returns when `startPos === targetPos` (line
+     1801). This is the idempotency guarantee the optimistic path relies on.
+
+4. Render lifecycle
+   - `installPendingMovementVisualLifecycle(...)` at `scenes/worldmap.tsx:2751` wires:
+     - `onMovementStart` -> `clearPendingArmyMovement(entityId, "movement_started")`
+     - `onMovementComplete` -> `arrivalGhostManager.resolveArrivalGhost(entityId)`
+
+5. Data needed to synthesize a tile update
+   - `ArmyData` (from `getArmy(entityId)`) has `owner.address`, `owner.ownerName`, `owner.guildName`,
+     `owningStructureId`, `category`, `tier`, `isDaydreamsAgent`, `troopCount`, `currentStamina`, `maxStamina`,
+     `onChainStamina`, battle fields.
+   - That matches every field in `ExplorerTroopsTileSystemUpdate` (`packages/core/src/systems/types.ts:17`).
+
+### Most important implication
+
+Because `moveArmy` is already idempotent on same-position targets, the same code path that Torii drives can be invoked
+directly from `transactionComplete` without coordination flags. The later indexer update becomes a confirming no-op.
+
+## Goals
+
+### User goals
+
+- Local army animations begin as soon as the move transaction confirms.
+- There is no visible pause between "tx sent → animation running" even under slow indexer lag.
+- The indexer update, when it arrives, does not double-animate, re-trigger travel FX, or replay the arrival ghost.
+
+### Engineering goals
+
+- Drive the existing visual pipeline (`updateArmyHexes` + `ArmyManager.onTileUpdate`) from the `transactionComplete`
+  event for local armies.
+- Keep the indexer path authoritative — it still runs, it just converges on an already-applied state.
+- Preserve every existing safety rail: tx-failed clears ghosts; 30s stale fallback still fires; explorer troop updates
+  still cannot clear pending movement.
+
+## Non-goals
+
+- Optimistic updates for remote (other players') armies. Those still flow exclusively through the indexer.
+- Optimistic stamina or troop count updates. `queuePendingMovementStamina(...)` already handles stamina; indexer still
+  owns troop counts.
+- Optimistic explore result (new biome reveal, extra rewards). Biome/reward data still arrives through Torii; only the
+  army's visible position is resolved optimistically.
+- Changing `ArmyActionManager`, system calls, or tx confirmation plumbing. Only the renderer-side listener changes.
+
+## Proposed Behavior
+
+### New lifecycle for local moves
+
+1. submit move
+2. mark pending + travel FX + arrival ghost (unchanged)
+3. record `tx_submitted`; store `{txHash -> entityId}` (unchanged)
+4. store `{txHash -> targetHex}` alongside the entity map
+5. **on `transactionComplete`**:
+   - record `tx_confirmed`
+   - synthesize an `ExplorerTroopsTileSystemUpdate` using tracked army data + cached target hex
+   - call `updateArmyHexes(synthetic)` and `await this.armyManager.onTileUpdate(synthetic)` — same pipeline the indexer
+     triggers
+   - record a new `movement_resolved_optimistically` latency phase
+   - mark the entity optimistically-resolved so downstream indexer handling can skip redundant convergence steps where
+     they would be wasteful
+6. later, Torii delivers the real tile update:
+   - `updateArmyHexes` re-confirms the cache (no visual effect — same position)
+   - `armyManager.onTileUpdate -> moveArmy` early-returns due to same-position guard
+   - clear the optimistically-resolved mark
+7. `onMovementStart` fires from the renderer → pending clears, lifecycle continues (unchanged)
+8. `onMovementComplete` fires → arrival ghost resolves, travel FX ends (unchanged)
+
+### Safety rails (preserved)
+
+- Tx failed: still clears pending, ghost, lifecycle, travel FX.
+- 30s stale fallback: still clears pending and ghost if nothing ever animates (handles confirmed tx whose tile never
+  arrives).
+- Explorer troop updates: still must not clear pending movement.
+- Remote armies: never resolve optimistically. We only act when `pendingArmyMovementTxMap` has an entry for the tx hash,
+  which we only populate for local moves we initiated.
+- Army removed between submit and confirm: if `armyManager.getArmy(entityId)` returns undefined, skip optimistic
+  resolution and wait for the indexer.
+
+### Source of truth
+
+- Chain state remains authoritative via Torii.
+- Optimistic render is derived from submitted action path; if the tx is reverted post-confirm in any exotic scenario,
+  the indexer will emit a corrective update that `updateArmyHexes` will apply through the normal code path.
+
+## Architecture
+
+### 1. Remember the destination per pending tx
+
+Today `pendingArmyMovementTxMap: Map<string, ID>` maps `txHash -> entityId`. Add a parallel structure:
+
+```ts
+private pendingArmyMovementTxTargets: Map<string, HexPosition> = new Map();
+```
+
+Populated in the `.then(result => ...)` branch of `onArmyMovement` right next to the existing
+`pendingArmyMovementTxMap.set(txHash, selectedEntityId)`. The destination hex comes from
+`actionPath[actionPath.length - 1].hex` (the same value we already compute for FX and ghost).
+
+Cleared anywhere `pendingArmyMovementTxMap` is cleared (clearPendingArmyMovement, transactionFailed handler, destroy).
+
+### 2. Optimistic resolver
+
+Add a private method (extracted into a pure planner for testability):
+
+```ts
+private resolveArmyMovementOptimistically(params: {
+  entityId: ID;
+  txHash: string;
+  targetHex: HexPosition;
+}): void
+```
+
+Responsibilities:
+
+- short-circuit if the army is no longer tracked
+- build the synthetic `ExplorerTroopsTileSystemUpdate` from the tracked `ArmyData`
+- call `this.updateArmyHexes(update)`
+- `void this.armyManager.onTileUpdate(update)` (fire-and-forget — animation starts)
+- record `movement_resolved_optimistically` latency phase
+- add `entityId` to a `Set<ID>` named `optimisticallyResolvedArmies` so the later indexer path can assert/log
+  convergence
+
+A companion pure function `buildOptimisticArmyTileUpdate(army, targetHex)` lives next to `worldmap.tsx` (e.g. in a
+sibling `worldmap-optimistic-movement.ts`) and is unit-tested separately.
+
+### 3. Wire it into `transactionComplete`
+
+`handleTransactionComplete` becomes:
+
+```ts
+const entityId = this.pendingArmyMovementTxMap.get(txHash);
+if (entityId === undefined) return;
+
+recordArmyMovementLatencyPhase({ phase: "tx_confirmed", source: "worldmap", entityId, txHash });
+
+const targetHex = this.pendingArmyMovementTxTargets.get(txHash);
+if (!targetHex) return;
+
+this.resolveArmyMovementOptimistically({ entityId, txHash, targetHex });
+```
+
+### 4. Converge on later indexer delivery
+
+`registerArmyWorldUpdateSubscriptions` already calls `updateArmyHexes` + `onTileUpdate`. No changes required for
+correctness — `moveArmy`'s same-position early-return handles the no-op. We do:
+
+- record a `movement_optimistic_convergence` phase when the authoritative tile update arrives for an entity that was
+  optimistically resolved
+- remove the entity from `optimisticallyResolvedArmies`
+
+This gives us latency instrumentation to verify convergence in dev and in traces without changing behavior.
+
+### 5. Cleanup wiring
+
+- `clearPendingArmyMovement(entityId, reason)` also prunes `pendingArmyMovementTxTargets` for any txHash mapped to this
+  entity, and removes the entity from `optimisticallyResolvedArmies`.
+- The existing `destroy()` path that clears `pendingArmyMovementTxMap` also clears the new maps.
+
+## TDD Plan
+
+### Red phase
+
+Add failing tests for:
+
+1. **Destination capture**: when tx submission resolves with `transaction_hash`, worldmap stores the destination hex
+   alongside `pendingArmyMovementTxMap`.
+   - Source assertion: `worldmap.tsx` contains `pendingArmyMovementTxTargets` and sets it in the
+     `.then((result) => ...)` branch of `onArmyMovement` next to the existing `pendingArmyMovementTxMap.set`.
+
+2. **Optimistic trigger on tx_confirmed**: `handleTransactionComplete` calls the optimistic resolver when a target hex
+   is known.
+   - Source assertion: `worldmap.tsx` contains `resolveArmyMovementOptimistically` and it is invoked from
+     `handleTransactionComplete`.
+
+3. **Synthetic tile update structure**: extracted pure builder returns a well-formed `ExplorerTroopsTileSystemUpdate`
+   when given real-looking `ArmyData` and a target hex.
+   - Behavioral test in a new file covering `buildOptimisticArmyTileUpdate`. Uses contract-style coordinates, checks
+     entityId / hexCoords / ownerAddress / troopType / troopTier are copied through, and that `removed` is never set.
+
+4. **Idempotency reliance**: the optimistic resolver calls `updateArmyHexes` and `armyManager.onTileUpdate` with the
+   synthetic update.
+   - Source assertion in `worldmap.tsx` and a unit test over an isolated planner that returns
+     `{ cacheUpdate, armyManagerUpdate }` payloads.
+
+5. **Latency instrumentation**: worldmap records `movement_resolved_optimistically` and
+   `movement_optimistic_convergence` phases.
+   - Extend `worldmap-movement-latency-tracing.source.test.ts` to assert those literals appear in source.
+
+6. **Remote army isolation**: when a `transactionComplete` hash has no `pendingArmyMovementTxMap` entry, no optimistic
+   resolution runs.
+   - Source assertion: the call into the resolver is gated by the existing txMap lookup.
+
+7. **Missing army guard**: when `armyManager.getArmy(entityId)` is undefined, the resolver is a no-op.
+   - Unit test against the pure builder: it returns `null` / undefined so the caller skips.
+
+### Green phase
+
+Implement:
+
+- `pendingArmyMovementTxTargets` map + cleanup
+- `buildOptimisticArmyTileUpdate(...)` pure function in `scenes/worldmap-optimistic-movement.ts`
+- `resolveArmyMovementOptimistically(...)` on `WorldmapScene`
+- Wire into `handleTransactionComplete` and converge-log on the indexer tile handler
+- Add the two new latency phases in the appropriate places
+
+### Refactor phase
+
+- Keep the optimistic planner a pure function (no `WorldmapScene` dependency) so tests are stable against rendering
+  details.
+- Keep `handleTransactionComplete` tiny: record phase, lookup, call resolver.
+- Keep `registerArmyWorldUpdateSubscriptions` changes minimal: single convergence-log call gated by
+  `optimisticallyResolvedArmies.has(entityId)`.
+
+## Verification
+
+Targeted tests:
+
+- `worldmap-optimistic-movement.source.test.ts` (new, red-phase assertions)
+- `worldmap-optimistic-movement.test.ts` (new, pure builder)
+- `worldmap-movement-latency-tracing.source.test.ts` (extended)
+- `worldmap-pending-movement-visual-handoff.source.test.ts` (must still pass — no regression)
+- `worldmap-arrival-ghost.source.test.ts` (must still pass)
+- `worldmap-travel-effect-lifecycle.source.test.ts` (must still pass)
+
+Broader:
+
+- `pnpm run format`
+- `pnpm --filter eternum-game-client test`
+
+## Expected Outcome
+
+After the change:
+
+- On tx confirmation the unit begins animating toward its destination immediately; the "move_requested →
+  movement_started" latency phase window collapses to the network+provider confirmation time, not the indexer delivery
+  time.
+- Indexer tile updates no longer gate visual movement for local armies. They continue to be authoritative but serve as
+  silent convergence for already-resolved moves.
+- Remote armies, explorer troop updates, failure paths, and the stale-movement fallback are unchanged.

--- a/client/apps/game/src/three/WORLDMAP_OPTIMISTIC_MOVE_PRD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_OPTIMISTIC_MOVE_PRD_TDD.md
@@ -90,20 +90,27 @@ directly from `transactionComplete` without coordination flags. The later indexe
 ## Non-goals
 
 - Optimistic updates for remote (other players') armies. Those still flow exclusively through the indexer.
+- Optimistic resolution for **explore** actions. The explore contract
+  (`contracts/game/src/systems/combat/contracts/troop_movement.cairo:170-286`) uses on-chain VRF to decide whether
+  treasure is found. When treasure _is_ found, the explorer is rewound to its source hex (lines 277-286). Because we
+  cannot predict the VRF result client-side, optimistically animating to the requested destination would produce a
+  visible source → destination → source ping-pong whenever treasure is discovered. Explore therefore continues to use
+  the indexer-driven path (tx confirmed → `tx_confirmed` latency phase only → real `onTileUpdate` drives the move).
 - Optimistic stamina or troop count updates. `queuePendingMovementStamina(...)` already handles stamina; indexer still
   owns troop counts.
-- Optimistic explore result (new biome reveal, extra rewards). Biome/reward data still arrives through Torii; only the
-  army's visible position is resolved optimistically.
+- Optimistic explore result (new biome reveal, extra rewards). Biome/reward data still arrives through Torii.
 - Changing `ArmyActionManager`, system calls, or tx confirmation plumbing. Only the renderer-side listener changes.
 
 ## Proposed Behavior
 
-### New lifecycle for local moves
+### New lifecycle for local travel moves
+
+Explore actions deliberately skip step 4 and therefore short-circuit at step 5 (see Non-goals above).
 
 1. submit move
 2. mark pending + travel FX + arrival ghost (unchanged)
 3. record `tx_submitted`; store `{txHash -> entityId}` (unchanged)
-4. store `{txHash -> targetHex}` alongside the entity map
+4. **travel actions only** — store `{txHash -> targetHex}` alongside the entity map
 5. **on `transactionComplete`**:
    - record `tx_confirmed`
    - synthesize an `ExplorerTroopsTileSystemUpdate` using tracked army data + cached target hex

--- a/client/apps/game/src/three/WORLDMAP_OPTIMISTIC_MOVE_PRD_TDD.md
+++ b/client/apps/game/src/three/WORLDMAP_OPTIMISTIC_MOVE_PRD_TDD.md
@@ -92,7 +92,8 @@ directly from `transactionComplete` without coordination flags. The later indexe
 - Optimistic updates for remote (other players') armies. Those still flow exclusively through the indexer.
 - Optimistic resolution for **explore** actions. The explore contract
   (`contracts/game/src/systems/combat/contracts/troop_movement.cairo:170-286`) uses on-chain VRF to decide whether
-  treasure is found. When treasure _is_ found, the explorer is rewound to its source hex (lines 277-286). Because we
+  treasure is found. When treasure _is_ found, the explorer is rewound to its source hex (lines 277-286 — the
+  `occupy_destination == false` branch sets `explorer.coord = from` and re-occupies the source tile). Because we
   cannot predict the VRF result client-side, optimistically animating to the requested destination would produce a
   visible source → destination → source ping-pong whenever treasure is discovered. Explore therefore continues to use
   the indexer-driven path (tx confirmed → `tx_confirmed` latency phase only → real `onTileUpdate` drives the move).

--- a/client/apps/game/src/three/managers/army-manager-move-race.source.test.ts
+++ b/client/apps/game/src/three/managers/army-manager-move-race.source.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("ArmyManager.moveArmy race guard", () => {
+  it("claims the destination in armies Map synchronously before any await", () => {
+    const source = readSource("src/three/managers/army-manager.ts");
+
+    const methodStart = source.indexOf("public async moveArmy(entityId: ID, hexCoords: Position)");
+    expect(methodStart).toBeGreaterThan(-1);
+    // Read a window large enough to cover the moveArmy body (~2500 chars).
+    const methodBody = source.slice(methodStart, methodStart + 2500);
+
+    const claimIndex = methodBody.indexOf("this.armies.set(entityId, { ...armyData, hexCoords })");
+    const findPathAwaitIndex = methodBody.indexOf("await gameWorkerManager.findPath");
+
+    expect(claimIndex).toBeGreaterThan(-1);
+    expect(findPathAwaitIndex).toBeGreaterThan(-1);
+    // Regression guard: moving this set below the findPath await reintroduces
+    // the optimistic ↔ authoritative moveArmy ping-pong because a racing
+    // second call sees the stale source position and runs a second animation
+    // that snaps the in-flight instance back to path[0] (source).
+    expect(claimIndex).toBeLessThan(findPathAwaitIndex);
+  });
+});

--- a/client/apps/game/src/three/managers/army-manager-move-race.source.test.ts
+++ b/client/apps/game/src/three/managers/army-manager-move-race.source.test.ts
@@ -7,14 +7,39 @@ import { describe, expect, it } from "vitest";
 
 const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
 
+const extractMethodBody = (source: string, signature: string): string => {
+  const signatureIndex = source.indexOf(signature);
+  if (signatureIndex < 0) {
+    throw new Error(`method signature not found: ${signature}`);
+  }
+
+  const bodyStart = source.indexOf("{", signatureIndex);
+  if (bodyStart < 0) {
+    throw new Error(`opening brace not found for: ${signature}`);
+  }
+
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i += 1) {
+    const ch = source[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(signatureIndex, i + 1);
+      }
+    }
+  }
+
+  throw new Error(`closing brace not found for: ${signature}`);
+};
+
 describe("ArmyManager.moveArmy race guard", () => {
   it("claims the destination in armies Map synchronously before any await", () => {
     const source = readSource("src/three/managers/army-manager.ts");
-
-    const methodStart = source.indexOf("public async moveArmy(entityId: ID, hexCoords: Position)");
-    expect(methodStart).toBeGreaterThan(-1);
-    // Read a window large enough to cover the moveArmy body (~2500 chars).
-    const methodBody = source.slice(methodStart, methodStart + 2500);
+    // Brace-balanced body extraction survives future growth of moveArmy so the
+    // test doesn't silently skip the findPath await by running off the end of
+    // a fixed-size window.
+    const methodBody = extractMethodBody(source, "public async moveArmy(entityId: ID, hexCoords: Position)");
 
     const claimIndex = methodBody.indexOf("this.armies.set(entityId, { ...armyData, hexCoords })");
     const findPathAwaitIndex = methodBody.indexOf("await gameWorkerManager.findPath");
@@ -26,5 +51,12 @@ describe("ArmyManager.moveArmy race guard", () => {
     // second call sees the stale source position and runs a second animation
     // that snaps the in-flight instance back to path[0] (source).
     expect(claimIndex).toBeLessThan(findPathAwaitIndex);
+
+    // Regression guard against silently reintroducing the post-await set in
+    // addition to the pre-await claim — two sets would let a concurrent
+    // moveArmy observe the old armyData between awaits.
+    const claimRegex = /this\.armies\.set\(entityId, \{ \.\.\.armyData, hexCoords \}\)/g;
+    const claimMatches = methodBody.match(claimRegex) ?? [];
+    expect(claimMatches).toHaveLength(1);
   });
 });

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1800,6 +1800,13 @@ export class ArmyManager {
 
     if (startPos.x === targetPos.x && startPos.y === targetPos.y) return;
 
+    // Claim the destination synchronously before the pathfinding await so that
+    // any concurrent moveArmy(entity, sameDest) call — e.g. an authoritative
+    // Torii tile update racing our optimistic resolution — sees the updated
+    // position and hits the same-position early return above instead of
+    // starting a second animation that would rewind the in-flight one.
+    this.armies.set(entityId, { ...armyData, hexCoords });
+
     // todo: currently taking max stamina of paladin as max stamina but need to refactor
     const maxTroopStamina = configManager.getTroopStaminaConfig(TroopType.Paladin, TroopTier.T3);
     const staminaMax = Number(maxTroopStamina?.staminaMax ?? 0);
@@ -1838,7 +1845,6 @@ export class ArmyManager {
 
     // Add to destination bucket (keep in source bucket too - updateSpatialIndex modified below)
     this.addToSpatialBucket(entityId, hexCoords);
-    this.armies.set(entityId, { ...armyData, hexCoords });
 
     const matrixIndex = armyData.matrixIndex;
     if (matrixIndex === undefined) {

--- a/client/apps/game/src/three/scenes/worldmap-army-tab-selection.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tab-selection.test.ts
@@ -269,7 +269,7 @@ describe("resolvePendingArmyMovementFallbackPlan", () => {
 
 describe("resolvePendingArmyMovementTxFailurePlan", () => {
   it("clears pending movement when txHash maps to a pending entity", () => {
-    const txEntityMap = new Map<string, number>([["0xabc", 42]]);
+    const txEntityMap = new Map<string, Set<number>>([["0xabc", new Set([42])]]);
     const pendingEntities = new Set<number>([42]);
 
     expect(
@@ -279,13 +279,12 @@ describe("resolvePendingArmyMovementTxFailurePlan", () => {
         pendingEntities,
       }),
     ).toEqual({
-      shouldClearPendingMovement: true,
-      entityId: 42,
+      entitiesToClear: [42],
     });
   });
 
   it("does not clear when txHash is not in the mapping", () => {
-    const txEntityMap = new Map<string, number>();
+    const txEntityMap = new Map<string, Set<number>>();
     const pendingEntities = new Set<number>([42]);
 
     expect(
@@ -295,13 +294,12 @@ describe("resolvePendingArmyMovementTxFailurePlan", () => {
         pendingEntities,
       }),
     ).toEqual({
-      shouldClearPendingMovement: false,
-      entityId: undefined,
+      entitiesToClear: [],
     });
   });
 
   it("does not clear when entity is no longer pending (already resolved)", () => {
-    const txEntityMap = new Map<string, number>([["0xabc", 42]]);
+    const txEntityMap = new Map<string, Set<number>>([["0xabc", new Set([42])]]);
     const pendingEntities = new Set<number>();
 
     expect(
@@ -311,8 +309,36 @@ describe("resolvePendingArmyMovementTxFailurePlan", () => {
         pendingEntities,
       }),
     ).toEqual({
-      shouldClearPendingMovement: false,
-      entityId: 42,
+      entitiesToClear: [],
     });
+  });
+
+  it("returns every still-pending entity when a batched tx hash covers multiple moves", () => {
+    // Regression guard: rapid successive moves are coalesced into one multicall
+    // by `PromiseQueue.processBatch`, so they share a single transaction_hash.
+    // All pending entities attached to that hash must be cleared on failure.
+    const txEntityMap = new Map<string, Set<number>>([["0xbatched", new Set([10, 20, 30])]]);
+    const pendingEntities = new Set<number>([10, 20, 30]);
+
+    const plan = resolvePendingArmyMovementTxFailurePlan({
+      txHash: "0xbatched",
+      txEntityMap,
+      pendingEntities,
+    });
+
+    expect(plan.entitiesToClear.sort()).toEqual([10, 20, 30]);
+  });
+
+  it("skips entities in the batch that have already resolved", () => {
+    const txEntityMap = new Map<string, Set<number>>([["0xbatched", new Set([10, 20, 30])]]);
+    const pendingEntities = new Set<number>([20]);
+
+    const plan = resolvePendingArmyMovementTxFailurePlan({
+      txHash: "0xbatched",
+      txEntityMap,
+      pendingEntities,
+    });
+
+    expect(plan.entitiesToClear).toEqual([20]);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-army-tab-selection.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tab-selection.ts
@@ -44,13 +44,16 @@ interface PendingArmyMovementFallbackPlan {
 
 interface ResolvePendingArmyMovementTxFailurePlanInput {
   txHash: string;
-  txEntityMap: Map<string, number>;
+  // txHash → entity set: a single batched multicall delivers one hash for
+  // N moves, so this MUST be a set, not a single entity id.
+  txEntityMap: Map<string, Set<number>>;
   pendingEntities: Set<number>;
 }
 
 interface PendingArmyMovementTxFailurePlan {
-  shouldClearPendingMovement: boolean;
-  entityId: number | undefined;
+  // All entities that initiated a move for this txHash AND are still pending.
+  // Caller should clear pending state + lifecycle + ghost for each.
+  entitiesToClear: number[];
 }
 
 /**
@@ -149,21 +152,26 @@ export function resolvePendingArmyMovementFallbackPlan(
 }
 
 /**
- * Decide whether to clear pending movement when a transaction fails on-chain.
- * The txEntityMap correlates transaction hashes to the entity that initiated the move.
+ * Decide which entities to clear pending movement for when a transaction
+ * fails on-chain. A single `txHash` may correspond to MULTIPLE entities when
+ * several moves were batched into one multicall (see `PromiseQueue.processBatch`).
+ * Returns only the subset of those entities that are still actively pending
+ * — entities that already resolved (e.g., via animation start) are skipped.
  */
 export function resolvePendingArmyMovementTxFailurePlan(
   input: ResolvePendingArmyMovementTxFailurePlanInput,
 ): PendingArmyMovementTxFailurePlan {
-  const entityId = input.txEntityMap.get(input.txHash);
-
-  if (entityId === undefined) {
-    return { shouldClearPendingMovement: false, entityId: undefined };
+  const entities = input.txEntityMap.get(input.txHash);
+  if (!entities || entities.size === 0) {
+    return { entitiesToClear: [] };
   }
 
-  if (!input.pendingEntities.has(entityId)) {
-    return { shouldClearPendingMovement: false, entityId };
+  const entitiesToClear: number[] = [];
+  for (const entityId of entities) {
+    if (input.pendingEntities.has(entityId)) {
+      entitiesToClear.push(entityId);
+    }
   }
 
-  return { shouldClearPendingMovement: true, entityId };
+  return { entitiesToClear };
 }

--- a/client/apps/game/src/three/scenes/worldmap-movement-latency-tracing.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-movement-latency-tracing.source.test.ts
@@ -25,6 +25,7 @@ describe("Worldmap movement latency tracing wiring", () => {
 
     expect(source).toContain('"movement_resolved_optimistically"');
     expect(source).toContain('"movement_optimistic_convergence"');
+    expect(source).toContain('"movement_optimistic_stale_skipped"');
   });
 
   it("uses an authoritative world-sync timeout longer than the old 10 second stale cutoff", () => {

--- a/client/apps/game/src/three/scenes/worldmap-movement-latency-tracing.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-movement-latency-tracing.source.test.ts
@@ -20,6 +20,13 @@ describe("Worldmap movement latency tracing wiring", () => {
     expect(source).toContain('"movement_completed"');
   });
 
+  it("records optimistic resolution and indexer convergence phases", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain('"movement_resolved_optimistically"');
+    expect(source).toContain('"movement_optimistic_convergence"');
+  });
+
   it("uses an authoritative world-sync timeout longer than the old 10 second stale cutoff", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
 

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
@@ -103,4 +103,38 @@ describe("Worldmap optimistic movement wiring", () => {
     const handlerBody = source.slice(handlerStart, handlerStart + 2200);
     expect(handlerBody).toMatch(/resolveArmyMovementOptimistically\([\s\S]*?\)\s*\.catch\(/);
   });
+
+  it("imports and wires the stale-update guard into the indexer tile-update handler", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("isStaleOptimisticIndexerUpdate");
+    // Gate the call on optimisticallyResolvedArmies so remote / freshly-synced
+    // armies without an optimistic marker keep the normal apply path.
+    expect(source).toMatch(
+      /this\.optimisticallyResolvedArmies\.has\(update\.entityId\)\s*&&\s*isStaleOptimisticIndexerUpdate\(/,
+    );
+    expect(source).toContain('"movement_optimistic_stale_skipped"');
+  });
+
+  it("keeps the optimistic marker set on stale-skip so the LATEST target's indexer delivery still converges", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const phaseIdx = source.indexOf('"movement_optimistic_stale_skipped"');
+    expect(phaseIdx).toBeGreaterThan(-1);
+    // Walk forward to the `return;` that ends the stale branch and make sure
+    // `optimisticallyResolvedArmies.delete` is NOT invoked in between — we
+    // want to keep waiting for the authoritative latest-tx update.
+    const staleBranch = source.slice(phaseIdx, phaseIdx + 800);
+    expect(staleBranch).toContain("return;");
+    expect(staleBranch).not.toContain("this.optimisticallyResolvedArmies.delete");
+  });
+
+  it("refreshes armyLastTileSyncAt on a stale-skip so the staleness fallback does not fire mid-optimistic-chain", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const phaseIdx = source.indexOf('"movement_optimistic_stale_skipped"');
+    expect(phaseIdx).toBeGreaterThan(-1);
+    const staleBranch = source.slice(phaseIdx, phaseIdx + 800);
+    expect(staleBranch).toMatch(/this\.armyLastTileSyncAt\.set\(update\.entityId,\s*Date\.now\(\)\)/);
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
@@ -15,6 +15,18 @@ describe("Worldmap optimistic movement wiring", () => {
     expect(source).toMatch(/pendingArmyMovementTxTargets\.set\(\s*txHash\s*,/);
   });
 
+  it("only registers the optimistic target for travel actions (explore rewinds on VRF treasure hit)", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const setIndex = source.indexOf("this.pendingArmyMovementTxTargets.set(txHash");
+    expect(setIndex).toBeGreaterThan(-1);
+    // Walk backwards from the set() call and find the nearest enclosing
+    // `if (...)` condition — it must gate on isTravelAction so explore txs
+    // never enter the optimistic pipeline.
+    const window = source.slice(Math.max(0, setIndex - 400), setIndex);
+    expect(window).toMatch(/if \(isTravelAction\)/);
+  });
+
   it("imports the pure optimistic update builder", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
 

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
@@ -70,7 +70,9 @@ describe("Worldmap optimistic movement wiring", () => {
 
     const methodStart = source.indexOf("private clearPendingArmyMovement");
     expect(methodStart).toBeGreaterThan(-1);
-    const methodBody = source.slice(methodStart, methodStart + 1600);
+    // Widened from 1600 → 2400 to accommodate the per-entity cleanup loop
+    // that iterates the batched-tx map-of-sets.
+    const methodBody = source.slice(methodStart, methodStart + 2400);
     expect(methodBody).toContain("pendingArmyMovementTxTargets");
     expect(methodBody).toContain("optimisticallyResolvedArmies");
   });
@@ -127,6 +129,39 @@ describe("Worldmap optimistic movement wiring", () => {
     const staleBranch = source.slice(phaseIdx, phaseIdx + 800);
     expect(staleBranch).toContain("return;");
     expect(staleBranch).not.toContain("this.optimisticallyResolvedArmies.delete");
+  });
+
+  it("stores txHash → entity SET (not a single entity) so batched multicalls resolve every move, not just the last", () => {
+    // Regression guard against the `pendingArmyMovementTxMap` reverting to
+    // `Map<string, ID>`. PromiseQueue.processBatch coalesces rapid moves into
+    // ONE multicall that returns a single transaction_hash; mapping txHash to
+    // a single entity id would only resolve the last-written move optimistically
+    // and leave the rest waiting on the indexer.
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toMatch(/pendingArmyMovementTxMap:\s*Map<string,\s*Set<ID>>/);
+    expect(source).toMatch(/pendingArmyMovementTxTargets:\s*Map<string,\s*Map<ID,\s*HexPosition>>/);
+
+    // Submit path must ADD to the entity set, not overwrite it.
+    expect(source).toMatch(/entitiesForTx\.add\(selectedEntityId\)/);
+    // And the target map must key by entity inside the per-tx map so siblings
+    // in a batch keep their own destinations.
+    expect(source).toMatch(/targetsForTx\.set\(selectedEntityId,/);
+  });
+
+  it("iterates every entity attached to a txHash when the tx confirms so a batched multicall resolves every move", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const handlerStart = source.indexOf("this.handleTransactionComplete");
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerBody = source.slice(handlerStart, handlerStart + 2400);
+
+    // A for-of over the entity set (snapshotted to array so downstream
+    // handlers that mutate the set — e.g. movement_started clears — don't
+    // disturb iteration) is the load-bearing bit.
+    expect(handlerBody).toMatch(/for\s*\(\s*const\s+entityId\s+of\s+\[\.\.\.entities\]\s*\)/);
+    // Per-entity target lookup inside the loop.
+    expect(handlerBody).toMatch(/targetsForTx\?\.get\(entityId\)/);
   });
 
   it("refreshes armyLastTileSyncAt on a stale-skip so the staleness fallback does not fire mid-optimistic-chain", () => {

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Worldmap optimistic movement wiring", () => {
+  it("captures the destination hex alongside the tx → entity map when the tx submits", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("pendingArmyMovementTxTargets");
+    expect(source).toMatch(/pendingArmyMovementTxTargets\.set\(\s*txHash\s*,/);
+  });
+
+  it("imports the pure optimistic update builder", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("buildOptimisticArmyTileUpdate");
+    expect(source).toContain('from "./worldmap-optimistic-movement"');
+  });
+
+  it("resolves the movement optimistically from the tx confirmation handler", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const handlerStart = source.indexOf("this.handleTransactionComplete");
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerBody = source.slice(handlerStart, handlerStart + 1800);
+    expect(handlerBody).toContain("resolveArmyMovementOptimistically");
+  });
+
+  it("drives the existing cache + army-manager pipeline from the optimistic resolver", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const methodMatch = source.match(/private (?:async )?resolveArmyMovementOptimistically\b/);
+    expect(methodMatch).not.toBeNull();
+    const methodStart = methodMatch!.index!;
+    const methodBody = source.slice(methodStart, methodStart + 2200);
+    expect(methodBody).toContain("this.updateArmyHexes(");
+    expect(methodBody).toContain("this.armyManager.onTileUpdate(");
+  });
+
+  it("records a new movement_resolved_optimistically latency phase", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    expect(source).toContain('"movement_resolved_optimistically"');
+  });
+
+  it("tracks optimistically-resolved armies for later indexer convergence", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    expect(source).toContain("optimisticallyResolvedArmies");
+    expect(source).toContain('"movement_optimistic_convergence"');
+  });
+
+  it("clears optimistic tracking when pending movement is cleared", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const methodStart = source.indexOf("private clearPendingArmyMovement");
+    expect(methodStart).toBeGreaterThan(-1);
+    const methodBody = source.slice(methodStart, methodStart + 1600);
+    expect(methodBody).toContain("pendingArmyMovementTxTargets");
+    expect(methodBody).toContain("optimisticallyResolvedArmies");
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.source.test.ts
@@ -74,4 +74,33 @@ describe("Worldmap optimistic movement wiring", () => {
     expect(methodBody).toContain("pendingArmyMovementTxTargets");
     expect(methodBody).toContain("optimisticallyResolvedArmies");
   });
+
+  it("drops a stale optimistic marker when a new pending movement starts so a stalled convergence cannot block future optimistic resolves", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const methodStart = source.indexOf("private markPendingArmyMovement");
+    expect(methodStart).toBeGreaterThan(-1);
+    const methodBody = source.slice(methodStart, methodStart + 800);
+    expect(methodBody).toContain("this.optimisticallyResolvedArmies.delete(entityId)");
+  });
+
+  it("mirrors the post-tile-update arrow recalculation the indexer handler runs so overlays follow the optimistic move", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const methodMatch = source.match(/private (?:async )?resolveArmyMovementOptimistically\b/);
+    expect(methodMatch).not.toBeNull();
+    const methodStart = methodMatch!.index!;
+    const methodBody = source.slice(methodStart, methodStart + 2500);
+    expect(methodBody).toContain("this.recalculateArrowsForEntity(entityId)");
+    expect(methodBody).toContain("this.recalculateArrowsForEntitiesRelatedTo(entityId)");
+  });
+
+  it("logs optimistic resolver failures instead of silently dropping them on the fire-and-forget path", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const handlerStart = source.indexOf("this.handleTransactionComplete");
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerBody = source.slice(handlerStart, handlerStart + 2200);
+    expect(handlerBody).toMatch(/resolveArmyMovementOptimistically\([\s\S]*?\)\s*\.catch\(/);
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.test.ts
@@ -52,10 +52,25 @@ describe("buildOptimisticArmyTileUpdate", () => {
     expect(update!.guildName).toBe("Democritus");
     expect(update!.ownerStructureId).toBe(7);
     expect(update!.isDaydreamsAgent).toBe(false);
-    expect(update!.troopCount).toBe(123);
-    expect(update!.currentStamina).toBe(200);
-    expect(update!.maxStamina).toBe(400);
-    expect(update!.onChainStamina?.amount).toBe(200n);
+  });
+
+  it("does NOT propagate stale cached stamina / troop count from the army into the synthetic update", () => {
+    // Regression guard: stamina and troop count are owned by pending-stamina
+    // store + explorerTroops indexer stream. Leaking the pre-move cached
+    // values through the synthetic update desyncs the UI against pending /
+    // on-chain sources.
+    const army = makeArmy({
+      currentStamina: 999,
+      maxStamina: 1000,
+      onChainStamina: { amount: 777n, updatedTick: 1234 },
+      troopCount: 42,
+    });
+    const update = buildOptimisticArmyTileUpdate(army, { col: 2147483750, row: 2147483749 });
+
+    expect(update!.currentStamina).toBeUndefined();
+    expect(update!.maxStamina).toBeUndefined();
+    expect(update!.onChainStamina).toBeUndefined();
+    expect(update!.troopCount).toBeUndefined();
   });
 
   it("uses the requested target hex, not the army's current position", () => {

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.test.ts
@@ -1,0 +1,89 @@
+import type { HexPosition } from "@bibliothecadao/types";
+import { TroopTier, TroopType } from "@bibliothecadao/types";
+import { describe, expect, it } from "vitest";
+
+import { Position } from "@bibliothecadao/eternum";
+
+import type { ArmyData } from "../types/common";
+import { buildOptimisticArmyTileUpdate } from "./worldmap-optimistic-movement";
+
+function makeArmy(overrides: Partial<ArmyData> = {}): ArmyData {
+  return {
+    entityId: 42,
+    hexCoords: new Position({ x: 2147483748, y: 2147483748 }),
+    isMine: true,
+    owningStructureId: 7,
+    owner: {
+      address: 0xabcdn,
+      ownerName: "Pondering",
+      guildName: "Democritus",
+    },
+    color: "#ff8800",
+    category: TroopType.Paladin,
+    tier: TroopTier.T3,
+    isDaydreamsAgent: false,
+    troopCount: 123,
+    currentStamina: 200,
+    maxStamina: 400,
+    onChainStamina: { amount: 200n, updatedTick: 9999 },
+    battleCooldownEnd: 0,
+    ...overrides,
+  } as ArmyData;
+}
+
+describe("buildOptimisticArmyTileUpdate", () => {
+  it("returns null when the army is missing", () => {
+    const update = buildOptimisticArmyTileUpdate(undefined, { col: 2147483750, row: 2147483750 });
+    expect(update).toBeNull();
+  });
+
+  it("copies troop identity and owner fields from the tracked army", () => {
+    const army = makeArmy();
+    const targetHex: HexPosition = { col: 2147483750, row: 2147483749 };
+
+    const update = buildOptimisticArmyTileUpdate(army, targetHex);
+
+    expect(update).not.toBeNull();
+    expect(update!.entityId).toBe(army.entityId);
+    expect(update!.troopType).toBe(TroopType.Paladin);
+    expect(update!.troopTier).toBe(TroopTier.T3);
+    expect(update!.ownerAddress).toBe(0xabcdn);
+    expect(update!.ownerName).toBe("Pondering");
+    expect(update!.guildName).toBe("Democritus");
+    expect(update!.ownerStructureId).toBe(7);
+    expect(update!.isDaydreamsAgent).toBe(false);
+    expect(update!.troopCount).toBe(123);
+    expect(update!.currentStamina).toBe(200);
+    expect(update!.maxStamina).toBe(400);
+    expect(update!.onChainStamina?.amount).toBe(200n);
+  });
+
+  it("uses the requested target hex, not the army's current position", () => {
+    const army = makeArmy({
+      hexCoords: new Position({ x: 2147483700, y: 2147483700 }),
+    });
+    const targetHex: HexPosition = { col: 2147483750, row: 2147483745 };
+
+    const update = buildOptimisticArmyTileUpdate(army, targetHex);
+
+    expect(update!.hexCoords).toEqual(targetHex);
+  });
+
+  it("never sets the removed flag so downstream handlers treat it as a positional update", () => {
+    const army = makeArmy();
+    const update = buildOptimisticArmyTileUpdate(army, { col: 1, row: 2 });
+    expect(update!.removed).toBeFalsy();
+  });
+
+  it("omits the battle attacker/defender history when the army has no battle state", () => {
+    const army = makeArmy({ battleCooldownEnd: 0 });
+    const update = buildOptimisticArmyTileUpdate(army, { col: 1, row: 2 });
+    expect(update!.battleData).toBeUndefined();
+  });
+
+  it("handles a null ownerStructureId without throwing", () => {
+    const army = makeArmy({ owningStructureId: null });
+    const update = buildOptimisticArmyTileUpdate(army, { col: 1, row: 2 });
+    expect(update!.ownerStructureId).toBeNull();
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { Position } from "@bibliothecadao/eternum";
 
 import type { ArmyData } from "../types/common";
-import { buildOptimisticArmyTileUpdate } from "./worldmap-optimistic-movement";
+import { buildOptimisticArmyTileUpdate, isStaleOptimisticIndexerUpdate } from "./worldmap-optimistic-movement";
 
 function makeArmy(overrides: Partial<ArmyData> = {}): ArmyData {
   return {
@@ -85,5 +85,44 @@ describe("buildOptimisticArmyTileUpdate", () => {
     const army = makeArmy({ owningStructureId: null });
     const update = buildOptimisticArmyTileUpdate(army, { col: 1, row: 2 });
     expect(update!.ownerStructureId).toBeNull();
+  });
+});
+
+describe("isStaleOptimisticIndexerUpdate", () => {
+  it("returns false when the tracked army is missing so the caller applies the update normally", () => {
+    const stale = isStaleOptimisticIndexerUpdate(undefined, {
+      hexCoords: { col: 2147483750, row: 2147483750 },
+    });
+    expect(stale).toBe(false);
+  });
+
+  it("returns false when the incoming update matches the army's current position (authoritative convergence)", () => {
+    const army = makeArmy({
+      hexCoords: new Position({ x: 2147483750, y: 2147483749 }),
+    });
+    const stale = isStaleOptimisticIndexerUpdate(army, {
+      hexCoords: { col: 2147483750, row: 2147483749 },
+    });
+    expect(stale).toBe(false);
+  });
+
+  it("returns true when the incoming update targets a position the client has already advanced past", () => {
+    // Scenario: armies map is at C (latest optimistic target); indexer is
+    // still delivering the earlier tx's update for B.
+    const armyAtC = makeArmy({
+      hexCoords: new Position({ x: 2147483752, y: 2147483752 }),
+    });
+    const staleUpdateForB = { hexCoords: { col: 2147483750, row: 2147483750 } };
+    expect(isStaleOptimisticIndexerUpdate(armyAtC, staleUpdateForB)).toBe(true);
+  });
+
+  it("compares on normalized coordinates so a mix of contract/normalized inputs still matches", () => {
+    // army stored with contract coords (FELT_CENTER-offset), update arriving
+    // with same position expressed either way should NOT be flagged stale.
+    const army = makeArmy({
+      hexCoords: new Position({ x: 2147483748, y: 2147483748 }),
+    });
+    const sameHex = { hexCoords: { col: 2147483748, row: 2147483748 } };
+    expect(isStaleOptimisticIndexerUpdate(army, sameHex)).toBe(false);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
@@ -1,0 +1,39 @@
+import type { ExplorerTroopsTileSystemUpdate } from "@bibliothecadao/eternum";
+import type { HexPosition } from "@bibliothecadao/types";
+
+import type { ArmyData } from "../types/common";
+
+/**
+ * Build a synthetic `ExplorerTroopsTileSystemUpdate` that drives the existing
+ * `updateArmyHexes` + `ArmyManager.onTileUpdate` pipeline when the chain tx for a
+ * local move confirms. Returns null when the tracked army is not available —
+ * in that case the caller should wait for the authoritative indexer update.
+ *
+ * The output is intentionally minimal: it only needs the fields the cache sync
+ * and army-manager transition path consume. Troop count / stamina / battle data
+ * continue to converge through the real indexer stream.
+ */
+export function buildOptimisticArmyTileUpdate(
+  army: ArmyData | undefined,
+  targetHex: HexPosition,
+): ExplorerTroopsTileSystemUpdate | null {
+  if (!army) {
+    return null;
+  }
+
+  return {
+    entityId: army.entityId,
+    hexCoords: { col: targetHex.col, row: targetHex.row },
+    troopType: army.category,
+    troopTier: army.tier,
+    isDaydreamsAgent: army.isDaydreamsAgent,
+    ownerName: army.owner.ownerName,
+    guildName: army.owner.guildName,
+    ownerAddress: army.owner.address,
+    ownerStructureId: army.owningStructureId,
+    troopCount: army.troopCount,
+    currentStamina: army.currentStamina,
+    maxStamina: army.maxStamina,
+    onChainStamina: army.onChainStamina,
+  };
+}

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
@@ -10,13 +10,28 @@ import type { ArmyData } from "../types/common";
  * local move confirms. Returns null when the tracked army is not available —
  * in that case the caller should wait for the authoritative indexer update.
  *
- * The output is intentionally minimal: it only needs the fields the cache sync
- * and army-manager transition path consume. Troop count / stamina / battle data
- * continue to converge through the real indexer stream. `battleData` is
- * deliberately omitted — travel can only originate from a non-battle state, so
- * there is no battle context to propagate optimistically, and downstream
- * `ArmyManager.onTileUpdate` destructures it with `|| {}` so the absence is
- * safe.
+ * The output is the minimum set of fields the position-handoff path consumes:
+ * entity id, destination hex, troop identity, and owner. We deliberately do NOT
+ * propagate stamina, troop count, or battle data:
+ *
+ *   - Stamina is owned by two sources: `useArmyStaminaSourceStore` (pending,
+ *     written at move submit with the debited amount + current tick) and the
+ *     on-chain update delivered via `onExplorerTroopsUpdate`. The synthetic
+ *     update's `army.onChainStamina` / `army.currentStamina` are stale cached
+ *     snapshots from BEFORE the move and would desync the UI from the pending
+ *     / on-chain sources if any path ever read them. Omitting them means the
+ *     stamina display is driven end-to-end by pending (until on-chain catches
+ *     up) with no chance of the optimistic path leaking pre-move values.
+ *   - Troop count is only touched by battles, and travel never enters a battle
+ *     tile — the authoritative explorer-troops update is the source of truth.
+ *   - Battle data: travel can only originate from a non-battle state, so there
+ *     is no battle context to propagate, and downstream `onTileUpdate`
+ *     destructures `battleData` with `|| {}` so the absence is safe.
+ *
+ * The `onTileUpdate` handler's existing-army branch ignores these fields
+ * anyway (it only calls `moveArmy` + `syncTrackedArmyOwnerState`), so omitting
+ * them changes nothing for the happy path — it just closes the door on any
+ * future reader picking up stale cached stamina from the optimistic update.
  */
 export function buildOptimisticArmyTileUpdate(
   army: ArmyData | undefined,
@@ -36,10 +51,6 @@ export function buildOptimisticArmyTileUpdate(
     guildName: army.owner.guildName,
     ownerAddress: army.owner.address,
     ownerStructureId: army.owningStructureId,
-    troopCount: army.troopCount,
-    currentStamina: army.currentStamina,
-    maxStamina: army.maxStamina,
-    onChainStamina: army.onChainStamina,
   };
 }
 

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
@@ -11,7 +11,11 @@ import type { ArmyData } from "../types/common";
  *
  * The output is intentionally minimal: it only needs the fields the cache sync
  * and army-manager transition path consume. Troop count / stamina / battle data
- * continue to converge through the real indexer stream.
+ * continue to converge through the real indexer stream. `battleData` is
+ * deliberately omitted — travel can only originate from a non-battle state, so
+ * there is no battle context to propagate optimistically, and downstream
+ * `ArmyManager.onTileUpdate` destructures it with `|| {}` so the absence is
+ * safe.
  */
 export function buildOptimisticArmyTileUpdate(
   army: ArmyData | undefined,

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement.ts
@@ -1,4 +1,5 @@
 import type { ExplorerTroopsTileSystemUpdate } from "@bibliothecadao/eternum";
+import { Position } from "@bibliothecadao/eternum";
 import type { HexPosition } from "@bibliothecadao/types";
 
 import type { ArmyData } from "../types/common";
@@ -40,4 +41,42 @@ export function buildOptimisticArmyTileUpdate(
     maxStamina: army.maxStamina,
     onChainStamina: army.onChainStamina,
   };
+}
+
+/**
+ * Returns true if an authoritative Torii tile update for an entity that has
+ * an unconverged optimistic resolution targets an EARLIER position than the
+ * one the client is currently showing.
+ *
+ * Scenario this guards against:
+ *
+ *   t0  user moves A → B (optimistic). armies.hexCoords = B.
+ *   t1  user moves B → C (optimistic). armies.hexCoords = C.
+ *   t2  Torii finally delivers the tile update for the first tx (hex = B).
+ *
+ * Without this guard, the handler at t2 would call `updateArmyHexes(B)` and
+ * `armyManager.onTileUpdate(B)` → `moveArmy(entity, B)`. Because the armies
+ * Map was already advanced to C, `moveArmy`'s same-position early-return does
+ * not fire, and the army animates C → B — the visible "ping-pong" users see.
+ *
+ * We detect the stale case by comparing the tracked army's current normalized
+ * position (which equals the latest optimistic target) to the incoming
+ * update's normalized position. A mismatch while the entity still holds an
+ * unconverged optimistic marker means this update is behind the client.
+ *
+ * Relies on Torii's in-order delivery of tile updates for a single entity:
+ * once the update for the latest target arrives and converges, we clear the
+ * marker, so any still-later updates flow through the normal path (e.g., a
+ * chain correction or a fresh on-chain move).
+ */
+export function isStaleOptimisticIndexerUpdate(
+  army: ArmyData | undefined,
+  update: { hexCoords: HexPosition },
+): boolean {
+  if (!army) {
+    return false;
+  }
+  const currentNorm = army.hexCoords.getNormalized();
+  const updateNorm = new Position({ x: update.hexCoords.col, y: update.hexCoords.row }).getNormalized();
+  return currentNorm.x !== updateNorm.x || currentNorm.y !== updateNorm.y;
 }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -611,8 +611,15 @@ export default class WorldmapScene extends WarpTravel {
   private pendingArmyMovements: Set<ID> = new Set();
   private pendingArmyMovementStartedAt: Map<ID, number> = new Map();
   private pendingArmyMovementFallbackTimeouts: Map<ID, ReturnType<typeof setTimeout>> = new Map();
-  private pendingArmyMovementTxMap: Map<string, ID> = new Map();
-  private pendingArmyMovementTxTargets: Map<string, HexPosition> = new Map();
+  // txHash → entity set. One tx can cover MULTIPLE moves because PromiseQueue
+  // batches rapid successive calls into a single multicall (see
+  // packages/provider/src/promise-queue.ts processBatch). We must resolve
+  // the optimistic move for every entity attached to the hash, not just the
+  // last one that wrote to this map.
+  private pendingArmyMovementTxMap: Map<string, Set<ID>> = new Map();
+  // txHash → (entityId → target hex). Keyed by entity inside each tx so that a
+  // batched multicall carries independent targets per move.
+  private pendingArmyMovementTxTargets: Map<string, Map<ID, HexPosition>> = new Map();
   private optimisticallyResolvedArmies: Set<ID> = new Set();
   private pendingArmyMovementVisualLifecycleDisposers: Map<ID, () => void> = new Map();
 
@@ -1069,26 +1076,35 @@ export default class WorldmapScene extends WarpTravel {
         return;
       }
 
-      const entityId = this.pendingArmyMovementTxMap.get(txHash);
-      if (entityId === undefined) {
+      const entities = this.pendingArmyMovementTxMap.get(txHash);
+      if (!entities || entities.size === 0) {
         return;
       }
 
-      recordArmyMovementLatencyPhase({
-        phase: "tx_confirmed",
-        source: "worldmap",
-        entityId,
-        txHash,
-      });
+      const targetsForTx = this.pendingArmyMovementTxTargets.get(txHash);
 
-      const targetHex = this.pendingArmyMovementTxTargets.get(txHash);
-      if (!targetHex) {
-        return;
+      // Resolve every entity attached to this hash: when rapid successive moves
+      // are batched into one multicall they share the hash, and only iterating
+      // resolves each one optimistically. Snapshot into an array so mutations
+      // by downstream handlers (e.g., clearPendingArmyMovement on animation
+      // start) don't disturb this iteration.
+      for (const entityId of [...entities]) {
+        recordArmyMovementLatencyPhase({
+          phase: "tx_confirmed",
+          source: "worldmap",
+          entityId,
+          txHash,
+        });
+
+        const targetHex = targetsForTx?.get(entityId);
+        if (!targetHex) {
+          continue;
+        }
+
+        this.resolveArmyMovementOptimistically({ entityId, txHash, targetHex }).catch((error) => {
+          console.error("[worldmap] optimistic army movement resolution failed", error);
+        });
       }
-
-      this.resolveArmyMovementOptimistically({ entityId, txHash, targetHex }).catch((error) => {
-        console.error("[worldmap] optimistic army movement resolution failed", error);
-      });
     };
 
     this.handleTransactionFailed = (payload: { transactionHash?: string }) => {
@@ -1102,11 +1118,11 @@ export default class WorldmapScene extends WarpTravel {
         txEntityMap: this.pendingArmyMovementTxMap,
         pendingEntities: this.pendingArmyMovements,
       });
-      if (plan.shouldClearPendingMovement && plan.entityId !== undefined) {
-        this.clearPendingArmyMovement(plan.entityId);
-        useArmyStaminaSourceStore.getState().clearPendingStaminaSource(plan.entityId);
-        this.disposePendingMovementVisualLifecycle(plan.entityId);
-        this.arrivalGhostManager?.clearArrivalGhost(plan.entityId, "tx_failed");
+      for (const entityId of plan.entitiesToClear) {
+        this.clearPendingArmyMovement(entityId);
+        useArmyStaminaSourceStore.getState().clearPendingStaminaSource(entityId);
+        this.disposePendingMovementVisualLifecycle(entityId);
+        this.arrivalGhostManager?.clearArrivalGhost(entityId, "tx_failed");
       }
       this.pendingArmyMovementTxMap.delete(txHash);
       this.pendingArmyMovementTxTargets.delete(txHash);
@@ -2589,7 +2605,16 @@ export default class WorldmapScene extends WarpTravel {
             txHash,
           });
           if (txHash) {
-            this.pendingArmyMovementTxMap.set(txHash, selectedEntityId);
+            // Multiple moves can share a txHash (multicall batching in
+            // PromiseQueue.processBatch), so ADD to the entity set for this
+            // hash rather than overwriting it — otherwise only the
+            // last-registered entity in the batch would optimistically resolve.
+            let entitiesForTx = this.pendingArmyMovementTxMap.get(txHash);
+            if (!entitiesForTx) {
+              entitiesForTx = new Set<ID>();
+              this.pendingArmyMovementTxMap.set(txHash, entitiesForTx);
+            }
+            entitiesForTx.add(selectedEntityId);
             // Optimistic resolution is only safe for travel: the explore
             // contract uses on-chain VRF to decide whether to grant treasure,
             // and on treasure discovery (troop_movement.cairo:277-286) the
@@ -2598,7 +2623,12 @@ export default class WorldmapScene extends WarpTravel {
             // would animate a move that the indexer will then contradict,
             // producing a source → dest → source ping-pong.
             if (isTravelAction) {
-              this.pendingArmyMovementTxTargets.set(txHash, {
+              let targetsForTx = this.pendingArmyMovementTxTargets.get(txHash);
+              if (!targetsForTx) {
+                targetsForTx = new Map<ID, HexPosition>();
+                this.pendingArmyMovementTxTargets.set(txHash, targetsForTx);
+              }
+              targetsForTx.set(selectedEntityId, {
                 col: targetHex.col,
                 row: targetHex.row,
               });
@@ -2799,16 +2829,26 @@ export default class WorldmapScene extends WarpTravel {
       this.pendingArmyMovementFallbackTimeouts.delete(entityId);
     }
 
-    // Remove any txHash entries pointing to this entity. Note: if two moves
-    // are queued for the same entity, the first `movement_started` clear will
-    // drop txMap/txTarget entries for BOTH — the second move's
-    // `handleTransactionComplete` will then fall back to the indexer path.
-    // This mirrors the pre-existing txMap-cleanup semantics and avoids
-    // racing a stale optimistic animation against a newer one.
-    for (const [txHash, eid] of this.pendingArmyMovementTxMap) {
-      if (eid === entityId) {
-        this.pendingArmyMovementTxMap.delete(txHash);
-        this.pendingArmyMovementTxTargets.delete(txHash);
+    // Remove this entity from every txHash's entity set (and target map),
+    // dropping the txHash entry entirely when its set empties. Sibling
+    // entities in a batched multicall remain registered so their optimistic
+    // resolution is untouched.
+    //
+    // Historical note: if the same entity is queued for two moves, the first
+    // `movement_started` clear drops the earlier entry — the second move's
+    // `handleTransactionComplete` for that entity then falls back to the
+    // indexer path. This mirrors the pre-existing txMap-cleanup semantics and
+    // avoids racing a stale optimistic animation against a newer one.
+    for (const [txHash, entities] of this.pendingArmyMovementTxMap) {
+      if (entities.delete(entityId)) {
+        const targetsForTx = this.pendingArmyMovementTxTargets.get(txHash);
+        targetsForTx?.delete(entityId);
+        if (entities.size === 0) {
+          this.pendingArmyMovementTxMap.delete(txHash);
+          this.pendingArmyMovementTxTargets.delete(txHash);
+        } else if (targetsForTx && targetsForTx.size === 0) {
+          this.pendingArmyMovementTxTargets.delete(txHash);
+        }
       }
     }
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -1086,7 +1086,9 @@ export default class WorldmapScene extends WarpTravel {
         return;
       }
 
-      void this.resolveArmyMovementOptimistically({ entityId, txHash, targetHex });
+      this.resolveArmyMovementOptimistically({ entityId, txHash, targetHex }).catch((error) => {
+        console.error("[worldmap] optimistic army movement resolution failed", error);
+      });
     };
 
     this.handleTransactionFailed = (payload: { transactionHash?: string }) => {
@@ -2565,7 +2567,7 @@ export default class WorldmapScene extends WarpTravel {
             this.pendingArmyMovementTxMap.set(txHash, selectedEntityId);
             // Optimistic resolution is only safe for travel: the explore
             // contract uses on-chain VRF to decide whether to grant treasure,
-            // and on treasure discovery (troop_movement.cairo:272-286) the
+            // and on treasure discovery (troop_movement.cairo:277-286) the
             // explorer is rewound to its source hex. Since we cannot predict
             // that outcome client-side, registering the destination here
             // would animate a move that the indexer will then contradict,
@@ -2772,7 +2774,12 @@ export default class WorldmapScene extends WarpTravel {
       this.pendingArmyMovementFallbackTimeouts.delete(entityId);
     }
 
-    // Remove any txHash entries pointing to this entity
+    // Remove any txHash entries pointing to this entity. Note: if two moves
+    // are queued for the same entity, the first `movement_started` clear will
+    // drop txMap/txTarget entries for BOTH — the second move's
+    // `handleTransactionComplete` will then fall back to the indexer path.
+    // This mirrors the pre-existing txMap-cleanup semantics and avoids
+    // racing a stale optimistic animation against a newer one.
     for (const [txHash, eid] of this.pendingArmyMovementTxMap) {
       if (eid === entityId) {
         this.pendingArmyMovementTxMap.delete(txHash);
@@ -2825,6 +2832,18 @@ export default class WorldmapScene extends WarpTravel {
 
     this.updateArmyHexes(syntheticUpdate);
     await this.armyManager.onTileUpdate(syntheticUpdate);
+
+    // Mirror the post-tile-update hooks the authoritative indexer handler runs
+    // so direction arrows and related-entity overlays follow the optimistic
+    // move instead of pointing at the pre-move hex until Torii converges.
+    // Chunk cache invalidation is already performed inside updateArmyHexes.
+    // armyLastTileSyncAt is intentionally NOT updated here — the staleness
+    // fallback should still consider this tile unsynced until the indexer
+    // actually delivers the authoritative update.
+    this.recalculateArrowsForEntity(entityId);
+    if (this.armiesPositions.has(entityId)) {
+      this.recalculateArrowsForEntitiesRelatedTo(entityId);
+    }
   }
 
   private installPendingMovementVisualLifecycle(input: {
@@ -2872,6 +2891,12 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private markPendingArmyMovement(entityId: ID): void {
+    // Drop any lingering optimistic marker from a prior move. The marker is
+    // intentionally preserved across `movement_started` so indexer convergence
+    // can log a phase — but if convergence never arrived (Torii stall, reorg,
+    // client disconnect) and the user initiates a new move, we must not
+    // short-circuit the next optimistic resolve at `optimisticallyResolvedArmies.has`.
+    this.optimisticallyResolvedArmies.delete(entityId);
     this.pendingArmyMovements.add(entityId);
     this.pendingArmyMovementStartedAt.set(entityId, Date.now());
     this.schedulePendingArmyMovementFallback(entityId);

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -206,7 +206,7 @@ import {
   type PendingArmyMovementEffectClearReason,
   type TravelEffectType,
 } from "./worldmap-travel-effect-policy";
-import { buildOptimisticArmyTileUpdate } from "./worldmap-optimistic-movement";
+import { buildOptimisticArmyTileUpdate, isStaleOptimisticIndexerUpdate } from "./worldmap-optimistic-movement";
 import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
@@ -1269,6 +1269,31 @@ export default class WorldmapScene extends WarpTravel {
           col: normalizedPos.x,
           row: normalizedPos.y,
         });
+
+        // Drop authoritative tile updates that target a position the client
+        // has already optimistically advanced past. Without this guard the
+        // late-arriving indexer update for an earlier tx will `moveArmy` the
+        // unit backwards — the visible ping-pong. Safe because Torii delivers
+        // tile updates per-entity in order, so the LATEST optimistic target
+        // will still arrive and converge, clearing the marker.
+        if (
+          this.optimisticallyResolvedArmies.has(update.entityId) &&
+          isStaleOptimisticIndexerUpdate(this.armyManager.getArmy(update.entityId), update)
+        ) {
+          recordArmyMovementLatencyPhase({
+            phase: "movement_optimistic_stale_skipped",
+            source: "worldmap",
+            entityId: update.entityId,
+            details: {
+              staleCol: update.hexCoords.col,
+              staleRow: update.hexCoords.row,
+            },
+          });
+          // We still saw a real tile update for this entity, so keep the
+          // staleness fallback quiet.
+          this.armyLastTileSyncAt.set(update.entityId, Date.now());
+          return;
+        }
 
         this.updateArmyHexes(update);
         this.resolvePendingCreateArmyFxOnArmyUpdate(update);

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -206,6 +206,7 @@ import {
   type PendingArmyMovementEffectClearReason,
   type TravelEffectType,
 } from "./worldmap-travel-effect-policy";
+import { buildOptimisticArmyTileUpdate } from "./worldmap-optimistic-movement";
 import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
@@ -611,6 +612,8 @@ export default class WorldmapScene extends WarpTravel {
   private pendingArmyMovementStartedAt: Map<ID, number> = new Map();
   private pendingArmyMovementFallbackTimeouts: Map<ID, ReturnType<typeof setTimeout>> = new Map();
   private pendingArmyMovementTxMap: Map<string, ID> = new Map();
+  private pendingArmyMovementTxTargets: Map<string, HexPosition> = new Map();
+  private optimisticallyResolvedArmies: Set<ID> = new Set();
   private pendingArmyMovementVisualLifecycleDisposers: Map<ID, () => void> = new Map();
 
   private get hydratedChunkRefreshes(): Set<string> {
@@ -1077,6 +1080,13 @@ export default class WorldmapScene extends WarpTravel {
         entityId,
         txHash,
       });
+
+      const targetHex = this.pendingArmyMovementTxTargets.get(txHash);
+      if (!targetHex) {
+        return;
+      }
+
+      void this.resolveArmyMovementOptimistically({ entityId, txHash, targetHex });
     };
 
     this.handleTransactionFailed = (payload: { transactionHash?: string }) => {
@@ -1097,6 +1107,7 @@ export default class WorldmapScene extends WarpTravel {
         this.arrivalGhostManager?.clearArrivalGhost(plan.entityId, "tx_failed");
       }
       this.pendingArmyMovementTxMap.delete(txHash);
+      this.pendingArmyMovementTxTargets.delete(txHash);
     };
 
     dojoContext.network?.provider?.on("transactionComplete", this.handleTransactionComplete);
@@ -1292,6 +1303,19 @@ export default class WorldmapScene extends WarpTravel {
             row: update.hexCoords.row,
           },
         });
+
+        if (this.optimisticallyResolvedArmies.delete(update.entityId)) {
+          recordArmyMovementLatencyPhase({
+            phase: "movement_optimistic_convergence",
+            source: "worldmap",
+            entityId: update.entityId,
+            details: {
+              col: update.hexCoords.col,
+              row: update.hexCoords.row,
+            },
+          });
+        }
+
         this.armyLastTileSyncAt.set(update.entityId, Date.now());
         if (recoveredPendingRemoval) {
           void this.armyManager.restoreArmyVisualIfVisible(update.entityId);
@@ -2539,6 +2563,10 @@ export default class WorldmapScene extends WarpTravel {
           });
           if (txHash) {
             this.pendingArmyMovementTxMap.set(txHash, selectedEntityId);
+            this.pendingArmyMovementTxTargets.set(txHash, {
+              col: targetHex.col,
+              row: targetHex.row,
+            });
             recordArmyMovementLatencyPhase({
               phase: "tx_submitted",
               source: "worldmap",
@@ -2739,13 +2767,55 @@ export default class WorldmapScene extends WarpTravel {
     for (const [txHash, eid] of this.pendingArmyMovementTxMap) {
       if (eid === entityId) {
         this.pendingArmyMovementTxMap.delete(txHash);
+        this.pendingArmyMovementTxTargets.delete(txHash);
       }
+    }
+
+    // Keep the optimistic marker alive on the "movement_started" clear so the
+    // authoritative indexer update can still record convergence. Failure and
+    // stale-timeout paths arrive with other reasons and drop the marker.
+    if (reason !== "movement_started") {
+      this.optimisticallyResolvedArmies.delete(entityId);
     }
 
     const trackedEffect = this.travelEffectsByEntity.get(entityId);
     if (trackedEffect && shouldCleanupTrackedTravelEffectOnPendingClear({ trackedEffect, reason })) {
       trackedEffect.cleanup();
     }
+  }
+
+  private async resolveArmyMovementOptimistically(params: {
+    entityId: ID;
+    txHash: string;
+    targetHex: HexPosition;
+  }): Promise<void> {
+    const { entityId, txHash, targetHex } = params;
+
+    if (this.optimisticallyResolvedArmies.has(entityId)) {
+      return;
+    }
+
+    const army = this.armyManager.getArmy(entityId);
+    const syntheticUpdate = buildOptimisticArmyTileUpdate(army, targetHex);
+    if (!syntheticUpdate) {
+      return;
+    }
+
+    this.optimisticallyResolvedArmies.add(entityId);
+
+    recordArmyMovementLatencyPhase({
+      phase: "movement_resolved_optimistically",
+      source: "worldmap",
+      entityId,
+      txHash,
+      details: {
+        col: targetHex.col,
+        row: targetHex.row,
+      },
+    });
+
+    this.updateArmyHexes(syntheticUpdate);
+    await this.armyManager.onTileUpdate(syntheticUpdate);
   }
 
   private installPendingMovementVisualLifecycle(input: {
@@ -8065,6 +8135,8 @@ export default class WorldmapScene extends WarpTravel {
       this.dojo.network?.provider?.off("transactionFailed", this.handleTransactionFailed);
     }
     this.pendingArmyMovementTxMap.clear();
+    this.pendingArmyMovementTxTargets.clear();
+    this.optimisticallyResolvedArmies.clear();
     this.stopToriiBoundsCounterLog();
     if (this.toriiStreamManager === activeSpatialStreamManager) {
       activeSpatialStreamManager = null;

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -2563,10 +2563,19 @@ export default class WorldmapScene extends WarpTravel {
           });
           if (txHash) {
             this.pendingArmyMovementTxMap.set(txHash, selectedEntityId);
-            this.pendingArmyMovementTxTargets.set(txHash, {
-              col: targetHex.col,
-              row: targetHex.row,
-            });
+            // Optimistic resolution is only safe for travel: the explore
+            // contract uses on-chain VRF to decide whether to grant treasure,
+            // and on treasure discovery (troop_movement.cairo:272-286) the
+            // explorer is rewound to its source hex. Since we cannot predict
+            // that outcome client-side, registering the destination here
+            // would animate a move that the indexer will then contradict,
+            // producing a source → dest → source ping-pong.
+            if (isTravelAction) {
+              this.pendingArmyMovementTxTargets.set(txHash, {
+                col: targetHex.col,
+                row: targetHex.row,
+              });
+            }
             recordArmyMovementLatencyPhase({
               phase: "tx_submitted",
               source: "worldmap",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-20",
+    title: "Faster Army Movement",
+    description:
+      "Local army moves now start animating the moment the transaction confirms, removing the pause that used to wait for the indexer to echo the new tile.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-20",
     title: "Blitz Settlement Sync",
     description:
       "Blitz settlement now waits for the requested settled realm count before advancing, so fresh entries no longer get stuck on finalizing when the index briefly returns an empty snapshot.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,9 +23,9 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-20",
-    title: "Faster Army Movement",
+    title: "Faster Army Travel",
     description:
-      "Local army moves now start animating the moment the transaction confirms, removing the pause that used to wait for the indexer to echo the new tile.",
+      "Local travel moves now start animating the moment the transaction confirms, removing the pause that used to wait for the indexer to echo the new tile. Explore still waits on the indexer because treasure rewards can rewind the unit.",
     type: "improvement",
     gameSlug: "eternum",
   },

--- a/packages/core/src/systems/army-movement-latency-trace.ts
+++ b/packages/core/src/systems/army-movement-latency-trace.ts
@@ -13,7 +13,8 @@ export type ArmyMovementLatencyPhase =
   | "movement_started"
   | "movement_completed"
   | "movement_resolved_optimistically"
-  | "movement_optimistic_convergence";
+  | "movement_optimistic_convergence"
+  | "movement_optimistic_stale_skipped";
 
 export type ArmyMovementLatencySource = "worldmap" | "torii_sync" | "world_update_listener";
 

--- a/packages/core/src/systems/army-movement-latency-trace.ts
+++ b/packages/core/src/systems/army-movement-latency-trace.ts
@@ -11,7 +11,9 @@ export type ArmyMovementLatencyPhase =
   | "worldmap_tile_update_received"
   | "army_manager_tile_update_applied"
   | "movement_started"
-  | "movement_completed";
+  | "movement_completed"
+  | "movement_resolved_optimistically"
+  | "movement_optimistic_convergence";
 
 export type ArmyMovementLatencySource = "worldmap" | "torii_sync" | "world_update_listener";
 


### PR DESCRIPTION
## Summary

- Local army movement animations now begin the moment the move transaction confirms on chain, instead of waiting for the Torii indexer to echo the new tile.
- The existing `updateArmyHexes` + `ArmyManager.onTileUpdate` pipeline is driven directly from `transactionComplete` using the action path's destination hex. The later indexer delivery hits `moveArmy`'s same-position early return and logs a convergence latency phase.
- PRD/TDD and implementation are scoped to `client/apps/game/src/three` per the request.

## Design

- Destination hex from `actionPath[last].hex` is captured alongside the existing `pendingArmyMovementTxMap` in a parallel `pendingArmyMovementTxTargets` map.
- On `transactionComplete`, a pure `buildOptimisticArmyTileUpdate(army, targetHex)` synthesizes an `ExplorerTroopsTileSystemUpdate` from the tracked army data and target hex, and the same cache + army-manager pipeline is invoked.
- An `optimisticallyResolvedArmies` set is kept until the real indexer tile update arrives, so convergence can be observed in traces without changing runtime behavior.
- `clearPendingArmyMovement("movement_started")` keeps the optimistic marker alive so indexer convergence can still fire; failure and stale-timeout clears drop it.
- New latency phases: `movement_resolved_optimistically`, `movement_optimistic_convergence` (added to `ArmyMovementLatencyPhase` union).

Safety rails preserved:
- Remote armies: never resolve optimistically — only entries in `pendingArmyMovementTxMap` (populated only for our own submitted moves) trigger the resolver.
- Missing army (e.g., removed between submit and confirm): resolver no-ops and waits for the authoritative indexer update.
- Tx-failed path: still clears pending, ghost, lifecycle, travel FX; also drops the target map and optimistic marker.
- 30s stale fallback and explorer-troop update paths are unchanged.

## Test plan

- [x] `pnpm --filter eternum-game-client exec vitest run src/three/scenes/worldmap-optimistic-movement src/three/scenes/worldmap-movement-latency-tracing src/three/scenes/worldmap-pending-movement-visual-handoff src/three/scenes/worldmap-arrival-ghost src/three/scenes/worldmap-travel-effect-lifecycle`
- [x] `pnpm --filter eternum-game-client exec vitest run src/three` (1610 tests passing)
- [x] `pnpm --filter @bibliothecadao/eternum exec vitest run` (core package)
- [x] `pnpm run test:three:types` (client three typecheck)
- [ ] Manual smoke on dev: submit a local move and confirm the army begins animating at tx confirmation without waiting for indexer lag; verify arrival ghost, travel FX, and pending gating still behave per the existing handoff PRD.
- [ ] Manual smoke: fail a move (insufficient stamina or reverted tx) and confirm pending, ghost, travel FX are cleared as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)