### PR TITLE
Harden game network and spectator recovery

### DIFF
--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -205,6 +205,34 @@ describe("ConnectionHealthMonitor", () => {
     monitor.dispose();
   });
 
+  it("treats an unhealthy HTTP response as disconnected", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const healthCheckFn = vi.fn(() => Promise.resolve(false));
+
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn,
+      healthCheckIntervalMs: 1_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      staleThresholdMs: 5_000,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(onReconnectSpatial).not.toHaveBeenCalled();
+    expect(onReconnectGlobal).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().status).toBe("disconnected");
+    expect(useConnectionStore.getState().spatialStatus).toBe("failed");
+    expect(useConnectionStore.getState().globalStatus).toBe("failed");
+    expect(useConnectionStore.getState().reconnectAttempts).toBe(1);
+
+    monitor.dispose();
+  });
+
   it("sets per-stream status to reconnecting then connected around a reconnect", async () => {
     const onReconnectSpatial = vi.fn(() => Promise.resolve());
     const onReconnectGlobal = vi.fn(() => Promise.resolve());

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -140,52 +140,60 @@ export class ConnectionHealthMonitor {
     // Skip polling if tab is hidden to save resources
     if (document.visibilityState === "hidden") return;
 
-    const store = useConnectionStore.getState();
-
     try {
       const healthy = await this.config.healthCheckFn();
-
-      if (healthy) {
-        store.recordHealthCheck();
-        this.markConnectedIfNeeded();
-        store.resetReconnectAttempts();
-
-        // Boot grace: only consider streams stale once we've seen both tick
-        // at least once *after* the monitor started. Until then, a quiet
-        // subscription could just be mid-handshake — don't cancel it.
-        if (!this.hasObservedHealthyStreams) {
-          if (store.lastSpatialUpdate > this.startedAtMs && store.lastGlobalUpdate > this.startedAtMs) {
-            this.hasObservedHealthyStreams = true;
-          } else {
-            return;
-          }
-        }
-
-        // Server is reachable, but a stream can silently die (WASM gRPC drop
-        // without onError firing) while the tab stays visible. If either stream
-        // has been silent past the stale threshold, force a resubscribe.
-        // Cooldown prevents reconnect storms when the area is genuinely idle.
-        const now = Date.now();
-        if (now - this.lastStreamReconnectAtMs >= this.reconnectCooldownMs) {
-          const spatialStale = now - store.lastSpatialUpdate > this.staleThresholdMs;
-          const globalStale = now - store.lastGlobalUpdate > this.staleThresholdMs;
-          if (spatialStale || globalStale) {
-            this.lastStreamReconnectAtMs = now;
-            void this.reconnectStaleStreams(spatialStale, globalStale);
-          }
-        }
+      if (!healthy) {
+        this.markHealthCheckFailed();
+        return;
       }
+
+      this.markHealthCheckPassed();
     } catch {
-      store.setStatus("disconnected");
-      store.setSpatialStatus("failed");
-      store.setGlobalStatus("failed");
-      store.incrementReconnectAttempts();
-      this.markOutageStart();
-      this.reportDeadEndIfNeeded();
+      this.markHealthCheckFailed();
     }
   }
 
   // --- Shared reconnect logic ---
+
+  private markHealthCheckPassed(): void {
+    const store = useConnectionStore.getState();
+    store.recordHealthCheck();
+    this.markConnectedIfNeeded();
+    store.resetReconnectAttempts();
+
+    if (!this.hasObservedHealthyStreams) {
+      this.hasObservedHealthyStreams = this.haveStreamsTickedSinceStart(store);
+      if (!this.hasObservedHealthyStreams) return;
+    }
+
+    this.reconnectSilentStreamsAfterCooldown(store);
+  }
+
+  private markHealthCheckFailed(): void {
+    const store = useConnectionStore.getState();
+    store.setStatus("disconnected");
+    store.setSpatialStatus("failed");
+    store.setGlobalStatus("failed");
+    store.incrementReconnectAttempts();
+    this.markOutageStart();
+    this.reportDeadEndIfNeeded();
+  }
+
+  private haveStreamsTickedSinceStart(store: ReturnType<typeof useConnectionStore.getState>): boolean {
+    return store.lastSpatialUpdate > this.startedAtMs && store.lastGlobalUpdate > this.startedAtMs;
+  }
+
+  private reconnectSilentStreamsAfterCooldown(store: ReturnType<typeof useConnectionStore.getState>): void {
+    const now = Date.now();
+    if (now - this.lastStreamReconnectAtMs < this.reconnectCooldownMs) return;
+
+    const spatialStale = now - store.lastSpatialUpdate > this.staleThresholdMs;
+    const globalStale = now - store.lastGlobalUpdate > this.staleThresholdMs;
+    if (!spatialStale && !globalStale) return;
+
+    this.lastStreamReconnectAtMs = now;
+    void this.reconnectStaleStreams(spatialStale, globalStale);
+  }
 
   private async reconnectStaleStreams(spatial: boolean, global: boolean): Promise<void> {
     if (this.reconnecting || this.disposed) return;

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -64,6 +64,7 @@ import {
 } from "./game-entry-settlement.utils";
 import { runBlitzSettlementFlow } from "./game-entry-blitz-settlement-flow";
 import {
+  isGameEntryPreflightComplete,
   resolveGameEntryBlockingError,
   resolveGameEntryModalPhase,
   type GameEntryModalPhase as ModalPhase,
@@ -3531,9 +3532,16 @@ export const GameEntryModal = ({
     isLoadingVillagePassInventory ||
     isLoadingOwnedStructures ||
     !worldMeta;
+  const entryPreflightComplete = isGameEntryPreflightComplete({
+    isEternumMode,
+    isSpectateMode,
+    isForgeMode,
+    isBlitzMode,
+    settlementCheckComplete,
+  });
   const bootstrapStatus: "idle" | "pending-world" | "loading" | "ready" | "error" = preflightError
     ? "error"
-    : isCheckingWorldAvailability || isLoadingWorldSystemAddresses || (!isEternumMode && !settlementCheckComplete)
+    : isCheckingWorldAvailability || isLoadingWorldSystemAddresses || !entryPreflightComplete
       ? "loading"
       : "ready";
   const tasks = useMemo(
@@ -3551,10 +3559,10 @@ export const GameEntryModal = ({
       {
         id: "preflight",
         label: isBlitzMode ? "Checking blitz settlement state" : "Checking world entry state",
-        status: settlementCheckComplete || isEternumMode ? ("complete" as const) : ("running" as const),
+        status: entryPreflightComplete ? ("complete" as const) : ("running" as const),
       },
     ],
-    [isBlitzMode, isEternumMode, resolvedWorldSystemAddresses, settlementCheckComplete, worldMeta],
+    [entryPreflightComplete, isBlitzMode, resolvedWorldSystemAddresses, worldMeta],
   );
   const progress = useMemo(() => {
     const completed = tasks.filter((task) => task.status === "complete").length;

--- a/client/apps/game/src/ui/features/landing/components/game-entry-phase.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-phase.test.ts
@@ -2,9 +2,37 @@
 
 import { describe, expect, it } from "vitest";
 
-import { resolveGameEntryBlockingError, resolveGameEntryModalPhase } from "./game-entry-phase";
+import {
+  isGameEntryPreflightComplete,
+  resolveGameEntryBlockingError,
+  resolveGameEntryModalPhase,
+} from "./game-entry-phase";
 
 describe("game entry phase resolution", () => {
+  it("marks spectator preflight complete without waiting for player settlement checks", () => {
+    const isComplete = isGameEntryPreflightComplete({
+      isEternumMode: false,
+      isSpectateMode: true,
+      isForgeMode: false,
+      isBlitzMode: true,
+      settlementCheckComplete: false,
+    });
+
+    expect(isComplete).toBe(true);
+  });
+
+  it("waits for player blitz settlement checks before normal play entry", () => {
+    const isComplete = isGameEntryPreflightComplete({
+      isEternumMode: false,
+      isSpectateMode: false,
+      isForgeMode: false,
+      isBlitzMode: true,
+      settlementCheckComplete: false,
+    });
+
+    expect(isComplete).toBe(false);
+  });
+
   it("surfaces a blocking error when world metadata settles into an unknown mode", () => {
     const error = resolveGameEntryBlockingError({
       worldAvailabilityErrorMessage: null,

--- a/client/apps/game/src/ui/features/landing/components/game-entry-phase.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-phase.ts
@@ -49,6 +49,26 @@ interface ResolveGameEntryModalPhaseInput {
   isBlitzSettlementUnlocked: boolean;
 }
 
+interface GameEntryPreflightInput {
+  isEternumMode: boolean;
+  isSpectateMode: boolean;
+  isForgeMode: boolean;
+  isBlitzMode: boolean;
+  settlementCheckComplete: boolean;
+}
+
+export const isGameEntryPreflightComplete = ({
+  isEternumMode,
+  isSpectateMode,
+  isForgeMode,
+  isBlitzMode,
+  settlementCheckComplete,
+}: GameEntryPreflightInput): boolean => {
+  const waitsForPlayerSettlementCheck = !isEternumMode && !isSpectateMode && !(isForgeMode && isBlitzMode);
+
+  return !waitsForPlayerSettlementCheck || settlementCheckComplete;
+};
+
 export const resolveBlitzSettlementPhase = ({
   canPlay,
   isSettlementUnlocked,

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.network-switch-replay.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.network-switch-replay.source.test.ts
@@ -21,4 +21,11 @@ describe("Game card network switch replay", () => {
     expect(source).toContain("latestPendingAction:");
     expect(source).not.toContain("onClose={() => setPendingNetworkAction(null)}");
   });
+
+  it("does not block read-only spectate behind wallet network switching", () => {
+    const source = readFileSync(fileURLToPath(new URL("./game-card-grid.tsx", import.meta.url)), "utf8");
+
+    expect(source).toContain("onClick={onSpectate}");
+    expect(source).not.toContain("onClick={() => runWithNetworkGuard(onSpectate)}");
+  });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -974,7 +974,7 @@ const GameCard = ({
           {/* Right slot: Spectate (always in same position) */}
           {canSpectate && (
             <button
-              onClick={() => runWithNetworkGuard(onSpectate)}
+              onClick={onSpectate}
               className={cn(
                 "flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-xs font-medium",
                 "bg-white/10 text-white hover:bg-white/20 transition-colors border border-white/10",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-29",
+    title: "Unblocked Spectating",
+    description:
+      "Spectate now opens directly from game cards and skips player-only settlement checks, so watching a world no longer gets stuck behind a wallet switch or blitz preflight.",
+    type: "fix",
+  },
+  {
     date: "2026-04-25",
     title: "Sidebar Transfer Bars",
     description:

--- a/packages/torii/src/utils/sql.test.ts
+++ b/packages/torii/src/utils/sql.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchJsonWithErrorHandling, fetchWithErrorHandling } from "./sql";
+
+const jsonResponse = (body: unknown, status = 200, statusText = "OK") =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("SQL fetch helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("retries transient HTTP failures before returning SQL rows", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ error: "unavailable" }, 503, "Service Unavailable"))
+      .mockResolvedValueOnce(jsonResponse([{ id: 1 }]));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchWithErrorHandling<{ id: number }>("https://torii.test/sql", "Failed to fetch rows", {
+        retryDelaysMs: [0],
+      }),
+    ).resolves.toEqual([{ id: 1 }]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-transient HTTP failures", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ error: "bad request" }, 400, "Bad Request"))
+      .mockResolvedValueOnce(jsonResponse([{ id: 1 }]));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchWithErrorHandling<{ id: number }>("https://torii.test/sql", "Failed to fetch rows", {
+        retryDelaysMs: [0],
+      }),
+    ).rejects.toThrow("Failed to fetch rows: Bad Request");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds stalled JSON fetches with a timeout", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>(
+      (_url, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason ?? new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = fetchJsonWithErrorHandling("https://torii.test/cache", "Failed to fetch cache", {
+      retryDelaysMs: [],
+      timeoutMs: 25,
+    });
+    const expectation = expect(request).rejects.toThrow("Failed to fetch cache: Request timed out after 25ms");
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expectation;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/torii/src/utils/sql.ts
+++ b/packages/torii/src/utils/sql.ts
@@ -36,6 +36,127 @@ export function buildApiUrl(baseUrl: string, query: string): string {
   return `${baseUrl}?query=${encodeQuery(query)}`;
 }
 
+export interface FetchWithErrorHandlingOptions {
+  timeoutMs?: number;
+  retryDelaysMs?: number[];
+}
+
+const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+const DEFAULT_FETCH_RETRY_DELAYS_MS = [250, 1_000];
+const RETRYABLE_HTTP_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+class FetchTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = "FetchTimeoutError";
+  }
+}
+
+class FetchResponseError extends Error {
+  constructor(
+    readonly status: number,
+    readonly statusText: string,
+  ) {
+    super(statusText);
+    this.name = "FetchResponseError";
+  }
+}
+
+const waitForRetryDelay = (delayMs: number): Promise<void> =>
+  delayMs <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, delayMs));
+
+const createFetchTimeout = (timeoutMs: number): { signal?: AbortSignal; clear: () => void } => {
+  if (timeoutMs <= 0 || typeof AbortController === "undefined") {
+    return { clear: () => undefined };
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new FetchTimeoutError(timeoutMs));
+  }, timeoutMs);
+
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeoutId),
+  };
+};
+
+const isRetryableFetchError = (error: unknown): boolean => {
+  if (error instanceof FetchResponseError) {
+    return RETRYABLE_HTTP_STATUSES.has(error.status);
+  }
+
+  if (error instanceof FetchTimeoutError) {
+    return true;
+  }
+
+  if (typeof DOMException !== "undefined" && error instanceof DOMException && error.name === "AbortError") {
+    return true;
+  }
+
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  return false;
+};
+
+const normalizeFetchError = (error: unknown, timeoutMs: number): Error => {
+  if (error instanceof Error) {
+    if (error.name === "AbortError") {
+      return new FetchTimeoutError(timeoutMs);
+    }
+    return error;
+  }
+
+  return new Error(String(error));
+};
+
+const formatFetchErrorMessage = (errorMessage: string, error: unknown): string => {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `${errorMessage}: ${detail}`;
+};
+
+const fetchJsonOnce = async (url: string, options: FetchWithErrorHandlingOptions): Promise<unknown> => {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+  const timeout = createFetchTimeout(timeoutMs);
+
+  try {
+    const response = await fetch(url, timeout.signal ? { signal: timeout.signal } : undefined);
+
+    if (!response.ok) {
+      throw new FetchResponseError(response.status, response.statusText);
+    }
+
+    return await response.json();
+  } catch (error) {
+    throw normalizeFetchError(error, timeoutMs);
+  } finally {
+    timeout.clear();
+  }
+};
+
+const fetchJsonWithRetry = async (
+  url: string,
+  errorMessage: string,
+  options: FetchWithErrorHandlingOptions,
+): Promise<unknown> => {
+  const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_FETCH_RETRY_DELAYS_MS;
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetchJsonOnce(url, options);
+    } catch (error) {
+      const retryDelayMs = retryDelaysMs[attempt];
+      if (retryDelayMs === undefined || !isRetryableFetchError(error)) {
+        throw new Error(formatFetchErrorMessage(errorMessage, error));
+      }
+
+      await waitForRetryDelay(retryDelayMs);
+    }
+  }
+};
+
 /**
  * Generic function to handle SQL API responses with error checking.
  * SQL queries always return arrays, even for single row results.
@@ -46,14 +167,12 @@ export function buildApiUrl(baseUrl: string, query: string): string {
  * @returns Promise resolving to an array of T items
  * @throws Error if the request fails or response is not ok
  */
-export async function fetchWithErrorHandling<T>(url: string, errorMessage: string): Promise<T[]> {
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`${errorMessage}: ${response.statusText}`);
-  }
-
-  const result = await response.json();
+export async function fetchWithErrorHandling<T>(
+  url: string,
+  errorMessage: string,
+  options: FetchWithErrorHandlingOptions = {},
+): Promise<T[]> {
+  const result = await fetchJsonWithRetry(url, errorMessage, options);
 
   // Ensure the result is always an array (defensive programming)
   if (!Array.isArray(result)) {
@@ -72,14 +191,12 @@ export async function fetchWithErrorHandling<T>(url: string, errorMessage: strin
  * @returns Promise resolving to the parsed JSON response
  * @throws Error if the request fails or response is not ok
  */
-export async function fetchJsonWithErrorHandling<T>(url: string, errorMessage: string): Promise<T> {
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`${errorMessage}: ${response.statusText}`);
-  }
-
-  return (await response.json()) as T;
+export async function fetchJsonWithErrorHandling<T>(
+  url: string,
+  errorMessage: string,
+  options: FetchWithErrorHandlingOptions = {},
+): Promise<T> {
+  return (await fetchJsonWithRetry(url, errorMessage, options)) as T;
 }
 
 /**


### PR DESCRIPTION
Fixes three bad-network and entry paths in the game client. Torii health checks that returned false now mark the connection disconnected, shared Torii SQL fetches have bounded timeouts with transient retries, and read-only Spectate bypasses both wallet network switching and player settlement preflight. Root cause: failed health probes and SQL stalls were not bounded consistently, while spectator entry reused player-only guards that can block on wrong-chain wallets or blitz settlement state. Verified with `pnpm run format`, `pnpm run knip`, `pnpm run build:packages`, `pnpm --dir client/apps/game typecheck`, focused game entry/network tests, Torii SQL tests, and a browser smoke that reached `/play/slot/boat-4-27/map?spectate=true` in view-only mode.