### PR TITLE
feat: add realm build counts to construction

### DIFF
--- a/client/apps/game/src/index.css
+++ b/client/apps/game/src/index.css
@@ -3,6 +3,21 @@
 @tailwind components;
 @tailwind utilities;
 
+@keyframes transfer-token {
+  0% {
+    left: 0%;
+  }
+
+  100% {
+    left: 100%;
+  }
+}
+
+.animate-transfer-token {
+  left: 0%;
+  animation: transfer-token 2.8s linear infinite;
+}
+
 .boot-loader-surface {
   font-family:
     "Space Grotesk",

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
@@ -1,0 +1,241 @@
+import { BUILDINGS_CENTER, BuildingType, getNeighborHexes, ResourcesIds } from "@bibliothecadao/types";
+import { TileManager } from "@bibliothecadao/eternum";
+import { toast } from "sonner";
+
+type RealmPosition = {
+  x: bigint | number;
+  y: bigint | number;
+};
+
+type BuildWorldContext = {
+  account: any;
+  components: any;
+  systemCalls: any;
+};
+
+type RealmBuildTarget = {
+  type: BuildingType;
+  resource?: ResourcesIds;
+};
+
+type BuildSelection = {
+  outerCol: number;
+  outerRow: number;
+  innerCol: number;
+  innerRow: number;
+};
+
+type RealmBuildActionOptions = {
+  entityId: number;
+  realmPosition?: RealmPosition | null;
+  target: RealmBuildTarget;
+  useSimpleCost: boolean;
+  world: BuildWorldContext;
+  occupiedSpots?: ReadonlySet<string>;
+  vacatedSpots?: ReadonlySet<string>;
+  onReserveSpot?: (spotKey: string) => void;
+  onReleaseSpot?: (spotKey: string) => void;
+  onBuildSuccess?: (selection: BuildSelection) => void;
+};
+
+type RealmAvailableTileOptions = {
+  entityId: number;
+  realmPosition?: RealmPosition | null;
+  world: Omit<BuildWorldContext, "account">;
+  occupiedSpots?: ReadonlySet<string>;
+  vacatedSpots?: ReadonlySet<string>;
+};
+
+const buildablePositionsCache = new Map<number, Array<{ col: number; row: number }>>();
+const OCCUPIED_SPACE_REASON = "space is occupied";
+
+const extractErrorMessage = (error: unknown): string => {
+  if (typeof error === "string") return error;
+  if (error instanceof Error) return error.message;
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+const isOccupiedSpaceError = (error: unknown): boolean =>
+  extractErrorMessage(error).toLowerCase().includes(OCCUPIED_SPACE_REASON);
+
+const generateBuildablePositions = (radius: number) => {
+  const cached = buildablePositionsCache.get(radius);
+  if (cached) return cached;
+
+  const positions: Array<{ col: number; row: number }> = [];
+  const seen = new Set<string>();
+
+  const addPosition = (col: number, row: number) => {
+    const key = `${col},${row}`;
+    if (seen.has(key)) return;
+    positions.push({ col, row });
+    seen.add(key);
+  };
+
+  const start = { col: BUILDINGS_CENTER[0], row: BUILDINGS_CENTER[1] };
+  addPosition(start.col, start.row);
+
+  let currentLayer = [start];
+  for (let i = 0; i < radius; i += 1) {
+    const nextLayer: Array<{ col: number; row: number }> = [];
+    currentLayer.forEach((position) => {
+      getNeighborHexes(position.col, position.row).forEach((neighbor) => {
+        const key = `${neighbor.col},${neighbor.row}`;
+        if (seen.has(key)) return;
+
+        addPosition(neighbor.col, neighbor.row);
+        nextLayer.push(neighbor);
+      });
+    });
+    currentLayer = nextLayer;
+  }
+
+  buildablePositionsCache.set(radius, positions);
+  return positions;
+};
+
+const createTileManager = (
+  entityId: number,
+  realmPosition: RealmPosition,
+  world: Omit<BuildWorldContext, "account">,
+) => {
+  const outerCol = Number(realmPosition.x);
+  const outerRow = Number(realmPosition.y);
+  const tileManager = new TileManager(world.components, world.systemCalls, {
+    col: outerCol,
+    row: outerRow,
+  });
+
+  return {
+    outerCol,
+    outerRow,
+    tileManager,
+    buildRadiusResolver: () => Math.max(1, Number(tileManager.getRealmLevel(entityId)) + 1),
+  };
+};
+
+const hasBuildableCandidate = ({
+  entityId,
+  realmPosition,
+  world,
+  occupiedSpots = new Set<string>(),
+  vacatedSpots = new Set<string>(),
+}: RealmAvailableTileOptions) => {
+  if (!realmPosition) return true;
+
+  const { tileManager, buildRadiusResolver } = createTileManager(entityId, realmPosition, world);
+  const buildRadius = buildRadiusResolver();
+  const candidates = generateBuildablePositions(buildRadius);
+  const centerKey = `${BUILDINGS_CENTER[0]},${BUILDINGS_CENTER[1]}`;
+
+  return candidates.some((position) => {
+    const key = `${position.col},${position.row}`;
+    if (key === centerKey) return false;
+    if (occupiedSpots.has(key)) return false;
+    if (vacatedSpots.has(key) && tileManager.isHexOccupied({ col: position.col, row: position.row })) return false;
+    return !tileManager.isHexOccupied({ col: position.col, row: position.row });
+  });
+};
+
+export const resolveRealmHasAvailableBuildingTile = (options: RealmAvailableTileOptions) =>
+  hasBuildableCandidate(options);
+
+export const buildRealmBuilding = async ({
+  entityId,
+  realmPosition,
+  target,
+  useSimpleCost,
+  world,
+  occupiedSpots = new Set<string>(),
+  vacatedSpots = new Set<string>(),
+  onReserveSpot,
+  onReleaseSpot,
+  onBuildSuccess,
+}: RealmBuildActionOptions) => {
+  if (!realmPosition) {
+    toast.error("Select a realm before building.");
+    return false;
+  }
+
+  const { outerCol, outerRow, tileManager, buildRadiusResolver } = createTileManager(entityId, realmPosition, world);
+  const buildRadius = buildRadiusResolver();
+  const candidates = generateBuildablePositions(buildRadius);
+  const centerKey = `${BUILDINGS_CENTER[0]},${BUILDINGS_CENTER[1]}`;
+
+  const availableSpots = candidates.filter((position) => {
+    const key = `${position.col},${position.row}`;
+    if (key === centerKey) return false;
+    if (occupiedSpots.has(key)) return false;
+    if (vacatedSpots.has(key) && tileManager.isHexOccupied({ col: position.col, row: position.row })) return false;
+    return !tileManager.isHexOccupied({ col: position.col, row: position.row });
+  });
+
+  if (availableSpots.length === 0) {
+    toast.error("No empty building tiles available.");
+    return false;
+  }
+
+  let reservedSpotKey: string | null = null;
+  let occupiedTileFailures = 0;
+
+  try {
+    for (const availableSpot of availableSpots) {
+      const spotKey = `${availableSpot.col},${availableSpot.row}`;
+      reservedSpotKey = spotKey;
+      onReserveSpot?.(spotKey);
+
+      try {
+        await tileManager.placeBuilding(
+          world.account,
+          entityId,
+          target.type,
+          { col: availableSpot.col, row: availableSpot.row },
+          useSimpleCost,
+        );
+
+        onBuildSuccess?.({
+          outerCol,
+          outerRow,
+          innerCol: availableSpot.col,
+          innerRow: availableSpot.row,
+        });
+        return true;
+      } catch (error) {
+        onReleaseSpot?.(spotKey);
+        reservedSpotKey = null;
+
+        if (isOccupiedSpaceError(error)) {
+          occupiedTileFailures += 1;
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    if (occupiedTileFailures > 0) {
+      toast.error("All auto-selected tiles became occupied. Please try again.");
+      return false;
+    }
+
+    toast.error("No empty building tiles available.");
+    return false;
+  } catch (error) {
+    console.error("Failed to auto-build", error);
+    if (isOccupiedSpaceError(error)) {
+      toast.error("This tile is occupied. Please try again.");
+    } else {
+      toast.error("Building failed. Please try again.");
+    }
+    return false;
+  } finally {
+    if (reservedSpotKey) {
+      onReleaseSpot?.(reservedSpotKey);
+    }
+  }
+};

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.build-actions.source.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.build-actions.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("RealmBuildingSummary hover build affordance", () => {
+  it("renders resource icons and a hover-only quick build button", () => {
+    const source = readSource("src/ui/features/settlement/construction/realm-building-summary.tsx");
+
+    expect(source).toContain("ResourceIcon");
+    expect(source).toContain("Plus");
+    expect(source).toContain("group-hover:opacity-100");
+    expect(source).toContain("buildActions?.get(item.buildingId)");
+  });
+});

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.test.ts
@@ -6,6 +6,11 @@ import { BuildingType, ResourcesIds } from "@bibliothecadao/types";
 describe("buildRealmBuildingSummary", () => {
   it("keeps construction-menu order and hides zero-count buildings", async () => {
     const { buildRealmBuildingSummary } = await import("./realm-building-summary");
+    const buildingCounts: Partial<Record<BuildingType, number>> = {
+      [BuildingType.ResourceWood]: 2,
+      [BuildingType.WorkersHut]: 1,
+      [BuildingType.ResourceKnightT1]: 3,
+    };
 
     const items = buildRealmBuildingSummary({
       realmResourceIds: [ResourcesIds.Wheat, ResourcesIds.Wood, ResourcesIds.Fish],
@@ -18,12 +23,7 @@ describe("buildRealmBuildingSummary", () => {
         BuildingType.ResourceKnightT1,
         BuildingType.ResourceKnightT2,
       ],
-      getBuildingCount: (buildingType) =>
-        ({
-          [BuildingType.ResourceWood]: 2,
-          [BuildingType.WorkersHut]: 1,
-          [BuildingType.ResourceKnightT1]: 3,
-        })[buildingType] ?? 0,
+      getBuildingCount: (buildingType) => buildingCounts[buildingType] ?? 0,
     });
 
     expect(items).toEqual([

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.test.ts
@@ -27,9 +27,9 @@ describe("buildRealmBuildingSummary", () => {
     });
 
     expect(items).toEqual([
-      { buildingId: BuildingType.ResourceWood, label: "Wood", count: 2 },
-      { buildingId: BuildingType.WorkersHut, label: "Workers Hut", count: 1 },
-      { buildingId: BuildingType.ResourceKnightT1, label: "Knight T1", count: 3 },
+      { buildingId: BuildingType.ResourceWood, label: "Wood", iconResource: "Wood", count: 2 },
+      { buildingId: BuildingType.WorkersHut, label: "Workers Hut", iconResource: "House", count: 1 },
+      { buildingId: BuildingType.ResourceKnightT1, label: "Knight T1", iconResource: "Knight", count: 3 },
     ]);
   });
 

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { BuildingType, ResourcesIds } from "@bibliothecadao/types";
+
+describe("buildRealmBuildingSummary", () => {
+  it("keeps construction-menu order and hides zero-count buildings", async () => {
+    const { buildRealmBuildingSummary } = await import("./realm-building-summary");
+
+    const items = buildRealmBuildingSummary({
+      realmResourceIds: [ResourcesIds.Wheat, ResourcesIds.Wood, ResourcesIds.Fish],
+      allowedBuildingTypes: [
+        BuildingType.WorkersHut,
+        BuildingType.ResourceWheat,
+        BuildingType.ResourceFish,
+        BuildingType.ResourceWood,
+        BuildingType.ResourceDonkey,
+        BuildingType.ResourceKnightT1,
+        BuildingType.ResourceKnightT2,
+      ],
+      getBuildingCount: (buildingType) =>
+        ({
+          [BuildingType.ResourceWood]: 2,
+          [BuildingType.WorkersHut]: 1,
+          [BuildingType.ResourceKnightT1]: 3,
+        })[buildingType] ?? 0,
+    });
+
+    expect(items).toEqual([
+      { buildingId: BuildingType.ResourceWood, label: "Wood", count: 2 },
+      { buildingId: BuildingType.WorkersHut, label: "Workers Hut", count: 1 },
+      { buildingId: BuildingType.ResourceKnightT1, label: "Knight T1", count: 3 },
+    ]);
+  });
+
+  it("returns an empty list when nothing is built on the selected realm", async () => {
+    const { buildRealmBuildingSummary } = await import("./realm-building-summary");
+
+    const items = buildRealmBuildingSummary({
+      realmResourceIds: [ResourcesIds.Wheat],
+      allowedBuildingTypes: [BuildingType.WorkersHut, BuildingType.ResourceWheat],
+      getBuildingCount: () => 0,
+    });
+
+    expect(items).toEqual([]);
+  });
+});

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.tsx
@@ -3,9 +3,12 @@ import {
   BuildingType,
   BuildingTypeToString,
   getBuildingFromResource,
+  getProducedResource,
   isEconomyBuilding,
   ResourcesIds,
 } from "@bibliothecadao/types";
+import Plus from "lucide-react/dist/esm/icons/plus";
+import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 
 export const MILITARY_BUILDING_GROUP_ORDER = ["Archery", "Stable", "Barracks"] as const;
 
@@ -14,6 +17,7 @@ type MilitaryBuildingGroup = (typeof MILITARY_BUILDING_GROUP_ORDER)[number];
 type RealmBuildingSummaryItem = {
   buildingId: BuildingType;
   label: string;
+  iconResource: string;
   count: number;
 };
 
@@ -21,6 +25,22 @@ type BuildRealmBuildingSummaryOptions = {
   realmResourceIds: ResourcesIds[];
   allowedBuildingTypes: BuildingType[];
   getBuildingCount: (buildingType: BuildingType) => number;
+};
+
+type RealmBuildingSummaryBuildAction = {
+  onBuild: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  title?: string;
+};
+
+type RealmBuildAvailabilityOptions = {
+  buildingId: BuildingType;
+  hasBalance: boolean;
+  hasEnoughPopulation: boolean;
+  hasCapacity: boolean;
+  hasAvailableBuildingTile: boolean;
+  useSimpleCost: boolean;
 };
 
 const prioritizeEconomicBuilding = (buildingType: BuildingType) => {
@@ -68,6 +88,19 @@ const resolveRealmBuildingSummaryOrder = (realmResourceIds: ResourcesIds[], allo
 
 const toSummaryLabel = (buildingType: BuildingType) => BuildingTypeToString[buildingType] ?? "Building";
 
+const toSummaryIconResource = (buildingType: BuildingType) => {
+  if (buildingType === BuildingType.WorkersHut) return "House";
+  if (buildingType === BuildingType.Storehouse) return "Silo";
+  if (buildingType === BuildingType.ResourceDonkey) return "Donkey";
+
+  const producedResource = getProducedResource(buildingType);
+  if (producedResource !== undefined) {
+    return ResourcesIds[producedResource];
+  }
+
+  return "House";
+};
+
 export const buildRealmBuildingSummary = ({
   realmResourceIds,
   allowedBuildingTypes,
@@ -81,6 +114,7 @@ export const buildRealmBuildingSummary = ({
       items.push({
         buildingId: buildingType,
         label: toSummaryLabel(buildingType),
+        iconResource: toSummaryIconResource(buildingType),
         count,
       });
       return items;
@@ -88,19 +122,73 @@ export const buildRealmBuildingSummary = ({
     [],
   );
 
+export const resolveRealmBuildingSummaryBuildability = ({
+  buildingId,
+  hasBalance,
+  hasEnoughPopulation,
+  hasCapacity,
+  hasAvailableBuildingTile,
+  useSimpleCost,
+}: RealmBuildAvailabilityOptions) => {
+  if (!hasAvailableBuildingTile) {
+    return { canBuild: false, disabledReason: "Realm full" };
+  }
+
+  const militaryInfo = getMilitaryBuildingInfo(buildingId);
+  if (useSimpleCost && (militaryInfo?.tier ?? 0) > 1) {
+    return {
+      canBuild: false,
+      disabledReason: `Switch to Resource mode to build Tier ${militaryInfo?.tier} military buildings.`,
+    };
+  }
+
+  const isLaborLockedResource =
+    useSimpleCost &&
+    (buildingId === BuildingType.ResourceDragonhide ||
+      buildingId === BuildingType.ResourceMithral ||
+      buildingId === BuildingType.ResourceAdamantine);
+  if (isLaborLockedResource) {
+    return { canBuild: false, disabledReason: "Switch to Resource mode to create this building." };
+  }
+
+  if (!hasBalance) {
+    return { canBuild: false, disabledReason: "Need more resources." };
+  }
+
+  if (buildingId === BuildingType.WorkersHut) {
+    return { canBuild: true, disabledReason: undefined };
+  }
+
+  if (!hasCapacity) {
+    return { canBuild: false, disabledReason: "Need more capacity." };
+  }
+
+  if (!hasEnoughPopulation) {
+    return { canBuild: false, disabledReason: "Need more population." };
+  }
+
+  return { canBuild: true, disabledReason: undefined };
+};
+
 export const RealmBuildingSummary = ({
   items,
   className,
   headline = "Built here",
+  variant = "section",
+  buildActions,
 }: {
   items: RealmBuildingSummaryItem[];
   className?: string;
   headline?: string;
+  variant?: "section" | "card";
+  buildActions?: Map<BuildingType, RealmBuildingSummaryBuildAction>;
 }) => {
   const totalBuildings = items.reduce((total, item) => total + item.count, 0);
+  const containerClassName =
+    variant === "card" ? "rounded border border-gold/20 bg-black/50 p-2" : "border-b border-gold/10 px-3 py-2";
 
   return (
-    <section className={clsx("realm-summary-selector border-b border-gold/10 px-3 py-2", className)}>
+    <section className={clsx("realm-summary-selector", containerClassName, className)}>
       <div className="flex items-center justify-between gap-3">
         <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-gold/60">{headline}</p>
         <p className="text-[10px] text-gold/45">{totalBuildings > 0 ? `${totalBuildings} total` : "Empty realm"}</p>
@@ -108,17 +196,42 @@ export const RealmBuildingSummary = ({
 
       {items.length > 0 ? (
         <div className="mt-2 flex flex-wrap gap-1.5">
-          {items.map((item) => (
-            <div
-              key={item.buildingId}
-              className="flex items-center gap-1.5 rounded-full border border-gold/20 bg-brown/30 px-2 py-1 text-[11px] text-gold/90"
-            >
-              <span className="max-w-[8rem] truncate">{item.label}</span>
-              <span className="rounded-full bg-gold/15 px-1.5 py-0.5 text-[10px] font-semibold text-gold">
-                {item.count}
-              </span>
-            </div>
-          ))}
+          {items.map((item) => {
+            const buildAction = buildActions?.get(item.buildingId);
+
+            return (
+              <div
+                key={item.buildingId}
+                className={clsx(
+                  "group relative flex items-center gap-1.5 rounded-full border border-gold/20 bg-brown/30 px-2 py-1 text-[11px] text-gold/90",
+                  buildAction && "pr-8",
+                )}
+              >
+                <span className="max-w-[8rem] truncate">{item.label}</span>
+                <span className="flex items-center gap-1 rounded-full bg-gold/15 px-1.5 py-0.5 text-[10px] font-semibold text-gold">
+                  <ResourceIcon resource={item.iconResource} size="xs" withTooltip={false} />
+                  <span>{item.count}</span>
+                </span>
+                {buildAction && (
+                  <button
+                    type="button"
+                    onClick={buildAction.onBuild}
+                    disabled={buildAction.disabled || buildAction.loading}
+                    title={buildAction.title}
+                    aria-label={`Build ${item.label}`}
+                    className={clsx(
+                      "absolute right-1 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded-full border border-gold/40 bg-black/70 text-gold transition-opacity opacity-0 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus-visible:ring-1 focus-visible:ring-gold",
+                      !(buildAction.disabled || buildAction.loading) && "hover:bg-gold/15",
+                      (buildAction.disabled || buildAction.loading) &&
+                        "cursor-not-allowed opacity-40 group-hover:opacity-40",
+                    )}
+                  >
+                    <Plus className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       ) : (
         <p className="mt-2 text-xs italic text-gold/55">No buildings yet.</p>

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.tsx
@@ -1,0 +1,146 @@
+import clsx from "clsx";
+import {
+  BuildingType,
+  BuildingTypeToString,
+  getBuildingFromResource,
+  isEconomyBuilding,
+  ResourcesIds,
+} from "@bibliothecadao/types";
+
+export const MILITARY_BUILDING_GROUP_ORDER = ["Archery", "Stable", "Barracks"] as const;
+
+type MilitaryBuildingGroup = (typeof MILITARY_BUILDING_GROUP_ORDER)[number];
+
+type RealmBuildingSummaryItem = {
+  buildingId: BuildingType;
+  label: string;
+  count: number;
+};
+
+type BuildRealmBuildingSummaryOptions = {
+  realmResourceIds: ResourcesIds[];
+  allowedBuildingTypes: BuildingType[];
+  getBuildingCount: (buildingType: BuildingType) => number;
+};
+
+const prioritizeEconomicBuilding = (buildingType: BuildingType) => {
+  if (buildingType === BuildingType.ResourceWheat) return -2;
+  if (buildingType === BuildingType.ResourceFish) return -1;
+  return 0;
+};
+
+const dedupeBuildingTypes = (buildingTypes: BuildingType[]) => {
+  const seen = new Set<BuildingType>();
+  return buildingTypes.filter((buildingType) => {
+    if (seen.has(buildingType)) return false;
+    seen.add(buildingType);
+    return true;
+  });
+};
+
+const resolveResourceBuildingTypes = (realmResourceIds: ResourcesIds[]) =>
+  dedupeBuildingTypes(
+    realmResourceIds
+      .map((resourceId) => getBuildingFromResource(resourceId))
+      .filter((buildingType): buildingType is BuildingType => buildingType !== BuildingType.None),
+  );
+
+const resolveEconomicBuildingTypes = (allowedBuildingTypes: BuildingType[]) =>
+  allowedBuildingTypes
+    .filter((buildingType) => isEconomyBuilding(buildingType))
+    .toSorted((left, right) => prioritizeEconomicBuilding(left) - prioritizeEconomicBuilding(right));
+
+const resolveMilitaryBuildingTypes = (allowedBuildingTypes: BuildingType[]) =>
+  MILITARY_BUILDING_GROUP_ORDER.flatMap((group) =>
+    allowedBuildingTypes
+      .filter((buildingType) => getMilitaryBuildingInfo(buildingType)?.type === group)
+      .toSorted(
+        (left, right) => (getMilitaryBuildingInfo(left)?.tier ?? 0) - (getMilitaryBuildingInfo(right)?.tier ?? 0),
+      ),
+  );
+
+const resolveRealmBuildingSummaryOrder = (realmResourceIds: ResourcesIds[], allowedBuildingTypes: BuildingType[]) =>
+  dedupeBuildingTypes([
+    ...resolveResourceBuildingTypes(realmResourceIds),
+    ...resolveEconomicBuildingTypes(allowedBuildingTypes),
+    ...resolveMilitaryBuildingTypes(allowedBuildingTypes),
+  ]);
+
+const toSummaryLabel = (buildingType: BuildingType) => BuildingTypeToString[buildingType] ?? "Building";
+
+export const buildRealmBuildingSummary = ({
+  realmResourceIds,
+  allowedBuildingTypes,
+  getBuildingCount,
+}: BuildRealmBuildingSummaryOptions): RealmBuildingSummaryItem[] =>
+  resolveRealmBuildingSummaryOrder(realmResourceIds, allowedBuildingTypes).reduce<RealmBuildingSummaryItem[]>(
+    (items, buildingType) => {
+      const count = getBuildingCount(buildingType);
+      if (count <= 0) return items;
+
+      items.push({
+        buildingId: buildingType,
+        label: toSummaryLabel(buildingType),
+        count,
+      });
+      return items;
+    },
+    [],
+  );
+
+export const RealmBuildingSummary = ({
+  items,
+  className,
+  headline = "Built here",
+}: {
+  items: RealmBuildingSummaryItem[];
+  className?: string;
+  headline?: string;
+}) => {
+  const totalBuildings = items.reduce((total, item) => total + item.count, 0);
+
+  return (
+    <section className={clsx("realm-summary-selector border-b border-gold/10 px-3 py-2", className)}>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[10px] font-semibold uppercase tracking-[0.24em] text-gold/60">{headline}</p>
+        <p className="text-[10px] text-gold/45">{totalBuildings > 0 ? `${totalBuildings} total` : "Empty realm"}</p>
+      </div>
+
+      {items.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {items.map((item) => (
+            <div
+              key={item.buildingId}
+              className="flex items-center gap-1.5 rounded-full border border-gold/20 bg-brown/30 px-2 py-1 text-[11px] text-gold/90"
+            >
+              <span className="max-w-[8rem] truncate">{item.label}</span>
+              <span className="rounded-full bg-gold/15 px-1.5 py-0.5 text-[10px] font-semibold text-gold">
+                {item.count}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-xs italic text-gold/55">No buildings yet.</p>
+      )}
+    </section>
+  );
+};
+
+export const getMilitaryBuildingInfo = (
+  buildingType: BuildingType,
+): { type: MilitaryBuildingGroup; tier: number } | null => {
+  if (buildingType === BuildingType.ResourceCrossbowmanT1) return { type: "Archery", tier: 1 };
+  if (buildingType === BuildingType.ResourceCrossbowmanT2) return { type: "Archery", tier: 2 };
+  if (buildingType === BuildingType.ResourceCrossbowmanT3) return { type: "Archery", tier: 3 };
+
+  if (buildingType === BuildingType.ResourcePaladinT1) return { type: "Stable", tier: 1 };
+  if (buildingType === BuildingType.ResourcePaladinT2) return { type: "Stable", tier: 2 };
+  if (buildingType === BuildingType.ResourcePaladinT3) return { type: "Stable", tier: 3 };
+
+  if (buildingType === BuildingType.ResourceKnightT1) return { type: "Barracks", tier: 1 };
+  if (buildingType === BuildingType.ResourceKnightT2) return { type: "Barracks", tier: 2 };
+  if (buildingType === BuildingType.ResourceKnightT3) return { type: "Barracks", tier: 3 };
+
+  return null;
+};

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.realm-summary.source.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.realm-summary.source.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("SelectPreviewBuildingMenu realm summary wiring", () => {
+  it("renders a built-here summary strip above the construction tabs", () => {
+    const source = readSource("src/ui/features/settlement/construction/select-preview-building.tsx");
+
+    expect(source).toContain("RealmBuildingSummary");
+    expect(source).toContain("realm-summary-selector");
+    expect(source).toContain("Built here");
+  });
+});

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -20,11 +20,13 @@ import {
   releaseOccupiedBuildSpot,
   reserveOccupiedBuildSpot,
 } from "./build-reservation-store";
+import { buildRealmBuilding, resolveRealmHasAvailableBuildingTile } from "./realm-build-actions";
 import {
   buildRealmBuildingSummary,
   getMilitaryBuildingInfo,
   MILITARY_BUILDING_GROUP_ORDER,
   RealmBuildingSummary,
+  resolveRealmBuildingSummaryBuildability,
 } from "./realm-building-summary";
 
 import {
@@ -44,13 +46,11 @@ import {
 } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import {
-  BUILDINGS_CENTER,
   BiomeType,
   BuildingType,
   BuildingTypeToString,
   findResourceById,
   getBuildingFromResource,
-  getNeighborHexes,
   ID,
   isEconomyBuilding,
   ResourceMiningTypes,
@@ -73,57 +73,6 @@ type ArmyGroup = {
   buildings: string[];
   isRecommended: boolean;
   bonus?: number;
-};
-
-const buildablePositionsCache = new Map<number, Array<{ col: number; row: number }>>();
-const OCCUPIED_SPACE_REASON = "space is occupied";
-
-const extractErrorMessage = (error: unknown): string => {
-  if (typeof error === "string") return error;
-  if (error instanceof Error) return error.message;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-};
-
-const isOccupiedSpaceError = (error: unknown): boolean =>
-  extractErrorMessage(error).toLowerCase().includes(OCCUPIED_SPACE_REASON);
-
-const generateBuildablePositions = (radius: number) => {
-  const cached = buildablePositionsCache.get(radius);
-  if (cached) return cached;
-  const positions: Array<{ col: number; row: number }> = [];
-  const seen = new Set<string>();
-
-  const addPosition = (col: number, row: number) => {
-    const key = `${col},${row}`;
-    if (seen.has(key)) return;
-    positions.push({ col, row });
-    seen.add(key);
-  };
-
-  const start = { col: BUILDINGS_CENTER[0], row: BUILDINGS_CENTER[1] };
-  addPosition(start.col, start.row);
-
-  let currentLayer = [start];
-  for (let i = 0; i < radius; i++) {
-    const nextLayer: Array<{ col: number; row: number }> = [];
-    currentLayer.forEach((pos) => {
-      getNeighborHexes(pos.col, pos.row).forEach((neighbor) => {
-        const key = `${neighbor.col},${neighbor.row}`;
-        if (!seen.has(key)) {
-          addPosition(neighbor.col, neighbor.row);
-          nextLayer.push(neighbor);
-        }
-      });
-    });
-    currentLayer = nextLayer;
-  }
-
-  buildablePositionsCache.set(radius, positions);
-  return positions;
 };
 
 type ResourceProductionStatus = {
@@ -206,26 +155,15 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
     structureBuildings,
   ]);
   const hasAvailableBuildingTile = useMemo(() => {
-    if (!realm?.position) return true;
-
-    const outerCol = Number(realm.position.x);
-    const outerRow = Number(realm.position.y);
-    const tileManager = new TileManager(dojo.setup.components, dojo.setup.systemCalls, {
-      col: outerCol,
-      row: outerRow,
-    });
-    const buildRadius = Math.max(1, Number(tileManager.getRealmLevel(entityId)) + 1);
-    const candidates = generateBuildablePositions(buildRadius);
-    const centerKey = `${BUILDINGS_CENTER[0]},${BUILDINGS_CENTER[1]}`;
-    const occupied = occupiedSpotsRef.current;
-    const vacated = vacatedSpotsRef.current;
-
-    return candidates.some((pos) => {
-      const key = `${pos.col},${pos.row}`;
-      if (key === centerKey) return false;
-      if (occupied.has(key)) return false;
-      if (vacated.has(key) && tileManager.isHexOccupied({ col: pos.col, row: pos.row })) return false;
-      return !tileManager.isHexOccupied({ col: pos.col, row: pos.row });
+    return resolveRealmHasAvailableBuildingTile({
+      entityId,
+      realmPosition: realm?.position,
+      world: {
+        components: dojo.setup.components,
+        systemCalls: dojo.setup.systemCalls,
+      },
+      occupiedSpots: occupiedSpotsRef.current,
+      vacatedSpots: vacatedSpotsRef.current,
     });
   }, [
     dojo.setup.components,
@@ -255,98 +193,31 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
 
   const handleAutoBuild = useCallback(
     async (target: { type: BuildingType; resource?: ResourcesIds }) => {
-      if (!realm?.position) {
-        toast.error("Select a realm before building.");
-        return;
-      }
       const buildingKey = target.type.toString();
-      const outerCol = Number(realm.position.x);
-      const outerRow = Number(realm.position.y);
-      const tileManager = new TileManager(dojo.setup.components, dojo.setup.systemCalls, {
-        col: outerCol,
-        row: outerRow,
-      });
-      const occupied = occupiedSpotsRef.current;
-      const vacated = vacatedSpotsRef.current;
-      let occupiedKey: string | null = null;
-      let didBuild = false;
-      let occupiedTileFailures = 0;
 
       setPendingBuilds((prev) => ({ ...prev, [buildingKey]: true }));
 
       try {
-        const buildRadius = Math.max(1, Number(tileManager.getRealmLevel(entityId)) + 1);
-        const candidates = generateBuildablePositions(buildRadius);
-        const centerKey = `${BUILDINGS_CENTER[0]},${BUILDINGS_CENTER[1]}`;
-
-        const availableSpots = candidates.filter((pos) => {
-          const key = `${pos.col},${pos.row}`;
-          if (key === centerKey) return false;
-          if (occupied.has(key)) return false;
-          if (vacated.has(key) && tileManager.isHexOccupied({ col: pos.col, row: pos.row })) return false;
-          return !tileManager.isHexOccupied({ col: pos.col, row: pos.row });
-        });
-
-        if (availableSpots.length === 0) {
-          toast.error("No empty building tiles available.");
-          return;
-        }
-
-        for (const availableSpot of availableSpots) {
-          const candidateKey = `${availableSpot.col},${availableSpot.row}`;
-          occupiedKey = candidateKey;
-          reserveOccupiedBuildSpot(entityId, candidateKey);
-
-          try {
-            await tileManager.placeBuilding(
-              dojo.account.account,
-              entityId,
-              target.type,
-              { col: availableSpot.col, row: availableSpot.row },
-              useSimpleCost,
-            );
-            didBuild = true;
-
+        await buildRealmBuilding({
+          entityId,
+          realmPosition: realm?.position,
+          target,
+          useSimpleCost,
+          world: {
+            account: dojo.account.account,
+            components: dojo.setup.components,
+            systemCalls: dojo.setup.systemCalls,
+          },
+          occupiedSpots: occupiedSpotsRef.current,
+          vacatedSpots: vacatedSpotsRef.current,
+          onReserveSpot: (spotKey) => reserveOccupiedBuildSpot(entityId, spotKey),
+          onReleaseSpot: (spotKey) => releaseOccupiedBuildSpot(entityId, spotKey),
+          onBuildSuccess: (selection) => {
             setPreviewBuilding(null);
-            setSelectedBuildingHex({
-              outerCol,
-              outerRow,
-              innerCol: availableSpot.col,
-              innerRow: availableSpot.row,
-            });
-            break;
-          } catch (error) {
-            releaseOccupiedBuildSpot(entityId, candidateKey);
-            occupiedKey = null;
-
-            if (isOccupiedSpaceError(error)) {
-              occupiedTileFailures += 1;
-              continue;
-            }
-
-            throw error;
-          }
-        }
-
-        if (!didBuild) {
-          if (occupiedTileFailures > 0) {
-            toast.error("All auto-selected tiles became occupied. Please try again.");
-            return;
-          }
-          toast.error("No empty building tiles available.");
-          return;
-        }
-      } catch (error) {
-        console.error("Failed to auto-build", error);
-        if (isOccupiedSpaceError(error)) {
-          toast.error("This tile is occupied. Please try again.");
-        } else {
-          toast.error("Building failed. Please try again.");
-        }
+            setSelectedBuildingHex(selection);
+          },
+        });
       } finally {
-        if (occupiedKey && !didBuild) {
-          releaseOccupiedBuildSpot(entityId, occupiedKey);
-        }
         setPendingBuilds((prev) => {
           const next = { ...prev };
           delete next[buildingKey];
@@ -694,6 +565,23 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   );
 
   const activeArmyType = selectedArmyType ?? recommendedArmyType ?? armyGroups[0]?.armyType ?? null;
+  const getSummaryBuildState = useCallback(
+    (buildingId: BuildingType) => {
+      const buildingCosts = getBuildingCosts(entityId, dojo.setup.components, buildingId, useSimpleCost);
+      const hasBalance = Boolean(buildingCosts && checkBalance(buildingCosts));
+      const hasEnoughPopulation = Boolean(realm && hasEnoughPopulationForBuilding(realm, buildingId));
+
+      return resolveRealmBuildingSummaryBuildability({
+        buildingId,
+        hasBalance,
+        hasEnoughPopulation,
+        hasCapacity: Boolean(realm?.hasCapacity),
+        hasAvailableBuildingTile,
+        useSimpleCost,
+      });
+    },
+    [checkBalance, dojo.setup.components, entityId, hasAvailableBuildingTile, realm, useSimpleCost],
+  );
   const allowedBuildingTypes = useMemo(
     () =>
       buildingTypes
@@ -709,6 +597,26 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
         getBuildingCount: getBuildingCountFor,
       }),
     [allowedBuildingTypes, getBuildingCountFor, realm?.resources],
+  );
+  const realmBuildingSummaryActions = useMemo(
+    () =>
+      new Map(
+        realmBuildingSummary.map((item) => {
+          const buildState = getSummaryBuildState(item.buildingId);
+          const isPending = Boolean(pendingBuilds[item.buildingId.toString()]);
+
+          return [
+            item.buildingId,
+            {
+              onBuild: () => void handleAutoBuild({ type: item.buildingId }),
+              disabled: !buildState.canBuild || isPending,
+              loading: isPending,
+              title: isPending ? `Building ${item.label}...` : (buildState.disabledReason ?? `Build ${item.label}`),
+            },
+          ] as const;
+        }),
+      ),
+    [getSummaryBuildState, handleAutoBuild, pendingBuilds, realmBuildingSummary],
   );
 
   const tabs = useMemo(
@@ -1143,7 +1051,12 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
         </div>
       </div>
 
-      <RealmBuildingSummary className="realm-summary-selector" headline="Built here" items={realmBuildingSummary} />
+      <RealmBuildingSummary
+        className="realm-summary-selector"
+        headline="Built here"
+        items={realmBuildingSummary}
+        buildActions={realmBuildingSummaryActions}
+      />
 
       <Tabs
         selectedIndex={selectedTab}

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -20,6 +20,12 @@ import {
   releaseOccupiedBuildSpot,
   reserveOccupiedBuildSpot,
 } from "./build-reservation-store";
+import {
+  buildRealmBuildingSummary,
+  getMilitaryBuildingInfo,
+  MILITARY_BUILDING_GROUP_ORDER,
+  RealmBuildingSummary,
+} from "./realm-building-summary";
 
 import {
   Biome,
@@ -61,8 +67,7 @@ import Trash from "lucide-react/dist/esm/icons/trash";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
-const ARMY_TYPES = ["Archery", "Stable", "Barracks"] as const;
-type ArmyTypeLabel = (typeof ARMY_TYPES)[number];
+type ArmyTypeLabel = (typeof MILITARY_BUILDING_GROUP_ORDER)[number];
 type ArmyGroup = {
   armyType: ArmyTypeLabel;
   buildings: string[];
@@ -608,7 +613,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
 
   const armyGroups = useMemo<ArmyGroup[]>(
     () =>
-      ARMY_TYPES.reduce<ArmyGroup[]>((acc, armyType) => {
+      MILITARY_BUILDING_GROUP_ORDER.reduce<ArmyGroup[]>((acc, armyType) => {
         const buildings = buildingTypes.filter((a) => {
           const building = BuildingType[a as keyof typeof BuildingType];
           const info = getMilitaryBuildingInfo(building);
@@ -689,6 +694,22 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   );
 
   const activeArmyType = selectedArmyType ?? recommendedArmyType ?? armyGroups[0]?.armyType ?? null;
+  const allowedBuildingTypes = useMemo(
+    () =>
+      buildingTypes
+        .map((buildingType) => BuildingType[buildingType as keyof typeof BuildingType])
+        .filter((buildingType): buildingType is BuildingType => typeof buildingType === "number"),
+    [buildingTypes],
+  );
+  const realmBuildingSummary = useMemo(
+    () =>
+      buildRealmBuildingSummary({
+        realmResourceIds: realm?.resources ?? [],
+        allowedBuildingTypes,
+        getBuildingCount: getBuildingCountFor,
+      }),
+    [allowedBuildingTypes, getBuildingCountFor, realm?.resources],
+  );
 
   const tabs = useMemo(
     () => [
@@ -1121,6 +1142,8 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
           </label>
         </div>
       </div>
+
+      <RealmBuildingSummary className="realm-summary-selector" headline="Built here" items={realmBuildingSummary} />
 
       <Tabs
         selectedIndex={selectedTab}
@@ -1731,31 +1754,4 @@ const BuildingInfo = ({
       )}
     </div>
   );
-};
-
-// Helper function to determine military building type and tier
-const getMilitaryBuildingInfo = (building: BuildingType) => {
-  // Check for Crossbowman buildings
-  if (building === BuildingType.ResourceCrossbowmanT1)
-    return { type: "Archery", tier: 1, resourceId: ResourcesIds.Crossbowman };
-  if (building === BuildingType.ResourceCrossbowmanT2)
-    return { type: "Archery", tier: 2, resourceId: ResourcesIds.CrossbowmanT2 };
-  if (building === BuildingType.ResourceCrossbowmanT3)
-    return { type: "Archery", tier: 3, resourceId: ResourcesIds.CrossbowmanT3 };
-
-  // Check for Paladin buildings
-  if (building === BuildingType.ResourcePaladinT1) return { type: "Stable", tier: 1, resourceId: ResourcesIds.Paladin };
-  if (building === BuildingType.ResourcePaladinT2)
-    return { type: "Stable", tier: 2, resourceId: ResourcesIds.PaladinT2 };
-  if (building === BuildingType.ResourcePaladinT3)
-    return { type: "Stable", tier: 3, resourceId: ResourcesIds.PaladinT3 };
-
-  // Check for Knight buildings
-  if (building === BuildingType.ResourceKnightT1) return { type: "Barracks", tier: 1, resourceId: ResourcesIds.Knight };
-  if (building === BuildingType.ResourceKnightT2)
-    return { type: "Barracks", tier: 2, resourceId: ResourcesIds.KnightT2 };
-  if (building === BuildingType.ResourceKnightT3)
-    return { type: "Barracks", tier: 3, resourceId: ResourcesIds.KnightT3 };
-
-  return null;
 };

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-25",
+    title: "Overview Build Shortcuts",
+    description:
+      "Realm building counts now show resource icons and hover build shortcuts in both construction and overview, so you can scan what is built and add the next structure faster.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-25",
     title: "Realm Build Counts",
     description:
       "Construction now shows a compact built-here summary for the selected realm, so you can check existing building counts without hovering the map.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-25",
+    title: "Sidebar Transfer Bars",
+    description:
+      "The realm sidebar now shows minimal transfer bars for active live and automated routes, so you can see what is moving between structures at a glance without reopening the transfers panel.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-25",
     title: "Clearer Attention Reasons",
     description:
       "Attention warnings now explain why a resource is blocked, so chips like Knight T2 tell you whether they are waiting on inputs or missing an active producer instead of showing a bare name.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-25",
+    title: "Realm Build Counts",
+    description:
+      "Construction now shows a compact built-here summary for the selected realm, so you can check existing building counts without hovering the map.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-24",
     title: "Steadier Realm Sidebar",
     description:

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-04-25",
+    title: "Clearer Attention Reasons",
+    description:
+      "Attention warnings now explain why a resource is blocked, so chips like Knight T2 tell you whether they are waiting on inputs or missing an active producer instead of showing a bare name.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-04-25",
     title: "Overview Build Shortcuts",
     description:
       "Realm building counts now show resource icons and hover build shortcuts in both construction and overview, so you can scan what is built and add the next structure faster.",

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-attention-row.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-attention-row.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import { buildStarvingResourceAttentionLabel } from "./realm-attention-row";
+
+describe("buildStarvingResourceAttentionLabel", () => {
+  it("turns troop shorthand and hidden skip reasons into readable chip copy", () => {
+    expect(buildStarvingResourceAttentionLabel(ResourcesIds.KnightT2, "KnightT2 waiting for recipe inputs")).toBe(
+      "Knight T2 waiting for inputs",
+    );
+  });
+
+  it("keeps the reason visible for inactive production buildings", () => {
+    expect(
+      buildStarvingResourceAttentionLabel(ResourcesIds.PaladinT2, "PaladinT2 has no active production building"),
+    ).toBe("Paladin T2 needs an active producer");
+  });
+});

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-attention-row.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-attention-row.tsx
@@ -43,6 +43,37 @@ const AttentionChip = ({ icon: Icon, label, tone, onClick, title }: AttentionChi
   );
 };
 
+const prettifyAttentionResourceLabel = (resourceId: ResourcesIds) =>
+  (ResourcesIds[resourceId] ?? String(resourceId)).replace(/([a-z])([A-Z])/g, "$1 $2");
+
+const summarizeStarvingReason = (resourceId: ResourcesIds, resourceLabel: string, reason?: string) => {
+  if (!reason) {
+    return `${resourceLabel} needs attention`;
+  }
+
+  const rawResourceLabel = ResourcesIds[resourceId] ?? String(resourceId);
+  const strippedReason = reason
+    .replace(new RegExp(`^${rawResourceLabel}\\s*`, "i"), "")
+    .replace(new RegExp(`^${resourceLabel}\\s*`, "i"), "")
+    .replace(/^:\s*/, "")
+    .trim();
+
+  if (strippedReason === "waiting for recipe inputs") {
+    return `${resourceLabel} waiting for inputs`;
+  }
+
+  if (strippedReason === "has no active production building") {
+    return `${resourceLabel} needs an active producer`;
+  }
+
+  return `${resourceLabel} ${strippedReason}`.trim();
+};
+
+export const buildStarvingResourceAttentionLabel = (resourceId: ResourcesIds, reason?: string) => {
+  const resourceLabel = prettifyAttentionResourceLabel(resourceId);
+  return summarizeStarvingReason(resourceId, resourceLabel, reason);
+};
+
 type StarvingResourceChipProps = {
   resourceId: ResourcesIds;
   reason?: string;
@@ -51,8 +82,9 @@ type StarvingResourceChipProps = {
 };
 
 const StarvingResourceChip = ({ resourceId, reason, canBuild, onBuild }: StarvingResourceChipProps) => {
-  const label = ResourcesIds[resourceId] ?? String(resourceId);
-  const title = reason ? `${label} starving — ${reason}` : `${label} starving`;
+  const resourceLabel = prettifyAttentionResourceLabel(resourceId);
+  const label = buildStarvingResourceAttentionLabel(resourceId, reason);
+  const title = reason ? `${resourceLabel} starving — ${reason}` : `${resourceLabel} starving`;
 
   return (
     <span
@@ -62,15 +94,15 @@ const StarvingResourceChip = ({ resourceId, reason, canBuild, onBuild }: Starvin
       title={title}
     >
       <AlertTriangle className="h-3 w-3" />
-      <ResourceIcon resource={label} size="xs" withTooltip={false} />
+      <ResourceIcon resource={resourceLabel} size="xs" withTooltip={false} />
       <span>{label}</span>
       {canBuild && onBuild && (
         <button
           type="button"
           onClick={onBuild}
           className="ml-0.5 inline-flex items-center rounded border border-danger/40 bg-danger/20 px-1 py-[1px] text-[9px] uppercase tracking-wide hover:bg-danger/40"
-          title={`Build a ${label} producer`}
-          aria-label={`Build ${label} producer`}
+          title={`Build a ${resourceLabel} producer`}
+          aria-label={`Build ${resourceLabel} producer`}
         >
           <Hammer className="h-2.5 w-2.5" />
           <span className="ml-0.5">Build</span>

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.build-summary.source.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.build-summary.source.test.ts
@@ -14,5 +14,7 @@ describe("RealmInfoPanel build summary wiring", () => {
     expect(source).toContain('headline="Built here"');
     expect(source).toContain("realmBuildingSummaryActions");
     expect(source).toContain("handleBuildSummaryItem");
+    expect(source).toContain("const realm = structureEntityId ? getRealmInfo(");
+    expect(source).not.toContain("const realm = useMemo(() =>");
   });
 });

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.build-summary.source.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.build-summary.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("RealmInfoPanel build summary wiring", () => {
+  it("shows the realm building summary with quick-build actions on the overview panel", () => {
+    const source = readSource("src/ui/modules/entity-details/realm/realm-info-panel.tsx");
+
+    expect(source).toContain("RealmBuildingSummary");
+    expect(source).toContain('headline="Built here"');
+    expect(source).toContain("realmBuildingSummaryActions");
+    expect(source).toContain("handleBuildSummaryItem");
+  });
+});

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.transfer-bars.source.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.transfer-bars.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("RealmInfoPanel transfer bars wiring", () => {
+  it("shows current and automation transfer bars in the sidebar overview", () => {
+    const source = readSource("src/ui/modules/entity-details/realm/realm-info-panel.tsx");
+
+    expect(source).toContain("RealmTransferBars");
+    expect(source).toContain("buildRealmTransferBarModels");
+    expect(source).toContain("transferBarModels.current");
+    expect(source).toContain("transferBarModels.automation");
+  });
+});

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.transfer-bars.source.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.transfer-bars.source.test.ts
@@ -14,5 +14,7 @@ describe("RealmInfoPanel transfer bars wiring", () => {
     expect(source).toContain("buildRealmTransferBarModels");
     expect(source).toContain("transferBarModels.current");
     expect(source).toContain("transferBarModels.automation");
+    expect(source).toContain("useTransferAutomationStore((state) => state.entries)");
+    expect(source).not.toContain("useTransferAutomationStore((state) => Object.values(state.entries))");
   });
 });

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -207,10 +207,7 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
     components.VillageTroop,
     structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
   ) as ComponentValue<ClientComponents["VillageTroop"]["schema"]> | null;
-  const realm = useMemo(
-    () => (structureEntityId ? getRealmInfo(getEntityIdFromKeys([BigInt(structureEntityId)]), components) : null),
-    [components, structureEntityId],
-  );
+  const realm = structureEntityId ? getRealmInfo(getEntityIdFromKeys([BigInt(structureEntityId)]), components) : null;
 
   const isVillage = structure?.base?.category === StructureType.Village;
   const isOwned = structure ? structure.owner === ContractAddress(account.account.address) : false;

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -22,6 +22,7 @@ import { ActiveRelicEffects } from "@/ui/features/world/components/entities/acti
 import { CompactEntityInventory } from "@/ui/features/world/components/entities/compact-entity-inventory";
 import { StructureProductionPanel } from "@/ui/features/world/components/entities/structure-production-panel";
 import { RealmAttentionRow } from "@/ui/modules/entity-details/realm/realm-attention-row";
+import { buildRealmTransferBarModels, RealmTransferBars } from "@/ui/modules/entity-details/realm/realm-transfer-bars";
 import { useRealmStarvedResources } from "@/ui/modules/entity-details/realm/use-realm-starved-resources";
 import { useRealmConsumptionPerSecond } from "@/ui/modules/entity-details/realm/use-realm-consumption-per-second";
 import { buildVillageTimerSummary } from "@/ui/shared/lib/village-timers";
@@ -54,6 +55,8 @@ import {
 import { useComponentValue } from "@dojoengine/react";
 import { ComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { useStoryEvents } from "@/hooks/store/use-story-events-store";
+import { useTransferAutomationStore } from "@/hooks/store/use-transfer-automation-store";
 import ArrowLeftRight from "lucide-react/dist/esm/icons/arrow-left-right";
 import Bot from "lucide-react/dist/esm/icons/bot";
 import Shield from "lucide-react/dist/esm/icons/shield";
@@ -183,7 +186,9 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   const setSelectedBuildingHex = useUIStore((state) => state.setSelectedBuildingHex);
   const setLeftNavigationView = useUIStore((state) => state.setLeftNavigationView);
   const useSimpleCost = useUIStore((state) => state.useSimpleCost);
+  const playerStructures = useUIStore((state) => state.playerStructures);
   const automationRealms = useAutomationStore((state) => state.realms);
+  const transferAutomationEntries = useTransferAutomationStore((state) => Object.values(state.entries));
   const hasAutomationFailures = useAutomationStore(
     useCallback((state) => Object.values(state.realms).some((r) => (r.lastStatus?.consecutiveFailures ?? 0) >= 3), []),
   );
@@ -250,8 +255,13 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   );
 
   const { currentArmiesTick, currentBlockTimestamp, currentDefaultTick } = useBlockTimestamp();
+  const { data: storyEvents = [] } = useStoryEvents(200);
   const mode = useGameModeConfig();
   const [pendingBuilds, setPendingBuilds] = useState<Record<string, boolean>>({});
+  const structureName = useMemo(
+    () => (structure ? mode.structure.getName(structure.structure).name : "Structure"),
+    [mode, structure],
+  );
 
   const relicEffects = useMemo(() => {
     if (!structure) return [];
@@ -431,6 +441,28 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
       useSimpleCost,
     ],
   );
+  const resolveTransferStructureName = useCallback(
+    (entityId: number) => {
+      if (realmId === entityId) return structureName;
+
+      const matchingStructure = playerStructures.find(
+        (playerStructure) => Number(playerStructure.entityId) === entityId,
+      );
+      return matchingStructure ? mode.structure.getName(matchingStructure.structure).name : null;
+    },
+    [mode, playerStructures, realmId, structureName],
+  );
+  const transferBarModels = useMemo(
+    () =>
+      buildRealmTransferBarModels({
+        selectedStructureId: realmId,
+        currentTimeMs: Date.now(),
+        storyEvents,
+        automationEntries: transferAutomationEntries,
+        resolveStructureName: resolveTransferStructureName,
+      }),
+    [realmId, resolveTransferStructureName, storyEvents, transferAutomationEntries],
+  );
   const shouldRenderVillageUi = isVillage;
   const isVillageMilitiaClaimed = Boolean(villageTroop?.claimed);
   const [isClaimingVillageMilitia, setIsClaimingVillageMilitia] = useState(false);
@@ -598,6 +630,8 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
           </div>
         </div>
       )}
+
+      <RealmTransferBars current={transferBarModels.current} automation={transferBarModels.automation} />
 
       {structureCapabilities.canOpenConstruction && (
         <RealmBuildingSummary

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -258,10 +258,7 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   const { data: storyEvents = [] } = useStoryEvents(200);
   const mode = useGameModeConfig();
   const [pendingBuilds, setPendingBuilds] = useState<Record<string, boolean>>({});
-  const structureName = useMemo(
-    () => (structure ? mode.structure.getName(structure.structure).name : "Structure"),
-    [mode, structure],
-  );
+  const structureName = useMemo(() => (structure ? mode.structure.getName(structure).name : "Structure"), [mode, structure]);
 
   const relicEffects = useMemo(() => {
     if (!structure) return [];

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -258,7 +258,10 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   const { data: storyEvents = [] } = useStoryEvents(200);
   const mode = useGameModeConfig();
   const [pendingBuilds, setPendingBuilds] = useState<Record<string, boolean>>({});
-  const structureName = useMemo(() => (structure ? mode.structure.getName(structure).name : "Structure"), [mode, structure]);
+  const structureName = useMemo(
+    () => (structure ? mode.structure.getName(structure).name : "Structure"),
+    [mode, structure],
+  );
 
   const relicEffects = useMemo(() => {
     if (!structure) return [];

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -188,7 +188,7 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   const useSimpleCost = useUIStore((state) => state.useSimpleCost);
   const playerStructures = useUIStore((state) => state.playerStructures);
   const automationRealms = useAutomationStore((state) => state.realms);
-  const transferAutomationEntries = useTransferAutomationStore((state) => Object.values(state.entries));
+  const transferAutomationEntriesById = useTransferAutomationStore((state) => state.entries);
   const hasAutomationFailures = useAutomationStore(
     useCallback((state) => Object.values(state.realms).some((r) => (r.lastStatus?.consecutiveFailures ?? 0) >= 3), []),
   );
@@ -455,10 +455,10 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
         selectedStructureId: realmId,
         currentTimeMs: Date.now(),
         storyEvents,
-        automationEntries: transferAutomationEntries,
+        automationEntries: Object.values(transferAutomationEntriesById),
         resolveStructureName: resolveTransferStructureName,
       }),
-    [realmId, resolveTransferStructureName, storyEvents, transferAutomationEntries],
+    [realmId, resolveTransferStructureName, storyEvents, transferAutomationEntriesById],
   );
   const shouldRenderVillageUi = isVillage;
   const isVillageMilitiaClaimed = Boolean(villageTroop?.claimed);

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -2,11 +2,21 @@ import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import type { RealmAutomationConfig } from "@/hooks/store/use-automation-store";
 import { useAutomationStore } from "@/hooks/store/use-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { LeftView } from "@/types";
 import { resolveStructureUiCapabilities } from "@/ui/lib/structure-capabilities";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { TRANSFER_POPUP_NAME } from "@/ui/features/economy/transfers/transfer-automation-popup";
 import { ProductionModal } from "@/ui/features/settlement";
+import {
+  buildRealmBuilding,
+  resolveRealmHasAvailableBuildingTile,
+} from "@/ui/features/settlement/construction/realm-build-actions";
+import {
+  buildRealmBuildingSummary,
+  RealmBuildingSummary,
+  resolveRealmBuildingSummaryBuildability,
+} from "@/ui/features/settlement/construction/realm-building-summary";
 import { productionAutomation } from "@/ui/features/world/components/config";
 import { ActiveRelicEffects } from "@/ui/features/world/components/entities/active-relic-effects";
 import { CompactEntityInventory } from "@/ui/features/world/components/entities/compact-entity-inventory";
@@ -19,10 +29,16 @@ import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/uti
 import { inferRealmPreset } from "@/utils/automation-presets";
 import { getRealmStatusColor, getFailureSeverity, timeAgo } from "@/utils/automation-status";
 import {
+  divideByPrecision,
   formatTime,
+  getBalance,
+  getBuildingCosts,
+  getBuildingCount,
   getGuardsByStructure,
+  getRealmInfo,
   getStructureArmyRelicEffects,
   getStructureRelicEffects,
+  hasEnoughPopulationForBuilding,
 } from "@bibliothecadao/eternum";
 import { useDojo, useExplorersByStructure } from "@bibliothecadao/react";
 import {
@@ -164,7 +180,9 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   const setTransferPanelSourceId = useUIStore((state) => state.setTransferPanelSourceId);
   const setPreviewBuilding = useUIStore((state) => state.setPreviewBuilding);
   const setSelectedBuilding = useUIStore((state) => state.setSelectedBuilding);
+  const setSelectedBuildingHex = useUIStore((state) => state.setSelectedBuildingHex);
   const setLeftNavigationView = useUIStore((state) => state.setLeftNavigationView);
+  const useSimpleCost = useUIStore((state) => state.useSimpleCost);
   const automationRealms = useAutomationStore((state) => state.realms);
   const hasAutomationFailures = useAutomationStore(
     useCallback((state) => Object.values(state.realms).some((r) => (r.lastStatus?.consecutiveFailures ?? 0) >= 3), []),
@@ -181,10 +199,18 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
     components.Resource,
     structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
   ) as ComponentValue<ClientComponents["Resource"]["schema"]> | null;
+  const structureBuildings = useComponentValue(
+    components.StructureBuildings,
+    structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
+  );
   const villageTroop = useComponentValue(
     components.VillageTroop,
     structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
   ) as ComponentValue<ClientComponents["VillageTroop"]["schema"]> | null;
+  const realm = useMemo(
+    () => (structureEntityId ? getRealmInfo(getEntityIdFromKeys([BigInt(structureEntityId)]), components) : null),
+    [components, structureEntityId],
+  );
 
   const isVillage = structure?.base?.category === StructureType.Village;
   const isOwned = structure ? structure.owner === ContractAddress(account.account.address) : false;
@@ -226,7 +252,9 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
     structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
   );
 
-  const { currentArmiesTick, currentBlockTimestamp } = useBlockTimestamp();
+  const { currentArmiesTick, currentBlockTimestamp, currentDefaultTick } = useBlockTimestamp();
+  const mode = useGameModeConfig();
+  const [pendingBuilds, setPendingBuilds] = useState<Record<string, boolean>>({});
 
   const relicEffects = useMemo(() => {
     if (!structure) return [];
@@ -279,6 +307,132 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
       setLeftNavigationView(LeftView.ConstructionView);
     },
     [setLeftNavigationView, setPreviewBuilding, setSelectedBuilding],
+  );
+  const getBuildingCountFor = useCallback(
+    (buildingType: BuildingType) => {
+      if (!structureBuildings) return 0;
+
+      const packedCounts = [
+        structureBuildings.packed_counts_1 || 0n,
+        structureBuildings.packed_counts_2 || 0n,
+        structureBuildings.packed_counts_3 || 0n,
+      ];
+      return getBuildingCount(buildingType, packedCounts) || 0;
+    },
+    [structureBuildings],
+  );
+  const checkBalance = useCallback(
+    (cost: any) =>
+      Object.keys(cost).every((resourceId) => {
+        const resourceCost = cost[Number(resourceId)];
+        const balance = getBalance(realmId ?? 0, resourceCost.resource, currentDefaultTick, components);
+        return divideByPrecision(balance.balance) >= resourceCost.amount;
+      }),
+    [components, currentDefaultTick, realmId],
+  );
+  const allowedBuildingTypes = useMemo(
+    () =>
+      Object.keys(BuildingType)
+        .filter((buildingType) => mode.rules.isBuildingTypeAllowed(buildingType))
+        .map((buildingType) => BuildingType[buildingType as keyof typeof BuildingType])
+        .filter((buildingType): buildingType is BuildingType => typeof buildingType === "number"),
+    [mode],
+  );
+  const hasAvailableBuildingTile = useMemo(
+    () =>
+      resolveRealmHasAvailableBuildingTile({
+        entityId: realmId ?? 0,
+        realmPosition: realm?.position,
+        world: {
+          components,
+          systemCalls: setup.systemCalls,
+        },
+      }),
+    [components, realm?.position, realmId, setup.systemCalls],
+  );
+  const realmBuildingSummary = useMemo(
+    () =>
+      buildRealmBuildingSummary({
+        realmResourceIds: realm?.resources ?? [],
+        allowedBuildingTypes,
+        getBuildingCount: getBuildingCountFor,
+      }),
+    [allowedBuildingTypes, getBuildingCountFor, realm?.resources],
+  );
+  const handleBuildSummaryItem = useCallback(
+    async (buildingId: BuildingType) => {
+      if (!realmId) return;
+
+      const buildingKey = buildingId.toString();
+      setPendingBuilds((prev) => ({ ...prev, [buildingKey]: true }));
+
+      try {
+        await buildRealmBuilding({
+          entityId: realmId,
+          realmPosition: realm?.position,
+          target: { type: buildingId },
+          useSimpleCost,
+          world: {
+            account: account.account,
+            components,
+            systemCalls: setup.systemCalls,
+          },
+          onBuildSuccess: (selection) => setSelectedBuildingHex(selection),
+        });
+      } finally {
+        setPendingBuilds((prev) => {
+          const next = { ...prev };
+          delete next[buildingKey];
+          return next;
+        });
+      }
+    },
+    [account.account, components, realm?.position, realmId, setSelectedBuildingHex, setup.systemCalls, useSimpleCost],
+  );
+  const realmBuildingSummaryActions = useMemo(
+    () =>
+      new Map(
+        realmBuildingSummary.map((item) => {
+          const buildingCosts = getBuildingCosts(realmId ?? 0, components, item.buildingId, useSimpleCost);
+          const hasBalance = Boolean(buildingCosts && checkBalance(buildingCosts));
+          const hasEnoughPopulation = Boolean(realm && hasEnoughPopulationForBuilding(realm, item.buildingId));
+          const buildState = resolveRealmBuildingSummaryBuildability({
+            buildingId: item.buildingId,
+            hasBalance,
+            hasEnoughPopulation,
+            hasCapacity: Boolean(realm?.hasCapacity),
+            hasAvailableBuildingTile,
+            useSimpleCost,
+          });
+          const isPending = Boolean(pendingBuilds[item.buildingId.toString()]);
+
+          return [
+            item.buildingId,
+            {
+              onBuild: () => void handleBuildSummaryItem(item.buildingId),
+              disabled: !isOwned || !buildState.canBuild || isPending,
+              loading: isPending,
+              title: !isOwned
+                ? "You do not own this realm."
+                : isPending
+                  ? `Building ${item.label}...`
+                  : (buildState.disabledReason ?? `Build ${item.label}`),
+            },
+          ] as const;
+        }),
+      ),
+    [
+      checkBalance,
+      components,
+      handleBuildSummaryItem,
+      hasAvailableBuildingTile,
+      isOwned,
+      pendingBuilds,
+      realm,
+      realmBuildingSummary,
+      realmId,
+      useSimpleCost,
+    ],
   );
   const shouldRenderVillageUi = isVillage;
   const isVillageMilitiaClaimed = Boolean(villageTroop?.claimed);
@@ -446,6 +600,15 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
             />
           </div>
         </div>
+      )}
+
+      {structureCapabilities.canOpenConstruction && (
+        <RealmBuildingSummary
+          headline="Built here"
+          items={realmBuildingSummary}
+          variant="card"
+          buildActions={realmBuildingSummaryActions}
+        />
       )}
 
       {relicEffects.length > 0 && structureEntityId && (

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.source.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.source.test.ts
@@ -1,0 +1,19 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Realm transfer bar presentation", () => {
+  it("renders a line-based transfer bar with animated resource icons", () => {
+    const source = readSource("src/ui/modules/entity-details/realm/realm-transfer-bars.tsx");
+
+    expect(source).toContain("TransferBar");
+    expect(source).toContain("animate-transfer-token");
+    expect(source).toContain("sourceLabel");
+    expect(source).toContain("destinationLabel");
+    expect(source).toContain("iconResources");
+  });
+});

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import type { TransferAutomationEntry } from "@/hooks/store/use-transfer-automation-store";
+import type { ProcessedStoryEvent } from "@/hooks/store/use-story-events-store";
+
+describe("buildRealmTransferBarModels", () => {
+  it("builds minimal live and automation transfer bars for the selected structure", async () => {
+    const { buildRealmTransferBarModels } = await import("./realm-transfer-bars");
+
+    const storyEvent = {
+      story: "ResourceTransferStory",
+      timestampMs: 1_000,
+      tx_hash: "0xabc",
+      presentation: {},
+      id: "story-1",
+      resource_transfer_from_entity_id: 209,
+      resource_transfer_to_entity_id: 101,
+      resource_transfer_resources: JSON.stringify([
+        { resourceId: ResourcesIds.Labor, amount: 2356 },
+        { resourceId: ResourcesIds.Wood, amount: 100 },
+      ]),
+      resource_transfer_travel_time: "300",
+    } satisfies Partial<ProcessedStoryEvent> as ProcessedStoryEvent;
+
+    const automationEntry: TransferAutomationEntry = {
+      id: "automation-1",
+      active: true,
+      createdAt: 10,
+      gameId: "game",
+      sourceEntityId: "209",
+      sourceName: "Camp 209",
+      destinationEntityId: "101",
+      destinationName: "Stolsli",
+      resourceIds: [ResourcesIds.Labor],
+      resourceConfigs: [{ resourceId: ResourcesIds.Labor, amount: 2356 }],
+      intervalMinutes: 5,
+      lastRunAt: 50,
+      nextRunAt: 120,
+    };
+
+    const bars = buildRealmTransferBarModels({
+      selectedStructureId: 101,
+      currentTimeMs: 110_000,
+      storyEvents: [storyEvent],
+      automationEntries: [automationEntry],
+      resolveStructureName: (entityId) => (entityId === 209 ? "Camp 209" : entityId === 101 ? "Stolsli" : null),
+    });
+
+    expect(bars.current).toEqual([
+      expect.objectContaining({
+        kind: "current",
+        sourceLabel: "Camp 209",
+        destinationLabel: "Stolsli",
+        iconResources: ["Labor", "Wood"],
+      }),
+    ]);
+    expect(bars.automation).toEqual([
+      expect.objectContaining({
+        kind: "automation",
+        sourceLabel: "Camp 209",
+        destinationLabel: "Stolsli",
+        iconResources: ["Labor"],
+      }),
+    ]);
+  });
+});

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.test.ts
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.test.ts
@@ -13,7 +13,7 @@ describe("buildRealmTransferBarModels", () => {
       story: "ResourceTransferStory",
       timestampMs: 1_000,
       tx_hash: "0xabc",
-      presentation: {},
+      presentation: { title: "Transfer", icon: "resource" },
       id: "story-1",
       resource_transfer_from_entity_id: 209,
       resource_transfer_to_entity_id: 101,

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.tsx
@@ -1,0 +1,235 @@
+import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
+import type { TransferAutomationEntry } from "@/hooks/store/use-transfer-automation-store";
+import type { ProcessedStoryEvent } from "@/hooks/store/use-story-events-store";
+import { ResourcesIds } from "@bibliothecadao/types";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+
+type TransferBarModel = {
+  id: string;
+  kind: "current" | "automation";
+  sourceLabel: string;
+  destinationLabel: string;
+  iconResources: string[];
+  progress?: number;
+};
+
+type BuildRealmTransferBarModelsOptions = {
+  selectedStructureId: number | null;
+  currentTimeMs: number;
+  storyEvents: ProcessedStoryEvent[];
+  automationEntries: TransferAutomationEntry[];
+  resolveStructureName: (entityId: number) => string | null;
+};
+
+type TransferBarSectionProps = {
+  current: TransferBarModel[];
+  automation: TransferBarModel[];
+  className?: string;
+};
+
+type TransferResourceLike = {
+  resourceId?: number;
+};
+
+const MAX_TRANSFER_ICONS = 3;
+
+const normalizeEntityId = (value: unknown) => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (typeof value === "bigint") return Number(value);
+  return null;
+};
+
+const parseTravelTimeMs = (value: unknown) => {
+  if (typeof value === "number") return Number.isFinite(value) ? value * 1000 : 0;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed * 1000 : 0;
+  }
+  return 0;
+};
+
+const parseTransferResources = (raw: unknown): TransferResourceLike[] => {
+  if (Array.isArray(raw)) {
+    return raw.filter((entry): entry is TransferResourceLike => Boolean(entry) && typeof entry === "object");
+  }
+
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((entry): entry is TransferResourceLike => Boolean(entry) && typeof entry === "object")
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const toIconResources = (resourceIds: number[]) =>
+  Array.from(new Set(resourceIds))
+    .slice(0, MAX_TRANSFER_ICONS)
+    .map((resourceId) => ResourcesIds[resourceId as ResourcesIds])
+    .filter((resource): resource is string => typeof resource === "string");
+
+const resolveStructureLabel = (entityId: number, resolveStructureName: (entityId: number) => string | null) =>
+  resolveStructureName(entityId) ?? `Structure ${entityId}`;
+
+const buildCurrentTransferBarModels = ({
+  selectedStructureId,
+  currentTimeMs,
+  storyEvents,
+  resolveStructureName,
+}: Omit<BuildRealmTransferBarModelsOptions, "automationEntries">): TransferBarModel[] => {
+  if (!selectedStructureId) return [];
+
+  return storyEvents
+    .filter((event) => event.story === "ResourceTransferStory" && !event.resource_transfer_is_mint)
+    .map((event) => {
+      const sourceId = normalizeEntityId(event.resource_transfer_from_entity_id);
+      const destinationId = normalizeEntityId(event.resource_transfer_to_entity_id);
+      const travelTimeMs = parseTravelTimeMs(event.resource_transfer_travel_time);
+      if (!sourceId || !destinationId || travelTimeMs <= 0) return null;
+      if (sourceId !== selectedStructureId && destinationId !== selectedStructureId) return null;
+
+      const startedAtMs = event.timestampMs;
+      const endsAtMs = startedAtMs + travelTimeMs;
+      if (currentTimeMs >= endsAtMs) return null;
+
+      const resources = parseTransferResources(event.resource_transfer_resources);
+      const iconResources = toIconResources(
+        resources.map((resource) => Number(resource.resourceId)).filter(Number.isFinite),
+      );
+      if (iconResources.length === 0) return null;
+
+      const progress = Math.max(0, Math.min((currentTimeMs - startedAtMs) / travelTimeMs, 1));
+
+      return {
+        id: event.id,
+        kind: "current" as const,
+        sourceLabel: resolveStructureLabel(sourceId, resolveStructureName),
+        destinationLabel: resolveStructureLabel(destinationId, resolveStructureName),
+        iconResources,
+        progress,
+      };
+    })
+    .filter((entry): entry is TransferBarModel => Boolean(entry))
+    .toSorted((left, right) => (right.progress ?? 0) - (left.progress ?? 0))
+    .slice(0, 3);
+};
+
+const buildAutomationTransferBarModels = ({
+  selectedStructureId,
+  automationEntries,
+  resolveStructureName,
+}: Omit<BuildRealmTransferBarModelsOptions, "storyEvents" | "currentTimeMs">): TransferBarModel[] => {
+  if (!selectedStructureId) return [];
+
+  return automationEntries
+    .filter((entry) => entry.active)
+    .map((entry) => {
+      const sourceId = normalizeEntityId(entry.sourceEntityId);
+      const destinationId = normalizeEntityId(entry.destinationEntityId);
+      if (!sourceId || !destinationId) return null;
+      if (sourceId !== selectedStructureId && destinationId !== selectedStructureId) return null;
+
+      const iconResources = toIconResources(
+        (entry.resourceConfigs?.map((resource) => resource.resourceId) ?? entry.resourceIds).filter(Number.isFinite),
+      );
+      if (iconResources.length === 0) return null;
+
+      return {
+        id: entry.id,
+        kind: "automation" as const,
+        sourceLabel: entry.sourceName ?? resolveStructureLabel(sourceId, resolveStructureName),
+        destinationLabel: entry.destinationName ?? resolveStructureLabel(destinationId, resolveStructureName),
+        iconResources,
+      };
+    })
+    .filter((entry): entry is TransferBarModel => Boolean(entry))
+    .slice(0, 3);
+};
+
+export const buildRealmTransferBarModels = ({
+  selectedStructureId,
+  currentTimeMs,
+  storyEvents,
+  automationEntries,
+  resolveStructureName,
+}: BuildRealmTransferBarModelsOptions) => ({
+  current: buildCurrentTransferBarModels({
+    selectedStructureId,
+    currentTimeMs,
+    storyEvents,
+    resolveStructureName,
+  }),
+  automation: buildAutomationTransferBarModels({
+    selectedStructureId,
+    automationEntries,
+    resolveStructureName,
+  }),
+});
+
+const TransferBar = ({ bar }: { bar: TransferBarModel }) => {
+  const movingTokenStyle =
+    bar.kind === "current" && bar.progress !== undefined ? { left: `${bar.progress * 100}%` } : undefined;
+
+  return (
+    <div className="rounded border border-gold/15 bg-black/40 px-2 py-2">
+      <div className="grid grid-cols-[minmax(0,1fr)_140px_minmax(0,1fr)] items-center gap-2 text-[11px] text-gold/85">
+        <div className="truncate text-left">{bar.sourceLabel}</div>
+        <div className="relative h-5">
+          <div className="absolute left-0 right-0 top-1/2 h-px -translate-y-1/2 bg-gold/25" />
+          <div
+            className={cn(
+              "absolute top-1/2 flex -translate-y-1/2 -translate-x-1/2 items-center gap-0.5 rounded-full border border-gold/20 bg-black/80 px-1 py-0.5 shadow-sm",
+              bar.kind === "automation" && "animate-transfer-token",
+            )}
+            style={movingTokenStyle}
+          >
+            {bar.iconResources.map((resource) => (
+              <ResourceIcon key={`${bar.id}-${resource}`} resource={resource} size="xs" withTooltip={false} />
+            ))}
+          </div>
+        </div>
+        <div className="truncate text-right">{bar.destinationLabel}</div>
+      </div>
+    </div>
+  );
+};
+
+const TransferSection = ({ title, bars }: { title: string; bars: TransferBarModel[] }) => {
+  if (bars.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <div className="text-[10px] uppercase tracking-[0.2em] text-gold/45">{title}</div>
+      <div className="space-y-1.5">
+        {bars.map((bar) => (
+          <TransferBar key={bar.id} bar={bar} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export const RealmTransferBars = ({ current, automation, className }: TransferBarSectionProps) => {
+  if (current.length === 0 && automation.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={cn("rounded border border-gold/20 bg-black/50 p-2", className)}>
+      <div className="text-xxs uppercase tracking-[0.2em] text-gold/60">Transfers</div>
+      <div className="mt-2 space-y-3">
+        <TransferSection title="Current" bars={current} />
+        <TransferSection title="Automation" bars={automation} />
+      </div>
+    </section>
+  );
+};

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-transfer-bars.tsx
@@ -80,6 +80,8 @@ const toIconResources = (resourceIds: number[]) =>
 const resolveStructureLabel = (entityId: number, resolveStructureName: (entityId: number) => string | null) =>
   resolveStructureName(entityId) ?? `Structure ${entityId}`;
 
+const isDefined = <T,>(value: T | null): value is T => value !== null;
+
 const buildCurrentTransferBarModels = ({
   selectedStructureId,
   currentTimeMs,
@@ -88,9 +90,9 @@ const buildCurrentTransferBarModels = ({
 }: Omit<BuildRealmTransferBarModelsOptions, "automationEntries">): TransferBarModel[] => {
   if (!selectedStructureId) return [];
 
-  return storyEvents
+  const bars = storyEvents
     .filter((event) => event.story === "ResourceTransferStory" && !event.resource_transfer_is_mint)
-    .map((event) => {
+    .map((event): TransferBarModel | null => {
       const sourceId = normalizeEntityId(event.resource_transfer_from_entity_id);
       const destinationId = normalizeEntityId(event.resource_transfer_to_entity_id);
       const travelTimeMs = parseTravelTimeMs(event.resource_transfer_travel_time);
@@ -118,9 +120,9 @@ const buildCurrentTransferBarModels = ({
         progress,
       };
     })
-    .filter((entry): entry is TransferBarModel => Boolean(entry))
-    .toSorted((left, right) => (right.progress ?? 0) - (left.progress ?? 0))
-    .slice(0, 3);
+    .filter(isDefined);
+
+  return bars.toSorted((left, right) => (right.progress ?? 0) - (left.progress ?? 0)).slice(0, 3);
 };
 
 const buildAutomationTransferBarModels = ({
@@ -130,9 +132,9 @@ const buildAutomationTransferBarModels = ({
 }: Omit<BuildRealmTransferBarModelsOptions, "storyEvents" | "currentTimeMs">): TransferBarModel[] => {
   if (!selectedStructureId) return [];
 
-  return automationEntries
+  const bars = automationEntries
     .filter((entry) => entry.active)
-    .map((entry) => {
+    .map((entry): TransferBarModel | null => {
       const sourceId = normalizeEntityId(entry.sourceEntityId);
       const destinationId = normalizeEntityId(entry.destinationEntityId);
       if (!sourceId || !destinationId) return null;
@@ -151,8 +153,9 @@ const buildAutomationTransferBarModels = ({
         iconResources,
       };
     })
-    .filter((entry): entry is TransferBarModel => Boolean(entry))
-    .slice(0, 3);
+    .filter(isDefined);
+
+  return bars.slice(0, 3);
 };
 
 export const buildRealmTransferBarModels = ({


### PR DESCRIPTION
## Summary
Adds a reusable built-here realm summary to both the construction menu and the overview panel. Each count now includes the relevant resource icon, and hovering a summary chip reveals a + quick-build action that uses the shared autobuild path when the realm can actually place that structure. This also extracts the realm autobuild logic into a shared helper, keeps construction and overview gating aligned, and adds focused tests plus a latest-features update.

## Verification
Ran `pnpm test -- src/ui/features/settlement/construction/realm-building-summary.test.ts src/ui/features/settlement/construction/realm-building-summary.build-actions.source.test.ts src/ui/features/settlement/construction/select-preview-building.realm-summary.source.test.ts src/ui/modules/entity-details/realm/realm-info-panel.build-summary.source.test.ts src/ui/features/world/latest-features.test.ts`, `pnpm typecheck` in `client/apps/game`, `pnpm run format`, and `pnpm run knip`.