### PR TITLE
fix(game): harden RPC lag recovery

### DIFF
--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ConnectionHealthMonitor } from "./connection-health-monitor";
+import { ConnectionHealthMonitor, resolveConnectionHealthToriiBaseUrl } from "./connection-health-monitor";
 import { useConnectionStore } from "@/hooks/store/use-connection-store";
 
 interface FakeEventTarget {
@@ -51,6 +51,7 @@ describe("ConnectionHealthMonitor", () => {
       lastGlobalUpdate: Date.now(),
       lastHealthCheck: Date.now(),
       reconnectAttempts: 0,
+      streamReconnectVersion: 0,
     });
   });
 
@@ -128,6 +129,48 @@ describe("ConnectionHealthMonitor", () => {
     monitor.dispose();
   });
 
+  it("uses a separate reconnect cooldown so idle worlds do not resubscribe every stale threshold", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      reconnectCooldownMs: 20_000,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(2);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(2);
+
+    monitor.dispose();
+  });
+
   it("does not reconnect when the health check fails", async () => {
     const onReconnectSpatial = vi.fn(() => Promise.resolve());
     const onReconnectGlobal = vi.fn(() => Promise.resolve());
@@ -156,5 +199,56 @@ describe("ConnectionHealthMonitor", () => {
     expect(useConnectionStore.getState().status).toBe("disconnected");
 
     monitor.dispose();
+  });
+
+  it("records a stream reconnect after stale streams are rebuilt", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+      streamReconnectVersion: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(useConnectionStore.getState().streamReconnectVersion).toBe(1);
+
+    monitor.dispose();
+  });
+});
+
+describe("resolveConnectionHealthToriiBaseUrl", () => {
+  it("prefers the active world Torii over the static env fallback", () => {
+    const toriiBaseUrl = resolveConnectionHealthToriiBaseUrl({
+      activeWorld: { toriiBaseUrl: "https://api.cartridge.gg/x/s0-game-5/torii" },
+      fallbackToriiUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/torii",
+      runtimeToriiUrl: "https://api.cartridge.gg/x/s0-game-5/torii",
+    });
+
+    expect(toriiBaseUrl).toBe("https://api.cartridge.gg/x/s0-game-5/torii");
+  });
+
+  it("uses the bootstrapped runtime Torii when no active profile is available", () => {
+    const toriiBaseUrl = resolveConnectionHealthToriiBaseUrl({
+      activeWorld: null,
+      fallbackToriiUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/torii",
+      runtimeToriiUrl: "https://api.cartridge.gg/x/bltz-warzone-04/torii",
+    });
+
+    expect(toriiBaseUrl).toBe("https://api.cartridge.gg/x/bltz-warzone-04/torii");
   });
 });

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -2,6 +2,7 @@ import { useConnectionStore } from "@/hooks/store/use-connection-store";
 
 const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 10_000;
 const DEFAULT_STALE_THRESHOLD_MS = 15_000;
