### PR TITLE
Delay Blitz auto-settle until onchain time

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.test.ts
@@ -50,8 +50,16 @@ describe("resolveAutoSettleRuntimeState", () => {
     });
   });
 
-  it("opens the entry route exactly when the countdown reaches settlement time", () => {
+  it("waits for onchain settlement time after the visible countdown reaches settlement time", () => {
     expect(resolveAutoSettleRuntimeState(createInput({ nowSec: 130 }))).toMatchObject({
+      phase: "prewarming",
+      shouldOpenEntry: false,
+      shouldRefreshAvailability: true,
+    });
+  });
+
+  it("opens the entry route after the onchain settlement delay", () => {
+    expect(resolveAutoSettleRuntimeState(createInput({ nowSec: 132 }))).toMatchObject({
       phase: "opening",
       shouldOpenEntry: true,
       shouldRefreshAvailability: true,

--- a/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/auto-settle-runtime.ts
@@ -33,6 +33,7 @@ interface AutoSettleRuntimeState {
 
 const PREWARM_WINDOW_SECONDS = 30;
 const REFRESH_WINDOW_SECONDS = 5;
+const ONCHAIN_SETTLEMENT_DELAY_SECONDS = 2;
 
 export const resolveAutoSettleRuntimeState = ({
   enabled,
@@ -94,6 +95,8 @@ export const resolveAutoSettleRuntimeState = ({
   });
   const resolvedUnlockAtSec = availability.unlockAtSec;
   const isDue = availability.isUnlocked;
+  const isReadyForOnchainSettlement =
+    resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec + ONCHAIN_SETTLEMENT_DELAY_SECONDS;
   const inPrewarmWindow = resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - PREWARM_WINDOW_SECONDS;
   const inRefreshWindow = resolvedUnlockAtSec != null && nowSec >= resolvedUnlockAtSec - REFRESH_WINDOW_SECONDS;
 
@@ -124,7 +127,7 @@ export const resolveAutoSettleRuntimeState = ({
     };
   }
 
-  if (isDue) {
+  if (isReadyForOnchainSettlement) {
     return {
       phase: "opening",
       shouldPrimeAssets: false,

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-21",
+    title: "Auto-Settle Timing Fix",
+    description:
+      "Blitz auto-settle now waits briefly after the visible countdown finishes before opening settlement, avoiding the early transaction failure popup.",
+    type: "fix",
+    gameSlug: "landing",
+  },
+  {
     date: "2026-04-20",
     title: "Cleaner Forge Flow",
     description:


### PR DESCRIPTION
Adds a 2-second on-chain settlement buffer before Blitz auto-settle opens the entry route, so the visible countdown can hit zero without triggering the early failed transaction popup. Updates the runtime tests to assert the countdown-zero hold and delayed open behavior, and adds the required landing latest-features note. Verification: direct tsx runtime check passed, git diff --check passed, and changed files were formatted with pnpm dlx prettier@3.8.1. Required repo checks were attempted but blocked because this workspace has no node_modules: pnpm test could not find vitest, pnpm run format could not find prettier, and pnpm run knip could not load @eslint/js.