### PR TITLE
fix(game): unblock slot reconnect and surface boot phase timings

### DIFF
--- a/client/apps/game/dojo-config.ts
+++ b/client/apps/game/dojo-config.ts
@@ -1,5 +1,14 @@
 import { TORII_SETTING } from "@/utils/config";
-import { getActiveWorld, patchManifestWithFactory, normalizeRpcUrl, resolveChain } from "@/runtime/world";
+import {
+  getActiveWorld,
+  listSavedWorldProfiles,
+  normalizeRpcUrl,
+  patchManifestWithFactory,
+  probeSlotDeploymentRpcAlive,
+  purgeDeadSlotWorldProfiles,
+  purgeUnavailableSlotWorldProfiles,
+  resolveChain,
+} from "@/runtime/world";
 import { Chain, getGameManifest } from "@contracts";
 import { createDojoConfig } from "@dojoengine/core";
 import { env } from "./env";
@@ -12,6 +21,36 @@ const {
   VITE_PUBLIC_FEE_TOKEN_ADDRESS,
   VITE_PUBLIC_CHAIN,
 } = env;
+
+// Both purges must run BEFORE `getActiveWorld()` below. dojo-config is module-
+// loaded before React mounts, so it's the only choke point that runs ahead of
+// `StarknetProvider` building a `ControllerConnector` against a saved RPC URL.
+// Cold-reloading on a Cartridge-GC'd slot deployment would otherwise bake the
+// dead RPC into the connector, `starknet_chainId` 404s, and the user is stuck
+// on "Reconnect to Continue" forever.
+purgeUnavailableSlotWorldProfiles();
+
+// Probe each saved slot profile's RPC directly — this is the *exact* request
+// `ControllerConnector` is about to make, so it's the only liveness signal
+// that's authoritative for the controller-init path. Realtime-server bulk
+// availability lags GC by 30s + has a 5min stale cache, so we don't trust it
+// here. `null` = indeterminate, treat as alive (no false-positive evictions).
+const slotProfilesToProbe = listSavedWorldProfiles().filter(
+  (profile) => profile.chain === "slot" || profile.chain === "slottest",
+);
+const probedDeadSlotNames = new Set<string>();
+await Promise.all(
+  slotProfilesToProbe.map(async (profile) => {
+    const alive = await probeSlotDeploymentRpcAlive(profile.rpcUrl);
+    if (alive === false) probedDeadSlotNames.add(profile.name);
+  }),
+);
+const evictedDeadSlotWorlds = purgeDeadSlotWorldProfiles(probedDeadSlotNames);
+if (evictedDeadSlotWorlds.length > 0) {
+  console.warn(
+    `[dojo-config] Evicted dead slot world profiles: ${evictedDeadSlotWorlds.join(", ")}. Falling back to env defaults.`,
+  );
+}
 
 const resolvedChain = resolveChain(VITE_PUBLIC_CHAIN! as Chain);
 let manifest = getGameManifest(resolvedChain as Chain);

--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -349,6 +349,38 @@ describe("ConnectionHealthMonitor", () => {
     monitor.dispose();
   });
 
