### PR TITLE
fix: keep chest morph instances WebGPU safe

### DIFF
--- a/client/apps/game/src/three/managers/instanced-model.material-semantics.test.ts
+++ b/client/apps/game/src/three/managers/instanced-model.material-semantics.test.ts
@@ -1,5 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Group, Mesh, MeshBasicMaterial, MeshStandardMaterial, PlaneGeometry, SphereGeometry } from "three";
+import {
+  AnimationClip,
+  BoxGeometry,
+  Group,
+  Matrix4,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  NumberKeyframeTrack,
+  PlaneGeometry,
+  SphereGeometry,
+} from "three";
 
 vi.mock("../utils/contact-shadow", () => ({
   disposeContactShadowResources: vi.fn(),
@@ -19,6 +30,30 @@ function createInstancedModelTestGltf(material: MeshStandardMaterial) {
     scene,
     animations: [],
   };
+}
+
+function createAnimatedMorphInstancedModelTestGltf(material: MeshStandardMaterial) {
+  const geometry = new BoxGeometry(1, 1, 1);
+  geometry.morphAttributes.position = [geometry.attributes.position.clone()];
+  geometry.morphAttributes.normal = [geometry.attributes.normal.clone()];
+
+  const scene = new Group();
+  const mesh = new Mesh(geometry, material);
+  mesh.name = "chest";
+  scene.add(mesh);
+
+  return {
+    scene,
+    animations: [
+      new AnimationClip("Idle", 1, [new NumberKeyframeTrack("chest.morphTargetInfluences[0]", [0, 1], [0, 1])]),
+    ],
+  };
+}
+
+function readInstanceMatrix(modelMesh: { getMatrixAt(index: number, matrix: Matrix4): void }, index: number): Matrix4 {
+  const matrix = new Matrix4();
+  modelMesh.getMatrixAt(index, matrix);
+  return matrix;
 }
 
 describe("InstancedModel material semantics", () => {
@@ -51,5 +86,30 @@ describe("InstancedModel material semantics", () => {
     expect(resolvedMaterial.depthWrite).toBe(false);
     expect(resolvedMaterial.alphaTest).toBe(0);
     expect(resolvedMaterial.emissiveIntensity).toBe(1.5);
+  });
+
+  it("keeps animated morph instances on the WebGPU-safe morph texture path", async () => {
+    const { default: InstancedModel } = await import("./instanced-model");
+    const morphChestMaterial = new MeshStandardMaterial();
+    const hiddenMatrix = new Matrix4().makeScale(0, 0, 0);
+    const visibleMatrix = new Matrix4().makeTranslation(1, 2, 3);
+
+    const model = new InstancedModel(createAnimatedMorphInstancedModelTestGltf(morphChestMaterial), 1, false, "Chest");
+    const chestMesh = model.instancedMeshes[0];
+
+    expect(chestMesh.morphTexture).not.toBeNull();
+    expect(model.getCount()).toBe(0);
+    expect(chestMesh.count).toBe(2);
+    expect(readInstanceMatrix(chestMesh, 0).elements).toEqual(hiddenMatrix.elements);
+    expect(readInstanceMatrix(chestMesh, 1).elements).toEqual(hiddenMatrix.elements);
+
+    model.setMatrixAt(0, visibleMatrix);
+    model.setCount(1);
+
+    expect(model.getCount()).toBe(1);
+    expect(chestMesh.count).toBe(2);
+    expect(readInstanceMatrix(chestMesh, 0).elements).toEqual(visibleMatrix.elements);
+    expect(readInstanceMatrix(chestMesh, 1).elements).toEqual(hiddenMatrix.elements);
+    expect(model.getMatricesAndCount().count).toBe(1);
   });
 });

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -37,6 +37,27 @@ const instanceMatrix = new Matrix4();
 const rotationMatrix = new Matrix4();
 const zeroMatrix = new Matrix4().makeScale(0, 0, 0);
 const DEFAULT_INITIAL_CAPACITY = 32;
+const MORPH_TEXTURE_RENDER_COUNT_FLOOR = 2;
+
+function hasInstancedMorphTexture(mesh: InstancedMesh): boolean {
+  return mesh.morphTexture !== null && mesh.morphTexture !== undefined;
+}
+
+function resolveRenderedInstanceCount(mesh: InstancedMesh, logicalCount: number): number {
+  return hasInstancedMorphTexture(mesh) ? Math.max(logicalCount, MORPH_TEXTURE_RENDER_COUNT_FLOOR) : logicalCount;
+}
+
+function hideUnusedRenderedInstances(mesh: InstancedMesh, logicalCount: number, renderedCount: number): void {
+  for (let index = logicalCount; index < renderedCount; index++) {
+    mesh.setMatrixAt(index, zeroMatrix);
+  }
+}
+
+function applyRenderedInstanceCount(mesh: InstancedMesh, logicalCount: number): void {
+  const renderedCount = resolveRenderedInstanceCount(mesh, logicalCount);
+  hideUnusedRenderedInstances(mesh, logicalCount, renderedCount);
+  mesh.count = renderedCount;
+}
 
 function shouldApplyStructureAlphaCutoutFallback(material: MeshStandardMaterial): boolean {
   return !material.depthWrite && !material.transparent;
@@ -111,7 +132,7 @@ export default class InstancedModel {
     this.name = name;
     this.group = new Group();
     this.count = 0;
-    this.capacity = Math.max(initialCapacity, 1);
+    this.capacity = Math.max(initialCapacity, MORPH_TEXTURE_RENDER_COUNT_FLOOR);
 
     this.timeOffsets = new Float32Array(this.capacity);
     this.animationBuckets = new Uint8Array(this.capacity);
@@ -169,7 +190,7 @@ export default class InstancedModel {
           tmp.raycast = () => {};
         }
 
-        tmp.count = 0;
+        applyRenderedInstanceCount(tmp, 0);
         this.group.add(tmp);
         this.instancedMeshes.push(tmp);
         this.biomeMeshes.push(biomeMesh);
@@ -231,7 +252,7 @@ export default class InstancedModel {
 
   getMatricesAndCount() {
     const mesh = this.group.children[0] as InstancedMesh;
-    const count = mesh.count;
+    const count = this.count;
     const pool = InstancedMatrixAttributePool.getInstance();
     const snapshot = pool.acquire(count);
     const requiredFloats = count * snapshot.itemSize;
@@ -254,7 +275,7 @@ export default class InstancedModel {
       if (floatsToCopy > 0) {
         targetArray.set(sourceArray.subarray(0, floatsToCopy));
       }
-      mesh.count = finalCount;
+      applyRenderedInstanceCount(mesh, finalCount);
       mesh.instanceMatrix.needsUpdate = true;
       resolvedCount = Math.min(resolvedCount, finalCount);
     });
@@ -291,7 +312,7 @@ export default class InstancedModel {
     this.ensureCapacity(count);
     this.count = count;
     this.instancedMeshes.forEach((mesh) => {
-      mesh.count = count;
+      applyRenderedInstanceCount(mesh, count);
     });
     if (this.contactShadowMesh) {
       this.contactShadowMesh.count = count;


### PR DESCRIPTION
## Summary
Fixes the chest instanced morph path so Three WebGPU keeps using morph textures even when a chunk has zero or one visible chest, hiding sentinel instances with zero-scale matrices while preserving logical instance counts.
Adds regression coverage for the animated morph chest path and logical matrix snapshots.

## Test plan
- [x] npx -y node@20.19.0 $(which pnpm) --dir /Users/os/conductor/workspaces/eternum/ottawa-v4/client/apps/game exec vitest run src/three/managers/instanced-model.material-semantics.test.ts src/three/managers/instanced-model.bounds-authority.test.ts
- [x] pnpm run format
- [x] pnpm run knip
- [x] npx -y node@20.19.0 $(which pnpm) --dir /Users/os/conductor/workspaces/eternum/ottawa-v4/client/apps/game run test:three:types