### PR TITLE
feat(game): Your Active Games bar + compact landing layout

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -1090,6 +1090,10 @@ interface UnifiedGameGridProps {
   sortClaimableRewardsFirst?: boolean;
   /** Sort ended games by most recently ended first */
   sortEndedNewestFirst?: boolean;
+  /** Filter by user registration status. "registered" keeps only games where
+   *  isRegistered === true; "unregistered" keeps everything else (including
+   *  null while lookups are pending, so discovery surfaces aren't suppressed). */
+  registeredFilter?: "registered" | "unregistered";
   /** Optional callback to expose the resolved list (for reuse without extra queries) */
   onGamesResolved?: (games: GameData[]) => void;
 }
@@ -1117,6 +1121,7 @@ export const UnifiedGameGrid = ({
   sortRegisteredFirst = false,
   sortClaimableRewardsFirst = false,
   sortEndedNewestFirst = false,
+  registeredFilter,
   onGamesResolved,
 }: UnifiedGameGridProps) => {
   // Track locally completed registrations (to show immediately before refetch)
@@ -1229,6 +1234,12 @@ export const UnifiedGameGrid = ({
       .filter((game) => {
         if (!modeFilter) return true;
         return game.config?.mode === modeFilter;
+      })
+      // Filter by user registration status if specified
+      .filter((game) => {
+        if (!registeredFilter) return true;
+        if (registeredFilter === "registered") return game.isRegistered === true;
+        return game.isRegistered !== true;
       });
 
     // Sort: optionally registered first, then by status, then by start time
@@ -1261,6 +1272,7 @@ export const UnifiedGameGrid = ({
     devModeFilter,
     statusFilter,
     sortRegisteredFirst,
+    registeredFilter,
   ]);
 
   const endedRegisteredGames = useMemo(

--- a/client/apps/game/src/ui/features/landing/views/play-view.live-dev-games.test.ts
+++ b/client/apps/game/src/ui/features/landing/views/play-view.live-dev-games.test.ts
@@ -4,15 +4,15 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("PlayView live games dev visibility", () => {
-  it("wires forge callback in the live ongoing grid", () => {
+  it("wires forge callback in the open games grid", () => {
     const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/play-view.tsx"), "utf8");
-    const liveStart = source.indexOf("{/* Live Games Column */}");
-    const upcomingStart = source.indexOf("{/* Upcoming Games Column */}");
-    const ongoingBlock = source.slice(liveStart, upcomingStart);
+    const openStart = source.indexOf("{/* Open Games Column */}");
+    const playedStart = source.indexOf("{/* Played Column (ended games) */}");
+    const openBlock = source.slice(openStart, playedStart);
 
-    expect(liveStart).toBeGreaterThan(-1);
-    expect(upcomingStart).toBeGreaterThan(liveStart);
-    expect(ongoingBlock).toContain("onForgeHyperstructures={onForgeHyperstructures}");
+    expect(openStart).toBeGreaterThan(-1);
+    expect(playedStart).toBeGreaterThan(openStart);
+    expect(openBlock).toContain("onForgeHyperstructures={onForgeHyperstructures}");
   });
 
   it("wires forge callback in learn tab practice games", () => {
@@ -26,14 +26,14 @@ describe("PlayView live games dev visibility", () => {
     expect(practiceBlock).toContain("onForgeHyperstructures={onForgeHyperstructures}");
   });
 
-  it("does not hard-filter the live ongoing grid to production only", () => {
+  it("does not hard-filter the open games grid to production only", () => {
     const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/play-view.tsx"), "utf8");
-    const liveStart = source.indexOf("{/* Live Games Column */}");
-    const upcomingStart = source.indexOf("{/* Upcoming Games Column */}");
-    const ongoingBlock = source.slice(liveStart, upcomingStart);
+    const openStart = source.indexOf("{/* Open Games Column */}");
+    const playedStart = source.indexOf("{/* Played Column (ended games) */}");
+    const openBlock = source.slice(openStart, playedStart);
 
-    expect(liveStart).toBeGreaterThan(-1);
-    expect(upcomingStart).toBeGreaterThan(liveStart);
-    expect(ongoingBlock).not.toContain("devModeFilter={false}");
+    expect(openStart).toBeGreaterThan(-1);
+    expect(playedStart).toBeGreaterThan(openStart);
+    expect(openBlock).not.toContain("devModeFilter={false}");
   });
 });

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -18,7 +18,6 @@ import {
   Wrench,
   TrendingUp,
   Bug,
-  Zap,
   Clock,
   Trophy,
   RefreshCw,
@@ -591,7 +590,7 @@ const ModeCoexistenceHero = ({
             onClick={() => onModeFilterChange(mode)}
             className={cn(
               "group relative overflow-hidden rounded-2xl border text-left transition-all duration-500 ease-out",
-              "min-h-[280px] md:min-h-[360px]",
+              "min-h-[140px] md:min-h-[180px]",
               config.panelBorder,
               isEmphasized
                 ? cn("opacity-100 scale-[1.02]", config.panelGlow, "ring-2 ring-gold/50")
@@ -618,7 +617,7 @@ const ModeCoexistenceHero = ({
             <div className={cn("absolute inset-0 bg-gradient-to-br", config.tone)} />
             <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/25 to-transparent" />
 
-            <div className="relative z-10 h-full p-4 md:p-6 flex flex-col justify-between">
+            <div className="relative z-10 h-full p-3 md:p-4 flex flex-col justify-between">
               <div className="flex items-center justify-between">
                 <span
                   className={cn(
@@ -636,29 +635,19 @@ const ModeCoexistenceHero = ({
                 />
               </div>
 
-              <div className="overflow-hidden">
+              <div className="flex items-end justify-between gap-3">
                 <h3
                   className={cn(
-                    "font-cinzel text-2xl md:text-3xl transition-all duration-500 ease-out",
-                    isEmphasized ? "text-gold translate-y-0" : "text-white/70 translate-y-1",
+                    "font-cinzel text-xl md:text-2xl transition-colors duration-500 ease-out",
+                    isEmphasized ? "text-gold" : "text-white/70",
                   )}
                 >
                   {config.title}
                 </h3>
-                <p
-                  className={cn(
-                    "text-sm mt-1.5 transition-all duration-500 ease-out delay-75",
-                    isEmphasized
-                      ? "text-gold/70 translate-y-0 opacity-100 max-h-20"
-                      : "text-white/40 translate-y-2 opacity-0 max-h-0",
-                  )}
-                >
-                  {config.subtitle}
-                </p>
                 <div
                   className={cn(
-                    "inline-flex items-center gap-1.5 mt-3 text-xs font-medium transition-all duration-500 ease-out delay-150",
-                    isEmphasized ? "text-gold translate-y-0 opacity-100" : "text-white/40 translate-y-3 opacity-0",
+                    "inline-flex items-center gap-1.5 text-xs font-medium pb-0.5 transition-colors duration-500 ease-out",
+                    isEmphasized ? "text-gold" : "text-white/50",
                   )}
                 >
                   {mode === "season" ? "Enter Campaigns" : "Enter Blitz"}
@@ -679,10 +668,71 @@ const ModeCoexistenceHero = ({
 };
 
 /**
- * Play tab content with centered hero + 3 columns layout:
- * - Hero centered at top with CTA
- * - Three columns below: Live | Upcoming | Ended
- * - Vertical scroll within each column
+ * Full-width strip of the user's active (live + upcoming) registered games for
+ * the current mode. Hidden until there is at least one match so the dashboard
+ * stays clean for anonymous users and players who haven't registered.
+ *
+ * The inner grid stays mounted while hidden so its onGamesResolved callback
+ * keeps firing and can re-reveal the bar when data changes.
+ */
+const RegisteredActiveGamesBar = ({
+  mode,
+  onPlayGame,
+  onSelectGame,
+  onAutoSettleGame,
+  onSpectate,
+  onForgeHyperstructures,
+  onRegistrationComplete,
+}: {
+  mode: "blitz" | "eternum";
+  onPlayGame: (selection: WorldSelection) => void;
+  onSelectGame: (selection: WorldSelection) => void;
+  onAutoSettleGame: (selection: WorldSelection) => void;
+  onSpectate: (selection: WorldSelection) => void;
+  onForgeHyperstructures: (selection: WorldSelection, numHyperstructuresLeft: number) => Promise<void> | void;
+  onRegistrationComplete: () => void;
+}) => {
+  const [registeredCount, setRegisteredCount] = useState(0);
+  const hasRegistered = registeredCount > 0;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-2xl border border-emerald-500/30 bg-black/40 p-3 backdrop-blur-sm",
+        !hasRegistered && "hidden",
+      )}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-emerald-500/20">
+          <Sparkles className="h-3.5 w-3.5 text-emerald-400" />
+        </div>
+        <h2 className="font-cinzel text-base text-emerald-400 uppercase tracking-wider">Your Active Games</h2>
+        <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(16,185,129,0.8)]" />
+      </div>
+      <UnifiedGameGrid
+        onPlayGame={onPlayGame}
+        onSelectGame={onSelectGame}
+        onAutoSettleGame={onAutoSettleGame}
+        onSpectate={onSpectate}
+        onForgeHyperstructures={onForgeHyperstructures}
+        onRegistrationComplete={onRegistrationComplete}
+        modeFilter={mode}
+        statusFilter={["ongoing", "upcoming"]}
+        registeredFilter="registered"
+        hideHeader
+        hideLegend
+        layout="horizontal"
+        onGamesResolved={(games) => setRegisteredCount(games.length)}
+      />
+    </div>
+  );
+};
+
+/**
+ * Play tab content layered as:
+ * - Half-height mode hero at the top
+ * - Full-width "Your Active Games" bar (shown only when relevant)
+ * - Two columns below: Open Games (live + upcoming, unregistered) | Played (ended)
  */
 const PlayTabContent = ({
   modeFilter,
@@ -715,232 +765,91 @@ const PlayTabContent = ({
   disabled?: boolean;
   onEndedGamesResolved?: (games: GameData[]) => void;
 }) => {
+  const resolvedMode: "blitz" | "eternum" = modeFilter === "season" ? "eternum" : "blitz";
+
   return (
     <div className={cn("flex flex-col gap-4", disabled && "opacity-50 pointer-events-none")}>
       <ModeCoexistenceHero modeFilter={modeFilter} onModeFilterChange={onModeFilterChange} />
 
-      {modeFilter === "season" && (
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            {/* Three columns: Live | Upcoming | Ended */}
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 flex-1 min-h-0">
-              {/* Live Games Column */}
-              <div className="flex flex-col rounded-2xl border border-emerald-500/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px]">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-emerald-500/20">
-                      <Zap className="h-3.5 w-3.5 text-emerald-400" />
-                    </div>
-                    <h2 className="font-cinzel text-base text-emerald-400 uppercase tracking-wider">Live Games</h2>
-                    <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(16,185,129,0.8)]" />
-                  </div>
-                  <button
-                    onClick={onRefresh}
-                    disabled={isRefreshing}
-                    className="p-1 rounded-md bg-emerald-500/10 text-emerald-400/70 hover:bg-emerald-500/20 hover:text-emerald-400 transition-all disabled:opacity-50"
-                    title="Refresh"
-                  >
-                    <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
-                  </button>
-                </div>
-                <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-emerald-500/20 scrollbar-track-transparent">
-                  <UnifiedGameGrid
-                    onPlayGame={onPlayGame}
-                    onSelectGame={onSelectGame}
-                    onAutoSettleGame={onAutoSettleGame}
-                    onSpectate={onSpectate}
-                    onForgeHyperstructures={onForgeHyperstructures}
-                    onRegistrationComplete={onRegistrationComplete}
-                    modeFilter="eternum"
-                    statusFilter="ongoing"
-                    hideHeader
-                    hideLegend
-                    layout="vertical"
-                    sortRegisteredFirst
-                  />
-                </div>
-              </div>
+      <RegisteredActiveGamesBar
+        mode={resolvedMode}
+        onPlayGame={onPlayGame}
+        onSelectGame={onSelectGame}
+        onAutoSettleGame={onAutoSettleGame}
+        onSpectate={onSpectate}
+        onForgeHyperstructures={onForgeHyperstructures}
+        onRegistrationComplete={onRegistrationComplete}
+      />
 
-              {/* Upcoming Games Column */}
-              <div className="flex flex-col rounded-2xl border border-amber-500/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px]">
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-amber-500/20">
-                      <Clock className="h-3.5 w-3.5 text-amber-400" />
-                    </div>
-                    <h2 className="font-cinzel text-base text-amber-400 uppercase tracking-wider">Upcoming Games</h2>
-                  </div>
-                  <button
-                    onClick={onRefresh}
-                    disabled={isRefreshing}
-                    className="p-1 rounded-md bg-amber-500/10 text-amber-400/70 hover:bg-amber-500/20 hover:text-amber-400 transition-all disabled:opacity-50"
-                    title="Refresh"
-                  >
-                    <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
-                  </button>
-                </div>
-                <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-amber-500/20 scrollbar-track-transparent">
-                  <UnifiedGameGrid
-                    onPlayGame={onPlayGame}
-                    onSelectGame={onSelectGame}
-                    onAutoSettleGame={onAutoSettleGame}
-                    onSpectate={onSpectate}
-                    onForgeHyperstructures={onForgeHyperstructures}
-                    onRegistrationComplete={onRegistrationComplete}
-                    modeFilter="eternum"
-                    devModeFilter={false}
-                    statusFilter="upcoming"
-                    hideHeader
-                    hideLegend
-                    layout="vertical"
-                    sortRegisteredFirst
-                  />
-                </div>
+      {/* Two columns: Open Games (live + upcoming, unregistered) | Played (ended) */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1 min-h-0">
+        {/* Open Games Column */}
+        <div className="flex flex-col rounded-2xl border border-amber-500/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px]">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-amber-500/20">
+                <Clock className="h-3.5 w-3.5 text-amber-400" />
               </div>
-
-              {/* Ended Games Column */}
-              <div className="flex flex-col rounded-2xl border border-gold/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px] md:col-span-2 xl:col-span-1">
-                <div className="flex items-center gap-2 mb-2">
-                  <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-gold/20">
-                    <Trophy className="h-3.5 w-3.5 text-gold" />
-                  </div>
-                  <h2 className="font-cinzel text-base text-gold uppercase tracking-wider">Ended Games</h2>
-                </div>
-                <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
-                  <UnifiedGameGrid
-                    onPlayGame={onPlayGame}
-                    onSelectGame={onSelectGame}
-                    onAutoSettleGame={onAutoSettleGame}
-                    onSpectate={onSpectate}
-                    onSeeScore={onSeeScore}
-                    onClaimRewards={onClaimRewards}
-                    onRegistrationComplete={onRegistrationComplete}
-                    modeFilter="eternum"
-                    devModeFilter={false}
-                    statusFilter="ended"
-                    hideHeader
-                    hideLegend
-                    layout="vertical"
-                    sortClaimableRewardsFirst
-                    sortEndedNewestFirst
-                  />
-                </div>
-              </div>
+              <h2 className="font-cinzel text-base text-amber-400 uppercase tracking-wider">Open Games</h2>
             </div>
+            <button
+              onClick={onRefresh}
+              disabled={isRefreshing}
+              className="p-1 rounded-md bg-amber-500/10 text-amber-400/70 hover:bg-amber-500/20 hover:text-amber-400 transition-all disabled:opacity-50"
+              title="Refresh"
+            >
+              <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-amber-500/20 scrollbar-track-transparent">
+            <UnifiedGameGrid
+              onPlayGame={onPlayGame}
+              onSelectGame={onSelectGame}
+              onAutoSettleGame={onAutoSettleGame}
+              onSpectate={onSpectate}
+              onForgeHyperstructures={onForgeHyperstructures}
+              onRegistrationComplete={onRegistrationComplete}
+              modeFilter={resolvedMode}
+              devModeFilter={false}
+              statusFilter={["ongoing", "upcoming"]}
+              registeredFilter="unregistered"
+              hideHeader
+              hideLegend
+              layout="vertical"
+            />
           </div>
         </div>
-      )}
 
-      {modeFilter === "blitz" && (
-        <div className="flex flex-col gap-2">
-          {/* Three columns: Live | Upcoming | Ended */}
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 flex-1 min-h-0">
-            {/* Live Games Column */}
-            <div className="flex flex-col rounded-2xl border border-emerald-500/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px]">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-2">
-                  <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-emerald-500/20">
-                    <Zap className="h-3.5 w-3.5 text-emerald-400" />
-                  </div>
-                  <h2 className="font-cinzel text-base text-emerald-400 uppercase tracking-wider">Live Games</h2>
-                  <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400 shadow-[0_0_8px_rgba(16,185,129,0.8)]" />
-                </div>
-                <button
-                  onClick={onRefresh}
-                  disabled={isRefreshing}
-                  className="p-1 rounded-md bg-emerald-500/10 text-emerald-400/70 hover:bg-emerald-500/20 hover:text-emerald-400 transition-all disabled:opacity-50"
-                  title="Refresh"
-                >
-                  <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
-                </button>
-              </div>
-              <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-emerald-500/20 scrollbar-track-transparent">
-                <UnifiedGameGrid
-                  onPlayGame={onPlayGame}
-                  onSelectGame={onSelectGame}
-                  onAutoSettleGame={onAutoSettleGame}
-                  onSpectate={onSpectate}
-                  onForgeHyperstructures={onForgeHyperstructures}
-                  onRegistrationComplete={onRegistrationComplete}
-                  modeFilter="blitz"
-                  statusFilter="ongoing"
-                  hideHeader
-                  hideLegend
-                  layout="vertical"
-                  sortRegisteredFirst
-                />
-              </div>
+        {/* Played Column (ended games) */}
+        <div className="flex flex-col rounded-2xl border border-gold/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px]">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-gold/20">
+              <Trophy className="h-3.5 w-3.5 text-gold" />
             </div>
-
-            {/* Upcoming Games Column */}
-            <div className="flex flex-col rounded-2xl border border-amber-500/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px]">
-              <div className="flex items-center justify-between mb-2">
-                <div className="flex items-center gap-2">
-                  <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-amber-500/20">
-                    <Clock className="h-3.5 w-3.5 text-amber-400" />
-                  </div>
-                  <h2 className="font-cinzel text-base text-amber-400 uppercase tracking-wider">Upcoming Games</h2>
-                </div>
-                <button
-                  onClick={onRefresh}
-                  disabled={isRefreshing}
-                  className="p-1 rounded-md bg-amber-500/10 text-amber-400/70 hover:bg-amber-500/20 hover:text-amber-400 transition-all disabled:opacity-50"
-                  title="Refresh"
-                >
-                  <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
-                </button>
-              </div>
-              <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-amber-500/20 scrollbar-track-transparent">
-                <UnifiedGameGrid
-                  onPlayGame={onPlayGame}
-                  onSelectGame={onSelectGame}
-                  onAutoSettleGame={onAutoSettleGame}
-                  onSpectate={onSpectate}
-                  onForgeHyperstructures={onForgeHyperstructures}
-                  onRegistrationComplete={onRegistrationComplete}
-                  modeFilter="blitz"
-                  devModeFilter={false}
-                  statusFilter="upcoming"
-                  hideHeader
-                  hideLegend
-                  layout="vertical"
-                  sortRegisteredFirst
-                />
-              </div>
-            </div>
-
-            {/* Ended Games Column */}
-            <div className="flex flex-col rounded-2xl border border-gold/30 bg-black/40 p-3 backdrop-blur-sm min-h-0 max-h-[500px] md:col-span-2 xl:col-span-1">
-              <div className="flex items-center gap-2 mb-2">
-                <div className="flex h-6 w-6 items-center justify-center rounded-lg bg-gold/20">
-                  <Trophy className="h-3.5 w-3.5 text-gold" />
-                </div>
-                <h2 className="font-cinzel text-base text-gold uppercase tracking-wider">Ended Games</h2>
-              </div>
-              <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
-                <UnifiedGameGrid
-                  onPlayGame={onPlayGame}
-                  onSelectGame={onSelectGame}
-                  onAutoSettleGame={onAutoSettleGame}
-                  onSpectate={onSpectate}
-                  onSeeScore={onSeeScore}
-                  onClaimRewards={onClaimRewards}
-                  onRegistrationComplete={onRegistrationComplete}
-                  modeFilter="blitz"
-                  devModeFilter={false}
-                  statusFilter="ended"
-                  hideHeader
-                  hideLegend
-                  layout="vertical"
-                  sortClaimableRewardsFirst
-                  sortEndedNewestFirst
-                  onGamesResolved={onEndedGamesResolved}
-                />
-              </div>
-            </div>
+            <h2 className="font-cinzel text-base text-gold uppercase tracking-wider">Played</h2>
+          </div>
+          <div className="flex-1 overflow-y-auto min-h-0 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent">
+            <UnifiedGameGrid
+              onPlayGame={onPlayGame}
+              onSelectGame={onSelectGame}
+              onAutoSettleGame={onAutoSettleGame}
+              onSpectate={onSpectate}
+              onSeeScore={onSeeScore}
+              onClaimRewards={onClaimRewards}
+              onRegistrationComplete={onRegistrationComplete}
+              modeFilter={resolvedMode}
+              devModeFilter={false}
+              statusFilter="ended"
+              hideHeader
+              hideLegend
+              layout="vertical"
+              sortClaimableRewardsFirst
+              sortEndedNewestFirst
+              onGamesResolved={resolvedMode === "blitz" ? onEndedGamesResolved : undefined}
+            />
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -810,7 +810,6 @@ const PlayTabContent = ({
               onForgeHyperstructures={onForgeHyperstructures}
               onRegistrationComplete={onRegistrationComplete}
               modeFilter={resolvedMode}
-              devModeFilter={false}
               statusFilter={["ongoing", "upcoming"]}
               registeredFilter="unregistered"
               hideHeader


### PR DESCRIPTION
## Summary
- Mode hero cards shrunk to half height (`min-h 280/360` → `140/180`); drop the hover-expand subtitle/CTA and keep a compact always-visible title + CTA.
- New full-width **Your Active Games** bar between the hero and the game grid — horizontally scrolling list of the user's live + upcoming registered games for the current mode, hidden unless at least one exists (anonymous users see nothing).
- Three-column Live / Upcoming / Ended grid collapsed into two columns: **Open Games** (live + upcoming, unregistered) and **Played** (ended, unchanged). Live and Upcoming are merged so unregistered live games are still surfaced.
- Adds a `registeredFilter: "registered" | "unregistered"` prop to `UnifiedGameGrid` that the bar, Open Games, and Played surfaces share so registered games are never duplicated between the bar and the Open column.

## Test plan
- [ ] Anonymous boot: bar hidden, Open Games + Played show all live+upcoming / ended
- [ ] Wallet connected, no registrations: bar stays hidden
- [ ] Wallet connected with ≥1 active registered game: bar appears; those games no longer appear in Open Games
- [ ] Toggle Blitz ↔ Season: bar contents swap; bar hides when the new mode has none
- [ ] Ended registered games: appear in Played column with existing registration banner + sort-first treatment
- [ ] Responsive: mobile stacks hero/bar/columns; desktop shows side-by-side hero and 2 columns