### PR TITLE
Move landing music controls into header

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/landing-header.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-header.tsx
@@ -7,7 +7,7 @@ import { getSectionFromPath, getActiveSubItem, getSubItemHref } from "../context
 import { resolveLandingSurfacePath, type LandingEntryRouteState } from "../lib/landing-entry-state";
 
 interface LandingHeaderProps {
-  walletButton?: React.ReactNode;
+  headerControls?: React.ReactNode;
   onSettingsClick?: () => void;
   className?: string;
 }
@@ -128,7 +128,7 @@ const MobileMenuDrawer = ({
 /**
  * Top navigation header with dynamic submenu based on active sidebar section.
  */
-export const LandingHeader = ({ walletButton, onSettingsClick, className }: LandingHeaderProps) => {
+export const LandingHeader = ({ headerControls, onSettingsClick, className }: LandingHeaderProps) => {
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const searchParams = new URLSearchParams(location.search);
@@ -204,9 +204,9 @@ export const LandingHeader = ({ walletButton, onSettingsClick, className }: Land
         {/* Spacer for centering on desktop */}
         <div className="hidden flex-1 lg:block" />
 
-        {/* Right side: Wallet + Hamburger (mobile) */}
+        {/* Right side: Header controls + Hamburger (mobile) */}
         <div className="flex items-center gap-2">
-          {walletButton}
+          {headerControls}
 
           {/* Hamburger menu button - mobile only */}
           <button

--- a/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
@@ -20,7 +20,7 @@ const resolvePlayerContainerClasses = (presentation: LandingMusicPlayerPresentat
 
 const resolvePlayerShellClasses = (presentation: LandingMusicPlayerPresentation) => {
   if (presentation === "header") {
-    return "w-[172px] rounded-full border border-gold/15 bg-black/45 shadow-[0_10px_30px_rgba(0,0,0,0.3)] xl:w-[192px]";
+    return "w-[124px] rounded-full border border-gold/15 bg-black/45 shadow-[0_10px_30px_rgba(0,0,0,0.3)] xl:w-[132px]";
   }
 
   return "w-full max-w-md rounded-full border border-gold/20 bg-black/70 shadow-[0_18px_70px_rgba(0,0,0,0.55)]";
@@ -110,22 +110,22 @@ export const LandingMusicPlayer = ({ className, presentation = "floating" }: Lan
             ) : null}
           </div>
 
-          <div className={cn("flex items-center gap-2", isHeaderPresentation ? "w-12" : "min-w-[132px]")}>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              value={Math.round(musicVolume * 100)}
-              onChange={(event) => setCategoryVolume(AudioCategory.MUSIC, Number(event.target.value) / 100)}
-              className={cn("flex-1 cursor-pointer accent-[#dfaa54]", isHeaderPresentation ? "h-1" : "h-1.5")}
-              aria-label="Music volume"
-            />
-            {!isHeaderPresentation ? (
+          {!isHeaderPresentation ? (
+            <div className="flex min-w-[132px] items-center gap-2">
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={Math.round(musicVolume * 100)}
+                onChange={(event) => setCategoryVolume(AudioCategory.MUSIC, Number(event.target.value) / 100)}
+                className="h-1.5 flex-1 cursor-pointer accent-[#dfaa54]"
+                aria-label="Music volume"
+              />
               <span className="w-10 text-right text-[11px] font-semibold uppercase tracking-[0.12em] text-gold/50">
                 {Math.round(musicVolume * 100)}%
               </span>
-            ) : null}
-          </div>
+            </div>
+          ) : null}
         </div>
       </section>
     </div>

--- a/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
@@ -42,10 +42,7 @@ const resolveControlButtonClasses = (presentation: LandingMusicPlayerPresentatio
   return "rounded-full border border-gold/15 bg-black/35 p-2 text-gold/65 transition-colors hover:border-gold/35 hover:text-gold";
 };
 
-export const LandingMusicPlayer = ({
-  className,
-  presentation = "floating",
-}: LandingMusicPlayerProps) => {
+export const LandingMusicPlayer = ({ className, presentation = "floating" }: LandingMusicPlayerProps) => {
   const { audioState, setCategoryVolume, setMuted } = useAudio();
   const { currentTrackId, trackName, next, requiresInteraction, requestStart } = useMusicPlayer();
 
@@ -71,12 +68,7 @@ export const LandingMusicPlayer = ({
 
   return (
     <div className={cn(resolvePlayerContainerClasses(presentation), className)}>
-      <section
-        className={cn(
-          "pointer-events-auto backdrop-blur-xl",
-          resolvePlayerShellClasses(presentation),
-        )}
-      >
+      <section className={cn("pointer-events-auto backdrop-blur-xl", resolvePlayerShellClasses(presentation))}>
         <div className={cn("flex items-center", resolvePlayerRowClasses(presentation))}>
           <div className="flex items-center gap-2 text-gold/55">
             <Music2 className={cn(isHeaderPresentation ? "h-3.5 w-3.5" : "h-4 w-4")} />

--- a/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
@@ -20,7 +20,7 @@ const resolvePlayerContainerClasses = (presentation: LandingMusicPlayerPresentat
 
 const resolvePlayerShellClasses = (presentation: LandingMusicPlayerPresentation) => {
   if (presentation === "header") {
-    return "w-[240px] rounded-full border border-gold/15 bg-black/45 shadow-[0_10px_30px_rgba(0,0,0,0.3)]";
+    return "w-[172px] rounded-full border border-gold/15 bg-black/45 shadow-[0_10px_30px_rgba(0,0,0,0.3)] xl:w-[192px]";
   }
 
   return "w-full max-w-md rounded-full border border-gold/20 bg-black/70 shadow-[0_18px_70px_rgba(0,0,0,0.55)]";
@@ -28,7 +28,7 @@ const resolvePlayerShellClasses = (presentation: LandingMusicPlayerPresentation)
 
 const resolvePlayerRowClasses = (presentation: LandingMusicPlayerPresentation) => {
   if (presentation === "header") {
-    return "gap-2 px-3 py-2";
+    return "gap-1.5 px-2.5 py-1.5";
   }
 
   return "gap-3 px-4 py-3";
@@ -95,22 +95,29 @@ export const LandingMusicPlayer = ({ className, presentation = "floating" }: Lan
           </div>
 
           <div className="min-w-0 flex-1">
-            <p className={cn("truncate font-cinzel text-gold", isHeaderPresentation ? "text-xs" : "text-sm")}>
-              {currentTrackLabel}
+            <p
+              className={cn(
+                "truncate font-cinzel text-gold",
+                isHeaderPresentation ? "text-[10px] uppercase tracking-[0.14em] text-gold/70" : "text-sm",
+              )}
+            >
+              {isHeaderPresentation ? "Music" : currentTrackLabel}
             </p>
-            <p className={cn(isHeaderPresentation ? "text-[10px]" : "text-[11px]", "text-gold/45")}>
-              {requiresInteraction ? "Start music with a control" : "Music"}
-            </p>
+            {!isHeaderPresentation ? (
+              <p className="text-[11px] text-gold/45">
+                {requiresInteraction ? "Start music with a control" : "Music"}
+              </p>
+            ) : null}
           </div>
 
-          <div className={cn("flex items-center gap-2", isHeaderPresentation ? "w-20" : "min-w-[132px]")}>
+          <div className={cn("flex items-center gap-2", isHeaderPresentation ? "w-12" : "min-w-[132px]")}>
             <input
               type="range"
               min={0}
               max={100}
               value={Math.round(musicVolume * 100)}
               onChange={(event) => setCategoryVolume(AudioCategory.MUSIC, Number(event.target.value) / 100)}
-              className="h-1.5 flex-1 cursor-pointer accent-[#dfaa54]"
+              className={cn("flex-1 cursor-pointer accent-[#dfaa54]", isHeaderPresentation ? "h-1" : "h-1.5")}
               aria-label="Music volume"
             />
             {!isHeaderPresentation ? (

--- a/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
@@ -3,13 +3,56 @@ import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { Music2, SkipForward, Volume2, VolumeX } from "lucide-react";
 import { useCallback } from "react";
 
-export const LandingMusicPlayer = () => {
+type LandingMusicPlayerPresentation = "floating" | "header";
+
+interface LandingMusicPlayerProps {
+  className?: string;
+  presentation?: LandingMusicPlayerPresentation;
+}
+
+const resolvePlayerContainerClasses = (presentation: LandingMusicPlayerPresentation) => {
+  if (presentation === "header") {
+    return "min-w-0 shrink-0";
+  }
+
+  return "pointer-events-none fixed inset-x-3 bottom-20 z-30 lg:inset-x-auto lg:bottom-6 lg:left-24";
+};
+
+const resolvePlayerShellClasses = (presentation: LandingMusicPlayerPresentation) => {
+  if (presentation === "header") {
+    return "w-[240px] rounded-full border border-gold/15 bg-black/45 shadow-[0_10px_30px_rgba(0,0,0,0.3)]";
+  }
+
+  return "w-full max-w-md rounded-full border border-gold/20 bg-black/70 shadow-[0_18px_70px_rgba(0,0,0,0.55)]";
+};
+
+const resolvePlayerRowClasses = (presentation: LandingMusicPlayerPresentation) => {
+  if (presentation === "header") {
+    return "gap-2 px-3 py-2";
+  }
+
+  return "gap-3 px-4 py-3";
+};
+
+const resolveControlButtonClasses = (presentation: LandingMusicPlayerPresentation) => {
+  if (presentation === "header") {
+    return "rounded-full border border-gold/15 bg-black/30 p-1.5 text-gold/65 transition-colors hover:border-gold/35 hover:text-gold";
+  }
+
+  return "rounded-full border border-gold/15 bg-black/35 p-2 text-gold/65 transition-colors hover:border-gold/35 hover:text-gold";
+};
+
+export const LandingMusicPlayer = ({
+  className,
+  presentation = "floating",
+}: LandingMusicPlayerProps) => {
   const { audioState, setCategoryVolume, setMuted } = useAudio();
   const { currentTrackId, trackName, next, requiresInteraction, requestStart } = useMusicPlayer();
 
   const isMuted = audioState?.muted ?? false;
   const musicVolume = audioState?.categoryVolumes?.[AudioCategory.MUSIC] ?? 0.08;
   const currentTrackLabel = currentTrackId ? trackName : "Awaiting first track";
+  const isHeaderPresentation = presentation === "header";
 
   const handleSkip = useCallback(() => {
     if (requiresInteraction) {
@@ -27,40 +70,48 @@ export const LandingMusicPlayer = () => {
   }, [isMuted, requestStart, requiresInteraction, setMuted]);
 
   return (
-    <div className="pointer-events-none fixed inset-x-3 bottom-20 z-30 lg:inset-x-auto lg:bottom-6 lg:left-24">
+    <div className={cn(resolvePlayerContainerClasses(presentation), className)}>
       <section
         className={cn(
-          "pointer-events-auto w-full max-w-md rounded-full border border-gold/20",
-          "bg-black/70 backdrop-blur-xl shadow-[0_18px_70px_rgba(0,0,0,0.55)]",
+          "pointer-events-auto backdrop-blur-xl",
+          resolvePlayerShellClasses(presentation),
         )}
       >
-        <div className="flex items-center gap-3 px-4 py-3">
+        <div className={cn("flex items-center", resolvePlayerRowClasses(presentation))}>
           <div className="flex items-center gap-2 text-gold/55">
-            <Music2 className="h-4 w-4" />
+            <Music2 className={cn(isHeaderPresentation ? "h-3.5 w-3.5" : "h-4 w-4")} />
             <button
               type="button"
               onClick={handleToggleMute}
-              className="rounded-full border border-gold/15 bg-black/35 p-2 text-gold/65 transition-colors hover:border-gold/35 hover:text-gold"
+              className={resolveControlButtonClasses(presentation)}
               aria-label={isMuted ? "Unmute music" : "Mute music"}
             >
-              {isMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
+              {isMuted ? (
+                <VolumeX className={cn(isHeaderPresentation ? "h-3 w-3" : "h-4 w-4")} />
+              ) : (
+                <Volume2 className={cn(isHeaderPresentation ? "h-3 w-3" : "h-4 w-4")} />
+              )}
             </button>
             <button
               type="button"
               onClick={handleSkip}
-              className="rounded-full border border-gold/15 bg-black/35 p-2 text-gold/65 transition-colors hover:border-gold/35 hover:text-gold"
+              className={resolveControlButtonClasses(presentation)}
               aria-label="Skip track"
             >
-              <SkipForward className="h-4 w-4" />
+              <SkipForward className={cn(isHeaderPresentation ? "h-3 w-3" : "h-4 w-4")} />
             </button>
           </div>
 
           <div className="min-w-0 flex-1">
-            <p className="truncate font-cinzel text-sm text-gold">{currentTrackLabel}</p>
-            <p className="text-[11px] text-gold/45">{requiresInteraction ? "Start music with a control" : "Music"}</p>
+            <p className={cn("truncate font-cinzel text-gold", isHeaderPresentation ? "text-xs" : "text-sm")}>
+              {currentTrackLabel}
+            </p>
+            <p className={cn(isHeaderPresentation ? "text-[10px]" : "text-[11px]", "text-gold/45")}>
+              {requiresInteraction ? "Start music with a control" : "Music"}
+            </p>
           </div>
 
-          <div className="flex min-w-[132px] items-center gap-2">
+          <div className={cn("flex items-center gap-2", isHeaderPresentation ? "w-20" : "min-w-[132px]")}>
             <input
               type="range"
               min={0}
@@ -70,9 +121,11 @@ export const LandingMusicPlayer = () => {
               className="h-1.5 flex-1 cursor-pointer accent-[#dfaa54]"
               aria-label="Music volume"
             />
-            <span className="w-10 text-right text-[11px] font-semibold uppercase tracking-[0.12em] text-gold/50">
-              {Math.round(musicVolume * 100)}%
-            </span>
+            {!isHeaderPresentation ? (
+              <span className="w-10 text-right text-[11px] font-semibold uppercase tracking-[0.12em] text-gold/50">
+                {Math.round(musicVolume * 100)}%
+              </span>
+            ) : null}
           </div>
         </div>
       </section>

--- a/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-music-player.tsx
@@ -104,9 +104,7 @@ export const LandingMusicPlayer = ({ className, presentation = "floating" }: Lan
               {isHeaderPresentation ? "Music" : currentTrackLabel}
             </p>
             {!isHeaderPresentation ? (
-              <p className="text-[11px] text-gold/45">
-                {requiresInteraction ? "Start music with a control" : "Music"}
-              </p>
+              <p className="text-[11px] text-gold/45">{requiresInteraction ? "Start music with a control" : "Music"}</p>
             ) : null}
           </div>
 

--- a/client/apps/game/src/ui/features/landing/landing-layout.tsx
+++ b/client/apps/game/src/ui/features/landing/landing-layout.tsx
@@ -87,10 +87,11 @@ const LandingLayoutContent = () => {
       {/* Left sidebar (desktop only) */}
       <LandingSidebar onSettingsClick={handleSettingsClick} />
 
-      {/* Top header with wallet */}
+      {/* Top header with landing controls */}
       <LandingHeader
-        walletButton={
+        headerControls={
           <>
+            <LandingMusicPlayer className="hidden lg:flex" presentation="header" />
             <DashboardNetworkSwitch className="hidden md:flex" />
             <Controller />
           </>
@@ -118,7 +119,6 @@ const LandingLayoutContent = () => {
       </main>
 
       {/* Bottom navigation (mobile only) */}
-      <LandingMusicPlayer />
       <MobileBottomNav />
 
       {/* Settings modal */}

--- a/client/apps/game/src/ui/features/landing/landing-music-player.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/landing-music-player.source.test.ts
@@ -8,19 +8,21 @@ import { describe, expect, it } from "vitest";
 const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
 
 describe("Landing music player wiring", () => {
-  it("mounts the compact music player inside the landing layout shell", () => {
+  it("mounts the compact music player in the landing header controls", () => {
     const layoutSource = readSource("src/ui/features/landing/landing-layout.tsx");
 
     expect(layoutSource).toContain('import { LandingMusicPlayer } from "./components/landing-music-player"');
-    expect(layoutSource).toContain("<LandingMusicPlayer />");
+    expect(layoutSource).toContain('<LandingMusicPlayer className="hidden lg:flex" presentation="header" />');
   });
 
-  it("keeps the landing player minimal while preserving playback controls", () => {
+  it("supports a smaller header presentation while preserving playback controls", () => {
     const playerSource = readSource("src/ui/features/landing/components/landing-music-player.tsx");
 
     expect(playerSource).toContain("requestStart");
     expect(playerSource).toContain("handleToggleMute");
     expect(playerSource).toContain("handleSkip");
+    expect(playerSource).toContain('presentation = "floating"');
+    expect(playerSource).toContain('presentation === "header"');
     expect(playerSource).toContain('aria-label="Music volume"');
     expect(playerSource).toContain("currentTrackLabel");
   });

--- a/client/apps/game/src/ui/features/landing/landing-network-switch.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/landing-network-switch.source.test.ts
@@ -13,7 +13,8 @@ describe("Landing network switch wiring", () => {
 
     expect(layoutSource).toContain('import { DashboardNetworkSwitch } from "./components/dashboard-network-switch"');
     expect(layoutSource).toContain("<LandingHeader");
-    expect(layoutSource).toContain("walletButton={");
+    expect(layoutSource).toContain("headerControls={");
+    expect(layoutSource).toContain('<LandingMusicPlayer className="hidden lg:flex" presentation="header" />');
     expect(layoutSource).toContain('<DashboardNetworkSwitch className="hidden md:flex" />');
     expect(layoutSource).toContain("<Controller />");
   });

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-24",
+    title: "Header Music Controls",
+    description:
+      "Moved the landing music controls into the top header beside the network and wallet actions, so the home dashboard stays clear while playback controls remain close at hand.",
+    type: "improvement",
+    gameSlug: "landing",
+  },
+  {
     date: "2026-04-23",
     title: "Bounded Renderer Startup",
     description:

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-24",
+    title: "Header Music Buttons",
+    description:
+      "Removed the landing header music slider so the compact audio pill keeps playback controls handy without stretching across the navigation bar.",
+    type: "improvement",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-24",
     title: "Slimmer Header Music",
     description:
       "Tightened the landing header music controls into a smaller pill, so audio stays accessible without crowding the home dashboard navigation.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-24",
+    title: "Slimmer Header Music",
+    description:
+      "Tightened the landing header music controls into a smaller pill, so audio stays accessible without crowding the home dashboard navigation.",
+    type: "improvement",
+    gameSlug: "landing",
+  },
+  {
+    date: "2026-04-24",
     title: "Header Music Controls",
     description:
       "Moved the landing music controls into the top header beside the network and wallet actions, so the home dashboard stays clear while playback controls remain close at hand.",


### PR DESCRIPTION
## Summary
- move the landing music controls out of the floating home dashboard bar and into the top header beside the network and wallet controls
- add a compact header presentation for the music player and update the landing wiring and source tests to match
- record the dashboard UX improvement in the latest features feed

## Verification
- `pnpm --dir client/apps/game test -- --run src/ui/features/landing/landing-network-switch.source.test.ts src/ui/features/landing/landing-music-player.source.test.ts` failed because `client/apps/game` is missing `node_modules`, so `vitest` was unavailable
- `pnpm run format` failed because local dependencies are missing, so `prettier` was unavailable
- `pnpm run knip` failed because local dependencies are missing, including `@eslint/js` from `client/apps/eternum-mobile`