### PR TITLE
[codex] Fix realtime worlds summary status

### DIFF
--- a/client/apps/realtime-server/src/http/routes/worlds.ts
+++ b/client/apps/realtime-server/src/http/routes/worlds.ts
@@ -5,8 +5,8 @@ import { availabilityService } from "../../services/torii-availability";
 const worldsRoutes = new Hono<AppEnv>();
 
 worldsRoutes.get("/summary", (c) => {
-  c.header("Cache-Control", availabilityService.isSummaryReady() ? "public, max-age=10" : "no-store");
-  return c.json(availabilityService.getSummaries());
+  const cacheControl = availabilityService.isSummaryReady() ? "public, max-age=10" : "no-store";
+  return c.json(availabilityService.getSummaries(), 200, { "Cache-Control": cacheControl });
 });
 
 export default worldsRoutes;


### PR DESCRIPTION
## Summary
Fixes the realtime `/api/worlds/summary` route so it returns the summary JSON with an explicit `200` status and cache header in one response call.

The regression came from setting `Cache-Control` on the Hono context before `c.json()`, which let an invalid status `0` leak into response construction under the production middleware path.

## Validation
- `pnpm --dir client/apps/realtime-server test src/http/routes/__tests__/worlds.test.ts`
- `pnpm run format`
- `pnpm run knip`