+const DEFAULT_RECONNECT_COOLDOWN_MS = 60_000;
 
 interface ConnectionHealthMonitorConfig {
   onReconnectSpatial: () => Promise<void>;
@@ -9,12 +10,20 @@ interface ConnectionHealthMonitorConfig {
   healthCheckFn: () => Promise<boolean>;
   healthCheckIntervalMs?: number;
   staleThresholdMs?: number;
+  reconnectCooldownMs?: number;
+}
+
+interface ConnectionHealthToriiInput {
+  activeWorld?: { toriiBaseUrl?: string | null } | null;
+  runtimeToriiUrl?: string | null;
+  fallbackToriiUrl: string;
 }
 
 export class ConnectionHealthMonitor {
   private readonly config: ConnectionHealthMonitorConfig;
   private readonly healthCheckIntervalMs: number;
   private readonly staleThresholdMs: number;
+  private readonly reconnectCooldownMs: number;
 
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
   private reconnecting = false;
@@ -25,6 +34,10 @@ export class ConnectionHealthMonitor {
     this.config = config;
     this.healthCheckIntervalMs = config.healthCheckIntervalMs ?? DEFAULT_HEALTH_CHECK_INTERVAL_MS;
     this.staleThresholdMs = config.staleThresholdMs ?? DEFAULT_STALE_THRESHOLD_MS;
+    this.reconnectCooldownMs = Math.max(
+      config.reconnectCooldownMs ?? DEFAULT_RECONNECT_COOLDOWN_MS,
+      this.staleThresholdMs,
+    );
   }
 
   start(): void {
@@ -105,7 +118,7 @@ export class ConnectionHealthMonitor {
         // has been silent past the stale threshold, force a resubscribe.
         // Cooldown prevents reconnect storms when the area is genuinely idle.
         const now = Date.now();
-        if (now - this.lastStreamReconnectAtMs >= this.staleThresholdMs) {
+        if (now - this.lastStreamReconnectAtMs >= this.reconnectCooldownMs) {
           const spatialStale = now - store.lastSpatialUpdate > this.staleThresholdMs;
           const globalStale = now - store.lastGlobalUpdate > this.staleThresholdMs;
           if (spatialStale || globalStale) {
@@ -126,13 +139,33 @@ export class ConnectionHealthMonitor {
     if (this.reconnecting || this.disposed) return;
 
     this.reconnecting = true;
+    const store = useConnectionStore.getState();
     try {
       const promises: Promise<void>[] = [];
       if (spatial) promises.push(this.config.onReconnectSpatial());
       if (global) promises.push(this.config.onReconnectGlobal());
       await Promise.all(promises);
+      if (promises.length > 0) {
+        store.recordStreamReconnect();
+      }
+    } catch (error) {
+      console.warn("[ConnectionHealthMonitor] Failed to reconnect stale streams", error);
+      store.setStatus("degraded");
+      store.incrementReconnectAttempts();
     } finally {
       this.reconnecting = false;
     }
   }
 }
+
+const trimOptionalUrl = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+};
+
+export const resolveConnectionHealthToriiBaseUrl = ({
+  activeWorld,
+  fallbackToriiUrl,
+  runtimeToriiUrl,
+}: ConnectionHealthToriiInput): string =>
+  trimOptionalUrl(activeWorld?.toriiBaseUrl) ?? trimOptionalUrl(runtimeToriiUrl) ?? fallbackToriiUrl;

--- a/client/apps/game/src/hooks/helpers/use-player-structure-sync.reconnect.source.test.ts
+++ b/client/apps/game/src/hooks/helpers/use-player-structure-sync.reconnect.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("usePlayerStructureSync reconnect wiring", () => {
+  it("resubscribes player-scoped Torii streams after the connection monitor rebuilds streams", () => {
+    const source = readSource("src/hooks/helpers/use-player-structure-sync.ts");
+
+    expect(source).toContain("useConnectionStore");
+    expect(source).toContain("streamReconnectVersion");
+    expect(source).toContain("subscriptionSetupTimeoutMs: env.VITE_PUBLIC_TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS");
+  });
+});

--- a/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
+++ b/client/apps/game/src/hooks/helpers/use-player-structure-sync.ts
@@ -8,7 +8,9 @@ import { useDojo, usePlayerStructures } from "@bibliothecadao/react";
 import { MemberClause } from "@dojoengine/sdk";
 import type { PatternMatching } from "@dojoengine/torii-client";
 import type { Clause } from "@dojoengine/torii-wasm/types";
+import { env } from "../../../env";
 import { useAccountStore } from "../store/use-account-store";
+import { useConnectionStore } from "../store/use-connection-store";
 import { selectUnsyncedOwnedStructureTargets } from "./player-structure-sync-utils";
 
 // Models synced per-player via a scoped subscription (see usePlayerStructureSync)
@@ -77,6 +79,7 @@ export const usePlayerStructureSync = () => {
   );
 
   const accountAddress = useAccountStore().account?.address;
+  const streamReconnectVersion = useConnectionStore((state) => state.streamReconnectVersion);
   const toriiComponents = contractComponents as unknown as Parameters<typeof getStructuresDataFromTorii>[1];
   const structureEntityIdsRef = useRef<ReadonlySet<number>>(new Set());
   const isBackfillRunning = useRef(false);
@@ -138,7 +141,7 @@ export const usePlayerStructureSync = () => {
         backfillOwnedStructuresRef.current = null;
       }
     };
-  }, [accountAddress, toriiClient, toriiComponents]);
+  }, [accountAddress, streamReconnectVersion, toriiClient, toriiComponents]);
 
   useEffect(() => {
     if (!accountAddress || !toriiClient) return;
@@ -171,7 +174,9 @@ export const usePlayerStructureSync = () => {
       ownerStructureSubscriptionRef.current = ownerSubscription;
     };
 
-    void subscribeToOwnedStructureUpdates();
+    void subscribeToOwnedStructureUpdates().catch((error) => {
+      console.error("[usePlayerStructureSync] Failed to subscribe to owned structure updates", error);
+    });
 
     return () => {
       cancelled = true;
@@ -180,7 +185,7 @@ export const usePlayerStructureSync = () => {
         ownerStructureSubscriptionRef.current = null;
       }
     };
-  }, [accountAddress, toriiClient]);
+  }, [accountAddress, streamReconnectVersion, toriiClient]);
 
   // Sync newly-seen structures into RECS (e.g. first settlement).
   useEffect(() => {
@@ -220,6 +225,8 @@ export const usePlayerStructureSync = () => {
   }, [playerStructures, toriiClient, toriiComponents]);
 
   useEffect(() => {
+    let cancelled = false;
+
     const subscribe = async () => {
       // Cancel previous subscription
       if (subscriptionRef.current) {
@@ -257,16 +264,28 @@ export const usePlayerStructureSync = () => {
         },
       };
 
-      subscriptionRef.current = await syncEntitiesDebounced(toriiClient, setup, clause, false);
+      const subscription = await syncEntitiesDebounced(toriiClient, setup, clause, false, undefined, {
+        subscriptionSetupTimeoutMs: env.VITE_PUBLIC_TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS,
+      });
+
+      if (cancelled) {
+        subscription.cancel();
+        return;
+      }
+
+      subscriptionRef.current = subscription;
     };
 
-    subscribe();
+    void subscribe().catch((error) => {
+      console.error("[usePlayerStructureSync] Failed to subscribe to player structure updates", error);
+    });
 
     return () => {
+      cancelled = true;
       if (subscriptionRef.current) {
         subscriptionRef.current.cancel();
         subscriptionRef.current = null;
       }
     };
-  }, [structureEntityIds, structurePositions, accountAddress, toriiClient, setup]);
+  }, [structureEntityIds, structurePositions, accountAddress, streamReconnectVersion, toriiClient, setup]);
 };