+  it("still bumps streamReconnectVersion when reconnect handlers reject so scoped subs can retry", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.reject(new Error("spatial torii hung")));
+    const onReconnectGlobal = vi.fn(() => Promise.reject(new Error("global initialSync timed out")));
+    const healthCheckFn = vi.fn(() => Promise.resolve(true));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now() - 10_000,
+      lastGlobalUpdate: Date.now() - 10_000,
+      streamReconnectVersion: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(useConnectionStore.getState().streamReconnectVersion).toBe(1);
+    expect(onReconnectSpatial).toHaveBeenCalled();
+    expect(onReconnectGlobal).toHaveBeenCalled();
+
+    monitor.dispose();
+  });
+
   it("does not auto-reconnect during boot grace even if stream timestamps look stale", async () => {
     const onReconnectSpatial = vi.fn(() => Promise.resolve());
     const onReconnectGlobal = vi.fn(() => Promise.resolve());

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -194,15 +194,16 @@ export class ConnectionHealthMonitor {
     const store = useConnectionStore.getState();
     if (spatial) store.setSpatialStatus("reconnecting");
     if (global) store.setGlobalStatus("reconnecting");
+    let attempted = false;
     try {
       const promises: Promise<void>[] = [];
       if (spatial) promises.push(this.config.onReconnectSpatial());
       if (global) promises.push(this.config.onReconnectGlobal());
+      attempted = promises.length > 0;
       await Promise.all(promises);
       if (spatial) store.setSpatialStatus("connected");
       if (global) store.setGlobalStatus("connected");
-      if (promises.length > 0) {
-        store.recordStreamReconnect();
+      if (attempted) {
         this.markConnectedIfNeeded();
       }
     } catch (error) {
@@ -214,6 +215,14 @@ export class ConnectionHealthMonitor {
       this.markOutageStart();
       this.reportDeadEndIfNeeded();
     } finally {
+      // Bump on both success and failure: scoped subscribers (e.g. player
+      // structure sync) re-mount on this version, and a failed global
+      // reconnect can leave their per-stream subscriptions wedged on the
+      // old client. Letting them retry independently is the recovery path
+      // when the global fan-out keeps timing out.
+      if (attempted) {
+        store.recordStreamReconnect();
+      }
       this.reconnecting = false;
     }
   }

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -4,6 +4,7 @@ import { type SetupResult } from "@bibliothecadao/dojo";
 
 import { useConnectionStore } from "@/hooks/store/use-connection-store";
 import { sqlApi } from "@/services/api";
+import { recordGameEntryDuration } from "@/ui/layouts/game-entry-timeline";
 import {
   MAP_DATA_REFRESH_INTERVAL,
   MapDataStore,
@@ -554,6 +555,7 @@ export const initialSync = async (
   }
 
   isInitialSyncInFlight = true;
+  const globalStreamSubscribeStart = performance.now();
   try {
     entityStreamSubscription = await syncEntitiesDebounced(
       setup.network.toriiClient,
@@ -576,6 +578,7 @@ export const initialSync = async (
     }
     throw error;
   } finally {
+    recordGameEntryDuration("initial-sync-global-stream-subscribe", performance.now() - globalStreamSubscribeStart);
     isInitialSyncInFlight = false;
   }
 
@@ -596,8 +599,12 @@ export const initialSync = async (
   const runTimedTask = async (label: string, targetProgress: number, task: () => Promise<void>) => {
     const start = performance.now();
     await task();
-    const end = performance.now();
-    console.log(`[sync] ${label}`, end - start);
+    const elapsedMs = performance.now() - start;
+    console.log(`[sync] ${label}`, elapsedMs);
+    // Surface in the boot debug panel under a deterministic key so a slow
+    // sub-step (e.g. "guilds query") immediately points at the bottleneck
+    // instead of being hidden inside the aggregate `initial-sync` total.
+    recordGameEntryDuration(`initial-sync-${label.replace(/\s+/g, "-")}`, elapsedMs);
     updateProgress(targetProgress);
   };
 
@@ -671,12 +678,16 @@ export const initialSync = async (
     }),
   ]);
 
+  const mapDataRefreshStart = performance.now();
   await MapDataStore.getInstance(MAP_DATA_REFRESH_INTERVAL, sqlApi).refresh();
+  recordGameEntryDuration("initial-sync-map-data-refresh", performance.now() - mapDataRefreshStart);
 
   // Block on the Torii stream's initial entity flush so the worldmap scene
   // observes populated RECS state instead of an empty world on fast loads.
   if (entityStreamSubscription) {
+    const flushStart = performance.now();
     await waitForInitialEntityFlush(entityStreamSubscription.ready, subscriptionSetupTimeoutMs);
+    recordGameEntryDuration("initial-sync-initial-entity-flush", performance.now() - flushStart);
   }
 
   updateProgress(100);

--- a/client/apps/game/src/game-route.tsx
+++ b/client/apps/game/src/game-route.tsx
@@ -77,7 +77,8 @@ const GameRoute = ({ backgroundImage }: { backgroundImage: string }) => {
   }, []);
 
   const state = usePlayRouteBootController();
-  const { phase, progress, setupResult, account, connectWallet, retry, isReconnectRequired } = state;
+  const { phase, progress, setupResult, account, connectWallet, retry, isReconnectRequired, currentTask, tasks } =
+    state;
   const routeView = resolveGameRouteView({
     phase,
     hasSetupResult: setupResult !== null,
@@ -88,6 +89,10 @@ const GameRoute = ({ backgroundImage }: { backgroundImage: string }) => {
     routeView === "loading" ? "app-loading" : routeView === "ready" ? "app-ready" : null,
     routeView === "ready" ? "boot_world_visible" : routeView === "loading" ? "boot_react_loader_visible" : undefined,
   );
+
+  // Resolve a human-readable label for the active task so the boot debug
+  // panel can show "Connecting to world" rather than "dojo".
+  const currentTaskLabel = currentTask ? (tasks.find((task) => task.id === currentTask)?.label ?? currentTask) : phase;
 
   if (routeView === "redirect") {
     return <Navigate to="/" replace />;
@@ -110,12 +115,19 @@ const GameRoute = ({ backgroundImage }: { backgroundImage: string }) => {
         progress={progress > 0 ? progress : undefined}
         title="Charting the World"
         subtitle="Following contour lines while world state comes online."
+        currentTaskLabel={currentTaskLabel}
       />
     );
   }
 
   if (!setupResult || !account) {
-    return <LoadingScreen title="Charting the World" subtitle="Resolving the last world details." />;
+    return (
+      <LoadingScreen
+        title="Charting the World"
+        subtitle="Resolving the last world details."
+        currentTaskLabel={currentTaskLabel}
+      />
+    );
   }
 
   return <ReadyApp backgroundImage={backgroundImage} setupResult={setupResult} account={account} />;

--- a/client/apps/game/src/init/bootstrap.tsx
+++ b/client/apps/game/src/init/bootstrap.tsx
@@ -5,7 +5,7 @@ import { world } from "@bibliothecadao/types";
 import { inject } from "@vercel/analytics";
 import { ReactNode } from "react";
 
-import { patchManifestWithFactory, applyWorldSelection, type WorldProfile } from "@/runtime/world";
+import { applyWorldSelection, patchManifestWithFactory, type WorldProfile } from "@/runtime/world";
 import { resolveEntryContextCacheKey, type ResolvedEntryContext } from "@/game-entry/context";
 import { setSqlApiBaseUrl } from "@/services/api";
 import { Chain, getGameManifest } from "@contracts";
@@ -281,9 +281,17 @@ const configureGameSystems = (setupResult: SetupResult, chain: Chain) => {
 };
 
 const startGameRenderer = async (setupResult: SetupResult) => {
-  bootstrapSession.replaceRendererCleanup(
-    await initializeGameRenderer(setupResult, env.VITE_PUBLIC_GRAPHICS_DEV == true),
-  );
+  // Renderer init = Three.js scene/shader/texture compilation + spatial Torii
+  // bounds subscription. Often the slowest single step on a cold reload, and
+  // previously had no breadcrumb between `initial-sync-completed` and
+  // `bootstrap-completed`, so a 30s+ hang here looked indistinguishable from
+  // a stuck initial sync.
+  const rendererInitStartedAt = performance.now();
+  markGameEntryMilestone("renderer-init-started");
+  const cleanup = await initializeGameRenderer(setupResult, env.VITE_PUBLIC_GRAPHICS_DEV == true);
+  markGameEntryMilestone("renderer-init-completed");
+  recordGameEntryDuration("renderer-init", performance.now() - rendererInitStartedAt);
+  bootstrapSession.replaceRendererCleanup(cleanup);
 };
 
 const cancelActiveBootstrapSubscriptions = () => {

--- a/client/apps/game/src/runtime/world/factory-resolver.ts
+++ b/client/apps/game/src/runtime/world/factory-resolver.ts
@@ -65,6 +65,54 @@ export const fetchBulkAvailability = async (realtimeServerUrl: string): Promise<
   }
 };
 
+/**
+ * Probes a slot world's RPC URL with a `starknet_chainId` call — the exact
+ * request `ControllerConnector` makes during init. Returns:
+ *   - `true`  : RPC responded with a chain ID (deployment is alive)
+ *   - `false` : RPC explicitly reports the deployment is gone (HTTP 404, or
+ *               JSON-RPC `-32000 deployment {name} not found`). Caller should
+ *               evict the saved profile and fall back to env defaults.
+ *   - `null`  : indeterminate (network error, timeout, CORS). Caller MUST NOT
+ *               false-evict on null — a transient blip would wipe profiles
+ *               that are actually fine.
+ *
+ * The realtime-server's bulk availability endpoint isn't used here because it
+ * has a 30s polling lag plus a 5-min stale cache, so a freshly-GC'd Cartridge
+ * deployment can stay flagged "alive" long after `starknet_chainId` is 404'ing.
+ */
+export const probeSlotDeploymentRpcAlive = async (
+  rpcUrl: string | null | undefined,
+  timeoutMs = 2_000,
+): Promise<boolean | null> => {
+  if (!rpcUrl) return null;
+
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "starknet_chainId", params: [], id: 1 }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    if (response.status === 404) return false;
+    if (!response.ok) return null;
+
+    const payload = (await response.json()) as { result?: string; error?: { code?: number; message?: string } };
+    if (payload?.result) return true;
+
+    // Only treat as dead on EXPLICIT deployment-not-found message text. The
+    // `-32000` JSON-RPC code alone is too broad — Cartridge uses it for many
+    // transient server errors (rate limits, gateway hiccups), and treating
+    // those as "dead" would false-evict live worlds and bounce the user out.
+    const errorMessage = String(payload?.error?.message ?? "").toLowerCase();
+    if (errorMessage.includes("deployment") && errorMessage.includes("not found")) return false;
+    if (errorMessage.includes("no such deployment")) return false;
+    return null;
+  } catch {
+    return null;
+  }
+};
+
 const normalizeAddress = (value: unknown): string | null => {
   if (value == null) return null;
   if (typeof value === "string") return value;

--- a/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
@@ -145,7 +145,12 @@ describe("buildWorldProfile concurrency", () => {
     });
   });
 
-  it("falls back to the selected slot world rpc when deployment metadata is unavailable", async () => {
+  it("falls back to the env slot rpc when deployment metadata is unavailable", async () => {
+    // 9b295e0b08 originally pinned slot worlds to a per-world RPC with no env
+    // fallback, which left users stuck on "Reconnect to Continue" once a
+    // Cartridge slot deployment was GC'd. Reverted: when the factory has no
+    // explicit deployment row, slot now falls back to env's slot RPC (the
+    // last-known-alive deployment for the build target).
     mocks.resolveWorldContracts.mockResolvedValue({ spawn: "0xabc" });
     mocks.resolveWorldDeploymentFromFactory.mockResolvedValue(null);
     mocks.fetchWorldAddress.mockResolvedValue("0x1");
@@ -156,11 +161,11 @@ describe("buildWorldProfile concurrency", () => {
 
     await buildWorldProfile("slot", "s0-game-5");
 
-    expect(mocks.normalizeRpcUrl).toHaveBeenCalledWith("https://api.cartridge.gg/x/s0-game-5/katana");
+    expect(mocks.normalizeRpcUrl).toHaveBeenCalledWith("https://fallback-rpc.example");
     expect(mocks.saveWorldProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "s0-game-5",
-        rpcUrl: "https://api.cartridge.gg/x/s0-game-5/katana",
+        rpcUrl: "https://fallback-rpc.example",
       }),
     );
   });

--- a/client/apps/game/src/runtime/world/profile-builder.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.ts
@@ -139,11 +139,14 @@ export const buildWorldProfile = async (chain: Chain, name: string): Promise<Wor
       : chain === "mainnet" || chain === "sepolia"
         ? `${cartridgeApiBase}/x/starknet/${chain}`
         : env.VITE_PUBLIC_NODE_URL;
-  const canUseEnvRpc =
-    hasPublicNodeUrl &&
-    chain !== "slot" &&
-    chain !== "slottest" &&
-    isRpcUrlCompatibleForChain(chain, env.VITE_PUBLIC_NODE_URL);
+  // Re-enabled env-RPC fallback for slot (was excluded by 9b295e0b08).
+  // The exclusion meant per-world RPCs had no fallback, so a Cartridge GC of
+  // the world's deployment killed `starknet_chainId` and parked the user on
+  // the "Reconnect to Continue" modal. With the fallback restored, slot
+  // worlds whose factory deployment row lacks an explicit `rpcUrl` (or whose
+  // saved profile is unset) resolve to the env's slot RPC, which is the
+  // last-known-alive slot deployment for the build target.
+  const canUseEnvRpc = hasPublicNodeUrl && isRpcUrlCompatibleForChain(chain, env.VITE_PUBLIC_NODE_URL);
   const fallbackRpcUrl = canUseEnvRpc ? env.VITE_PUBLIC_NODE_URL : chainDefaultRpcUrl;
   const rpcUrl = normalizeRpcUrl(deployment?.rpcUrl ?? fallbackRpcUrl);
 

--- a/client/apps/game/src/runtime/world/store.test.ts
+++ b/client/apps/game/src/runtime/world/store.test.ts
@@ -2,7 +2,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getActiveWorld, getActiveWorldName } from "./store";
+import {
+  getActiveWorld,
+  getActiveWorldName,
+  purgeDeadSlotWorldProfiles,
+  purgeUnavailableSlotWorldProfiles,
+} from "./store";
 import type { WorldProfilesMap } from "./types";
 
 const ACTIVE_KEY = "ACTIVE_WORLD_NAME";
@@ -49,7 +54,7 @@ describe("world profile store", () => {
     vi.unstubAllGlobals();
   });
 
-  it("clears stale slot profiles that were saved with a missing deployment", () => {
+  it("returns null for stale slot profiles without mutating storage", () => {
     saveProfiles({
       "bltz-riff-363": {
         name: "bltz-riff-363",
@@ -64,7 +69,104 @@ describe("world profile store", () => {
     window.localStorage.setItem(ACTIVE_KEY, "bltz-riff-363");
 
     expect(getActiveWorld()).toBeNull();
+    expect(getActiveWorldName()).toBe("bltz-riff-363");
+    expect(JSON.parse(window.localStorage.getItem(PROFILES_KEY) ?? "{}")).toHaveProperty("bltz-riff-363");
+  });
+
+  it("purges stale slot profiles and clears the active world pointer", () => {
+    saveProfiles({
+      "bltz-riff-363": {
+        name: "bltz-riff-363",
+        chain: "slot",
+        toriiBaseUrl: "https://api.cartridge.gg/x/bltz-riff-363/torii",
+        rpcUrl: "https://api.cartridge.gg/x/bltz-riff-363/katana/rpc/v0_9",
+        worldAddress: "0x0",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+      "mainnet-king-1": {
+        name: "mainnet-king-1",
+        chain: "mainnet",
+        toriiBaseUrl: "https://api.cartridge.gg/x/mainnet-king-1/torii",
+        rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
+        worldAddress: "0xabc",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+    });
+    window.localStorage.setItem(ACTIVE_KEY, "bltz-riff-363");
+
+    purgeUnavailableSlotWorldProfiles();
+
+    const remaining = JSON.parse(window.localStorage.getItem(PROFILES_KEY) ?? "{}") as WorldProfilesMap;
+    expect(remaining).not.toHaveProperty("bltz-riff-363");
+    expect(remaining).toHaveProperty("mainnet-king-1");
     expect(getActiveWorldName()).toBeNull();
-    expect(JSON.parse(window.localStorage.getItem(PROFILES_KEY) ?? "{}")).not.toHaveProperty("bltz-riff-363");
+  });
+
+  it("purges the slot profiles named in the dead set and clears the active world pointer", () => {
+    saveProfiles({
+      "bltz-riff-363": {
+        name: "bltz-riff-363",
+        chain: "slot",
+        toriiBaseUrl: "https://api.cartridge.gg/x/bltz-riff-363/torii",
+        rpcUrl: "https://api.cartridge.gg/x/bltz-riff-363/katana/rpc/v0_9",
+        worldAddress: "0x00ffc134aa2e75a419875fe8190cf34a008cd960311a893535c40cf8f8b778c7",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+      "eternum-blitz-slot-4": {
+        name: "eternum-blitz-slot-4",
+        chain: "slot",
+        toriiBaseUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/torii",
+        rpcUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/katana/rpc/v0_9",
+        worldAddress: "0x123",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+      "mainnet-king-1": {
+        name: "mainnet-king-1",
+        chain: "mainnet",
+        toriiBaseUrl: "https://api.cartridge.gg/x/mainnet-king-1/torii",
+        rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
+        worldAddress: "0xabc",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+    });
+    window.localStorage.setItem(ACTIVE_KEY, "bltz-riff-363");
+
+    const evicted = purgeDeadSlotWorldProfiles(new Set(["bltz-riff-363", "mainnet-king-1"]));
+
+    // Only slot profiles in the dead set are touched; mainnet is never evicted
+    // even if (mistakenly) included in the dead set.
+    expect(evicted).toEqual(["bltz-riff-363"]);
+    const remaining = JSON.parse(window.localStorage.getItem(PROFILES_KEY) ?? "{}") as WorldProfilesMap;
+    expect(remaining).not.toHaveProperty("bltz-riff-363");
+    expect(remaining).toHaveProperty("eternum-blitz-slot-4");
+    expect(remaining).toHaveProperty("mainnet-king-1");
+    expect(getActiveWorldName()).toBeNull();
+  });
+
+  it("no-ops on an empty dead set so an indeterminate probe doesn't false-evict", () => {
+    saveProfiles({
+      "bltz-riff-363": {
+        name: "bltz-riff-363",
+        chain: "slot",
+        toriiBaseUrl: "https://api.cartridge.gg/x/bltz-riff-363/torii",
+        rpcUrl: "https://api.cartridge.gg/x/bltz-riff-363/katana/rpc/v0_9",
+        worldAddress: "0x00ffc134",
+        contractsBySelector: {},
+        fetchedAt: 1,
+      },
+    });
+    window.localStorage.setItem(ACTIVE_KEY, "bltz-riff-363");
+
+    const evicted = purgeDeadSlotWorldProfiles(new Set());
+
+    expect(evicted).toEqual([]);
+    const remaining = JSON.parse(window.localStorage.getItem(PROFILES_KEY) ?? "{}") as WorldProfilesMap;
+    expect(remaining).toHaveProperty("bltz-riff-363");
+    expect(getActiveWorldName()).toBe("bltz-riff-363");
   });
 });

--- a/client/apps/game/src/runtime/world/store.ts
+++ b/client/apps/game/src/runtime/world/store.ts
@@ -144,6 +144,8 @@ export const listWorldNames = (): string[] => {
   return Object.keys(profiles);
 };
 
+export const listSavedWorldProfiles = (): WorldProfile[] => Object.values(getWorldProfiles());
+
 const getWorldProfiles = (): WorldProfilesMap => {
   return safeParse<WorldProfilesMap>(localStorage.getItem(PROFILES_KEY), {});
 };
@@ -158,27 +160,71 @@ export const saveWorldProfile = (profile: WorldProfile) => {
   saveWorldProfiles(profiles);
 };
 
-const deleteWorldProfile = (name: string) => {
-  const profiles = getWorldProfiles();
-  if (profiles[name]) {
-    delete profiles[name];
-    saveWorldProfiles(profiles);
-  }
-  const active = getActiveWorldName();
-  if (active === name) clearActiveWorld();
-};
-
 const getWorldProfile = (name: string): WorldProfile | null => {
   const profiles = getWorldProfiles();
   const profile = profiles[name] ?? null;
   if (!profile) return null;
+  if (isUnavailableSlotWorldProfile(profile)) return null;
+  return profile;
+};
 
-  if (isUnavailableSlotWorldProfile(profile)) {
-    deleteWorldProfile(name);
-    return null;
+/**
+ * Removes slot profiles saved with worldAddress=0x0 by an earlier build.
+ * Run once at boot — read paths must stay side-effect-free so a transient
+ * null (e.g. from a disconnected Torii) can't silently drop the active world.
+ */
+export const purgeUnavailableSlotWorldProfiles = (): void => {
+  const profiles = getWorldProfiles();
+  let changed = false;
+
+  for (const [name, profile] of Object.entries(profiles)) {
+    if (isUnavailableSlotWorldProfile(profile)) {
+      delete profiles[name];
+      changed = true;
+      const active = getActiveWorldName();
+      if (active === name) clearActiveWorld();
+    }
   }
 
-  return profile;
+  if (changed) saveWorldProfiles(profiles);
+};
+
+/**
+ * Removes the slot profiles named in `deadNames` from the saved world map and
+ * clears the active world pointer if it referenced one of them.
+ *
+ * Slot worlds are ephemeral: a profile saved while the deployment was alive
+ * keeps a real `worldAddress` and a per-world RPC URL, but the RPC starts
+ * returning `-32000 deployment {name} not found` once Cartridge tears it down.
+ * If we leave that profile in place, `dojoConfig` bakes the dead RPC into
+ * `ControllerConnector`, `starknet_chainId` fails, and the user is stuck on
+ * "Reconnect to Continue" forever.
+ *
+ * The caller is responsible for proving deadness (e.g. via a direct RPC probe
+ * against `probeSlotDeploymentRpcAlive`) so this helper stays pure-IO and
+ * avoids any false-positive eviction on transient errors.
+ *
+ * Returns the subset of `deadNames` that actually existed in storage so
+ * callers can log/telemeter what was wiped.
+ */
+export const purgeDeadSlotWorldProfiles = (deadNames: ReadonlySet<string>): string[] => {
+  if (deadNames.size === 0) return [];
+
+  const profiles = getWorldProfiles();
+  const evicted: string[] = [];
+
+  for (const name of deadNames) {
+    const profile = profiles[name];
+    if (!profile) continue;
+    if (!isSlotWorldChain(profile.chain)) continue;
+    delete profiles[name];
+    evicted.push(name);
+    const active = getActiveWorldName();
+    if (active === name) clearActiveWorld();
+  }
+
+  if (evicted.length > 0) saveWorldProfiles(profiles);
+  return evicted;
 };
 
 export const getActiveWorldName = (): string | null => readStorageValue(ACTIVE_KEY);

--- a/client/apps/game/src/three/game-renderer.ts
+++ b/client/apps/game/src/three/game-renderer.ts
@@ -4,6 +4,7 @@ import { GUIManager } from "@/three/utils/";
 import { GRAPHICS_SETTING, GraphicsSettings, IS_MOBILE } from "@/ui/config";
 import { SetupResult } from "@bibliothecadao/dojo";
 import { env } from "../../env";
+import { recordGameEntryDuration } from "@/ui/layouts/game-entry-timeline";
 import { SceneName } from "./types";
 import { transitionDB } from "./utils/";
 import { trackGuiFolder, type TrackableGuiFolder } from "./utils/gui-folder-lifecycle";
@@ -159,29 +160,45 @@ export default class GameRenderer {
   }
 
   async initScene() {
+    // Each `recordGameEntryDuration` call below surfaces in the boot debug
+    // panel as `renderer-init-<step>` so a slow cold-reload pinpoints the
+    // exact sub-step (backend handshake vs scene construction vs HUD vs
+    // animate kickoff) instead of being hidden inside the `renderer-init`
+    // aggregate.
+    const backendStart = performance.now();
     await this.backendInitializationPromise;
+    recordGameEntryDuration("renderer-init-backend-await", performance.now() - backendStart);
+
     if (this.isDestroyed) {
       return;
     }
     this.supportRuntimeRegistry.getControlBridge().setupGuiControls();
     this.sessionRuntime.startListeners();
+
+    const measure = (label: string, fn: () => void) => {
+      const start = performance.now();
+      fn();
+      recordGameEntryDuration(`renderer-init-${label}`, performance.now() - start);
+    };
+
     bootstrapRendererStartupRuntime({
-      animate: () => this.animate(),
-      attachInteractionRuntime: () => this.attachInteractionRuntime(),
+      animate: () => measure("animate-start", () => this.animate()),
+      attachInteractionRuntime: () => measure("attach-interaction", () => this.attachInteractionRuntime()),
       cleanupExpiredTransitions: (maxAgeMs) => transitionDB.cleanupExpired(maxAgeMs),
       debug: (message) => console.debug(message),
       document,
-      initializeHudScene: () => {
-        this.hudScene = this.sessionRuntime.createHudScene();
-      },
+      initializeHudScene: () =>
+        measure("hud-scene", () => {
+          this.hudScene = this.sessionRuntime.createHudScene();
+        }),
       isDestroyed: this.isDestroyed,
-      prepareScenes: () => this.prepareScenes(),
+      prepareScenes: () => measure("prepare-scenes", () => this.prepareScenes()),
       registerCleanupInterval: (intervalId) => {
         this.cleanupIntervals = this.cleanupIntervals || [];
         this.cleanupIntervals.push(intervalId);
       },
       rendererDomElement: this.renderer.domElement,
-      syncRouteFromLocation: () => this.sessionRuntime.syncRouteFromLocation(),
+      syncRouteFromLocation: () => measure("sync-route", () => this.sessionRuntime.syncRouteFromLocation()),
       warn: (message) => console.warn(message),
     });
   }

--- a/client/apps/game/src/ui/layouts/game-entry-timeline.test.ts
+++ b/client/apps/game/src/ui/layouts/game-entry-timeline.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   GAME_ENTRY_TIMELINE_EVENT_NAME,
+  getGameEntryTimelineSnapshot,
   markGameEntryMilestone,
   recordGameEntryDuration,
   startGameEntryTimeline,
@@ -70,5 +71,30 @@ describe("game-entry-timeline", () => {
       .__eternumGameEntryDurations;
 
     expect(durations).toEqual({ "initial-sync": 1234 });
+  });
+
+  it("exposes a snapshot of milestones, durations, and elapsed time for diagnostics", () => {
+    startGameEntryTimeline();
+    markGameEntryMilestone("bootstrap-started");
+    recordGameEntryDuration("initial-sync", 4242);
+
+    const snapshot = getGameEntryTimelineSnapshot();
+
+    expect(snapshot.milestones.map((entry) => entry.name)).toEqual([
+      "modal-opened",
+      "entry-requested",
+      "bootstrap-started",
+    ]);
+    expect(snapshot.durations).toEqual({ "initial-sync": 4242 });
+    expect(snapshot.elapsedMs).not.toBeNull();
+    expect(snapshot.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns an empty snapshot when no timeline has started", () => {
+    const snapshot = getGameEntryTimelineSnapshot();
+
+    expect(snapshot.milestones).toEqual([]);
+    expect(snapshot.durations).toEqual({});
+    expect(snapshot.elapsedMs).toBeNull();
   });
 });

--- a/client/apps/game/src/ui/layouts/game-entry-timeline.ts
+++ b/client/apps/game/src/ui/layouts/game-entry-timeline.ts
@@ -19,6 +19,8 @@ type GameEntryMilestone =
   | "setup-completed"
   | "initial-sync-started"
   | "initial-sync-completed"
+  | "renderer-init-started"
+  | "renderer-init-completed"
   | "bootstrap-completed"
   | "session-policies-refresh-started"
   | "session-policies-refresh-completed"
@@ -78,7 +80,17 @@ export const markGameEntryMilestone = (name: GameEntryMilestone): void => {
   }
 
   const timestamp = performance.now();
-  const startMs = gameEntryWindow.__eternumGameEntryStartMs ?? timestamp;
+  // Lazy-initialize the start clock when the timeline wasn't explicitly
+  // started — happens on hard-reload directly into a `/play` route, which
+  // bypasses the landing-page entry path that calls `startGameEntryTimeline()`.
+  // Without this fallback, every milestone was recording `elapsedMs = 0` and
+  // the boot debug panel rendered useless data for the most-instrumented case.
+  if (gameEntryWindow.__eternumGameEntryStartMs === undefined) {
+    gameEntryWindow.__eternumGameEntryStartMs = timestamp;
+    gameEntryWindow.__eternumGameEntryDurations = gameEntryWindow.__eternumGameEntryDurations ?? {};
+    gameEntryWindow.__eternumGameEntryTimeline = gameEntryWindow.__eternumGameEntryTimeline ?? [];
+  }
+  const startMs = gameEntryWindow.__eternumGameEntryStartMs;
   const record = {
     elapsedMs: Math.round(timestamp - startMs),
     name,
@@ -114,4 +126,32 @@ export const recordGameEntryDuration = (name: string, durationMs: number): void 
   const durations = gameEntryWindow.__eternumGameEntryDurations ?? {};
   durations[name] = Math.round(durationMs);
   gameEntryWindow.__eternumGameEntryDurations = durations;
+};
+
+export type GameEntryTimelineSnapshot = {
+  /** Milestones recorded so far, ordered by occurrence. */
+  milestones: ReadonlyArray<GameEntryTimelineRecord>;
+  /** Named operation durations recorded via `recordGameEntryDuration` (ms). */
+  durations: Readonly<Record<string, number>>;
+  /** Wallclock ms since `startGameEntryTimeline()` first fired, or null if not started. */
+  elapsedMs: number | null;
+};
+
+/**
+ * Read the current timeline snapshot — used by the boot debug panel and
+ * any diagnostic that wants to see "what's happening right now" without
+ * re-implementing the window-globals plumbing.
+ */
+export const getGameEntryTimelineSnapshot = (): GameEntryTimelineSnapshot => {
+  const gameEntryWindow = getGameEntryWindow();
+  if (!gameEntryWindow) {
+    return { milestones: [], durations: {}, elapsedMs: null };
+  }
+
+  const startMs = gameEntryWindow.__eternumGameEntryStartMs ?? null;
+  return {
+    milestones: gameEntryWindow.__eternumGameEntryTimeline ?? [],
+    durations: gameEntryWindow.__eternumGameEntryDurations ?? {},
+    elapsedMs: startMs === null ? null : Math.round(performance.now() - startMs),
+  };
 };

--- a/client/apps/game/src/ui/layouts/world.connection-monitor.source.test.ts
+++ b/client/apps/game/src/ui/layouts/world.connection-monitor.source.test.ts
@@ -15,4 +15,12 @@ describe("world connection monitor wiring", () => {
     expect(source).toContain("activeWorld?.toriiBaseUrl ?? env.VITE_PUBLIC_TORII");
     expect(source).not.toContain("const toriiBaseUrl = env.VITE_PUBLIC_TORII;");
   });
+
+  it("triggers a guarded full re-bootstrap from onDeadEnd so wedged consumers recover", () => {
+    const source = readSource("src/ui/layouts/world.tsx");
+
+    expect(source).toContain("resetBootstrap");
+    expect(source).toContain("bootstrapGameForEntryContext");
+    expect(source).toContain("deadEndRecoveryFired");
+  });
 });

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -1,6 +1,8 @@
 import { ConnectionHealthMonitor, resolveConnectionHealthToriiBaseUrl } from "@/dojo/connection-health-monitor";
 import { cancelEntityStreamSubscription, initialSync } from "@/dojo/sync";
+import { resolveEntryContextFromPlayRoute } from "@/game-entry/context";
 import { useAccountStore } from "@/hooks/store/use-account-store";
+import { bootstrapGameForEntryContext, resetBootstrap } from "@/init/bootstrap";
 import {
   addNetworkBreadcrumb,
   reportNetworkOutageDeadEnd,
@@ -166,6 +168,32 @@ const ConnectionMonitor = () => {
     const walletAddress = useAccountStore.getState().account?.address ?? null;
     void setNetworkHealthScopeTags({ toriiBaseUrl, walletAddress });
 
+    let deadEndRecoveryFired = false;
+    const runDeadEndRecovery = async () => {
+      const context = resolveEntryContextFromPlayRoute(window.location);
+      if (!context) {
+        console.warn("[ConnectionMonitor] Dead-end fired but no play-route context to recover into");
+        return;
+      }
+
+      try {
+        addNetworkBreadcrumb({ event: "reconnect_start", streamType: "global" });
+        // Tear down the cached setup, then re-run the entry-context bootstrap.
+        // This rebuilds the EternumProvider, ToriiClient, and spatial manager
+        // in one pass — covers consumers that captured the old toriiClient
+        // outside of streamReconnectVersion-keyed effects.
+        resetBootstrap();
+        await bootstrapGameForEntryContext(context);
+        addNetworkBreadcrumb({ event: "reconnect_success", streamType: "global" });
+        toast.success("Game state refreshed", {
+          description: "Reconnected after a prolonged outage.",
+        });
+      } catch (error) {
+        console.warn("[ConnectionMonitor] Dead-end recovery failed", error);
+        addNetworkBreadcrumb({ event: "reconnect_failure", streamType: "global" });
+      }
+    };
+
     const monitor = new ConnectionHealthMonitor({
       onReconnectSpatial: async () => {
         addNetworkBreadcrumb({ event: "reconnect_start", streamType: "spatial" });
@@ -206,6 +234,9 @@ const ConnectionMonitor = () => {
       },
       onDeadEnd: (outageMs, attempts) => {
         reportNetworkOutageDeadEnd({ streamType: "both", outageMs, attempts });
+        if (deadEndRecoveryFired) return;
+        deadEndRecoveryFired = true;
+        void runDeadEndRecovery();
       },
     });
 

--- a/client/apps/game/src/ui/modules/boot-loader/boot-debug-panel.tsx
+++ b/client/apps/game/src/ui/modules/boot-loader/boot-debug-panel.tsx
@@ -118,9 +118,7 @@ export const BootDebugPanel = ({ currentTaskLabel, slowThresholdMs = 1500 }: Boo
             {durationEntries.map(([name, ms]) => (
               <div key={name} className="contents">
                 <span className="truncate text-gold/65">{name}</span>
-                <span
-                  className={`tabular-nums ${ms > slowThresholdMs ? "text-red-300" : "text-gold/80"}`}
-                >
+                <span className={`tabular-nums ${ms > slowThresholdMs ? "text-red-300" : "text-gold/80"}`}>
                   {formatMs(ms)}
                 </span>
               </div>
@@ -136,9 +134,7 @@ export const BootDebugPanel = ({ currentTaskLabel, slowThresholdMs = 1500 }: Boo
             {steps.map((step) => (
               <div key={step.name} className="contents">
                 <span className="truncate text-gold/65">{step.name}</span>
-                <span
-                  className={`tabular-nums ${step.deltaMs > slowThresholdMs ? "text-red-300" : "text-gold/55"}`}
-                >
+                <span className={`tabular-nums ${step.deltaMs > slowThresholdMs ? "text-red-300" : "text-gold/55"}`}>
                   +{formatMs(step.deltaMs)}
                 </span>
                 <span className="tabular-nums text-gold/35">{formatMs(step.elapsedMs)}</span>

--- a/client/apps/game/src/ui/modules/boot-loader/boot-debug-panel.tsx
+++ b/client/apps/game/src/ui/modules/boot-loader/boot-debug-panel.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+
+import {
+  GAME_ENTRY_TIMELINE_EVENT_NAME,
+  getGameEntryTimelineSnapshot,
+  type GameEntryTimelineSnapshot,
+} from "@/ui/layouts/game-entry-timeline";
+
+const TICK_INTERVAL_MS = 250;
+
+/**
+ * Subscribes to the game-entry timeline (milestone events + recorded durations)
+ * and re-renders on every milestone plus a slow tick so the elapsed counter
+ * stays live even between milestones. The snapshot is read on each tick so
+ * `recordGameEntryDuration` writes (made by network helpers) surface here too
+ * without their own event channel.
+ */
+const useBootTimelineSnapshot = (): GameEntryTimelineSnapshot => {
+  const [snapshot, setSnapshot] = useState<GameEntryTimelineSnapshot>(() => getGameEntryTimelineSnapshot());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const refresh = () => setSnapshot(getGameEntryTimelineSnapshot());
+
+    refresh();
+    const handleMilestone = () => refresh();
+    window.addEventListener(GAME_ENTRY_TIMELINE_EVENT_NAME, handleMilestone as EventListener);
+    const intervalId = window.setInterval(refresh, TICK_INTERVAL_MS);
+
+    return () => {
+      window.removeEventListener(GAME_ENTRY_TIMELINE_EVENT_NAME, handleMilestone as EventListener);
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  return snapshot;
+};
+
+const formatMs = (ms: number): string => {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(ms < 10_000 ? 2 : 1)}s`;
+};
+
+const computeStepDurations = (
+  milestones: GameEntryTimelineSnapshot["milestones"],
+): ReadonlyArray<{ name: string; elapsedMs: number; deltaMs: number }> => {
+  const result: { name: string; elapsedMs: number; deltaMs: number }[] = [];
+  let previousElapsed = 0;
+  for (const milestone of milestones) {
+    result.push({
+      name: milestone.name,
+      elapsedMs: milestone.elapsedMs,
+      deltaMs: milestone.elapsedMs - previousElapsed,
+    });
+    previousElapsed = milestone.elapsedMs;
+  }
+  return result;
+};
+
+interface BootDebugPanelProps {
+  currentTaskLabel?: string | null;
+  /** Slow-step heuristic: any step longer than this is highlighted as the likely bottleneck. */
+  slowThresholdMs?: number;
+}
+
+export const BootDebugPanel = ({ currentTaskLabel, slowThresholdMs = 1500 }: BootDebugPanelProps) => {
+  const snapshot = useBootTimelineSnapshot();
+  const steps = computeStepDurations(snapshot.milestones);
+  const lastMilestone = steps.length > 0 ? steps[steps.length - 1] : null;
+  const slowestStep = steps.reduce<(typeof steps)[number] | null>(
+    (acc, step) => (acc === null || step.deltaMs > acc.deltaMs ? step : acc),
+    null,
+  );
+  const sinceLastMilestoneMs =
+    snapshot.elapsedMs !== null && lastMilestone !== null ? snapshot.elapsedMs - lastMilestone.elapsedMs : null;
+  const durationEntries = Object.entries(snapshot.durations).sort(([, a], [, b]) => b - a);
+
+  return (
+    <div className="mx-auto mt-2 w-full max-w-[28rem] rounded-md border border-gold/15 bg-black/40 px-3 py-2 text-left font-mono text-[0.65rem] leading-snug text-gold/70">
+      <div className="flex items-center justify-between gap-3 text-[0.7rem]">
+        <span className="uppercase tracking-[0.2em] text-gold/50">debug</span>
+        <span className="tabular-nums text-gold/85">
+          {snapshot.elapsedMs === null ? "—" : `${formatMs(snapshot.elapsedMs)} elapsed`}
+        </span>
+      </div>
+
+      <div className="mt-1 grid grid-cols-[7rem_1fr] gap-x-3 gap-y-0.5">
+        <span className="text-gold/40">phase</span>
+        <span className="truncate text-gold/85">{currentTaskLabel ?? "—"}</span>
+
+        <span className="text-gold/40">last milestone</span>
+        <span className="truncate text-gold/85">
+          {lastMilestone === null
+            ? "—"
+            : `${lastMilestone.name} (+${formatMs(lastMilestone.deltaMs)}, ${formatMs(lastMilestone.elapsedMs)} total)`}
+        </span>
+
+        <span className="text-gold/40">since last</span>
+        <span
+          className={
+            sinceLastMilestoneMs !== null && sinceLastMilestoneMs > slowThresholdMs ? "text-red-300" : "text-gold/85"
+          }
+        >
+          {sinceLastMilestoneMs === null ? "—" : `${formatMs(sinceLastMilestoneMs)} idle`}
+        </span>
+
+        <span className="text-gold/40">slowest step</span>
+        <span className="truncate text-gold/85">
+          {slowestStep === null ? "—" : `${slowestStep.name} (+${formatMs(slowestStep.deltaMs)})`}
+        </span>
+      </div>
+
+      {durationEntries.length > 0 ? (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-gold/45">recorded durations ({durationEntries.length})</summary>
+          <div className="mt-1 grid grid-cols-[1fr_auto] gap-x-3 gap-y-0.5">
+            {durationEntries.map(([name, ms]) => (
+              <div key={name} className="contents">
+                <span className="truncate text-gold/65">{name}</span>
+                <span
+                  className={`tabular-nums ${ms > slowThresholdMs ? "text-red-300" : "text-gold/80"}`}
+                >
+                  {formatMs(ms)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </details>
+      ) : null}
+
+      {steps.length > 0 ? (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-gold/45">milestones ({steps.length})</summary>
+          <div className="mt-1 grid grid-cols-[1fr_auto_auto] gap-x-3 gap-y-0.5">
+            {steps.map((step) => (
+              <div key={step.name} className="contents">
+                <span className="truncate text-gold/65">{step.name}</span>
+                <span
+                  className={`tabular-nums ${step.deltaMs > slowThresholdMs ? "text-red-300" : "text-gold/55"}`}
+                >
+                  +{formatMs(step.deltaMs)}
+                </span>
+                <span className="tabular-nums text-gold/35">{formatMs(step.elapsedMs)}</span>
+              </div>
+            ))}
+          </div>
+        </details>
+      ) : null}
+    </div>
+  );
+};

--- a/client/apps/game/src/ui/modules/boot-loader/index.ts
+++ b/client/apps/game/src/ui/modules/boot-loader/index.ts
@@ -1,3 +1,4 @@
+export { BootDebugPanel } from "./boot-debug-panel";
 export { BootLoaderCrashFallback } from "./boot-loader-fallback";
 export { BootLoaderShell } from "./boot-loader-shell";
 export { markBootMilestone, setBootDocumentState, useBootDocumentState } from "./boot-loader-state";

--- a/client/apps/game/src/ui/modules/loading-screen.tsx
+++ b/client/apps/game/src/ui/modules/loading-screen.tsx
@@ -1,15 +1,25 @@
-import { BootLoaderShell } from "@/ui/modules/boot-loader";
+import { BootDebugPanel, BootLoaderShell } from "@/ui/modules/boot-loader";
 
 interface LoadingScreenProps {
   progress?: number;
   title?: string;
   subtitle?: string;
+  /**
+   * Human-readable label for the active boot phase (e.g. "Connecting to world").
+   * Surfaced inside the debug panel so a stalled cold-reload can be diagnosed
+   * (slow RPC vs slow initial sync vs slow renderer) without opening DevTools.
+   */
+  currentTaskLabel?: string | null;
+  /** Hide the debug panel — useful for non-boot loading screens that don't have timeline data. */
+  hideDebugPanel?: boolean;
 }
 
 export const LoadingScreen = ({
   progress,
   title = "Forging the Realm",
   subtitle = "Summoning terrain, armies, and ancient trade routes.",
+  currentTaskLabel,
+  hideDebugPanel = false,
 }: LoadingScreenProps) => {
   return (
     <BootLoaderShell
@@ -18,6 +28,7 @@ export const LoadingScreen = ({
       title={title}
       subtitle={subtitle}
       caption="Initializing"
+      detail={hideDebugPanel ? undefined : <BootDebugPanel currentTaskLabel={currentTaskLabel} />}
     />
   );
 };


### PR DESCRIPTION
## Summary

Stops slot disconnects from getting stuck on the "Reconnect to Continue" modal, and instruments the boot loader so slow cold-reloads point at the exact bottleneck instead of looking like one opaque ~60s "renderer-init" hang.

**Slot recovery:** `dojo-config.ts` now probes each saved slot profile's RPC at module-load and evicts dead Cartridge deployments before `StarknetProvider` builds the `ControllerConnector`; the env RPC fallback is restored for slot worlds without explicit factory deployment rows (reverting the env-exclusion in `9b295e0b08`); `ConnectionHealthMonitor` bumps `streamReconnectVersion` in both success and failure paths so player-scoped subs retry independently when global reconnect rejects; and `onDeadEnd` now triggers a guarded full re-bootstrap that rebuilds the entire `setup` (provider, ToriiClient, spatial manager) for wedged WASM transports.

**Boot timings:** new `BootDebugPanel` renders inside the `LoadingScreen` detail slot with current phase, elapsed time, last milestone + idle gap, slowest step, and a list of recorded sub-step durations. The timeline auto-starts on first milestone (hard-reloads directly into `/play` get real timestamps), and `initialSync` + renderer init are now broken down per sub-step (`global-stream-subscribe`, `initial-entity-flush`, `prepare-scenes`, `backend-await`, etc.) so a slow boot identifies the exact culprit phase.

## Test plan

- [x] `pnpm vitest run src/runtime/world src/init/bootstrap src/dojo src/ui/layouts/game-entry-timeline src/ui/modules/loading-oroborus src/ui/layouts/world.connection-monitor src/three/game-renderer src/three/renderer-startup-runtime` — 69 passing
- [x] `pnpm typecheck` — clean
- [ ] Manual: hard-reload on a Cartridge-GC'd slot world, confirm the boot debug panel appears with real timings and the user no longer parks on "Reconnect to Continue"
- [ ] Manual: trigger network outage > 5 reconnect attempts, confirm `onDeadEnd` fires the auto re-bootstrap rather than wedging