### PR TITLE
[codex] Fix rotation retry schedule validation

### DIFF
--- a/config/deployer/clean/launch/rotation-runner.ts
+++ b/config/deployer/clean/launch/rotation-runner.ts
@@ -5,6 +5,7 @@ import {
   persistRotationLaunchSummary,
   reconcileRotationLaunchSummary,
   resolveDefaultRotationRetryIntervalMinutes,
+  resolveRotationRequestWithPersistedSchedule,
   validateRotationLaunchRequest,
 } from "./rotation-summary";
 import type {
@@ -47,27 +48,29 @@ function buildDryRunRotationSummary(
 }
 
 export async function runLaunchRotationStep(request: LaunchRotationStepRequest): Promise<LaunchRotationSummary> {
-  validateRotationLaunchRequest(request);
-  const summary = await resolvePlannedRotationSummary(request);
+  const scheduledRequest = resolveRotationRequestWithPersistedSchedule(request);
+  validateRotationLaunchRequest(scheduledRequest);
+  const summary = await resolvePlannedRotationSummary(scheduledRequest);
 
-  if (request.dryRun) {
-    return buildDryRunRotationSummary(request, summary);
+  if (scheduledRequest.dryRun) {
+    return buildDryRunRotationSummary(scheduledRequest, summary);
   }
 
-  return executeRotationStep(request, summary);
+  return executeRotationStep(scheduledRequest, summary);
 }
 
 export async function launchRotation(request: LaunchRotationRequest): Promise<LaunchRotationSummary> {
-  validateRotationLaunchRequest(request);
-  let summary = await resolvePlannedRotationSummary(request);
+  const scheduledRequest = resolveRotationRequestWithPersistedSchedule(request);
+  validateRotationLaunchRequest(scheduledRequest);
+  let summary = await resolvePlannedRotationSummary(scheduledRequest);
 
-  if (request.dryRun) {
-    return buildDryRunRotationSummary(request, summary);
+  if (scheduledRequest.dryRun) {
+    return buildDryRunRotationSummary(scheduledRequest, summary);
   }
 
-  for (const stepId of resolveSeriesLaunchStepIds(request.environmentId)) {
+  for (const stepId of resolveSeriesLaunchStepIds(scheduledRequest.environmentId)) {
     summary = await runLaunchRotationStep({
-      ...request,
+      ...scheduledRequest,
       stepId: stepId as RotationLaunchStepId,
       resumeSummary: summary,
     });

--- a/config/deployer/clean/launch/rotation-summary.ts
+++ b/config/deployer/clean/launch/rotation-summary.ts
@@ -62,10 +62,56 @@ export function validateRotationLaunchRequest(request: LaunchRotationRequest): v
   parseStartTime(request.firstGameStartTime);
 }
 
+export function resolveRotationRequestWithPersistedSchedule<TRequest extends LaunchRotationRequest>(
+  request: TRequest,
+): TRequest {
+  if (hasRequestSchedule(request)) {
+    return request;
+  }
+
+  const summary = resolvePersistedRotationScheduleSummary(request);
+  if (!summary) {
+    return request;
+  }
+
+  return {
+    ...request,
+    gameIntervalMinutes: resolvePersistedRotationGameIntervalMinutes(request, summary),
+    weeklyCadence: hasWeeklyCadence(request) ? request.weeklyCadence : summary.weeklyCadence,
+  };
+}
+
+function hasRequestSchedule(request: LaunchRotationRequest): boolean {
+  return hasWeeklyCadence(request) || isRotationPositiveInteger(request.gameIntervalMinutes);
+}
+
+function resolvePersistedRotationScheduleSummary(request: LaunchRotationRequest): LaunchRotationSummary | null {
+  return (
+    request.resumeSummary ?? loadRotationLaunchSummaryIfPresent(request.environmentId, request.rotationName.trim())
+  );
+}
+
+function resolvePersistedRotationGameIntervalMinutes(
+  request: LaunchRotationRequest,
+  summary: LaunchRotationSummary,
+): number {
+  if (hasWeeklyCadence(summary)) {
+    return request.gameIntervalMinutes;
+  }
+
+  return isRotationPositiveInteger(summary.gameIntervalMinutes)
+    ? summary.gameIntervalMinutes
+    : request.gameIntervalMinutes;
+}
+
 function validateRotationPositiveInteger(value: number, label: string): void {
-  if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+  if (!isRotationPositiveInteger(value)) {
     throw new Error(`${label} must be a positive integer`);
   }
+}
+
+function isRotationPositiveInteger(value: number): boolean {
+  return Number.isFinite(value) && Number.isInteger(value) && value > 0;
 }
 
 function hasWeeklyCadence(request: Pick<LaunchRotationRequest, "weeklyCadence">): boolean {

--- a/config/deployer/clean/tests/rotation-summary.test.ts
+++ b/config/deployer/clean/tests/rotation-summary.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { buildInitialRotationLaunchSummary, reconcileRotationLaunchSummary } from "../launch/rotation-summary";
+import {
+  buildInitialRotationLaunchSummary,
+  reconcileRotationLaunchSummary,
+  resolveRotationRequestWithPersistedSchedule,
+  validateRotationLaunchRequest,
+} from "../launch/rotation-summary";
 import type { LaunchRotationRequest } from "../types";
 
 function buildWeeklyRotationRequest(overrides: Partial<LaunchRotationRequest> = {}): LaunchRotationRequest {
@@ -130,5 +135,18 @@ describe("rotation launch summary", () => {
       "na-gladiator-20-04-26-0100",
       "na-gladiator-20-04-26-0300",
     ]);
+  });
+
+  test("validates a retry request with the persisted weekly cadence", () => {
+    const persistedRequest = buildWeeklyRotationRequest();
+    const retryRequest = buildWeeklyRotationRequest({
+      weeklyCadence: undefined,
+      resumeSummary: buildInitialRotationLaunchSummary(persistedRequest),
+    });
+
+    const resolvedRequest = resolveRotationRequestWithPersistedSchedule(retryRequest);
+
+    expect(() => validateRotationLaunchRequest(resolvedRequest)).not.toThrow();
+    expect(resolvedRequest.weeklyCadence).toEqual(persistedRequest.weeklyCadence);
   });
 });


### PR DESCRIPTION
Fixes rotation launch retries that failed before hydration when the workflow only supplied the persisted weekly cadence through stored run state.

The rotation runner now resolves the effective schedule from a resume summary or persisted summary before validating and executing, so weekly cadence rotations can retry with the `game_interval_minutes=0` placeholder.

Adds a regression test covering persisted weekly cadence validation.

Validated with `bun test config/deployer/clean/tests/rotation-summary.test.ts`, `pnpm run format`, `pnpm run knip`, and `git diff --check`.