--- a/client/apps/game/src/hooks/store/use-connection-store.ts
+++ b/client/apps/game/src/hooks/store/use-connection-store.ts
@@ -8,10 +8,12 @@ interface ConnectionState {
   lastGlobalUpdate: number;
   lastHealthCheck: number;
   reconnectAttempts: number;
+  streamReconnectVersion: number;
   setStatus: (status: ConnectionStatus) => void;
   recordSpatialUpdate: () => void;
   recordGlobalUpdate: () => void;
   recordHealthCheck: () => void;
+  recordStreamReconnect: () => void;
   incrementReconnectAttempts: () => void;
   resetReconnectAttempts: () => void;
 }
@@ -22,10 +24,12 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   lastGlobalUpdate: Date.now(),
   lastHealthCheck: Date.now(),
   reconnectAttempts: 0,
+  streamReconnectVersion: 0,
   setStatus: (status: ConnectionStatus) => set({ status }),
   recordSpatialUpdate: () => set({ lastSpatialUpdate: Date.now() }),
   recordGlobalUpdate: () => set({ lastGlobalUpdate: Date.now() }),
   recordHealthCheck: () => set({ lastHealthCheck: Date.now() }),
+  recordStreamReconnect: () => set((state) => ({ streamReconnectVersion: state.streamReconnectVersion + 1 })),
   incrementReconnectAttempts: () => set((state) => ({ reconnectAttempts: state.reconnectAttempts + 1 })),
   resetReconnectAttempts: () => set({ reconnectAttempts: 0 }),
 }));

--- a/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
@@ -144,4 +144,24 @@ describe("buildWorldProfile concurrency", () => {
       worldAddress: "0x1",
     });
   });
