### PR TITLE
fix(game): block missing slot deployment RPC

### DIFF
--- a/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
@@ -164,4 +164,21 @@ describe("buildWorldProfile concurrency", () => {
       }),
     );
   });
+
+  it("rejects unavailable slot worlds before saving a dead rpc profile", async () => {
+    mocks.resolveWorldContracts.mockResolvedValue({ spawn: "0xabc" });
+    mocks.resolveWorldDeploymentFromFactory.mockResolvedValue(null);
+    mocks.fetchWorldAddress.mockResolvedValue(null);
+    mocks.fetch.mockResolvedValue({
+      ok: false,
+      json: async () => [],
+    });
+
+    await expect(buildWorldProfile("slot", "bltz-riff-363")).rejects.toThrow(
+      "Slot world deployment is not available: bltz-riff-363",
+    );
+
+    expect(mocks.normalizeRpcUrl).not.toHaveBeenCalledWith("https://api.cartridge.gg/x/bltz-riff-363/katana");
+    expect(mocks.saveWorldProfile).not.toHaveBeenCalled();
+  });
 });

--- a/client/apps/game/src/runtime/world/profile-builder.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.ts
@@ -13,6 +13,23 @@ const cartridgeApiBase = env.VITE_PUBLIC_CARTRIDGE_API_BASE || "https://api.cart
 
 const toriiBaseUrlFromName = (name: string) => `${cartridgeApiBase}/x/${name}/torii`;
 
+const isSlotWorldChain = (chain: Chain): boolean => chain === "slot" || chain === "slottest";
+
+const assertSlotWorldAddressIsAvailable = ({
+  chain,
+  name,
+  worldAddress,
+}: {
+  chain: Chain;
+  name: string;
+  worldAddress: string | null;
+}) => {
+  if (!isSlotWorldChain(chain)) return;
+  if (worldAddress) return;
+
+  throw new Error(`Slot world deployment is not available: ${name}`);
+};
+
 const measureAsyncDuration = async <T>(name: string, run: () => Promise<T>): Promise<T> => {
   const startedAt = performance.now();
   try {
@@ -109,6 +126,8 @@ export const buildWorldProfile = async (chain: Chain, name: string): Promise<Wor
     // Fallback: read from factory's wf-WorldDeployed table
     worldAddress = normalizeAddress(deployment?.worldAddress) ?? deployment?.worldAddress ?? null;
   }
+
+  assertSlotWorldAddressIsAvailable({ chain, name, worldAddress });
 
   // As a last resort, default to 0x0 so configuration can still proceed with patched contracts
   if (!worldAddress) worldAddress = "0x0";

--- a/client/apps/game/src/runtime/world/store.test.ts
+++ b/client/apps/game/src/runtime/world/store.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getActiveWorld, getActiveWorldName } from "./store";
+import type { WorldProfilesMap } from "./types";
+
+const ACTIVE_KEY = "ACTIVE_WORLD_NAME";
+const PROFILES_KEY = "WORLD_PROFILES";
+
+const createLocalStorage = () => {
+  const values = new Map<string, string>();
+
+  return {
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+};
+
+const saveProfiles = (profiles: WorldProfilesMap) => {
+  window.localStorage.setItem(PROFILES_KEY, JSON.stringify(profiles));
+};
+
+describe("world profile store", () => {
+  beforeEach(() => {
+    const localStorage = createLocalStorage();
+    vi.stubGlobal(
+      "CustomEvent",
+      class CustomEvent<T> extends Event {
+        detail: T;
+
+        constructor(type: string, eventInitDict?: CustomEventInit<T>) {
+          super(type);
+          this.detail = eventInitDict?.detail as T;
+        }
+      },
+    );
+    vi.stubGlobal("localStorage", localStorage);
+    vi.stubGlobal("window", {
+      dispatchEvent: vi.fn(),
+      localStorage,
+    });
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("clears stale slot profiles that were saved with a missing deployment", () => {
+    saveProfiles({
+      "bltz-riff-363": {
+        name: "bltz-riff-363",
+        chain: "slot",
+        toriiBaseUrl: "https://api.cartridge.gg/x/bltz-riff-363/torii",
+        rpcUrl: "https://api.cartridge.gg/x/bltz-riff-363/katana/rpc/v0_9",
+        worldAddress: "0x0",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+    });
+    window.localStorage.setItem(ACTIVE_KEY, "bltz-riff-363");
+
+    expect(getActiveWorld()).toBeNull();
+    expect(getActiveWorldName()).toBeNull();
+    expect(JSON.parse(window.localStorage.getItem(PROFILES_KEY) ?? "{}")).not.toHaveProperty("bltz-riff-363");
+  });
+});

--- a/client/apps/game/src/runtime/world/store.ts
+++ b/client/apps/game/src/runtime/world/store.ts
@@ -1,11 +1,13 @@
 import type { Chain } from "@contracts";
-import { WorldProfile, WorldProfilesMap } from "./types";
+import type { WorldProfile, WorldProfilesMap } from "./types";
 
 const ACTIVE_KEY = "ACTIVE_WORLD_NAME";
 const CHAIN_KEY = "ACTIVE_WORLD_CHAIN";
 const PROFILES_KEY = "WORLD_PROFILES";
 const ACTIVE_WORLD_EVENT = "runtime:active-world-changed";
 const SELECTED_CHAIN_EVENT = "runtime:selected-chain-changed";
+const ZERO_WORLD_ADDRESS = "0x0";
+const PADDED_ZERO_WORLD_ADDRESS = `0x${"0".repeat(64)}`;
 
 const safeParse = <T>(raw: string | null, fallback: T): T => {
   if (!raw) return fallback;
@@ -21,6 +23,17 @@ const CHAIN_VALUES: Chain[] = ["sepolia", "mainnet", "slot", "slottest", "local"
 const isValidChain = (value: string | null): value is Chain => {
   if (!value) return false;
   return CHAIN_VALUES.includes(value as Chain);
+};
+
+const isSlotWorldChain = (chain: Chain): boolean => chain === "slot" || chain === "slottest";
+
+const isZeroWorldAddress = (worldAddress: string | null | undefined): boolean => {
+  const normalized = worldAddress?.toLowerCase();
+  return normalized === ZERO_WORLD_ADDRESS || normalized === PADDED_ZERO_WORLD_ADDRESS;
+};
+
+const isUnavailableSlotWorldProfile = (profile: WorldProfile): boolean => {
+  return isSlotWorldChain(profile.chain) && isZeroWorldAddress(profile.worldAddress);
 };
 
 const readStorageValue = (key: string): string | null => {
@@ -157,7 +170,15 @@ const deleteWorldProfile = (name: string) => {
 
 const getWorldProfile = (name: string): WorldProfile | null => {
   const profiles = getWorldProfiles();
-  return profiles[name] ?? null;
+  const profile = profiles[name] ?? null;
+  if (!profile) return null;
+
+  if (isUnavailableSlotWorldProfile(profile)) {
+    deleteWorldProfile(name);
+    return null;
+  }
+
+  return profile;
 };
 
 export const getActiveWorldName = (): string | null => readStorageValue(ACTIVE_KEY);


### PR DESCRIPTION
Prevents Slot world profile creation when the selected world has no resolvable deployment address, avoiding synthesized Cartridge RPC URLs that fail chain ID lookup. Clears stale active Slot profiles saved with a zero world address so affected browsers recover without manual localStorage cleanup. Adds regression coverage for both unavailable profile creation and stale profile cleanup. Verification: `pnpm --dir client/apps/game test src/runtime/world`, `pnpm run format`, and `pnpm run knip` passed.