### PR TITLE
[codex] Fix config-backed game launch steps

### DIFF
--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -289,6 +289,11 @@ jobs:
           fi
 
           cat > .context/game-launch/launch-env.sh <<'EOF'
+          if [ -f .context/game-launch/launch-config-inputs.sh ]; then
+            # shellcheck disable=SC1091
+            source .context/game-launch/launch-config-inputs.sh
+          fi
+
           if [ -f .context/game-launch/launch-options.sh ]; then
             # shellcheck disable=SC1091
             source .context/game-launch/launch-options.sh


### PR DESCRIPTION
Config-backed Game Launch runs were loading YAML values only during the prepare step, so later workflow steps lost rotation fields and failed validation. This changes the generated launch environment to re-source the config exports before building step arguments, preserving YAML-backed series and rotation inputs across the job. Validated with `pnpm run format` and `pnpm run knip`.