+
+  it("falls back to the selected slot world rpc when deployment metadata is unavailable", async () => {
+    mocks.resolveWorldContracts.mockResolvedValue({ spawn: "0xabc" });
+    mocks.resolveWorldDeploymentFromFactory.mockResolvedValue(null);
+    mocks.fetchWorldAddress.mockResolvedValue("0x1");
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => [{ entry_token_address: "0x2", fee_token: "0x3" }],
+    });
+
+    await buildWorldProfile("slot", "s0-game-5");
+
+    expect(mocks.normalizeRpcUrl).toHaveBeenCalledWith("https://api.cartridge.gg/x/s0-game-5/katana");
+    expect(mocks.saveWorldProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "s0-game-5",
+        rpcUrl: "https://api.cartridge.gg/x/s0-game-5/katana",
+      }),
+    );
+  });
 });

--- a/client/apps/game/src/runtime/world/profile-builder.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.ts
@@ -113,14 +113,18 @@ export const buildWorldProfile = async (chain: Chain, name: string): Promise<Wor
   // As a last resort, default to 0x0 so configuration can still proceed with patched contracts
   if (!worldAddress) worldAddress = "0x0";
 
-  const slotDefaultRpcUrl = `${cartridgeApiBase}/x/eternum-blitz-slot-4/katana`;
+  const slotDefaultRpcUrl = `${cartridgeApiBase}/x/${name}/katana`;
   const chainDefaultRpcUrl =
     chain === "slot" || chain === "slottest"
       ? slotDefaultRpcUrl
       : chain === "mainnet" || chain === "sepolia"
         ? `${cartridgeApiBase}/x/starknet/${chain}`
         : env.VITE_PUBLIC_NODE_URL;
-  const canUseEnvRpc = hasPublicNodeUrl && isRpcUrlCompatibleForChain(chain, env.VITE_PUBLIC_NODE_URL);
+  const canUseEnvRpc =
+    hasPublicNodeUrl &&
+    chain !== "slot" &&
+    chain !== "slottest" &&
+    isRpcUrlCompatibleForChain(chain, env.VITE_PUBLIC_NODE_URL);
   const fallbackRpcUrl = canUseEnvRpc ? env.VITE_PUBLIC_NODE_URL : chainDefaultRpcUrl;
   const rpcUrl = normalizeRpcUrl(deployment?.rpcUrl ?? fallbackRpcUrl);
 

--- a/client/apps/game/src/ui/layouts/world.connection-monitor.source.test.ts
+++ b/client/apps/game/src/ui/layouts/world.connection-monitor.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("world connection monitor wiring", () => {
+  it("checks the active world's Torii health endpoint instead of the build-time default", () => {
+    const source = readSource("src/ui/layouts/world.tsx");
+
+    expect(source).toContain("useActiveWorldProfile");
+    expect(source).toContain("activeWorld?.toriiBaseUrl ?? env.VITE_PUBLIC_TORII");
+    expect(source).not.toContain("const toriiBaseUrl = env.VITE_PUBLIC_TORII;");
+  });
+});

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -1,10 +1,12 @@
-import { ConnectionHealthMonitor } from "@/dojo/connection-health-monitor";
+import { ConnectionHealthMonitor, resolveConnectionHealthToriiBaseUrl } from "@/dojo/connection-health-monitor";
 import { cancelEntityStreamSubscription, initialSync } from "@/dojo/sync";
+import { useActiveWorldProfile } from "@/runtime/world";
 import { getActiveSpatialStreamManager } from "@/three/scenes/worldmap";
 import { EndgameModal, NotLoggedInMessage } from "@/ui/shared";
 import { useDojo } from "@bibliothecadao/react";
 import { Leva } from "leva";
 import { useEffect } from "react";
+import { dojoConfig } from "../../../dojo-config";
 import { env } from "../../../env";
 import { useUIStore } from "../../hooks/store/use-ui-store";
 import { Tooltip } from "../design-system/molecules/tooltip";
