### PR TITLE
Fix missing world map structure labels

### DIFF
--- a/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
+++ b/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
@@ -6,6 +6,14 @@ vi.mock("@/hooks/store/use-account-store", () => ({
   },
 }));
 
+vi.mock("@/hooks/store/use-chain-time-store", () => ({
+  useChainTimeStore: {
+    getState: vi.fn(() => ({
+      getNowSeconds: () => 0,
+    })),
+  },
+}));
+
 vi.mock("@/config/game-modes", () => ({
   getGameModeConfig: vi.fn(() => ({
     assets: {
@@ -564,6 +572,35 @@ describe("StructureManager destroy lifecycle", () => {
     expect(subject.finalizeVisibleStructureModelPass).not.toHaveBeenCalled();
     expect(subject.finalizeVisibleStructurePass).not.toHaveBeenCalled();
     expect(setCount).not.toHaveBeenCalled();
+  });
+
+  it("keeps structure marker presentation alive even when a model bucket is unavailable", async () => {
+    const { subject } = createVisibleStructurePassSubject();
+    const visibleStructure = {
+      entityId: 11,
+      hexCoords: { col: 3, row: 7 },
+      structureType: "HolySite",
+    };
+
+    subject.getVisibleStructuresForChunk = vi.fn(() => [visibleStructure]);
+    subject.createVisibleStructureRenderPlan = vi.fn(() => ({
+      structuresByType: new Map([["HolySite", [visibleStructure]]]),
+      structuresByCosmeticId: new Map(),
+      missingStructureModels: [],
+      missingCosmeticModels: [],
+    }));
+    subject.finalizeVisibleStructureModelPass = vi.fn();
+
+    await subject.performVisibleStructuresUpdate();
+
+    expect(subject.syncVisibleStructurePresentation).toHaveBeenCalledWith(
+      undefined,
+      visibleStructure,
+      0,
+      expect.any(Set),
+    );
+    expect(subject.finalizeVisibleStructurePass).toHaveBeenCalledWith(new Set([11]), expect.any(Set));
+    expect(subject.finalizeVisibleStructureModelPass).toHaveBeenCalled();
   });
 
   it("discards an older visible refresh when a newer pass supersedes it", async () => {

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -2,7 +2,6 @@ import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
 import { getGameModeConfig } from "@/config/game-modes";
 import type { GameModeConfig } from "@/config/game-modes";
-import { isVillageLikeStructureCategory } from "@/lib/structure-type-utils";
 import InstancedModel, { LAND_NAME } from "@/three/managers/instanced-model";
 import { recordWorldmapRenderDuration, setWorldmapRenderGauge } from "@/three/perf/worldmap-render-diagnostics";
 import { CameraView, HexagonScene } from "@/three/scenes/hexagon-scene";
@@ -73,6 +72,7 @@ import {
 import { removeStructureLabels, syncStructureLabelVisibility } from "./structure-label-visibility";
 import { refreshStructureCosmeticsByOwner } from "./structure-cosmetics-refresh";
 import { normalizeStructureEntityId as normalizeEntityId } from "./structure-entity-id";
+import { resolveStructurePointRendererKey, type StructurePointRendererKey } from "./structure-point-renderer-key";
 import {
   mapPendingStructureGuardArmies,
   queuePendingBuildingLabelUpdate,
@@ -90,6 +90,7 @@ import {
   shouldRebuildVisibleStructuresForStructureUpdate,
   shouldRefreshVisibleStructures,
 } from "./structure-update-policy";
+import { presentVisibleStructures } from "./structure-visible-presentation-pass";
 
 const INITIAL_STRUCTURE_CAPACITY = 64;
 const WONDER_MODEL_INDEX = 4;
@@ -157,17 +158,7 @@ export class StructureManager {
   private readonly animationCullDistance = 140;
   private animationCameraPosition: Vector3 = new Vector3();
   private animationVisibilityContext?: AnimationVisibilityContext;
-  private pointsRenderers?: {
-    myVillage: PointsLabelRenderer;
-    enemyVillage: PointsLabelRenderer;
-    allyVillage: PointsLabelRenderer;
-    myRealm: PointsLabelRenderer;
-    enemyRealm: PointsLabelRenderer;
-    allyRealm: PointsLabelRenderer;
-    hyperstructure: PointsLabelRenderer;
-    bank: PointsLabelRenderer;
-    fragmentMine: PointsLabelRenderer;
-  };
+  private pointsRenderers?: Record<StructurePointRendererKey, PointsLabelRenderer>;
   private frustumManager?: FrustumManager;
   private frustumVisibilityDirty = false;
   private lastLabelVisibilityUpdate = 0;
@@ -1222,6 +1213,7 @@ export class StructureManager {
       const modelInstanceCounts = new Map<InstancedModel, number>();
       const nextActiveStructureModels = new Set<InstancedModel>();
       const nextActiveCosmeticStructureModels = new Set<InstancedModel>();
+      const presentedStructureIds = new Set<ID>();
 
       // Begin batch mode for all point renderers (avoids computeBoundingSphere per setPoint)
       if (this.pointsRenderers) {
@@ -1237,6 +1229,7 @@ export class StructureManager {
 
         structures.forEach((structure) => {
           visibleStructureIds.add(structure.entityId);
+          presentedStructureIds.add(structure.entityId);
           const rotationY = this.resolveVisibleStructureRotationY(structure);
           this.syncVisibleStructurePresentation(undefined, structure, rotationY, attachmentRetain);
           this.bindVisibleStructureInstance(
@@ -1261,6 +1254,7 @@ export class StructureManager {
 
         structures.forEach((structure) => {
           visibleStructureIds.add(structure.entityId);
+          presentedStructureIds.add(structure.entityId);
           const rotationY = this.resolveVisibleStructureRotationY(structure);
           this.syncVisibleStructurePresentation(undefined, structure, rotationY, attachmentRetain);
           this.bindVisibleCosmeticStructureInstance(
@@ -1274,6 +1268,18 @@ export class StructureManager {
 
         // Note: setCount will be called once per model after all structures are processed
       }
+
+      const fallbackVisibleStructureIds = presentVisibleStructures({
+        visibleStructures: visibleStructures.filter((structure) => !presentedStructureIds.has(structure.entityId)),
+        presentStructure: (structure) => {
+          const rotationY = this.resolveVisibleStructureRotationY(structure);
+          this.syncVisibleStructurePresentation(undefined, structure, rotationY, attachmentRetain);
+        },
+      });
+
+      fallbackVisibleStructureIds.forEach((entityId) => {
+        visibleStructureIds.add(entityId);
+      });
 
       this.finalizeVisibleStructureModelPass(
         modelInstanceCounts,
@@ -1465,32 +1471,13 @@ export class StructureManager {
   private getRendererForStructure(structure: StructureInfo): PointsLabelRenderer | null {
     if (!this.pointsRenderers) return null;
 
-    const { structureType, isMine, isAlly } = structure;
+    const rendererKey = resolveStructurePointRendererKey({
+      structureType: structure.structureType,
+      isMine: structure.isMine,
+      isAlly: structure.isAlly,
+    });
 
-    if (isVillageLikeStructureCategory(structureType)) {
-      return isMine
-        ? this.pointsRenderers.myVillage
-        : isAlly
-          ? this.pointsRenderers.allyVillage
-          : this.pointsRenderers.enemyVillage;
-    }
-    if (structureType === StructureType.Realm) {
-      return isMine
-        ? this.pointsRenderers.myRealm
-        : isAlly
-          ? this.pointsRenderers.allyRealm
-          : this.pointsRenderers.enemyRealm;
-    }
-    if (structureType === StructureType.Hyperstructure) {
-      return this.pointsRenderers.hyperstructure;
-    }
-    if (structureType === StructureType.Bank) {
-      return this.pointsRenderers.bank;
-    }
-    if (structureType === StructureType.FragmentMine) {
-      return this.pointsRenderers.fragmentMine;
-    }
-    return null;
+    return rendererKey ? this.pointsRenderers[rendererKey] : null;
   }
 
   private getVisibleStructuresForChunk(startRow: number, startCol: number): StructureInfo[] {

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -1269,7 +1269,7 @@ export class StructureManager {
         // Note: setCount will be called once per model after all structures are processed
       }
 
-      const fallbackVisibleStructureIds = presentVisibleStructures({
+      const fallbackVisibleStructureIds = presentVisibleStructures<StructureInfo, ID>({
         visibleStructures: visibleStructures.filter((structure) => !presentedStructureIds.has(structure.entityId)),
         presentStructure: (structure) => {
           const rotationY = this.resolveVisibleStructureRotationY(structure);

--- a/client/apps/game/src/three/managers/structure-point-renderer-key.test.ts
+++ b/client/apps/game/src/three/managers/structure-point-renderer-key.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@bibliothecadao/types", () => ({
+  StructureType: {
+    Village: 1,
+    Realm: 2,
+    Hyperstructure: 3,
+    Bank: 4,
+    FragmentMine: 5,
+    HolySite: 6,
+    Camp: 7,
+    BitcoinMine: 8,
+  },
+}));
+
+const { StructureType } = await import("@bibliothecadao/types");
+const { resolveStructurePointRendererKey } = await import("./structure-point-renderer-key");
+
+describe("resolveStructurePointRendererKey", () => {
+  it("routes village-like structures through village ownership buckets", () => {
+    expect(
+      resolveStructurePointRendererKey({
+        structureType: StructureType.Camp,
+        isMine: false,
+        isAlly: true,
+      }),
+    ).toBe("allyVillage");
+  });
+
+  it("routes holy sites through the hyperstructure marker bucket", () => {
+    expect(
+      resolveStructurePointRendererKey({
+        structureType: StructureType.HolySite,
+        isMine: false,
+        isAlly: false,
+      }),
+    ).toBe("hyperstructure");
+  });
+
+  it("routes bitcoin mines through the fragment-mine marker bucket", () => {
+    expect(
+      resolveStructurePointRendererKey({
+        structureType: StructureType.BitcoinMine,
+        isMine: false,
+        isAlly: false,
+      }),
+    ).toBe("fragmentMine");
+  });
+});

--- a/client/apps/game/src/three/managers/structure-point-renderer-key.ts
+++ b/client/apps/game/src/three/managers/structure-point-renderer-key.ts
@@ -1,0 +1,50 @@
+import { isVillageLikeStructureCategory, normalizeStructureCategory } from "@/lib/structure-type-utils";
+import { StructureType } from "@bibliothecadao/types";
+
+export type StructurePointRendererKey =
+  | "myVillage"
+  | "enemyVillage"
+  | "allyVillage"
+  | "myRealm"
+  | "enemyRealm"
+  | "allyRealm"
+  | "hyperstructure"
+  | "bank"
+  | "fragmentMine";
+
+interface ResolveStructurePointRendererKeyInput {
+  structureType: StructureType | number | bigint | null | undefined;
+  isMine: boolean;
+  isAlly: boolean;
+}
+
+export function resolveStructurePointRendererKey(
+  input: ResolveStructurePointRendererKeyInput,
+): StructurePointRendererKey | null {
+  const structureType = normalizeStructureCategory(input.structureType);
+  if (structureType === null) {
+    return null;
+  }
+
+  if (isVillageLikeStructureCategory(structureType)) {
+    return input.isMine ? "myVillage" : input.isAlly ? "allyVillage" : "enemyVillage";
+  }
+
+  if (structureType === StructureType.Realm) {
+    return input.isMine ? "myRealm" : input.isAlly ? "allyRealm" : "enemyRealm";
+  }
+
+  if (structureType === StructureType.Hyperstructure || structureType === StructureType.HolySite) {
+    return "hyperstructure";
+  }
+
+  if (structureType === StructureType.Bank) {
+    return "bank";
+  }
+
+  if (structureType === StructureType.FragmentMine || structureType === StructureType.BitcoinMine) {
+    return "fragmentMine";
+  }
+
+  return null;
+}

--- a/client/apps/game/src/three/managers/structure-visible-presentation-pass.test.ts
+++ b/client/apps/game/src/three/managers/structure-visible-presentation-pass.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { presentVisibleStructures } = await import("./structure-visible-presentation-pass");
+
+describe("presentVisibleStructures", () => {
+  it("presents every visible structure and returns the retained entity ids", () => {
+    const presentStructure = vi.fn();
+    const visibleStructureIds = presentVisibleStructures({
+      visibleStructures: [
+        { entityId: 11, structureType: "HolySite" },
+        { entityId: 12, structureType: "Village" },
+      ],
+      presentStructure,
+    });
+
+    expect(presentStructure).toHaveBeenCalledTimes(2);
+    expect(presentStructure).toHaveBeenNthCalledWith(1, { entityId: 11, structureType: "HolySite" });
+    expect(presentStructure).toHaveBeenNthCalledWith(2, { entityId: 12, structureType: "Village" });
+    expect(visibleStructureIds).toEqual(new Set([11, 12]));
+  });
+});

--- a/client/apps/game/src/three/managers/structure-visible-presentation-pass.ts
+++ b/client/apps/game/src/three/managers/structure-visible-presentation-pass.ts
@@ -1,0 +1,13 @@
+export function presentVisibleStructures<
+  TStructure extends { entityId: TEntityId },
+  TEntityId extends string | number | bigint,
+>(input: { visibleStructures: TStructure[]; presentStructure: (structure: TStructure) => void }): Set<TEntityId> {
+  const visibleStructureIds = new Set<TEntityId>();
+
+  input.visibleStructures.forEach((structure) => {
+    visibleStructureIds.add(structure.entityId);
+    input.presentStructure(structure);
+  });
+
+  return visibleStructureIds;
+}

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-25",
+    title: "Structure Map Labels",
+    description:
+      "World map structure markers now stay visible across more structure types and fallback cases, so named locations are easier to spot again while scanning the map.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-24",
     title: "Steadier Realm Sidebar",
     description:


### PR DESCRIPTION
This restores missing world-map structure markers by aligning structure point-label routing with the existing structure label definitions and by keeping marker presentation alive even when a visible structure does not bind to a model bucket.

The regression came from the point-marker path lagging newer structure types and from presentation being skipped when model-backed rendering was unavailable, which left some structures unlabeled on the map. Players should now see structure markers again for camps, holy sites, bitcoin mines, and other fallback cases, and the change adds focused coverage for the routing and fallback presentation paths. Validation used targeted Vitest helper tests plus `git diff --check`; repo-level `pnpm run format` and `pnpm run knip` remain blocked in this workspace by missing `prettier` and missing `@eslint/js` in `client/apps/eternum-mobile/eslint.config.js`.
