### PR TITLE
fix(game): harden automation against insufficient-balance reverts

### DIFF
--- a/client/apps/game/src/hooks/store/use-automation-store.ts
+++ b/client/apps/game/src/hooks/store/use-automation-store.ts
@@ -28,6 +28,12 @@ export const isAutomationResourceBlocked = (
 };
 
 export const MAX_RESOURCE_ALLOCATION_PERCENT = 90;
+// Execution-time safety ceiling on per-input spend. User-facing percentages remain
+// clamped at MAX_RESOURCE_ALLOCATION_PERCENT, but the effective budget applied during
+// plan building is bounded here to absorb drift between the client's projected balance
+// and the on-chain balance at tx inclusion (torii indexer lag, production projection
+// overshoot, un-indexed sibling burns).
+export const AUTOMATION_INPUT_BUDGET_PERCENT = 75;
 export const DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES: ResourceAutomationPercentages = {
   resourceToResource: 0,
   laborToResource: 5,

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -35,7 +35,7 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { calculatePresetAllocations, getAutomationOverallocation } from "@/utils/automation-presets";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { useDojo } from "@bibliothecadao/react";
-import { getBlockTimestamp, getConservativeBlockTimestamp, configManager } from "@bibliothecadao/eternum";
+import { getAutomationProjectionTick, getBlockTimestamp, configManager } from "@bibliothecadao/eternum";
 import { ResourcesIds } from "@bibliothecadao/types";
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
@@ -249,8 +249,10 @@ export const useAutomation = () => {
     let anyExecuted = false;
 
     try {
-      // Use conservative tick for resource validation to prevent tx failures from clock desync
-      const { currentDefaultTick: conservativeTick } = getConservativeBlockTimestamp();
+      // Use the automation projection tick (deeper buffer than the default conservative
+      // accessor) so the planner's projected balance stays behind what the chain will
+      // report at tx-inclusion, preventing Insufficient Balance reverts on overshoot.
+      const { currentDefaultTick: conservativeTick } = getAutomationProjectionTick();
 
       // Phase 1: Build all plans synchronously (no awaits, so no event loop yields)
       const executablePlans: ExecutableProductionPlan[] = [];

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.ts
@@ -4,8 +4,8 @@ import { useDojo } from "@bibliothecadao/react";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import {
   configManager,
+  getAutomationProjectionTick,
   getBlockTimestamp,
-  getConservativeBlockTimestamp,
   isMilitaryResource,
   ResourceManager,
 } from "@bibliothecadao/eternum";
@@ -109,7 +109,7 @@ export const useTransferAutomationRunner = () => {
 
       const { currentBlockTimestamp } = getBlockTimestamp();
       // Use conservative tick for resource validation to prevent tx failures from clock desync
-      const { currentDefaultTick: conservativeTick } = getConservativeBlockTimestamp();
+      const { currentDefaultTick: conservativeTick } = getAutomationProjectionTick();
       if (isSeasonOver(currentBlockTimestamp)) {
         stopTransferAutomation();
         return;

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.test.ts
@@ -437,11 +437,11 @@ describe("buildRealmProductionPlan", () => {
     });
   });
 
-  it("splits a shared input's 90% budget proportionally so late-ordered consumers aren't starved", () => {
+  it("splits a shared input's execution budget proportionally so late-ordered consumers aren't starved", () => {
     // Reproduces the user-reported troop-starvation bug: when raw resources and a troop
-    // share Wheat as input and aggregate allocation > 90%, sequential first-come reservation
-    // leaves the last consumer with crumbs. Proportional allocation must give each consumer
-    // its scaled share of the cap.
+    // share Wheat as input and aggregate allocation exceeds the execution budget cap,
+    // sequential first-come reservation leaves the last consumer with crumbs. Proportional
+    // allocation must give each consumer its scaled share of the cap.
     configureComplexRecipe(ResourcesIds.Wood, [{ resource: ResourcesIds.Wheat, amount: 1 }], 1);
     configureComplexRecipe(ResourcesIds.Coal, [{ resource: ResourcesIds.Wheat, amount: 1 }], 1);
     // Knight's troop recipe is already configured: needs 1 Wheat + 1 Copper per cycle, output 1.
@@ -461,8 +461,8 @@ describe("buildRealmProductionPlan", () => {
       }),
     });
 
-    // Total Wheat demand = 40 + 40 + 50 = 130%. Cap = 90%. Scale ≈ 90/130 ≈ 0.6923.
-    // Knight scaled demand ≈ 50% * 0.6923 * 1000 ≈ 346 Wheat → 346 cycles.
+    // Total Wheat demand = 40 + 40 + 50 = 130%. Execution budget cap = 75%. Scale = 75/130 ≈ 0.5769.
+    // Knight scaled demand ≈ 50% * 0.5769 * 1000 ≈ 288 Wheat → 288 cycles.
     const knightCycles =
       plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Knight)?.cycles ?? 0;
     const woodCycles =
@@ -470,19 +470,19 @@ describe("buildRealmProductionPlan", () => {
     const coalCycles =
       plan.callset.resourceToResource.find((call) => call.resourceId === ResourcesIds.Coal)?.cycles ?? 0;
 
-    // Sequential-first-come would give Knight ~0-100 cycles after Wood/Coal drain the budget.
+    // Sequential-first-come would give Knight ~0 cycles after Wood/Coal drain the budget.
     // Proportional allocation gives every consumer their scaled share simultaneously.
-    expect(knightCycles).toBeGreaterThan(300);
-    expect(woodCycles).toBeGreaterThan(250);
-    expect(coalCycles).toBeGreaterThan(250);
+    expect(knightCycles).toBeGreaterThan(250);
+    expect(woodCycles).toBeGreaterThan(200);
+    expect(coalCycles).toBeGreaterThan(200);
 
-    // Total Wheat consumed must never exceed the 90% cap.
+    // Total Wheat consumed must never exceed the 75% execution budget cap.
     const totalWheat = plan.consumptionByResource[ResourcesIds.Wheat] ?? 0;
-    expect(totalWheat).toBeLessThanOrEqual(900);
+    expect(totalWheat).toBeLessThanOrEqual(750);
   });
 
-  it("does not scale when aggregate demand fits inside the 90% cap", () => {
-    // Regression: if demand <= 90%, every consumer gets its full unscaled desired share.
+  it("does not scale when aggregate demand fits inside the execution budget cap", () => {
+    // Regression: if demand <= execution budget, every consumer gets its full unscaled desired share.
     configureComplexRecipe(ResourcesIds.Wood, [{ resource: ResourcesIds.Wheat, amount: 1 }], 1);
 
     const plan = buildRealmProductionPlan({

--- a/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
+++ b/client/apps/game/src/ui/features/infrastructure/automation/model/automation-processor.ts
@@ -1,4 +1,5 @@
 import {
+  AUTOMATION_INPUT_BUDGET_PERCENT,
   DONKEY_DEFAULT_RESOURCE_PERCENT,
   DEFAULT_RESOURCE_AUTOMATION_PERCENTAGES,
   MAX_RESOURCE_ALLOCATION_PERCENT,
@@ -460,7 +461,7 @@ export const buildRealmProductionPlan = ({
   resourcesToTrack.forEach((resourceId) => {
     const balanceHuman = computeHumanBalance(resourceId);
     totalAvailable.set(resourceId, balanceHuman);
-    const maxConsumable = Math.floor((balanceHuman * MAX_RESOURCE_ALLOCATION_PERCENT) / 100);
+    const maxConsumable = Math.floor((balanceHuman * AUTOMATION_INPUT_BUDGET_PERCENT) / 100);
     availableBudget.set(resourceId, Math.max(0, maxConsumable));
   });
 
@@ -496,7 +497,7 @@ export const buildRealmProductionPlan = ({
   }
   const scaleFactorByInput = new Map<ResourcesIds, number>();
   totalDemandByInput.forEach((demand, inputId) => {
-    const scale = demand > MAX_RESOURCE_ALLOCATION_PERCENT ? MAX_RESOURCE_ALLOCATION_PERCENT / demand : 1;
+    const scale = demand > AUTOMATION_INPUT_BUDGET_PERCENT ? AUTOMATION_INPUT_BUDGET_PERCENT / demand : 1;
     scaleFactorByInput.set(inputId, scale);
   });
   const getInputShareScale = (inputId: ResourcesIds) => scaleFactorByInput.get(inputId) ?? 1;

--- a/packages/core/src/utils/timestamp.ts
+++ b/packages/core/src/utils/timestamp.ts
@@ -11,6 +11,13 @@ let timestampSource: TimestampSource = defaultTimestampSource;
 // preventing tx failures when client clock is ahead of chain.
 const CONSERVATIVE_TICK_BUFFER = 1;
 
+// Deeper buffer used specifically for automation projections. Automation plans
+// spend up to AUTOMATION_INPUT_BUDGET_PERCENT of a projected balance, so any
+// overshoot in the projection (wall-clock drift, torii lag, tx-queue wait before
+// block inclusion) directly causes on-chain "Insufficient Balance" reverts.
+// Holding the projection further behind chain time widens the safety margin.
+const CONSERVATIVE_TICK_BUFFER_AUTOMATION = 3;
+
 export const setBlockTimestampSource = (source: TimestampSource | null) => {
   timestampSource = source ? () => Math.floor(source()) : defaultTimestampSource;
 };
@@ -43,5 +50,20 @@ export const getConservativeBlockTimestamp = () => {
     currentBlockTimestamp,
     currentDefaultTick: Math.max(0, currentDefaultTick - CONSERVATIVE_TICK_BUFFER),
     currentArmiesTick: Math.max(0, currentArmiesTick - CONSERVATIVE_TICK_BUFFER),
+  };
+};
+
+/**
+ * Projection tick for automation plan building. Uses a deeper buffer than the
+ * default conservative accessor so the projected balance stays behind what the
+ * chain will report at tx-inclusion time, preventing Insufficient Balance reverts.
+ */
+export const getAutomationProjectionTick = () => {
+  const { currentBlockTimestamp, currentDefaultTick, currentArmiesTick } = getBlockTimestamp();
+
+  return {
+    currentBlockTimestamp,
+    currentDefaultTick: Math.max(0, currentDefaultTick - CONSERVATIVE_TICK_BUFFER_AUTOMATION),
+    currentArmiesTick: Math.max(0, currentArmiesTick - CONSERVATIVE_TICK_BUFFER_AUTOMATION),
   };
 };


### PR DESCRIPTION
## Summary

Automation was overshooting on-chain balance because plans spent up to 90% of a *projected* balance using only a 1-tick buffer, leaving no headroom for torii lag, wall-clock drift, or un-indexed sibling burns — producing `Insufficient Balance` reverts in Sentry. This PR introduces a separate execution-time cap `AUTOMATION_INPUT_BUDGET_PERCENT = 75` applied only during plan building; the user-facing `MAX_RESOURCE_ALLOCATION_PERCENT = 90` (slider max, overallocation checks) is unchanged so existing configs keep working. A new `getAutomationProjectionTick()` (3-tick buffer) is wired into the production and transfer automation runners; `getConservativeBlockTimestamp()` (1-tick) stays on UI display paths so HUD numbers don't shift. Combined effect: the projection stays further behind chain time, and only 75% of that conservative projection is spent — 25% headroom vs the previous 10%.

## Test plan

- [x] `automation-processor.test.ts` — 17/17 pass (one test's numerical expectations updated for the new 75% execution budget)
- [x] `use-automation-store.test.ts` — 26/26 pass
- [x] `pnpm typecheck` — no new errors (pre-existing `packages/provider/src/index.ts` errors verified unchanged by stashing the diff)
- [ ] Manual smoke: run automation on a realm with aggressive allocation % and confirm no `Insufficient Balance` reverts across several ticks