@@ -137,10 +139,16 @@ const HUD = () => (
  */
 const ConnectionMonitor = () => {
   const { setup } = useDojo();
+  const activeWorld = useActiveWorldProfile();
   const state = useUIStore.getState();
+  const fallbackToriiBaseUrl = activeWorld?.toriiBaseUrl ?? env.VITE_PUBLIC_TORII;
 
   useEffect(() => {
-    const toriiBaseUrl = env.VITE_PUBLIC_TORII;
+    const toriiBaseUrl = resolveConnectionHealthToriiBaseUrl({
+      activeWorld,
+      fallbackToriiUrl: fallbackToriiBaseUrl,
+      runtimeToriiUrl: dojoConfig.toriiUrl,
+    });
 
     const monitor = new ConnectionHealthMonitor({
       onReconnectSpatial: async () => {
@@ -164,7 +172,7 @@ const ConnectionMonitor = () => {
 
     monitor.start();
     return () => monitor.dispose();
-  }, [setup, state]);
+  }, [activeWorld, fallbackToriiBaseUrl, setup, state]);
 
   return null;
 };

--- a/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
+++ b/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
@@ -1,7 +1,9 @@
 import type { Call, ResourceBoundsBN } from "starknet";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { EternumProvider } from "./index";
+import { PromiseQueue } from "./promise-queue";
 import type { TransactionFailedPayload } from "./types";
+import { TransactionType } from "./types";
 
 const makeResourceBounds = (l2GasMaxAmount: bigint): ResourceBoundsBN => ({
   l1_gas: { max_amount: 1n, max_price_per_unit: 1n },
@@ -30,6 +32,8 @@ const makeProvider = () => {
   provider.pendingTransactionSpans = new Map();
   provider.pendingVrfExecutionLocks = new Map();
   provider.TRANSACTION_CONFIRM_TIMEOUT_MS = 10_000;
+  provider.TRANSACTION_SUBMIT_TIMEOUT_MS = 20_000;
+  provider.FEE_ESTIMATE_TIMEOUT_MS = 5_000;
   return provider;
 };
 
@@ -40,6 +44,10 @@ const findTransactionFailedPayload = (
 };
 
 describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("caps l2 gas max_amount at the current v3 mainnet limit", async () => {
     const provider = makeProvider();
     const signer = {
@@ -203,9 +211,9 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
       waitForConfirmation: false,
     });
 
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(provider.execute).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => {
+      expect(provider.execute).toHaveBeenCalledTimes(2);
+    });
 
     resolveFirstWait({ isReverted: () => false });
 
@@ -419,5 +427,101 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
       stage: "background_confirmation",
       message: "confirmation failed",
     });
+  });
+
+  it("times out stuck submissions before a transaction hash so the queue can drain later actions", async () => {
+    vi.useFakeTimers();
+    const provider = makeProvider();
+    provider.promiseQueue = new PromiseQueue(provider, { batchDelayMs: 0 });
+    provider.TRANSACTION_SUBMIT_TIMEOUT_MS = 50;
+    provider.execute = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce({ transaction_hash: "0xnext" });
+
+    const signer = {
+      address: "0xabc",
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const firstCall: Call = {
+      contractAddress: "0x1",
+      entrypoint: "set_entity_name",
+      calldata: [],
+    };
+    const secondCall: Call = {
+      contractAddress: "0x1",
+      entrypoint: "set_address_name",
+      calldata: [],
+    };
+
+    const firstResult = provider.promiseQueue
+      .enqueue({
+        signer,
+        calls: firstCall,
+        transactionType: TransactionType.SET_ENTITY_NAME,
+      })
+      .then(
+        () => "resolved",
+        (error: unknown) => error,
+      );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(provider.execute).toHaveBeenCalledTimes(1);
+
+    const secondResult = provider.promiseQueue.enqueue({
+      signer,
+      calls: secondCall,
+      transactionType: TransactionType.SET_ADDRESS_NAME,
+    });
+
+    await vi.advanceTimersByTimeAsync(50);
+    const timedOutFirstResult = await Promise.race([firstResult, Promise.resolve("still-pending")]);
+
+    expect(timedOutFirstResult).toBeInstanceOf(Error);
+    expect((timedOutFirstResult as Error).message).toContain("Transaction submission timed out");
+    await expect(secondResult).resolves.toMatchObject({
+      statusReceipt: "PENDING",
+      transaction_hash: "0xnext",
+    });
+    expect(provider.execute).toHaveBeenCalledTimes(2);
+    expect(findTransactionFailedPayload(provider)).toMatchObject({
+      stage: "submit",
+      message: expect.stringContaining("Transaction submission timed out"),
+    });
+  });
+
+  it("uses default v3 execution details when fee estimation stalls before submission", async () => {
+    vi.useFakeTimers();
+    const provider = makeProvider();
+    provider.FEE_ESTIMATE_TIMEOUT_MS = 50;
+
+    const signer = {
+      estimateInvokeFee: vi.fn(() => new Promise(() => {})),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    const result = provider
+      .executeAndCheckTransaction(signer, call, undefined, {
+        waitForConfirmation: false,
+      })
+      .then(
+        (value: unknown) => value,
+        (error: unknown) => error,
+      );
+
+    await vi.advanceTimersByTimeAsync(50);
+    const timedOutEstimateResult = await Promise.race([result, Promise.resolve("still-pending")]);
+
+    expect(timedOutEstimateResult).toMatchObject({
+      statusReceipt: "PENDING",
+      transaction_hash: "0xabc",
+    });
+    expect(provider.execute).toHaveBeenCalledWith(signer, call, "s1_eternum", { version: 3 });
   });
 });

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -61,6 +61,8 @@ export type { VrfSource } from "./vrf";
 const MAX_V3_L2_GAS_MAX_AMOUNT = 1_200_000_000n;
 const V3_L2_GAS_OVERHEAD_PERCENT = 50n;
 const HUNDRED_PERCENT = 100n;
+const DEFAULT_FEE_ESTIMATE_TIMEOUT_MS = 5_000;
+const DEFAULT_TRANSACTION_SUBMIT_TIMEOUT_MS = 20_000;
 const NON_MEANINGFUL_ERROR_MESSAGES = new Set(["", "[object Object]", "undefined", "null"]);
 const GENERIC_ERROR_MESSAGES = new Set([
   "transaction execution error",
@@ -76,6 +78,18 @@ const WRAPPED_ERROR_PREFIXES = [
   "Transaction failed while waiting for confirmation:",
   "Transaction failed with reason:",
 ];
+
+const formatTimeoutDuration = (timeoutMs: number): string =>
+  timeoutMs >= 1_000 ? `${Math.round(timeoutMs / 1_000)}s` : `${timeoutMs}ms`;
+
+class TransactionSubmissionTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(
+      `Transaction submission timed out after ${formatTimeoutDuration(timeoutMs)} before a transaction hash was returned`,
+    );
+    this.name = "TransactionSubmissionTimeoutError";
+  }
+}
 
 const normalizeErrorKey = (value: string): string =>
   value
@@ -346,6 +360,8 @@ const extractErrorMessage = (error: unknown, fallback = "Unknown error"): string
   return fallback;
 };
 
