### PR TITLE
Add Enter submit shortcuts to action popups

### DIFF
--- a/client/apps/game/src/ui/design-system/molecules/base-popup.tsx
+++ b/client/apps/game/src/ui/design-system/molecules/base-popup.tsx
@@ -1,4 +1,5 @@
 import Button from "@/ui/design-system/atoms/button";
+import { handlePopupShortcutKeyDown } from "@/ui/design-system/molecules/popup-submit-shortcut";
 import X from "lucide-react/dist/esm/icons/x";
 import React, { useEffect, useRef } from "react";
 
@@ -10,6 +11,9 @@ interface BasePopupProps {
   className?: string;
   contentClassName?: string;
   width?: string;
+  submitOnEnter?: boolean;
+  onSubmit?: () => void;
+  isSubmitDisabled?: boolean;
 }
 
 export const BasePopup: React.FC<BasePopupProps> = ({
@@ -20,6 +24,9 @@ export const BasePopup: React.FC<BasePopupProps> = ({
   className = "",
   contentClassName = "",
   width = "max-w-md",
+  submitOnEnter = false,
+  onSubmit,
+  isSubmitDisabled = false,
 }) => {
   const popupRef = useRef<HTMLDivElement>(null);
 
@@ -49,6 +56,14 @@ export const BasePopup: React.FC<BasePopupProps> = ({
       <div
         ref={popupRef}
         tabIndex={-1}
+        onKeyDown={(event) =>
+          handlePopupShortcutKeyDown(event, {
+            onClose,
+            onSubmit,
+            submitOnEnter,
+            isSubmitDisabled,
+          })
+        }
         className={`border border-gold/10 bg-brown/90 panel-wood rounded p-8 w-full ${width} mx-auto flex flex-col items-center relative ${className}`}
       >
         <div className="absolute top-3 right-3">

--- a/client/apps/game/src/ui/design-system/molecules/popup-submit-shortcut.test.tsx
+++ b/client/apps/game/src/ui/design-system/molecules/popup-submit-shortcut.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/audio/hooks/useUISound", () => ({
+  useUISound: () => vi.fn(),
+}));
+
+vi.mock("@/audio", () => ({
+  useUISound: () => vi.fn(),
+}));
+
+vi.mock("@/ui/design-system/atoms/button", () => ({
+  default: ({ children, onClick, ...props }: React.ComponentProps<"button">) => (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/ui/design-system/molecules/hint-modal-button", () => ({
+  HintModalButton: () => null,
+}));
+
+vi.mock("react-draggable", () => ({
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, ...props }: React.ComponentProps<"div">) => <div {...props}>{children}</div>,
+  },
+}));
+
+import { BasePopup } from "./base-popup";
+import { SecondaryPopup } from "./secondary-popup";
+
+const SecondaryPopupWithSubmit = SecondaryPopup as typeof SecondaryPopup & ((props: any) => React.ReactElement);
+const BasePopupWithSubmit = BasePopup as typeof BasePopup & ((props: any) => React.ReactElement);
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("popup submit shortcuts", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const render = (ui: React.ReactNode) => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root.render(ui);
+    });
+  };
+
+  it("submits a SecondaryPopup when Enter is pressed in an input", () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <SecondaryPopupWithSubmit width="560" submitOnEnter onSubmit={onSubmit}>
+        <SecondaryPopup.Head>Army</SecondaryPopup.Head>
+        <SecondaryPopup.Body width="100%" height="auto">
+          <input aria-label="Troop count" />
+        </SecondaryPopup.Body>
+      </SecondaryPopupWithSubmit>,
+    );
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+
+    act(() => {
+      input?.focus();
+      input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not submit a SecondaryPopup from textarea Enter", () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <SecondaryPopupWithSubmit width="560" submitOnEnter onSubmit={onSubmit}>
+        <SecondaryPopup.Head>Notes</SecondaryPopup.Head>
+        <SecondaryPopup.Body width="100%" height="auto">
+          <textarea aria-label="Notes" />
+        </SecondaryPopup.Body>
+      </SecondaryPopupWithSubmit>,
+    );
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    act(() => {
+      textarea?.focus();
+      textarea?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits a BasePopup when Enter is pressed in an input", () => {
+    const onSubmit = vi.fn();
+
+    render(
+      <BasePopupWithSubmit title="Confirm" onClose={vi.fn()} submitOnEnter onSubmit={onSubmit}>
+        <input aria-label="Amount" />
+      </BasePopupWithSubmit>,
+    );
+
+    const input = container.querySelector("input");
+    expect(input).not.toBeNull();
+
+    act(() => {
+      input?.focus();
+      input?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/apps/game/src/ui/design-system/molecules/popup-submit-shortcut.test.tsx
+++ b/client/apps/game/src/ui/design-system/molecules/popup-submit-shortcut.test.tsx
@@ -41,6 +41,12 @@ import { SecondaryPopup } from "./secondary-popup";
 const SecondaryPopupWithSubmit = SecondaryPopup as typeof SecondaryPopup & ((props: any) => React.ReactElement);
 const BasePopupWithSubmit = BasePopup as typeof BasePopup & ((props: any) => React.ReactElement);
 
+declare global {
+  // React checks this flag in tests to suppress act environment warnings.
+  // It is only present at runtime, so the test declares it explicitly here.
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("popup submit shortcuts", () => {

--- a/client/apps/game/src/ui/design-system/molecules/popup-submit-shortcut.ts
+++ b/client/apps/game/src/ui/design-system/molecules/popup-submit-shortcut.ts
@@ -1,0 +1,49 @@
+import type React from "react";
+
+type PopupShortcutOptions = {
+  onClose?: () => void;
+  onSubmit?: () => void;
+  submitOnEnter?: boolean;
+  isSubmitDisabled?: boolean;
+};
+
+const POPUP_SUBMIT_IGNORE_SELECTOR =
+  "button,a,select,textarea,[contenteditable=''],[contenteditable='true'],[role='textbox'][aria-multiline='true']";
+
+const isModifiedEnterKey = (event: React.KeyboardEvent<HTMLElement>) =>
+  event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+
+const isComposingInput = (event: React.KeyboardEvent<HTMLElement>) => event.nativeEvent.isComposing;
+
+const shouldIgnorePopupSubmitTarget = (target: EventTarget | null) =>
+  target instanceof HTMLElement && target.closest(POPUP_SUBMIT_IGNORE_SELECTOR) !== null;
+
+const shouldSubmitPopupOnEnter = (
+  event: React.KeyboardEvent<HTMLElement>,
+  options: Pick<PopupShortcutOptions, "onSubmit" | "submitOnEnter" | "isSubmitDisabled">,
+) => {
+  if (!options.submitOnEnter || !options.onSubmit || options.isSubmitDisabled) {
+    return false;
+  }
+
+  if (event.defaultPrevented || event.key !== "Enter" || isModifiedEnterKey(event) || isComposingInput(event)) {
+    return false;
+  }
+
+  return !shouldIgnorePopupSubmitTarget(event.target);
+};
+
+export const handlePopupShortcutKeyDown = (event: React.KeyboardEvent<HTMLElement>, options: PopupShortcutOptions) => {
+  if (event.key === "Escape") {
+    options.onClose?.();
+    return;
+  }
+
+  if (!shouldSubmitPopupOnEnter(event, options)) {
+    return;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  options.onSubmit?.();
+};

--- a/client/apps/game/src/ui/design-system/molecules/secondary-popup.tsx
+++ b/client/apps/game/src/ui/design-system/molecules/secondary-popup.tsx
@@ -1,6 +1,7 @@
 import { useUISound } from "@/audio/hooks/useUISound";
 import Button from "@/ui/design-system/atoms/button";
 import { HintModalButton } from "@/ui/design-system/molecules/hint-modal-button";
+import { handlePopupShortcutKeyDown } from "@/ui/design-system/molecules/popup-submit-shortcut";
 import clsx from "clsx";
 import { motion } from "framer-motion";
 import X from "lucide-react/dist/esm/icons/x";
@@ -13,7 +14,11 @@ type FilterPopupProps = {
   containerClassName?: string;
   name?: string;
   width?: string;
+  onClose?: () => void;
   onOutsideClick?: () => void;
+  submitOnEnter?: boolean;
+  onSubmit?: () => void;
+  isSubmitDisabled?: boolean;
 };
 
 export const resolvePopupWidth = (width?: string) => {
@@ -31,7 +36,11 @@ export const SecondaryPopup = ({
   containerClassName,
   name,
   width,
+  onClose,
   onOutsideClick,
+  submitOnEnter,
+  onSubmit,
+  isSubmitDisabled,
 }: FilterPopupProps) => {
   const playPopupOpen = useUISound("ui.modal_open");
   const nodeRef = useRef<HTMLDivElement>(null);
@@ -143,10 +152,19 @@ export const SecondaryPopup = ({
           <div
             onClick={handleClick}
             ref={nodeRef}
+            onKeyDown={(event) =>
+              handlePopupShortcutKeyDown(event, {
+                onClose,
+                onSubmit,
+                submitOnEnter,
+                isSubmitDisabled,
+              })
+            }
             className={clsx(
               "fixed popup z-50 flex flex-col translate-x-6 top-[200px] left-[450px] panel-wood panel-wood-corners bg-dark-wood",
               className,
             )}
+            tabIndex={-1}
             style={resolvedWidth ? { width: resolvedWidth } : undefined}
           >
             {/* Ornate corner elements for panel-wood-corners */}

--- a/client/apps/game/src/ui/features/economy/banking/confirmation-popup.tsx
+++ b/client/apps/game/src/ui/features/economy/banking/confirmation-popup.tsx
@@ -33,7 +33,15 @@ export const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
   );
 
   return (
-    <BasePopup title={title} onClose={onCancel} footer={footer} contentClassName="">
+    <BasePopup
+      title={title}
+      onClose={onCancel}
+      footer={footer}
+      contentClassName=""
+      submitOnEnter
+      onSubmit={onConfirm}
+      isSubmitDisabled={Boolean(disabled) || isLoading}
+    >
       {children}
     </BasePopup>
   );

--- a/client/apps/game/src/ui/features/economy/resources/craft-relic-popup.tsx
+++ b/client/apps/game/src/ui/features/economy/resources/craft-relic-popup.tsx
@@ -330,7 +330,15 @@ export const CraftRelicPopup = ({ structureId, onClose }: CraftRelicPopupProps) 
   );
 
   return (
-    <BasePopup title="Craft Relic" onClose={onClose} footer={footer} contentClassName="max-w-[520px]">
+    <BasePopup
+      title="Craft Relic"
+      onClose={onClose}
+      footer={footer}
+      contentClassName="max-w-[520px]"
+      submitOnEnter
+      onSubmit={handleCraftRelic}
+      isSubmitDisabled={isCrafting || !canCraft}
+    >
       <div className="space-y-4 text-left">
         <div className="rounded border border-relic/40 bg-gradient-to-b from-relic/20 to-dark-brown/30 p-4">
           <div className="flex items-start justify-between gap-3">

--- a/client/apps/game/src/ui/features/economy/resources/relic-activation-popup.tsx
+++ b/client/apps/game/src/ui/features/economy/resources/relic-activation-popup.tsx
@@ -116,7 +116,15 @@ export const RelicActivationPopup: React.FC<RelicActivationPopupProps> = ({
   );
 
   return (
-    <BasePopup title="Activate Relic" onClose={onClose} footer={footer} contentClassName="">
+    <BasePopup
+      title="Activate Relic"
+      onClose={onClose}
+      footer={footer}
+      contentClassName=""
+      submitOnEnter
+      onSubmit={handleConfirm}
+      isSubmitDisabled={isLoading || !!error || !compatible || !hasEnoughEssence}
+    >
       <RelicSummary
         resourceKey={resourceKey}
         title={resourceName}

--- a/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/action-footer.tsx
+++ b/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/action-footer.tsx
@@ -9,9 +9,10 @@ interface ActionFooterProps {
   isLoading: boolean;
   isDisabled: boolean;
   onSubmit: () => void;
+  shortcutHint?: string | null;
 }
 
-export const ActionFooter = ({ armyType, label, isLoading, isDisabled, onSubmit }: ActionFooterProps) => {
+export const ActionFooter = ({ armyType, label, isLoading, isDisabled, onSubmit, shortcutHint }: ActionFooterProps) => {
   return (
     <div className="p-1.5 rounded-xl bg-gradient-to-br from-brown/10 to-brown/5 border border-gold/20">
       <Button
@@ -33,6 +34,11 @@ export const ActionFooter = ({ armyType, label, isLoading, isDisabled, onSubmit 
           <span className="drop-shadow-sm">{label}</span>
         </div>
       </Button>
+      {shortcutHint && !isDisabled && !isLoading && (
+        <div className="mt-1.5 text-center text-[11px] font-medium uppercase tracking-[0.16em] text-gold/55">
+          {shortcutHint}
+        </div>
+      )}
     </div>
   );
 };

--- a/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx
+++ b/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx
@@ -687,7 +687,11 @@ export const UnifiedArmyCreationModal = ({
       width="800"
       name="unified-army-creation-modal"
       containerClassName="absolute left-0 top-0"
+      onClose={handleClose}
       onOutsideClick={handleClose}
+      submitOnEnter
+      onSubmit={handleCreate}
+      isSubmitDisabled={isActionDisabled}
     >
       <SecondaryPopup.Head onClose={handleClose}>{modalTitle}</SecondaryPopup.Head>
       <SecondaryPopup.Body width="100%" height="auto">
@@ -765,6 +769,7 @@ export const UnifiedArmyCreationModal = ({
                 isLoading={isLoading}
                 isDisabled={isActionDisabled}
                 onSubmit={handleCreate}
+                shortcutHint="Press Enter to submit"
               />
             </div>
           </div>

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-25",
+    title: "Keyboard Confirm Shortcuts",
+    description:
+      "Army creation and confirmation popups now accept Enter as the primary submit shortcut, so you can finish common actions from the keyboard without hunting for the confirm button.",
+    type: "improvement",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-24",
     title: "Steadier Realm Sidebar",
     description:


### PR DESCRIPTION
## Summary
- add a shared opt-in Enter-to-submit contract for `BasePopup` and `SecondaryPopup`, covered by popup shortcut tests
- wire the shared shortcut into army creation and confirmation-style relic/banking popups while ignoring multiline and interactive controls
- surface the shortcut hint in the army modal and record the UX update in latest features

## Verification
- `pnpm --dir client/apps/game test src/ui/design-system/molecules/popup-submit-shortcut.test.tsx`
- `pnpm run format`
- `pnpm run knip`