### PR TITLE
Visible network desync UX + Sentry monitoring + boot-reconnect fix

### DIFF
--- a/client/apps/game/env.ts
+++ b/client/apps/game/env.ts
@@ -196,6 +196,21 @@ const envSchema = z.object({
     .optional()
     .default("false"),
   VITE_PUBLIC_SENTRY_TX_WALLET_IDENTITY: z.enum(["hashed", "raw", "none"]).optional().default("hashed"),
+  VITE_PUBLIC_SENTRY_NETWORK_HEALTH_ENABLED: z
+    .string()
+    .transform((v) => v === "true")
+    .optional()
+    .default("true"),
+  VITE_PUBLIC_SENTRY_NETWORK_HEALTH_MIN_OUTAGE_MS: z
+    .string()
+    .optional()
+    .default("10000")
+    .transform((v) => Number(v)),
+  VITE_PUBLIC_SENTRY_NETWORK_HEALTH_MAX_PER_SESSION: z
+    .string()
+    .optional()
+    .default("50")
+    .transform((v) => Number(v)),
 
   // Tracing Configuration
   VITE_TRACING_ENABLED: z
@@ -217,6 +232,7 @@ const envSchema = z.object({
     .transform((v) => v === "true")
     .optional()
     .default("true"),
+
   VITE_PUBLIC_TORII_BOUNDS_DEBUG: z
     .string()
     .transform((v) => v === "true")

--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -75,6 +75,7 @@ describe("ConnectionHealthMonitor", () => {
     });
 
     monitor.start();
+    monitor.exitBootGraceForTests();
 
     useConnectionStore.setState({
       lastSpatialUpdate: Date.now() - 10_000,
@@ -104,6 +105,7 @@ describe("ConnectionHealthMonitor", () => {
     });
 
     monitor.start();
+    monitor.exitBootGraceForTests();
 
     useConnectionStore.setState({
       lastSpatialUpdate: Date.now() - 10_000,
@@ -144,6 +146,7 @@ describe("ConnectionHealthMonitor", () => {
     });
 
     monitor.start();
+    monitor.exitBootGraceForTests();
 
     useConnectionStore.setState({
       lastSpatialUpdate: Date.now() - 10_000,
@@ -185,6 +188,7 @@ describe("ConnectionHealthMonitor", () => {
     });
 
     monitor.start();
+    monitor.exitBootGraceForTests();
 
     useConnectionStore.setState({
       lastSpatialUpdate: Date.now() - 10_000,
@@ -197,6 +201,120 @@ describe("ConnectionHealthMonitor", () => {
     expect(onReconnectSpatial).not.toHaveBeenCalled();
     expect(onReconnectGlobal).not.toHaveBeenCalled();
     expect(useConnectionStore.getState().status).toBe("disconnected");
+
+    monitor.dispose();
+  });
+
+  it("sets per-stream status to reconnecting then connected around a reconnect", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    let spatialStatusDuringReconnect: string | null = null;
+    const origSetSpatialStatus = useConnectionStore.getState().setSpatialStatus;
+    useConnectionStore.setState({
+      setSpatialStatus: (s) => {
+        if (s === "reconnecting") spatialStatusDuringReconnect = s;
+        origSetSpatialStatus(s);
+      },
+    });
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now(),
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(spatialStatusDuringReconnect).toBe("reconnecting");
+    expect(useConnectionStore.getState().spatialStatus).toBe("connected");
+
+    monitor.dispose();
+  });
+
+  it("forceReconnect bypasses the reconnect cooldown", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      reconnectCooldownMs: 20_000,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(1);
+
+    await monitor.forceReconnect();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(2);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(2);
+
+    monitor.dispose();
+  });
+
+  it("fires onRecovery after an outage >= recoveryToastThresholdMs", async () => {
+    const onRecovery = vi.fn();
+    let healthy = false;
+    const healthCheckFn = vi.fn(() => (healthy ? Promise.resolve(true) : Promise.reject(new Error("offline"))));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal: vi.fn(() => Promise.resolve()),
+      onReconnectSpatial: vi.fn(() => Promise.resolve()),
+      onRecovery,
+      staleThresholdMs: 5_000,
+      recoveryToastThresholdMs: 10_000,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+
+    // First tick: health check fails → pendingRecoveryToastFromMs is stamped.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+    expect(useConnectionStore.getState().status).toBe("disconnected");
+    expect(onRecovery).not.toHaveBeenCalled();
+
+    // Keep failing for >10s of real (fake) time so outage threshold is cleared.
+    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.runOnlyPendingTimersAsync();
+    expect(onRecovery).not.toHaveBeenCalled();
+
+    // Now succeed — next tick should flip to connected and fire onRecovery.
+    healthy = true;
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onRecovery).toHaveBeenCalledTimes(1);
+    expect(onRecovery.mock.calls[0][0]).toBeGreaterThanOrEqual(10_000);
 
     monitor.dispose();
   });
@@ -215,6 +333,7 @@ describe("ConnectionHealthMonitor", () => {
     });
 
     monitor.start();
+    monitor.exitBootGraceForTests();
 
     useConnectionStore.setState({
       lastSpatialUpdate: Date.now() - 10_000,
@@ -226,6 +345,97 @@ describe("ConnectionHealthMonitor", () => {
     await vi.runOnlyPendingTimersAsync();
 
     expect(useConnectionStore.getState().streamReconnectVersion).toBe(1);
+
+    monitor.dispose();
+  });
+
+  it("does not auto-reconnect during boot grace even if stream timestamps look stale", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+    // Simulate a slow boot: timestamps are from before the monitor started.
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+    });
+
+    // Several ticks pass with streams still "stale" by timestamp.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).not.toHaveBeenCalled();
+    expect(onReconnectGlobal).not.toHaveBeenCalled();
+
+    monitor.dispose();
+  });
+
+  it("exits boot grace once both streams tick after start, then behaves normally", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+
+    // Simulate streams ticking healthily after start.
+    await vi.advanceTimersByTimeAsync(1_000);
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now(),
+      lastGlobalUpdate: Date.now(),
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    // Now drive them stale. Grace should have exited; reconnect should fire.
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+
+    monitor.dispose();
+  });
+
+  it("forceReconnect works during boot grace (manual retry always allowed)", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+    // Grace is active (no exitBootGraceForTests call).
+
+    await monitor.forceReconnect();
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onReconnectSpatial).toHaveBeenCalledTimes(1);
+    expect(onReconnectGlobal).toHaveBeenCalledTimes(1);
 
     monitor.dispose();
   });

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -3,14 +3,20 @@ import { useConnectionStore } from "@/hooks/store/use-connection-store";
 const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 10_000;
 const DEFAULT_STALE_THRESHOLD_MS = 15_000;
 const DEFAULT_RECONNECT_COOLDOWN_MS = 60_000;
+const DEFAULT_RECOVERY_TOAST_THRESHOLD_MS = 30_000;
+const DEFAULT_DEAD_END_ATTEMPTS = 5;
 
 interface ConnectionHealthMonitorConfig {
   onReconnectSpatial: () => Promise<void>;
   onReconnectGlobal: () => Promise<void>;
   healthCheckFn: () => Promise<boolean>;
+  onRecovery?: (outageMs: number, attempts: number) => void;
+  onDeadEnd?: (outageMs: number, attempts: number) => void;
   healthCheckIntervalMs?: number;
   staleThresholdMs?: number;
   reconnectCooldownMs?: number;
+  recoveryToastThresholdMs?: number;
+  deadEndAttempts?: number;
 }
 
 interface ConnectionHealthToriiInput {
@@ -19,16 +25,26 @@ interface ConnectionHealthToriiInput {
   fallbackToriiUrl: string;
 }
 
+let activeMonitor: ConnectionHealthMonitor | null = null;
+
+export const getConnectionHealthMonitor = (): ConnectionHealthMonitor | null => activeMonitor;
+
 export class ConnectionHealthMonitor {
   private readonly config: ConnectionHealthMonitorConfig;
   private readonly healthCheckIntervalMs: number;
   private readonly staleThresholdMs: number;
   private readonly reconnectCooldownMs: number;
+  private readonly recoveryToastThresholdMs: number;
 
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
   private reconnecting = false;
   private disposed = false;
   private lastStreamReconnectAtMs = 0;
+  private pendingRecoveryToastFromMs: number | null = null;
+  private deadEndReported = false;
+  private startedAtMs = 0;
+  private hasObservedHealthyStreams = false;
+  private readonly deadEndAttempts: number;
 
   constructor(config: ConnectionHealthMonitorConfig) {
     this.config = config;
@@ -38,11 +54,16 @@ export class ConnectionHealthMonitor {
       config.reconnectCooldownMs ?? DEFAULT_RECONNECT_COOLDOWN_MS,
       this.staleThresholdMs,
     );
+    this.recoveryToastThresholdMs = config.recoveryToastThresholdMs ?? DEFAULT_RECOVERY_TOAST_THRESHOLD_MS;
+    this.deadEndAttempts = config.deadEndAttempts ?? DEFAULT_DEAD_END_ATTEMPTS;
   }
 
   start(): void {
     if (this.disposed) return;
 
+    activeMonitor = this;
+    this.startedAtMs = Date.now();
+    this.hasObservedHealthyStreams = false;
     document.addEventListener("visibilitychange", this.handleVisibilityChange);
     window.addEventListener("online", this.handleOnline);
     this.startHealthCheckLoop();
@@ -52,6 +73,7 @@ export class ConnectionHealthMonitor {
     document.removeEventListener("visibilitychange", this.handleVisibilityChange);
     window.removeEventListener("online", this.handleOnline);
     this.stopHealthCheckLoop();
+    if (activeMonitor === this) activeMonitor = null;
   }
 
   dispose(): void {
@@ -59,11 +81,25 @@ export class ConnectionHealthMonitor {
     this.disposed = true;
   }
 
+  /** Bypasses the reconnect cooldown and boot grace — used by the UI retry button. */
+  async forceReconnect(): Promise<void> {
+    if (this.disposed) return;
+    this.lastStreamReconnectAtMs = Date.now();
+    this.hasObservedHealthyStreams = true;
+    await this.reconnectStaleStreams(true, true);
+  }
+
+  /** Test-only: skip the boot grace period so tests can exercise steady-state staleness. */
+  exitBootGraceForTests(): void {
+    this.hasObservedHealthyStreams = true;
+  }
+
   // --- Phase 3: Visibility & Online Handlers ---
 
   private handleVisibilityChange = (): void => {
     if (this.disposed) return;
     if (document.visibilityState !== "visible") return;
+    if (!this.hasObservedHealthyStreams) return;
 
     const store = useConnectionStore.getState();
     const now = Date.now();
@@ -77,6 +113,7 @@ export class ConnectionHealthMonitor {
 
   private handleOnline = (): void => {
     if (this.disposed) return;
+    if (!this.hasObservedHealthyStreams) return;
 
     useConnectionStore.getState().resetReconnectAttempts();
     void this.reconnectStaleStreams(true, true);
@@ -110,8 +147,19 @@ export class ConnectionHealthMonitor {
 
       if (healthy) {
         store.recordHealthCheck();
-        store.setStatus("connected");
+        this.markConnectedIfNeeded();
         store.resetReconnectAttempts();
+
+        // Boot grace: only consider streams stale once we've seen both tick
+        // at least once *after* the monitor started. Until then, a quiet
+        // subscription could just be mid-handshake — don't cancel it.
+        if (!this.hasObservedHealthyStreams) {
+          if (store.lastSpatialUpdate > this.startedAtMs && store.lastGlobalUpdate > this.startedAtMs) {
+            this.hasObservedHealthyStreams = true;
+          } else {
+            return;
+          }
+        }
 
         // Server is reachable, but a stream can silently die (WASM gRPC drop
         // without onError firing) while the tab stays visible. If either stream
@@ -129,7 +177,11 @@ export class ConnectionHealthMonitor {
       }
     } catch {
       store.setStatus("disconnected");
+      store.setSpatialStatus("failed");
+      store.setGlobalStatus("failed");
       store.incrementReconnectAttempts();
+      this.markOutageStart();
+      this.reportDeadEndIfNeeded();
     }
   }
 
@@ -140,20 +192,61 @@ export class ConnectionHealthMonitor {
 
     this.reconnecting = true;
     const store = useConnectionStore.getState();
+    if (spatial) store.setSpatialStatus("reconnecting");
+    if (global) store.setGlobalStatus("reconnecting");
     try {
       const promises: Promise<void>[] = [];
       if (spatial) promises.push(this.config.onReconnectSpatial());
       if (global) promises.push(this.config.onReconnectGlobal());
       await Promise.all(promises);
+      if (spatial) store.setSpatialStatus("connected");
+      if (global) store.setGlobalStatus("connected");
       if (promises.length > 0) {
         store.recordStreamReconnect();
+        this.markConnectedIfNeeded();
       }
     } catch (error) {
       console.warn("[ConnectionHealthMonitor] Failed to reconnect stale streams", error);
       store.setStatus("degraded");
+      if (spatial) store.setSpatialStatus("failed");
+      if (global) store.setGlobalStatus("failed");
       store.incrementReconnectAttempts();
+      this.markOutageStart();
+      this.reportDeadEndIfNeeded();
     } finally {
       this.reconnecting = false;
+    }
+  }
+
+  private reportDeadEndIfNeeded(): void {
+    if (this.deadEndReported) return;
+    const store = useConnectionStore.getState();
+    if (store.reconnectAttempts < this.deadEndAttempts) return;
+    this.deadEndReported = true;
+    const outageMs = this.pendingRecoveryToastFromMs !== null ? Date.now() - this.pendingRecoveryToastFromMs : 0;
+    this.config.onDeadEnd?.(outageMs, store.reconnectAttempts);
+  }
+
+  private markOutageStart(): void {
+    if (this.pendingRecoveryToastFromMs === null) {
+      const store = useConnectionStore.getState();
+      this.pendingRecoveryToastFromMs = store.lastDisconnectedAt ?? Date.now();
+    }
+  }
+
+  private markConnectedIfNeeded(): void {
+    const store = useConnectionStore.getState();
+    const wasDown = store.status !== "connected" || this.pendingRecoveryToastFromMs !== null;
+    const attemptsBeforeReset = store.reconnectAttempts;
+    store.setStatus("connected");
+
+    if (this.pendingRecoveryToastFromMs !== null) {
+      const outageMs = Date.now() - this.pendingRecoveryToastFromMs;
+      this.pendingRecoveryToastFromMs = null;
+      this.deadEndReported = false;
+      if (wasDown && outageMs >= this.recoveryToastThresholdMs) {
+        this.config.onRecovery?.(outageMs, attemptsBeforeReset);
+      }
     }
   }
 }

--- a/client/apps/game/src/dojo/sync.regression.source.test.ts
+++ b/client/apps/game/src/dojo/sync.regression.source.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("network boot-regression guards", () => {
+  it("sync.ts resets the global staleness clock after a successful subscription handshake", () => {
+    const source = readSource("src/dojo/sync.ts");
+
+    expect(source).toContain("isInitialSyncInFlight");
+    // Reset happens after successful await, before the try{}'s catch branch.
+    expect(source).toMatch(/entityStreamSubscription = await syncEntitiesDebounced[\s\S]*?recordGlobalUpdate\(\)/);
+  });
+
+  it("sync.ts cancelEntityStreamSubscription no-ops while initial sync is in flight", () => {
+    const source = readSource("src/dojo/sync.ts");
+
+    expect(source).toMatch(/cancelEntityStreamSubscription[\s\S]*?if \(isInitialSyncInFlight\) return/);
+  });
+
+  it("torii-stream-manager.ts resets spatial clock after a bounds switch subscription is applied", () => {
+    const source = readSource("src/dojo/torii-stream-manager.ts");
+
+    expect(source).toContain("useConnectionStore");
+    expect(source).toContain("recordSpatialUpdate()");
+  });
+
+  it("connection-health-monitor exposes the boot grace gate", () => {
+    const source = readSource("src/dojo/connection-health-monitor.ts");
+
+    expect(source).toContain("hasObservedHealthyStreams");
+    expect(source).toContain("startedAtMs");
+    expect(source).toContain("exitBootGraceForTests");
+  });
+});

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -38,13 +38,18 @@ interface SyncEntitiesSubscriptionOptions {
 }
 
 let entityStreamSubscription: { cancel: () => void; ready: Promise<void> } | null = null;
+let isInitialSyncInFlight = false;
 
 /**
  * Cancel the global entity stream subscription.
  * Used during game switching to stop the old Torii client from writing
  * stale data into RECS while the new world is being bootstrapped.
+ *
+ * No-op while a boot is still handshaking — tearing down a half-built
+ * subscription strands RECS and the monitor then re-enters the same loop.
  */
 export const cancelEntityStreamSubscription = () => {
+  if (isInitialSyncInFlight) return;
   if (entityStreamSubscription) {
     entityStreamSubscription.cancel();
     entityStreamSubscription = null;
@@ -548,6 +553,7 @@ export const initialSync = async (
     setInitialSyncProgress(0);
   }
 
+  isInitialSyncInFlight = true;
   try {
     entityStreamSubscription = await syncEntitiesDebounced(
       setup.network.toriiClient,
@@ -560,11 +566,17 @@ export const initialSync = async (
         onSubscriptionSetupTimeout: options.onSubscriptionSetupTimeout,
       },
     );
+    // Handshake succeeded — restart the staleness clock so the monitor
+    // measures "time since last entity *after* the subscription exists",
+    // not time since module load.
+    useConnectionStore.getState().recordGlobalUpdate();
   } catch (error) {
     if (error instanceof Error && error.message.includes("Timed out waiting for")) {
       throw new Error(`Timed out connecting to the world stream after ${subscriptionSetupTimeoutMs}ms.`);
     }
     throw error;
+  } finally {
+    isInitialSyncInFlight = false;
   }
 
   const contractComponents = setup.network.contractComponents as unknown as Component<Schema, Metadata, undefined>[];

--- a/client/apps/game/src/dojo/torii-stream-manager.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.ts
@@ -2,6 +2,7 @@ import { SetupResult } from "@bibliothecadao/dojo";
 import { AndComposeClause, MemberClause } from "@dojoengine/sdk";
 import { PatternMatching } from "@dojoengine/torii-client";
 import type { Clause, ToriiClient } from "@dojoengine/torii-wasm/types";
+import { useConnectionStore } from "@/hooks/store/use-connection-store";
 import { syncEntitiesDebounced } from "./sync";
 import type { ToriiSubscriptionSetupTimeoutInfo } from "./torii-subscription-setup";
 
@@ -282,6 +283,9 @@ export class ToriiStreamManager {
       this.cancelCurrentSubscription();
       this.currentSubscription = subscription;
       this.currentSignature = signature;
+      // Handshake succeeded — restart the staleness clock so the monitor
+      // measures "time since last spatial entity *after* subscription is live".
+      useConnectionStore.getState().recordSpatialUpdate();
       return { outcome: "applied" };
     });
 

--- a/client/apps/game/src/hooks/store/use-connection-store.test.ts
+++ b/client/apps/game/src/hooks/store/use-connection-store.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useConnectionStore } from "./use-connection-store";
+
+describe("useConnectionStore", () => {
+  beforeEach(() => {
+    useConnectionStore.setState({
+      status: "connected",
+      spatialStatus: "connected",
+      globalStatus: "connected",
+      lastSpatialUpdate: Date.now(),
+      lastGlobalUpdate: Date.now(),
+      lastHealthCheck: Date.now(),
+      lastConnectedAt: Date.now(),
+      lastDisconnectedAt: null,
+      reconnectAttempts: 0,
+      streamReconnectVersion: 0,
+    });
+  });
+
+  afterEach(() => {
+    useConnectionStore.setState({
+      status: "connected",
+      spatialStatus: "connected",
+      globalStatus: "connected",
+      lastDisconnectedAt: null,
+      reconnectAttempts: 0,
+    });
+  });
+
+  it("derives overall status as disconnected when any stream is failed", () => {
+    useConnectionStore.getState().setSpatialStatus("failed");
+    expect(useConnectionStore.getState().status).toBe("disconnected");
+  });
+
+  it("derives overall status as degraded when a stream is reconnecting", () => {
+    useConnectionStore.getState().setGlobalStatus("reconnecting");
+    expect(useConnectionStore.getState().status).toBe("degraded");
+  });
+
+  it("stamps lastDisconnectedAt when transitioning from connected to degraded/disconnected", () => {
+    expect(useConnectionStore.getState().lastDisconnectedAt).toBeNull();
+    useConnectionStore.getState().setSpatialStatus("failed");
+    expect(useConnectionStore.getState().lastDisconnectedAt).toBeGreaterThan(0);
+  });
+
+  it("clears lastDisconnectedAt and stamps lastConnectedAt when both streams recover", () => {
+    useConnectionStore.getState().setSpatialStatus("failed");
+    expect(useConnectionStore.getState().lastDisconnectedAt).toBeGreaterThan(0);
+
+    useConnectionStore.getState().setSpatialStatus("connected");
+    expect(useConnectionStore.getState().status).toBe("connected");
+    expect(useConnectionStore.getState().lastDisconnectedAt).toBeNull();
+  });
+
+  it("keeps lastDisconnectedAt when already unhealthy and a second stream fails", () => {
+    useConnectionStore.getState().setSpatialStatus("failed");
+    const firstStamp = useConnectionStore.getState().lastDisconnectedAt;
+    expect(firstStamp).toBeGreaterThan(0);
+
+    useConnectionStore.getState().setGlobalStatus("failed");
+    expect(useConnectionStore.getState().lastDisconnectedAt).toBe(firstStamp);
+  });
+});

--- a/client/apps/game/src/hooks/store/use-connection-store.ts
+++ b/client/apps/game/src/hooks/store/use-connection-store.ts
@@ -1,15 +1,22 @@
 import { create } from "zustand";
 
-type ConnectionStatus = "connected" | "degraded" | "disconnected";
+export type ConnectionStatus = "connected" | "degraded" | "disconnected";
+export type StreamStatus = "connected" | "stale" | "reconnecting" | "failed";
 
 interface ConnectionState {
   status: ConnectionStatus;
+  spatialStatus: StreamStatus;
+  globalStatus: StreamStatus;
   lastSpatialUpdate: number;
   lastGlobalUpdate: number;
   lastHealthCheck: number;
+  lastConnectedAt: number;
+  lastDisconnectedAt: number | null;
   reconnectAttempts: number;
   streamReconnectVersion: number;
   setStatus: (status: ConnectionStatus) => void;
+  setSpatialStatus: (status: StreamStatus) => void;
+  setGlobalStatus: (status: StreamStatus) => void;
   recordSpatialUpdate: () => void;
   recordGlobalUpdate: () => void;
   recordHealthCheck: () => void;
@@ -18,14 +25,65 @@ interface ConnectionState {
   resetReconnectAttempts: () => void;
 }
 
+const deriveOverallStatus = (spatial: StreamStatus, global: StreamStatus): ConnectionStatus => {
+  if (spatial === "failed" || global === "failed") return "disconnected";
+  if (spatial === "connected" && global === "connected") return "connected";
+  return "degraded";
+};
+
 export const useConnectionStore = create<ConnectionState>((set) => ({
   status: "connected",
+  spatialStatus: "connected",
+  globalStatus: "connected",
   lastSpatialUpdate: Date.now(),
   lastGlobalUpdate: Date.now(),
   lastHealthCheck: Date.now(),
+  lastConnectedAt: Date.now(),
+  lastDisconnectedAt: null,
   reconnectAttempts: 0,
   streamReconnectVersion: 0,
-  setStatus: (status: ConnectionStatus) => set({ status }),
+  setStatus: (status: ConnectionStatus) =>
+    set((state) => {
+      const now = Date.now();
+      return {
+        status,
+        lastConnectedAt: status === "connected" ? now : state.lastConnectedAt,
+        lastDisconnectedAt:
+          status !== "connected" && state.status === "connected" ? now : status === "connected" ? null : state.lastDisconnectedAt,
+      };
+    }),
+  setSpatialStatus: (spatialStatus: StreamStatus) =>
+    set((state) => {
+      const nextStatus = deriveOverallStatus(spatialStatus, state.globalStatus);
+      const now = Date.now();
+      return {
+        spatialStatus,
+        status: nextStatus,
+        lastConnectedAt: nextStatus === "connected" ? now : state.lastConnectedAt,
+        lastDisconnectedAt:
+          nextStatus !== "connected" && state.status === "connected"
+            ? now
+            : nextStatus === "connected"
+              ? null
+              : state.lastDisconnectedAt,
+      };
+    }),
+  setGlobalStatus: (globalStatus: StreamStatus) =>
+    set((state) => {
+      const nextStatus = deriveOverallStatus(state.spatialStatus, globalStatus);
+      const now = Date.now();
+      return {
+        globalStatus,
+        status: nextStatus,
+        lastConnectedAt: nextStatus === "connected" ? now : state.lastConnectedAt,
+        lastDisconnectedAt:
+          nextStatus !== "connected" && state.status === "connected"
+            ? now
+            : nextStatus === "connected"
+              ? null
+              : state.lastDisconnectedAt,
+      };
+    }),
   recordSpatialUpdate: () => set({ lastSpatialUpdate: Date.now() }),
   recordGlobalUpdate: () => set({ lastGlobalUpdate: Date.now() }),
   recordHealthCheck: () => set({ lastHealthCheck: Date.now() }),

--- a/client/apps/game/src/hooks/store/use-connection-store.ts
+++ b/client/apps/game/src/hooks/store/use-connection-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type ConnectionStatus = "connected" | "degraded" | "disconnected";
+type ConnectionStatus = "connected" | "degraded" | "disconnected";
 export type StreamStatus = "connected" | "stale" | "reconnecting" | "failed";
 
 interface ConnectionState {
@@ -49,7 +49,11 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
         status,
         lastConnectedAt: status === "connected" ? now : state.lastConnectedAt,
         lastDisconnectedAt:
-          status !== "connected" && state.status === "connected" ? now : status === "connected" ? null : state.lastDisconnectedAt,
+          status !== "connected" && state.status === "connected"
+            ? now
+            : status === "connected"
+              ? null
+              : state.lastDisconnectedAt,
       };
     }),
   setSpatialStatus: (spatialStatus: StreamStatus) =>

--- a/client/apps/game/src/observability/network-health-reporting.test.ts
+++ b/client/apps/game/src/observability/network-health-reporting.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sentryMocks = vi.hoisted(() => {
+  const captureMessage = vi.fn();
+  const addBreadcrumb = vi.fn();
+  const setUser = vi.fn();
+  const setTags = vi.fn();
+  const getCurrentScope = vi.fn(() => ({ setTags }));
+  return { captureMessage, addBreadcrumb, setUser, setTags, getCurrentScope };
+});
+
+vi.mock("@sentry/react", () => ({
+  captureMessage: sentryMocks.captureMessage,
+  addBreadcrumb: sentryMocks.addBreadcrumb,
+  setUser: sentryMocks.setUser,
+  getCurrentScope: sentryMocks.getCurrentScope,
+}));
+
+vi.mock("@/runtime/world", () => ({
+  getActiveWorld: () => ({ chain: "mainnet", name: "eternum" }),
+}));
+
+vi.mock("../../env", () => ({
+  env: {
+    VITE_PUBLIC_SENTRY_DSN: "https://test@example.ingest.sentry.io/1",
+    VITE_PUBLIC_SENTRY_NETWORK_HEALTH_ENABLED: true,
+    VITE_PUBLIC_SENTRY_NETWORK_HEALTH_MIN_OUTAGE_MS: 10_000,
+    VITE_PUBLIC_SENTRY_NETWORK_HEALTH_MAX_PER_SESSION: 50,
+    VITE_PUBLIC_SENTRY_TX_WALLET_IDENTITY: "none",
+  },
+}));
+
+vi.stubGlobal("import.meta", { env: { PROD: true } });
+
+import {
+  addNetworkBreadcrumb,
+  reportNetworkOutageDeadEnd,
+  reportNetworkOutageResolved,
+  reportSubscriptionSetupTimeout,
+  resetNetworkHealthStateForTests,
+  setNetworkHealthEnabledForTests,
+  setNetworkHealthScopeTags,
+} from "./network-health-reporting";
+
+describe("network-health-reporting", () => {
+  beforeEach(() => {
+    resetNetworkHealthStateForTests();
+    setNetworkHealthEnabledForTests(true);
+    sentryMocks.captureMessage.mockClear();
+    sentryMocks.addBreadcrumb.mockClear();
+    sentryMocks.setUser.mockClear();
+    sentryMocks.setTags.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reportNetworkOutageResolved captures a warning-level message with measurements", () => {
+    reportNetworkOutageResolved({ streamType: "spatial", outageMs: 45_000, attempts: 2 });
+
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+    const [message, opts] = sentryMocks.captureMessage.mock.calls[0];
+    expect(message).toContain("Network outage resolved");
+    expect(opts.level).toBe("warning");
+    expect(opts.tags.feature).toBe("network-health");
+    expect(opts.tags["network.stream_type"]).toBe("spatial");
+    expect(opts.tags["network.outcome"]).toBe("resolved");
+    expect(opts.contexts.network.outage_seconds).toBe(45);
+    expect(opts.contexts.network.reconnect_attempts).toBe(2);
+    expect(opts.contexts.network.recovered).toBe(true);
+  });
+
+  it("reportNetworkOutageDeadEnd captures an error-level message", () => {
+    reportNetworkOutageDeadEnd({ streamType: "global", outageMs: 120_000, attempts: 5 });
+
+    const [, opts] = sentryMocks.captureMessage.mock.calls[0];
+    expect(opts.level).toBe("error");
+    expect(opts.tags["network.outcome"]).toBe("dead-end");
+    expect(opts.contexts.network.recovered).toBe(false);
+  });
+
+  it("skips duplicate outage reports within the dedup window", () => {
+    reportNetworkOutageResolved({ streamType: "spatial", outageMs: 45_000, attempts: 1 });
+    reportNetworkOutageResolved({ streamType: "spatial", outageMs: 45_000, attempts: 1 });
+
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips outages below the minimum outage threshold", () => {
+    reportNetworkOutageResolved({ streamType: "spatial", outageMs: 5_000, attempts: 1 });
+
+    expect(sentryMocks.captureMessage).not.toHaveBeenCalled();
+  });
+
+  it("reportSubscriptionSetupTimeout captures and dedups by label", () => {
+    reportSubscriptionSetupTimeout({ label: "entity subscription", timeoutMs: 8000, requestId: 42 });
+    reportSubscriptionSetupTimeout({ label: "entity subscription", timeoutMs: 8000, requestId: 43 });
+
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
+    const [message, opts] = sentryMocks.captureMessage.mock.calls[0];
+    expect(message).toContain("entity subscription");
+    expect(opts.tags["network.kind"]).toBe("subscription_setup_timeout");
+    expect(opts.contexts.network.label).toBe("entity subscription");
+  });
+
+  it("addNetworkBreadcrumb writes a breadcrumb with structured data", () => {
+    addNetworkBreadcrumb({ event: "reconnect_start", streamType: "spatial" });
+
+    expect(sentryMocks.addBreadcrumb).toHaveBeenCalledTimes(1);
+    const crumb = sentryMocks.addBreadcrumb.mock.calls[0][0];
+    expect(crumb.category).toBe("network-health");
+    expect(crumb.message).toBe("network-health:reconnect_start");
+    expect(crumb.data.stream_type).toBe("spatial");
+  });
+
+  it("setNetworkHealthScopeTags sets host and world tags", async () => {
+    await setNetworkHealthScopeTags({ toriiBaseUrl: "https://api.cartridge.gg/x/s0/torii", walletAddress: null });
+
+    expect(sentryMocks.setTags).toHaveBeenCalledTimes(1);
+    const tags = sentryMocks.setTags.mock.calls[0][0];
+    expect(tags["network.torii_host"]).toBe("api.cartridge.gg");
+    expect(tags["chain"]).toBe("mainnet");
+    expect(tags["world"]).toBe("eternum");
+  });
+});

--- a/client/apps/game/src/observability/network-health-reporting.ts
+++ b/client/apps/game/src/observability/network-health-reporting.ts
@@ -1,0 +1,208 @@
+import * as Sentry from "@sentry/react";
+
+import { env } from "../../env";
+import { getActiveWorld } from "@/runtime/world";
+import { resolveUserIdentity } from "./wallet-identity";
+
+export type NetworkStreamType = "spatial" | "global" | "both";
+export type NetworkHealthEvent =
+  | "outage_start"
+  | "stream_stale"
+  | "reconnect_start"
+  | "reconnect_success"
+  | "reconnect_failure"
+  | "force_retry"
+  | "visibility_resume"
+  | "online_event";
+
+interface OutageReport {
+  streamType: NetworkStreamType;
+  outageMs: number;
+  attempts: number;
+}
+
+interface SetupTimeoutReport {
+  label: string;
+  timeoutMs: number;
+  requestId?: number | string;
+}
+
+interface NetworkScopeTags {
+  toriiBaseUrl?: string | null;
+  walletAddress?: string | null;
+}
+
+const DUPLICATE_TTL_MS = 5 * 60 * 1000;
+const reportedKeys = new Map<string, number>();
+let eventsThisSession = 0;
+let enabledOverride: boolean | null = null;
+
+const isEnabled = (): boolean => {
+  if (enabledOverride !== null) return enabledOverride;
+  return import.meta.env.PROD && Boolean(env.VITE_PUBLIC_SENTRY_DSN) && env.VITE_PUBLIC_SENTRY_NETWORK_HEALTH_ENABLED;
+};
+
+const canEmitMore = (): boolean => eventsThisSession < env.VITE_PUBLIC_SENTRY_NETWORK_HEALTH_MAX_PER_SESSION;
+
+const bucketOutageSeconds = (outageMs: number): string => {
+  const seconds = Math.floor(outageMs / 1000);
+  if (seconds < 30) return "10-30s";
+  if (seconds < 60) return "30-60s";
+  if (seconds < 180) return "1-3m";
+  if (seconds < 600) return "3-10m";
+  return "10m+";
+};
+
+const pruneReportedKeys = (now: number) => {
+  for (const [key, timestamp] of reportedKeys) {
+    if (now - timestamp > DUPLICATE_TTL_MS) reportedKeys.delete(key);
+  }
+  while (reportedKeys.size > 200) {
+    const oldest = reportedKeys.keys().next().value;
+    if (!oldest) break;
+    reportedKeys.delete(oldest);
+  }
+};
+
+const shouldSkipDuplicate = (key: string): boolean => {
+  const now = Date.now();
+  pruneReportedKeys(now);
+  const existing = reportedKeys.get(key);
+  if (existing && now - existing <= DUPLICATE_TTL_MS) return true;
+  reportedKeys.set(key, now);
+  return false;
+};
+
+const extractHost = (url: string | null | undefined): string | undefined => {
+  if (!url) return undefined;
+  try {
+    return new URL(url).host;
+  } catch {
+    return undefined;
+  }
+};
+
+export const setNetworkHealthScopeTags = async ({ toriiBaseUrl, walletAddress }: NetworkScopeTags): Promise<void> => {
+  if (!isEnabled()) return;
+
+  const host = extractHost(toriiBaseUrl);
+  const activeWorld = getActiveWorld();
+  const walletIdentity = await resolveUserIdentity(walletAddress);
+
+  Sentry.getCurrentScope().setTags({
+    ...(host ? { "network.torii_host": host } : {}),
+    ...(activeWorld?.chain ? { chain: activeWorld.chain } : {}),
+    ...(activeWorld?.name ? { world: activeWorld.name } : {}),
+  });
+
+  if (walletIdentity) {
+    Sentry.setUser({ id: walletIdentity });
+  }
+};
+
+export const clearNetworkHealthUser = (): void => {
+  if (!isEnabled()) return;
+  Sentry.setUser(null);
+};
+
+export const addNetworkBreadcrumb = ({
+  event,
+  streamType,
+  status,
+  ageMs,
+}: {
+  event: NetworkHealthEvent;
+  streamType?: NetworkStreamType;
+  status?: string;
+  ageMs?: number;
+}): void => {
+  if (!isEnabled()) return;
+
+  Sentry.addBreadcrumb({
+    category: "network-health",
+    type: "default",
+    level: event === "reconnect_failure" ? "warning" : "info",
+    message: `network-health:${event}`,
+    data: {
+      ...(streamType ? { stream_type: streamType } : {}),
+      ...(status ? { status } : {}),
+      ...(typeof ageMs === "number" ? { age_ms: Math.round(ageMs) } : {}),
+    },
+  });
+};
+
+const reportOutage = (report: OutageReport, recovered: boolean): void => {
+  if (!isEnabled()) return;
+  if (report.outageMs < env.VITE_PUBLIC_SENTRY_NETWORK_HEALTH_MIN_OUTAGE_MS) return;
+  if (!canEmitMore()) return;
+
+  const bucket = bucketOutageSeconds(report.outageMs);
+  const dedupeKey = `outage:${report.streamType}:${bucket}:${recovered ? "resolved" : "dead-end"}`;
+  if (shouldSkipDuplicate(dedupeKey)) return;
+
+  eventsThisSession += 1;
+
+  Sentry.captureMessage(
+    recovered
+      ? `Network outage resolved (${report.streamType}, ~${bucket})`
+      : `Network outage dead-end (${report.streamType}, ~${bucket})`,
+    {
+      level: recovered ? "warning" : "error",
+      tags: {
+        feature: "network-health",
+        "network.stream_type": report.streamType,
+        "network.outcome": recovered ? "resolved" : "dead-end",
+        "network.duration_bucket": bucket,
+      },
+      contexts: {
+        network: {
+          outage_seconds: Math.round(report.outageMs / 1000),
+          reconnect_attempts: report.attempts,
+          recovered,
+        },
+      },
+      fingerprint: ["network-health", report.streamType, recovered ? "resolved" : "dead-end", bucket],
+    },
+  );
+};
+
+export const reportNetworkOutageResolved = (report: OutageReport): void => reportOutage(report, true);
+
+export const reportNetworkOutageDeadEnd = (report: OutageReport): void => reportOutage(report, false);
+
+export const reportSubscriptionSetupTimeout = ({ label, timeoutMs, requestId }: SetupTimeoutReport): void => {
+  if (!isEnabled()) return;
+  if (!canEmitMore()) return;
+
+  const dedupeKey = `setup-timeout:${label}`;
+  if (shouldSkipDuplicate(dedupeKey)) return;
+
+  eventsThisSession += 1;
+
+  Sentry.captureMessage(`Torii subscription setup timed out (${label})`, {
+    level: "warning",
+    tags: {
+      feature: "network-health",
+      "network.kind": "subscription_setup_timeout",
+      "network.subscription_label": label,
+    },
+    contexts: {
+      network: {
+        label,
+        timeout_ms: timeoutMs,
+        ...(typeof requestId !== "undefined" ? { request_id: String(requestId) } : {}),
+      },
+    },
+    fingerprint: ["network-health", "setup-timeout", label],
+  });
+};
+
+export const resetNetworkHealthStateForTests = (): void => {
+  reportedKeys.clear();
+  eventsThisSession = 0;
+  enabledOverride = null;
+};
+
+export const setNetworkHealthEnabledForTests = (enabled: boolean): void => {
+  enabledOverride = enabled;
+};

--- a/client/apps/game/src/observability/network-health-reporting.ts
+++ b/client/apps/game/src/observability/network-health-reporting.ts
@@ -4,8 +4,8 @@ import { env } from "../../env";
 import { getActiveWorld } from "@/runtime/world";
 import { resolveUserIdentity } from "./wallet-identity";
 
-export type NetworkStreamType = "spatial" | "global" | "both";
-export type NetworkHealthEvent =
+type NetworkStreamType = "spatial" | "global" | "both";
+type NetworkHealthEvent =
   | "outage_start"
   | "stream_stale"
   | "reconnect_start"
@@ -98,11 +98,6 @@ export const setNetworkHealthScopeTags = async ({ toriiBaseUrl, walletAddress }:
   if (walletIdentity) {
     Sentry.setUser({ id: walletIdentity });
   }
-};
-
-export const clearNetworkHealthUser = (): void => {
-  if (!isEnabled()) return;
-  Sentry.setUser(null);
 };
 
 export const addNetworkBreadcrumb = ({

--- a/client/apps/game/src/observability/sentry-user-sync.tsx
+++ b/client/apps/game/src/observability/sentry-user-sync.tsx
@@ -1,0 +1,33 @@
+import { useAccountStore } from "@/hooks/store/use-account-store";
+import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
+
+import { env } from "../../env";
+import { resolveUserIdentity } from "./wallet-identity";
+
+const isSentryEnabled = (): boolean => Boolean(env.VITE_PUBLIC_SENTRY_DSN) && import.meta.env.PROD;
+
+export const SentryUserSync = (): null => {
+  const address = useAccountStore((s) => s.account?.address ?? null);
+
+  useEffect(() => {
+    if (!isSentryEnabled()) return;
+
+    if (!address) {
+      Sentry.setUser(null);
+      return;
+    }
+
+    let cancelled = false;
+    void resolveUserIdentity(address).then((identity) => {
+      if (cancelled) return;
+      if (identity) Sentry.setUser({ id: identity });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  return null;
+};

--- a/client/apps/game/src/observability/transaction-failure-reporting.ts
+++ b/client/apps/game/src/observability/transaction-failure-reporting.ts
@@ -7,6 +7,7 @@ import {
 import { env } from "../../env";
 import { getActiveWorld } from "@/runtime/world";
 import { extractReadableErrorMessage } from "@/utils/error-message";
+import { resolveUserIdentity, resolveWalletIdentityMode } from "./wallet-identity";
 
 export type ClientTransactionSurface =
   | "dojo_provider"
@@ -73,11 +74,6 @@ const reportedFailureKeys = new Map<string, number>();
 
 const readString = (value: unknown): string | undefined =>
   typeof value === "string" && value.length > 0 ? value : undefined;
-
-const resolveWalletIdentityMode = (): "hashed" | "raw" | "none" => {
-  const configuredMode = env.VITE_PUBLIC_SENTRY_TX_WALLET_IDENTITY;
-  return configuredMode === "raw" || configuredMode === "none" ? configuredMode : "hashed";
-};
 
 const isSentryTransactionMonitoringEnabled = (): boolean => {
   return import.meta.env.PROD && Boolean(env.VITE_PUBLIC_SENTRY_DSN) && env.VITE_PUBLIC_SENTRY_TX_FAILURES_ENABLED;
@@ -221,30 +217,6 @@ const buildDedupeKey = ({
   }
 
   return `${surface}:${operation}:${stage}:${normalizedReason}`;
-};
-
-const resolveUserIdentity = async (walletAddress: string | null | undefined): Promise<string | null> => {
-  if (!walletAddress) {
-    return null;
-  }
-
-  const identityMode = resolveWalletIdentityMode();
-  if (identityMode === "none") {
-    return null;
-  }
-
-  if (identityMode === "raw") {
-    return walletAddress;
-  }
-
-  if (typeof globalThis.crypto?.subtle === "undefined") {
-    return null;
-  }
-
-  const payload = new TextEncoder().encode(walletAddress.toLowerCase());
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", payload);
-  const hash = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
-  return `wallet:${hash}`;
 };
 
 const buildBreadcrumbData = (context: Partial<Omit<ClientTransactionFailureContext, "stage">> & { stage?: string }) => {

--- a/client/apps/game/src/observability/wallet-identity.ts
+++ b/client/apps/game/src/observability/wallet-identity.ts
@@ -1,6 +1,6 @@
 import { env } from "../../env";
 
-export type WalletIdentityMode = "hashed" | "raw" | "none";
+type WalletIdentityMode = "hashed" | "raw" | "none";
 
 export const resolveWalletIdentityMode = (): WalletIdentityMode => {
   const configured = env.VITE_PUBLIC_SENTRY_TX_WALLET_IDENTITY;

--- a/client/apps/game/src/observability/wallet-identity.ts
+++ b/client/apps/game/src/observability/wallet-identity.ts
@@ -1,0 +1,23 @@
+import { env } from "../../env";
+
+export type WalletIdentityMode = "hashed" | "raw" | "none";
+
+export const resolveWalletIdentityMode = (): WalletIdentityMode => {
+  const configured = env.VITE_PUBLIC_SENTRY_TX_WALLET_IDENTITY;
+  return configured === "raw" || configured === "none" ? configured : "hashed";
+};
+
+export const resolveUserIdentity = async (walletAddress: string | null | undefined): Promise<string | null> => {
+  if (!walletAddress) return null;
+
+  const mode = resolveWalletIdentityMode();
+  if (mode === "none") return null;
+  if (mode === "raw") return walletAddress;
+
+  if (typeof globalThis.crypto?.subtle === "undefined") return null;
+
+  const payload = new TextEncoder().encode(walletAddress.toLowerCase());
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", payload);
+  const hash = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `wallet:${hash}`;
+};

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -1,6 +1,8 @@
 import { playUnitCommandSound, playUnitCommandSoundForWorldmapAction } from "@/audio/unit-command-audio";
 import { toast } from "sonner";
 
+import { reportSubscriptionSetupTimeout } from "@/observability/network-health-reporting";
+
 import { ensureStructureSynced, getExplorerTroopsFromToriiExact, getMapFromToriiExact } from "@/dojo/queries";
 import { initializeSyncSimulator } from "@/dojo/sync-simulator";
 import {
@@ -492,6 +494,9 @@ type WorldmapCameraTransitionStatus = "idle" | "transitioning";
 let activeSpatialStreamManager: ToriiStreamManagerType | null = null;
 
 export const getActiveSpatialStreamManager = (): ToriiStreamManagerType | null => activeSpatialStreamManager;
+
+const SETUP_TIMEOUT_TOAST_THROTTLE_MS = 30_000;
+let lastSetupTimeoutToastAtMs = 0;
 
 let worldmapInteractionDebugInstanceCounter = 0;
 
@@ -5598,6 +5603,16 @@ export default class WorldmapScene extends WarpTravel {
       label: info.label,
       timeoutMs: info.timeoutMs,
     });
+    const now = Date.now();
+    if (now - lastSetupTimeoutToastAtMs >= SETUP_TIMEOUT_TOAST_THROTTLE_MS) {
+      lastSetupTimeoutToastAtMs = now;
+      toast("Map sync delayed", { description: "Retrying…" });
+      reportSubscriptionSetupTimeout({
+        label: info.label,
+        timeoutMs: info.timeoutMs,
+        requestId: info.requestId,
+      });
+    }
     this.toriiBoundsAreaKey = null;
     this.requestToriiResubscribe("bounds_setup_timeout", this.currentChunk);
     this.scheduleChunkRecovery("torii_bounds_timeout", this.currentChunk, {

--- a/client/apps/game/src/ui/features/world/components/network-status-banner.tsx
+++ b/client/apps/game/src/ui/features/world/components/network-status-banner.tsx
@@ -1,0 +1,130 @@
+import { useConnectionStore } from "@/hooks/store/use-connection-store";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import { AnimatePresence, motion } from "framer-motion";
+import AlertTriangle from "lucide-react/dist/esm/icons/alert-triangle";
+import RotateCcw from "lucide-react/dist/esm/icons/rotate-ccw";
+import X from "lucide-react/dist/esm/icons/x";
+import { useEffect, useState } from "react";
+
+const OUTAGE_BANNER_THRESHOLD_MS = 30_000;
+const OUTAGE_BANNER_ATTEMPT_THRESHOLD = 3;
+
+interface NetworkStatusBannerProps {
+  onRetry: () => void | Promise<void>;
+}
+
+export const NetworkStatusBanner = ({ onRetry }: NetworkStatusBannerProps) => {
+  const status = useConnectionStore((s) => s.status);
+  const spatialStatus = useConnectionStore((s) => s.spatialStatus);
+  const globalStatus = useConnectionStore((s) => s.globalStatus);
+  const lastDisconnectedAt = useConnectionStore((s) => s.lastDisconnectedAt);
+  const reconnectAttempts = useConnectionStore((s) => s.reconnectAttempts);
+
+  const [now, setNow] = useState(() => Date.now());
+  const [dismissedAt, setDismissedAt] = useState<number | null>(null);
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const outageLongEnough = lastDisconnectedAt !== null && now - lastDisconnectedAt >= OUTAGE_BANNER_THRESHOLD_MS;
+  const manyAttempts = reconnectAttempts >= OUTAGE_BANNER_ATTEMPT_THRESHOLD;
+  const dismissedThisOutage = dismissedAt !== null && lastDisconnectedAt !== null && lastDisconnectedAt <= dismissedAt;
+
+  const visible = status !== "connected" && (outageLongEnough || manyAttempts) && !dismissedThisOutage;
+  const reconnecting = spatialStatus === "reconnecting" || globalStatus === "reconnecting";
+
+  const message =
+    status === "disconnected" ? "Disconnected from the realm" : reconnecting ? "Reconnecting…" : "Sync is lagging";
+
+  const submessage = lastDisconnectedAt
+    ? `Offline for ${Math.max(0, Math.floor((now - lastDisconnectedAt) / 1000))}s · Attempt ${reconnectAttempts}`
+    : `Attempt ${reconnectAttempts}`;
+
+  return (
+    <AnimatePresence mode="wait">
+      {visible && (
+        <motion.div
+          key="network-status-banner"
+          initial={{ y: -32, opacity: 0, scale: 0.96 }}
+          animate={{ y: 0, opacity: 1, scale: 1 }}
+          exit={{ y: -16, opacity: 0, scale: 0.98 }}
+          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+          className="fixed inset-x-0 top-16 z-30 flex justify-center px-4"
+        >
+          <div className="w-[520px] max-w-full">
+            <div className="panel-wood panel-wood-corners pointer-events-auto relative overflow-hidden rounded-xl border border-gold/20 bg-dark-wood text-gold shadow-[0_25px_45px_-25px_rgba(0,0,0,0.8)]">
+              <div className="corner-bl z-100" />
+              <div className="corner-br z-100" />
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-white/[0.04] via-transparent to-black/20" />
+              <div className="pointer-events-none absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-gold/70 to-transparent" />
+              <div
+                className={cn(
+                  "pointer-events-none absolute inset-y-4 left-0 w-[2px] rounded-full",
+                  status === "disconnected" ? "bg-anger-light/80" : "bg-orange/80",
+                )}
+              />
+
+              <div className="relative grid grid-cols-[52px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3.5">
+                <div className="flex justify-center">
+                  <div
+                    className={cn(
+                      "flex h-10 w-10 items-center justify-center rounded-full border shadow-[inset_0_1px_4px_rgba(0,0,0,0.45)]",
+                      status === "disconnected"
+                        ? "border-anger-light/35 bg-anger-light/10 text-anger-light"
+                        : "border-orange/35 bg-orange/10 text-orange",
+                    )}
+                  >
+                    <AlertTriangle className={cn("h-[18px] w-[18px]", reconnecting && "animate-pulse")} aria-hidden />
+                  </div>
+                </div>
+
+                <div className="min-w-0">
+                  <div
+                    className={cn(
+                      "text-[9px] font-semibold uppercase tracking-[0.38em]",
+                      status === "disconnected" ? "text-anger-light" : "text-orange",
+                    )}
+                  >
+                    Network
+                  </div>
+                  <div className="mt-1 font-[Cinzel] text-sm font-semibold uppercase tracking-[0.2em] text-gold">
+                    {message}
+                  </div>
+                  <div className="mt-1 text-[12px] leading-[1.35] text-gold/78">{submessage}</div>
+                </div>
+
+                <div className="relative flex min-h-[52px] flex-col items-center justify-center gap-1.5 pl-3 before:absolute before:inset-y-1 before:left-0 before:w-px before:bg-gold/10">
+                  <button
+                    type="button"
+                    onClick={(evt) => {
+                      evt.stopPropagation();
+                      void onRetry();
+                    }}
+                    disabled={reconnecting}
+                    className={cn(
+                      "button-wood inline-flex h-9 w-11 flex-col items-center justify-center gap-0.5 rounded-md border text-[8px] font-semibold uppercase tracking-[0.16em] transition-colors",
+                      "border-gold/25 bg-black/20 text-gold hover:border-gold/45 hover:bg-black/35",
+                      reconnecting && "cursor-not-allowed opacity-60",
+                    )}
+                  >
+                    <RotateCcw className={cn("h-3 w-3", reconnecting && "animate-spin")} />
+                    <span>Retry</span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setDismissedAt(Date.now())}
+                    className="button-wood inline-flex h-7 w-7 items-center justify-center rounded-full border-gold/15 bg-black/20 p-0 text-gold/45 hover:bg-black/35 hover:text-gold"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/client/apps/game/src/ui/features/world/components/network-status-pill.tsx
+++ b/client/apps/game/src/ui/features/world/components/network-status-pill.tsx
@@ -1,0 +1,116 @@
+import { useConnectionStore, type StreamStatus } from "@/hooks/store/use-connection-store";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import Globe from "lucide-react/dist/esm/icons/globe";
+import MapPin from "lucide-react/dist/esm/icons/map-pin";
+import WifiOff from "lucide-react/dist/esm/icons/wifi-off";
+import { useEffect, useMemo, useState } from "react";
+
+interface NetworkStatusPillProps {
+  onRetry: () => void | Promise<void>;
+}
+
+const formatAge = (ms: number) => {
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m`;
+};
+
+const pickLabel = (spatial: StreamStatus, global: StreamStatus, overall: string): string => {
+  if (overall === "disconnected") return "Offline";
+  if (spatial === "reconnecting" || global === "reconnecting") return "Reconnecting…";
+  return "Sync lag";
+};
+
+const pickTone = (overall: string): { container: string; text: string; ring: string; dot: string } => {
+  if (overall === "disconnected") {
+    return {
+      container: "border-danger/60 bg-danger/15 hover:bg-danger/25",
+      text: "text-danger",
+      ring: "focus-visible:ring-danger/50",
+      dot: "bg-danger",
+    };
+  }
+  return {
+    container: "border-orange/60 bg-orange/15 hover:bg-orange/25",
+    text: "text-orange",
+    ring: "focus-visible:ring-orange/50",
+    dot: "bg-orange",
+  };
+};
+
+export const NetworkStatusPill = ({ onRetry }: NetworkStatusPillProps) => {
+  const status = useConnectionStore((s) => s.status);
+  const spatialStatus = useConnectionStore((s) => s.spatialStatus);
+  const globalStatus = useConnectionStore((s) => s.globalStatus);
+  const lastSpatialUpdate = useConnectionStore((s) => s.lastSpatialUpdate);
+  const lastGlobalUpdate = useConnectionStore((s) => s.lastGlobalUpdate);
+  const reconnectAttempts = useConnectionStore((s) => s.reconnectAttempts);
+
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (status === "connected") return;
+    const id = setInterval(() => setNow(Date.now()), 1_000);
+    return () => clearInterval(id);
+  }, [status]);
+
+  const reconnecting = spatialStatus === "reconnecting" || globalStatus === "reconnecting";
+  const spatialSick = spatialStatus !== "connected";
+  const globalSick = globalStatus !== "connected";
+
+  const tooltip = useMemo(
+    () =>
+      [
+        `Spatial: ${spatialStatus} · ${formatAge(now - lastSpatialUpdate)} ago`,
+        `Global: ${globalStatus} · ${formatAge(now - lastGlobalUpdate)} ago`,
+        reconnectAttempts > 0 ? `Reconnect attempt ${reconnectAttempts}` : null,
+        "Click to retry",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    [spatialStatus, globalStatus, lastSpatialUpdate, lastGlobalUpdate, now, reconnectAttempts],
+  );
+
+  if (status === "connected") return null;
+
+  const tone = pickTone(status);
+  const label = pickLabel(spatialStatus, globalStatus, status);
+
+  return (
+    <button
+      type="button"
+      title={tooltip}
+      onClick={() => {
+        if (!reconnecting) void onRetry();
+      }}
+      disabled={reconnecting}
+      aria-label={`Network ${label}. Click to retry.`}
+      className={cn(
+        "relative inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em]",
+        "transition-colors focus:outline-none focus-visible:ring-2",
+        tone.container,
+        tone.text,
+        tone.ring,
+        reconnecting && "cursor-wait",
+      )}
+    >
+      <span
+        className={cn(
+          "inline-flex h-2 w-2 rounded-full shadow-[0_0_6px_currentColor]",
+          tone.dot,
+          reconnecting && "animate-pulse",
+        )}
+      />
+      {status === "disconnected" && !reconnecting ? (
+        <WifiOff className="h-3 w-3" aria-hidden />
+      ) : (
+        <>
+          {spatialSick ? <MapPin className="h-3 w-3" aria-hidden /> : null}
+          {globalSick ? <Globe className="h-3 w-3" aria-hidden /> : null}
+        </>
+      )}
+      <span>{label}</span>
+    </button>
+  );
+};

--- a/client/apps/game/src/ui/features/world/components/network-status-retry.ts
+++ b/client/apps/game/src/ui/features/world/components/network-status-retry.ts
@@ -1,0 +1,9 @@
+import { getConnectionHealthMonitor } from "@/dojo/connection-health-monitor";
+import { addNetworkBreadcrumb } from "@/observability/network-health-reporting";
+
+export const triggerConnectionForceReconnect = async (): Promise<void> => {
+  const monitor = getConnectionHealthMonitor();
+  if (!monitor) return;
+  addNetworkBreadcrumb({ event: "force_retry" });
+  await monitor.forceReconnect();
+};

--- a/client/apps/game/src/ui/features/world/components/network-status.source.test.ts
+++ b/client/apps/game/src/ui/features/world/components/network-status.source.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("network status wiring", () => {
+  it("mounts NetworkStatusPill in the secondary menu and passes the forceReconnect helper", () => {
+    const source = readSource("src/ui/features/world/containers/secondary-menu-items.tsx");
+
+    expect(source).toContain("NetworkStatusPill");
+    expect(source).toContain("triggerConnectionForceReconnect");
+    expect(source).not.toContain('title={connectionStatus === "degraded"');
+  });
+
+  it("mounts NetworkStatusBanner and wires onRecovery toast in the world layout", () => {
+    const source = readSource("src/ui/layouts/world.tsx");
+
+    expect(source).toContain("NetworkStatusBanner");
+    expect(source).toContain("triggerConnectionForceReconnect");
+    expect(source).toContain("onRecovery:");
+    expect(source).toContain('toast.success("Back online"');
+  });
+
+  it("exposes a module-level getConnectionHealthMonitor for UI retry callbacks", () => {
+    const source = readSource("src/dojo/connection-health-monitor.ts");
+
+    expect(source).toContain("export const getConnectionHealthMonitor");
+    expect(source).toContain("forceReconnect");
+    expect(source).toContain("setSpatialStatus(\"reconnecting\")");
+    expect(source).toContain("setGlobalStatus(\"reconnecting\")");
+  });
+
+  it("fires a throttled subscription-setup-timeout toast from worldmap", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("SETUP_TIMEOUT_TOAST_THROTTLE_MS");
+    expect(source).toContain('toast("Map sync delayed"');
+    expect(source).toContain("handleToriiSubscriptionSetupTimeout");
+  });
+});

--- a/client/apps/game/src/ui/features/world/components/network-status.source.test.ts
+++ b/client/apps/game/src/ui/features/world/components/network-status.source.test.ts
@@ -30,8 +30,8 @@ describe("network status wiring", () => {
 
     expect(source).toContain("export const getConnectionHealthMonitor");
     expect(source).toContain("forceReconnect");
-    expect(source).toContain("setSpatialStatus(\"reconnecting\")");
-    expect(source).toContain("setGlobalStatus(\"reconnecting\")");
+    expect(source).toContain('setSpatialStatus("reconnecting")');
+    expect(source).toContain('setGlobalStatus("reconnecting")');
   });
 
   it("fires a throttled subscription-setup-timeout toast from worldmap", () => {

--- a/client/apps/game/src/ui/features/world/containers/secondary-menu-items.tsx
+++ b/client/apps/game/src/ui/features/world/containers/secondary-menu-items.tsx
@@ -1,10 +1,11 @@
 import { useAccountStore } from "@/hooks/store/use-account-store";
-import { useConnectionStore } from "@/hooks/store/use-connection-store";
 import { useTransactionStore } from "@/hooks/store/use-transaction-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { useLatestFeaturesSeen } from "@/hooks/use-latest-features-seen";
 import { BuildingThumbs } from "@/ui/config";
 import CircleButton from "@/ui/design-system/molecules/circle-button";
+import { NetworkStatusPill } from "@/ui/features/world/components/network-status-pill";
+import { triggerConnectionForceReconnect } from "@/ui/features/world/components/network-status-retry";
 import { latestFeatures, leaderboard, rewards, settings, shortcuts, transactions } from "@/ui/features/world";
 import { Controller } from "@/ui/modules/controller/controller";
 import { HomeButton } from "@/ui/shared/components/home-button";
@@ -32,9 +33,6 @@ export const SecondaryMenuItems = () => {
   const togglePopup = useUIStore((state) => state.togglePopup);
   const isPopupOpen = useUIStore((state) => state.isPopupOpen);
   const structureEntityId = useUIStore((state) => state.structureEntityId);
-
-  // Connection health status
-  const connectionStatus = useConnectionStore((state) => state.status);
 
   // Transaction status for the network button indicator
   const txTransactions = useTransactionStore((state) => state.transactions);
@@ -152,19 +150,9 @@ export const SecondaryMenuItems = () => {
           onClick={() => togglePopup(settings)}
         />
         {/* Connection health indicator - only visible when unhealthy */}
-        {connectionStatus !== "connected" && (
-          <div
-            className="relative self-center"
-            title={connectionStatus === "degraded" ? "Connection Degraded" : "Disconnected"}
-          >
-            <div
-              className={`w-3 h-3 rounded-full animate-pulse border border-dark-brown
-                          ${connectionStatus === "degraded" ? "bg-orange" : ""}
-                          ${connectionStatus === "disconnected" ? "bg-danger" : ""}
-                          shadow-[0_0_6px_currentColor]`}
-            />
-          </div>
-        )}
+        <div className="self-center">
+          <NetworkStatusPill onRetry={triggerConnectionForceReconnect} />
+        </div>
         {/* Transactions */}
         <div className="relative">
           <CircleButton

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -1,15 +1,26 @@
 import { ConnectionHealthMonitor, resolveConnectionHealthToriiBaseUrl } from "@/dojo/connection-health-monitor";
 import { cancelEntityStreamSubscription, initialSync } from "@/dojo/sync";
+import { useAccountStore } from "@/hooks/store/use-account-store";
+import {
+  addNetworkBreadcrumb,
+  reportNetworkOutageDeadEnd,
+  reportNetworkOutageResolved,
+  setNetworkHealthScopeTags,
+} from "@/observability/network-health-reporting";
+import { SentryUserSync } from "@/observability/sentry-user-sync";
 import { useActiveWorldProfile } from "@/runtime/world";
 import { getActiveSpatialStreamManager } from "@/three/scenes/worldmap";
 import { EndgameModal, NotLoggedInMessage } from "@/ui/shared";
 import { useDojo } from "@bibliothecadao/react";
 import { Leva } from "leva";
 import { useEffect } from "react";
+import { toast } from "sonner";
 import { dojoConfig } from "../../../dojo-config";
 import { env } from "../../../env";
 import { useUIStore } from "../../hooks/store/use-ui-store";
 import { Tooltip } from "../design-system/molecules/tooltip";
+import { NetworkStatusBanner } from "../features/world/components/network-status-banner";
+import { triggerConnectionForceReconnect } from "../features/world/components/network-status-retry";
 import { RealmTransferManager } from "../features/economy/resources";
 import { AutomationManager } from "../features/infrastructure/automation/automation-manager";
 import { ExplorationAutomationManager } from "../features/infrastructure/automation/exploration-automation-manager";
@@ -78,6 +89,8 @@ const BackgroundSystems = () => (
     <TransferAutomationManager />
     <ExplorationAutomationManager />
     <ConnectionMonitor />
+    <NetworkStatusBanner onRetry={triggerConnectionForceReconnect} />
+    <SentryUserSync />
   </>
 );
 
@@ -150,16 +163,33 @@ const ConnectionMonitor = () => {
       runtimeToriiUrl: dojoConfig.toriiUrl,
     });
 
+    const walletAddress = useAccountStore.getState().account?.address ?? null;
+    void setNetworkHealthScopeTags({ toriiBaseUrl, walletAddress });
+
     const monitor = new ConnectionHealthMonitor({
       onReconnectSpatial: async () => {
-        const manager = getActiveSpatialStreamManager();
-        if (manager) {
-          await manager.resubscribe();
+        addNetworkBreadcrumb({ event: "reconnect_start", streamType: "spatial" });
+        try {
+          const manager = getActiveSpatialStreamManager();
+          if (manager) {
+            await manager.resubscribe();
+          }
+          addNetworkBreadcrumb({ event: "reconnect_success", streamType: "spatial" });
+        } catch (error) {
+          addNetworkBreadcrumb({ event: "reconnect_failure", streamType: "spatial" });
+          throw error;
         }
       },
       onReconnectGlobal: async () => {
-        cancelEntityStreamSubscription();
-        await initialSync(setup, state, () => {}, { logging: false, reportProgress: false });
+        addNetworkBreadcrumb({ event: "reconnect_start", streamType: "global" });
+        try {
+          cancelEntityStreamSubscription();
+          await initialSync(setup, state, () => {}, { logging: false, reportProgress: false });
+          addNetworkBreadcrumb({ event: "reconnect_success", streamType: "global" });
+        } catch (error) {
+          addNetworkBreadcrumb({ event: "reconnect_failure", streamType: "global" });
+          throw error;
+        }
       },
       healthCheckFn: async () => {
         const response = await fetch(`${toriiBaseUrl}/health`, {
@@ -167,6 +197,15 @@ const ConnectionMonitor = () => {
           signal: AbortSignal.timeout(5_000),
         });
         return response.ok;
+      },
+      onRecovery: (outageMs, attempts) => {
+        toast.success("Back online", {
+          description: `Reconnected after ${Math.max(1, Math.round(outageMs / 1000))}s offline.`,
+        });
+        reportNetworkOutageResolved({ streamType: "both", outageMs, attempts });
+      },
+      onDeadEnd: (outageMs, attempts) => {
+        reportNetworkOutageDeadEnd({ streamType: "both", outageMs, attempts });
       },
     });
 


### PR DESCRIPTION
## Summary

- **Visible network desync UI.** The toolbar red dot is replaced with a `NetworkStatusPill` that shows per-stream age, an icon for spatial vs global trouble, a "Reconnecting..." state, and click-to-retry. A `NetworkStatusBanner` appears for outages >= 30s or >= 3 reconnect attempts (dismissible, reappears on a new outage). Recovery from a >= 30s outage shows a "Back online" sonner toast; subscription-setup timeouts in `worldmap.tsx` show a throttled "Map sync delayed" toast.
- **Sentry network-health reporting.** New `observability/network-health-reporting.ts` emits dedup'd outage-resolved / outage-dead-end / setup-timeout events with sanitized scope tags (`network.torii_host`, `chain`, `world`) and breadcrumbs around every stream-state transition. Global `Sentry.setUser` is wired via a new `SentryUserSync` watching `useAccountStore`, using a shared `wallet-identity` helper that was extracted from `transaction-failure-reporting`.
- **Boot-reconnect storm fix.** On slow cold-cache Torii the monitor was cancelling the boot subscription mid-handshake, producing a black worldmap and a silent reconnect loop. Fixed via three layered guards: clocks reset only on successful subscription handshake, boot grace until both streams tick once after `monitor.start()` (manual `forceReconnect` bypasses), and `cancelEntityStreamSubscription` no-ops while an initial sync is in flight.

## Test plan

- [ ] `pnpm --filter game dev` and confirm the pill is hidden on a normal connected boot, with no second `[STARTING syncEntitiesDebounced]` in the console.
- [ ] DevTools -> Offline for > 15s: pill flips to "Reconnecting..." then "Offline"; banner appears after 30s.
- [ ] Re-enable network: "Back online" toast fires, pill clears, banner clears.
- [ ] Click the pill while offline: `forceReconnect` runs immediately (bypasses cooldown + grace).
- [ ] Throttle Torii to force a subscription-setup timeout: confirm "Map sync delayed" toast at most once per 30s and a Sentry `setup-timeout` event in the dashboard.
- [ ] `pnpm typecheck` is clean.
- [ ] `pnpm test` against the touched suites is green (39 targeted tests, including the restored `tracer.lifecycle.test.ts`).

## Out of scope

An OTEL + PostHog deprecation was attempted on this branch and then reverted after a render regression appeared in dev. That work will land as its own PR once smoke-tested in isolation.