+const matchesNonceError = (error: unknown): boolean => extractErrorMessage(error, "").toLowerCase().includes("nonce");
+
 const withL2GasHeadroom = (resourceBounds?: ResourceBoundsBN): ResourceBoundsBN | undefined => {
   if (!resourceBounds?.l2_gas || typeof resourceBounds.l2_gas.max_amount !== "bigint") {
     return resourceBounds;
@@ -496,6 +512,8 @@ export class EternumProvider extends EnhancedDojoProvider {
     transactionDetails: AllowArray<Call>,
   ) => Promise<GetTransactionReceiptResponse>;
   private readonly TRANSACTION_CONFIRM_TIMEOUT_MS = 10_000;
+  private readonly TRANSACTION_SUBMIT_TIMEOUT_MS = DEFAULT_TRANSACTION_SUBMIT_TIMEOUT_MS;
+  private readonly FEE_ESTIMATE_TIMEOUT_MS = DEFAULT_FEE_ESTIMATE_TIMEOUT_MS;
   private pendingTransactionSpans = new Map<string, Span>();
   private pendingVrfExecutionLocks = new Map<string, VrfExecutionLock>();
   private readonly retryConfig?: RetryConfig;
@@ -633,9 +651,16 @@ export class EternumProvider extends EnhancedDojoProvider {
     }
 
     try {
-      const estimate = (await estimateInvokeFee.call(signer, transactionDetails, {
-        version: 3,
-      })) as { resourceBounds?: ResourceBoundsBN };
+      const estimate = (await this.withTimeout(
+        estimateInvokeFee.call(signer, transactionDetails, {
+          version: 3,
+        }),
+        this.FEE_ESTIMATE_TIMEOUT_MS,
+        () =>
+          new Error(
+            `Transaction fee estimation timed out after ${formatTimeoutDuration(this.FEE_ESTIMATE_TIMEOUT_MS)}`,
+          ),
+      )) as { resourceBounds?: ResourceBoundsBN };
       const resourceBounds = withL2GasHeadroom(estimate?.resourceBounds);
       if (!resourceBounds) {
         return details;
@@ -648,6 +673,59 @@ export class EternumProvider extends EnhancedDojoProvider {
     } catch (error) {
       console.warn("[provider] Failed to estimate invoke fee, using default v3 tx details", error);
       return details;
+    }
+  }
+
+  private async submitTransaction(
+    signer: Account | AccountInterface,
+    transactionDetails: AllowArray<Call>,
+    executionDetails: UniversalDetails,
+  ): Promise<{ transaction_hash: string }> {
+    if (this.retryConfig && this.retryConfig.maxRetries > 0) {
+      let currentExecutionDetails = executionDetails;
+      return await withRetry(
+        () => this.execute(signer as any, transactionDetails, NAMESPACE, currentExecutionDetails),
+        this.retryConfig,
+        async (error, attempt) => {
+          if (matchesNonceError(error)) {
+            currentExecutionDetails = await this.getV3ExecutionDetails(signer, transactionDetails);
+          }
+          console.warn(`[provider] Retry attempt ${attempt} for transaction: ${extractErrorMessage(error)}`);
+        },
+      );
+    }
+
+    return await this.execute(signer as any, transactionDetails, NAMESPACE, executionDetails);
+  }
+
+  private async submitTransactionWithTimeout(
+    signer: Account | AccountInterface,
+    transactionDetails: AllowArray<Call>,
+    executionDetails: UniversalDetails,
+  ): Promise<{ transaction_hash: string }> {
+    return await this.withTimeout(
+      this.submitTransaction(signer, transactionDetails, executionDetails),
+      this.TRANSACTION_SUBMIT_TIMEOUT_MS,
+      () => new TransactionSubmissionTimeoutError(this.TRANSACTION_SUBMIT_TIMEOUT_MS),
+    );
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, buildError: () => Error): Promise<T> {
+    if (timeoutMs <= 0) {
+      return await promise;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => reject(buildError()), timeoutMs);
+    });
+
+    try {
+      return await Promise.race([promise, timeout]);
+    } finally {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
     }
   }
 
@@ -890,23 +968,7 @@ export class EternumProvider extends EnhancedDojoProvider {
 
     let tx;
     try {
-      if (this.retryConfig && this.retryConfig.maxRetries > 0) {
-        let currentExecutionDetails = executionDetails;
-        tx = await withRetry(
-          () => this.execute(signer as any, sanitizedTransactionDetails, NAMESPACE, currentExecutionDetails),
-          this.retryConfig,
-          async (error, attempt) => {
-            // Re-estimate gas on nonce-related errors
-            const msg = error instanceof Error ? error.message.toLowerCase() : "";
-            if (msg.includes("nonce")) {
-              currentExecutionDetails = await this.getV3ExecutionDetails(signer, sanitizedTransactionDetails);
-            }
-            console.warn(`[provider] Retry attempt ${attempt} for transaction: ${extractErrorMessage(error)}`);
-          },
-        );
-      } else {
-        tx = await this.execute(signer as any, sanitizedTransactionDetails, NAMESPACE, executionDetails);
-      }
+      tx = await this.submitTransactionWithTimeout(signer, sanitizedTransactionDetails, executionDetails);
     } catch (error) {
       releaseVrfExecutionLock?.();
       releaseVrfExecutionLock = undefined;


### PR DESCRIPTION
## Summary
Fixes the client-side failure modes behind actions appearing disconnected: provider submission and fee-estimation stalls now time out instead of blocking the queue, runtime slot worlds fall back to their selected world RPC, and Torii health checks use the active world endpoint.
Stream recovery now has a longer reconnect cooldown, marks reconnect attempts centrally, and player-scoped structure/resource subscriptions resubscribe after global recovery.

## Test plan
Passed: targeted game connection/profile tests, provider transaction timeout tests, `pnpm run format`, and `pnpm run knip`.
Note: game app typecheck was attempted but the workspace currently fails before this diff because local `@bibliothecadao/*` package declarations are unresolved.