### PR TITLE
fix(game): lower move-highlight renderOrder below structures

### DIFF
--- a/client/apps/game/src/three/managers/highlight-hex-manager.ts
+++ b/client/apps/game/src/three/managers/highlight-hex-manager.ts
@@ -91,7 +91,7 @@ export class HighlightHexManager {
     this.routeLayer = this.createLayer(hexagonGeometry, {
       color: 0xffffff,
       opacity: 0.16,
-      renderOrder: 40,
+      renderOrder: 5,
       baseOpacity: 0.16,
       opacityPulseScale: 1.25,
       targetScale: 0.92,
@@ -100,7 +100,7 @@ export class HighlightHexManager {
     this.endpointLayer = this.createLayer(hexagonGeometry, {
       color: 0xffffff,
       opacity: 0.22,
-      renderOrder: 41,
+      renderOrder: 6,
       baseOpacity: 0.22,
       opacityPulseScale: 1.5,
       targetScale: 0.56,
@@ -109,7 +109,7 @@ export class HighlightHexManager {
     this.frontierLayer = this.createLayer(hexagonGeometry, {
       color: 0xffffff,
       opacity: 0.3,
-      renderOrder: 42,
+      renderOrder: 7,
       baseOpacity: 0.3,
       opacityPulseScale: 1.8,
       targetScale: 0.74,
@@ -358,7 +358,7 @@ export class HighlightHexManager {
     glowMesh.position.set(position.x, this.routeLayer.baseY + this.yOffset, position.z);
     glowMesh.rotation.x = -Math.PI / 2;
     glowMesh.scale.setScalar(0.42);
-    glowMesh.renderOrder = 43;
+    glowMesh.renderOrder = 8;
     glowMesh.raycast = () => {};
 
     const glowEntry = { mesh: glowMesh, material: glowMaterial };

--- a/client/apps/game/src/three/scenes/hexagon-scene.ts
+++ b/client/apps/game/src/three/scenes/hexagon-scene.ts
@@ -191,7 +191,7 @@ export abstract class HexagonScene {
     this.inputManager = new InputManager(this.sceneName, this.sceneManager, this.raycaster, this.mouse, this.camera);
     this.interactiveHexManager = new InteractiveHexManager(this.scene);
     this.worldUpdateListener = new WorldUpdateListener(this.dojo, sqlApi);
-    this.highlightHexManager = new HighlightHexManager(this.interactionOverlayScene);
+    this.highlightHexManager = new HighlightHexManager(this.scene);
     this.thunderBoltManager = new ThunderBoltManager(this.scene, this.controls);
     this.scene.background = new Color(0x2a1a3e);
     this.state = useUIStore.getState();


### PR DESCRIPTION
## Summary
- Move-highlight hex layers were rendered at `renderOrder` 40-43 with `depthWrite: false`, which painted them over buildings, armies, and contact shadows instead of sitting on top of biome tiles.
- Dropped the three highlight layers (route/endpoint/frontier) and the launch glow to `renderOrder` 5-8 so they sit just above biome geometry/outlines (1-4) but below structures, armies, and contact shadows (9+), letting depth testing occlude them naturally.

## Z-stack after change
| Layer | renderOrder |
|---|---|
| Biome ocean | 1 |
| Biome opaque | 2 |
| Biome alpha-tested | 3 |
| Biome outline | 4 |
| **Move highlight (route)** | **5** |
| **Move highlight (endpoint)** | **6** |
| **Move highlight (frontier)** | **7** |
| **Launch glow** | **8** |
| Contact shadow | 9 |
| Arrival ghost / armies / buildings | 10+ |

## Test plan
- [ ] Select an army near buildings — blue movable-tile highlights should appear on biome tiles but render *under* nearby castles/structures instead of bleeding over them.
- [ ] Launch glow on movement still plays at the origin hex without clipping through the selected army.
- [ ] Route/endpoint/frontier layering still renders in the expected order (frontier on top of endpoint on top of route).
- [ ] Hover hex and selection pulse still render above the move highlights.