### PR TITLE
[codex] Fix realtime zlib imports

### DIFF
--- a/client/apps/realtime-server/src/http/routes/__tests__/cache-response.test.ts
+++ b/client/apps/realtime-server/src/http/routes/__tests__/cache-response.test.ts
@@ -1,4 +1,4 @@
-import { brotliDecompressSync } from "zlib";
+import * as nodeZlib from "node:zlib";
 import { describe, expect, it } from "vitest";
 
 import { createCachedJsonResponse, createJsonPayload } from "../cache-response";
@@ -21,7 +21,7 @@ describe("createCachedJsonResponse", () => {
     expect(response.headers.get("Vary")).toBe("Accept-Encoding");
 
     const compressedBody = new Uint8Array(await response.arrayBuffer());
-    const decompressedBody = brotliDecompressSync(compressedBody).toString();
+    const decompressedBody = nodeZlib.brotliDecompressSync(compressedBody).toString();
 
     expect(decompressedBody).toContain("message");
   });

--- a/client/apps/realtime-server/src/http/routes/cache-response.ts
+++ b/client/apps/realtime-server/src/http/routes/cache-response.ts
@@ -1,4 +1,4 @@
-import { brotliCompressSync, gzipSync } from "zlib";
+import * as nodeZlib from "node:zlib";
 
 export type SerializedJson = string;
 
@@ -24,13 +24,13 @@ export const createJsonPayload = (value: unknown): CachedJsonPayload => {
 const getCompressedPayload = (payload: CachedJsonPayload, encoding: "br" | "gzip"): Uint8Array => {
   if (encoding === "br") {
     if (!payload.br) {
-      payload.br = brotliCompressSync(payload.json);
+      payload.br = nodeZlib.brotliCompressSync(payload.json);
     }
     return payload.br;
   }
 
   if (!payload.gzip) {
-    payload.gzip = gzipSync(payload.json);
+    payload.gzip = nodeZlib.gzipSync(payload.json);
   }
   return payload.gzip;
 };


### PR DESCRIPTION
## Summary
Use `node:zlib` namespace imports for realtime cache compression and test decompression so Bun resolves the built-in module reliably.
This preserves the brotli/gzip response behavior while fixing the realtime server startup failure.

## Validation
- `bun run src/server.ts`
- `pnpm --dir client/apps/realtime-server test`
- `pnpm --dir client/apps/realtime-server typecheck`
- `pnpm run format`
- `pnpm run knip`