### PR TITLE
[codex] Stabilize army position reconciliation

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.authoritative-reconciliation.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.authoritative-reconciliation.test.ts
@@ -23,7 +23,8 @@ describe("ArmyManager authoritative reconciliation seam", () => {
     expect(moveArmyStart).toBeGreaterThan(0);
     const body = source.slice(moveArmyStart, moveArmyStart + 900);
 
-    expect(body).toMatch(/optimisticallyMovingArmies\.has\(entityId\)[\s\S]*?runAuthoritativeReconcileListeners/);
+    expect(body).toMatch(/optimisticallyMovingArmies\.has\(entityId\)[\s\S]*?markOptimisticTargetConfirmed/);
+    expect(source).toMatch(/private markOptimisticTargetConfirmed[\s\S]*?runAuthoritativeReconcileListeners/);
   });
 
   it("exposes hasReceivedAuthoritativeReconciliation accessor for gating dequeue", () => {

--- a/client/apps/game/src/three/managers/army-manager.optimistic-position-lock.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.optimistic-position-lock.test.ts
@@ -12,9 +12,9 @@ describe("ArmyManager optimistic position lock", () => {
   it("exposes an optimisticPositionLocks map keyed per entity with normalizedTarget + lockedAtMs", () => {
     const source = readSource();
 
-    const fieldStart = source.indexOf("private optimisticPositionLocks: Map<");
+    const fieldStart = source.indexOf("interface OptimisticPositionLockState");
     expect(fieldStart).toBeGreaterThan(0);
-    const declaration = source.slice(fieldStart, fieldStart + 500);
+    const declaration = source.slice(fieldStart, fieldStart + 250);
     expect(declaration).toContain("normalizedTarget");
     expect(declaration).toContain("lockedAtMs");
   });

--- a/client/apps/game/src/three/managers/army-manager.optimistic-revert-on-source.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.optimistic-revert-on-source.test.ts
@@ -21,9 +21,9 @@ describe("ArmyManager optimistic revert-on-source", () => {
   it("stores normalizedSource alongside normalizedTarget in the lock type", () => {
     const source = readSource();
 
-    const fieldStart = source.indexOf("private optimisticPositionLocks: Map<");
+    const fieldStart = source.indexOf("interface OptimisticPositionLockState");
     expect(fieldStart).toBeGreaterThan(0);
-    const declaration = source.slice(fieldStart, fieldStart + 500);
+    const declaration = source.slice(fieldStart, fieldStart + 250);
     expect(declaration).toContain("normalizedSource");
     expect(declaration).toContain("normalizedTarget");
   });
@@ -87,5 +87,43 @@ describe("ArmyManager optimistic revert-on-source", () => {
     // Target match is the success path — no rewind; the tween completes naturally.
     const targetBlock = body.slice(body.indexOf("matchesTarget"), body.indexOf("matchesSource"));
     expect(targetBlock).not.toContain("rewindOptimisticMovement");
+  });
+
+  it("keeps stale-source protection after the optimistic target has been confirmed", () => {
+    const source = readSource();
+
+    const methodStart = source.indexOf(
+      "public shouldSkipStalePositionUpdate(entityId: ID, incomingNormalized: { x: number; y: number }): boolean",
+    );
+    expect(methodStart).toBeGreaterThan(0);
+    const methodEnd = source.indexOf("\n  public ", methodStart + 20);
+    const body = source.slice(methodStart, methodEnd);
+
+    const targetBlock = body.slice(body.indexOf("matchesTarget"), body.indexOf("matchesSource"));
+    expect(targetBlock).toContain("this.markOptimisticTargetConfirmed(entityId, lock)");
+    expect(targetBlock).not.toContain("this.optimisticPositionLocks.delete(entityId)");
+
+    const sourceBlock = body.slice(body.indexOf("matchesSource"), body.indexOf("if (nowMs - lock.lockedAtMs"));
+    expect(sourceBlock).toMatch(/hasFreshConfirmedOptimisticTarget\(lock, nowMs\)[\s\S]{0,160}?return true/);
+    expect(sourceBlock).toMatch(
+      /hasConfirmedOptimisticTarget\(lock\)[\s\S]{0,160}?optimisticPositionLocks\.delete\(entityId\)/,
+    );
+    expect(sourceBlock.indexOf("return true")).toBeLessThan(sourceBlock.indexOf("rewindOptimisticMovement"));
+  });
+
+  it("rewindOptimisticMovement restores manager state from the lock when no source bucket exists", () => {
+    const source = readSource();
+
+    const methodStart = source.indexOf("public rewindOptimisticMovement(entityId: ID)");
+    expect(methodStart).toBeGreaterThan(0);
+    const methodEnd = source.indexOf("\n  }\n", methodStart);
+    expect(methodEnd).toBeGreaterThan(methodStart);
+    const body = source.slice(methodStart, methodEnd);
+
+    // Same-bucket moves do not populate movingArmySourceBuckets, so the rewind
+    // path must still use the lock's normalizedSource to restore armyData.
+    expect(body).toContain("const rewindSource = resolveOptimisticRewindSource");
+    expect(body).toMatch(/if \(rewindSource && armyData\)/);
+    expect(body).toMatch(/new Position\(\{ x: rewindSource\.col, y: rewindSource\.row \}\)/);
   });
 });

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -126,15 +126,56 @@ import { snapshotRendererDiagnostics } from "../renderer-diagnostics";
 const MEMORY_MONITORING_ENABLED = env.VITE_PUBLIC_ENABLE_MEMORY_MONITORING;
 
 // Auto-release window for an optimistic position lock. If no authoritative
-// update matches the locked destination within this window, the lock is
-// released so the next update can drive a correction tween — covers the rare
-// server-divergent-path case without stranding the visual state.
+// update reconciles within this window, later divergent updates can drive a
+// correction tween — covers the rare server-divergent-path case without
+// stranding the visual state.
 const OPTIMISTIC_POSITION_LOCK_TTL_MS = 15_000;
 
 interface MovingArmySourceState {
   bucketKey: string;
   col: number;
   row: number;
+}
+
+interface OptimisticPositionLockState {
+  normalizedSource: { x: number; y: number };
+  normalizedTarget: { x: number; y: number };
+  lockedAtMs: number;
+  targetConfirmedAtMs?: number;
+}
+
+interface OptimisticRewindSource {
+  col: number;
+  row: number;
+}
+
+function resolveOptimisticRewindSource(input: {
+  lock: OptimisticPositionLockState | undefined;
+  sourceState: MovingArmySourceState | undefined;
+}): OptimisticRewindSource | null {
+  if (input.sourceState) {
+    return {
+      col: input.sourceState.col,
+      row: input.sourceState.row,
+    };
+  }
+
+  if (!input.lock) {
+    return null;
+  }
+
+  return {
+    col: input.lock.normalizedSource.x,
+    row: input.lock.normalizedSource.y,
+  };
+}
+
+function hasConfirmedOptimisticTarget(lock: OptimisticPositionLockState): boolean {
+  return lock.targetConfirmedAtMs !== undefined;
+}
+
+function hasFreshConfirmedOptimisticTarget(lock: OptimisticPositionLockState, nowMs: number): boolean {
+  return lock.targetConfirmedAtMs !== undefined && nowMs - lock.targetConfirmedAtMs <= OPTIMISTIC_POSITION_LOCK_TTL_MS;
 }
 
 export interface ArmyMovementPlan {
@@ -256,15 +297,9 @@ export class ArmyManager {
   // pre-tx tile. normalizedSource is retained so explore-discovery reverts —
   // where the chain leaves `explorer.coord = from` after rolling a treasure —
   // are recognised as authoritative and allowed through instead of being
-  // suppressed as stale. Auto-release on matching update or TTL expiry.
-  private optimisticPositionLocks: Map<
-    ID,
-    {
-      normalizedSource: { x: number; y: number };
-      normalizedTarget: { x: number; y: number };
-      lockedAtMs: number;
-    }
-  > = new Map();
+  // suppressed as stale. Target confirmations stay fresh long enough to skip
+  // delayed source replays, then expire so later corrections can proceed.
+  private optimisticPositionLocks: Map<ID, OptimisticPositionLockState> = new Map();
   // Armies that have been visually hidden but not yet fully removed — all rendering
   // paths must skip these to prevent ghost units from reappearing during chunk transitions
   private suppressedArmies: Set<ID> = new Set();
@@ -1638,10 +1673,7 @@ export class ArmyManager {
       return false;
     }
 
-    const numericEntityId = this.toNumericId(entityId);
-    const { x, y } = army.hexCoords.getContract();
-    const biome = Biome.getBiome(x, y);
-    const modelType = this.armyModel.getModelTypeForEntity(numericEntityId, army.category, army.tier, biome);
+    const modelType = this.resolveArmyModelType(army);
     await this.armyModel.preloadModels([modelType]);
 
     const latestArmy = this.armies.get(entityId);
@@ -1661,6 +1693,13 @@ export class ArmyManager {
     this.updateArmyAttachmentTransforms();
     this.updateVisibleArmyBuffers();
     return true;
+  }
+
+  private resolveArmyModelType(army: ArmyData): ModelType {
+    const numericEntityId = this.toNumericId(army.entityId);
+    const { x, y } = army.hexCoords.getContract();
+    const biome = Biome.getBiome(x, y);
+    return this.armyModel.getModelTypeForEntity(numericEntityId, army.category, army.tier, biome);
   }
 
   public restoreArmyVisualIfVisible(entityId: ID): Promise<boolean> {
@@ -1974,9 +2013,8 @@ export class ArmyManager {
         source: "world_update_listener",
         entityId,
       });
+      this.markOptimisticTargetConfirmed(entityId, this.optimisticPositionLocks.get(entityId));
       this.optimisticallyMovingArmies.delete(entityId);
-      this.authoritativeReconciledArmies.add(entityId);
-      this.runAuthoritativeReconcileListeners(this.toNumericId(entityId));
     }
 
     const plan = await this.computeMovementPlan(entityId, hexCoords);
@@ -1994,29 +2032,38 @@ export class ArmyManager {
 
   /**
    * True when an incoming position update should be skipped because it disagrees
-   * with an active optimistic lock and the TTL hasn't elapsed. Matching updates
-   * release the lock as a side effect.
+   * with an active optimistic lock and the TTL hasn't elapsed. Target matches
+   * confirm the optimistic destination while keeping the lock alive briefly so
+   * late source replays cannot start a reverse tween.
    *
-   * Source-match is treated the same as target-match: `explorer_explore` can
-   * roll a treasure that leaves `explorer.coord = from` on-chain
-   * (troop_movement.cairo:193). That authoritative revert would otherwise be
-   * swallowed as "stale" and the army would stay visually stranded on the
-   * discovered tile until the TTL expired.
+   * Source-match before target confirmation is an authoritative revert:
+   * `explorer_explore` can roll a treasure that leaves `explorer.coord = from`
+   * on-chain (troop_movement.cairo:193). After target confirmation, a fresh
+   * source-match is treated as a late replay and skipped only within the lock
+   * window.
    */
   public shouldSkipStalePositionUpdate(entityId: ID, incomingNormalized: { x: number; y: number }): boolean {
     const lock = this.optimisticPositionLocks.get(entityId);
     if (!lock) return false;
+    const nowMs = Date.now();
 
     const matchesTarget =
       lock.normalizedTarget.x === incomingNormalized.x && lock.normalizedTarget.y === incomingNormalized.y;
     if (matchesTarget) {
-      this.optimisticPositionLocks.delete(entityId);
+      this.markOptimisticTargetConfirmed(entityId, lock);
       return false;
     }
 
     const matchesSource =
       lock.normalizedSource.x === incomingNormalized.x && lock.normalizedSource.y === incomingNormalized.y;
     if (matchesSource) {
+      if (hasFreshConfirmedOptimisticTarget(lock, nowMs)) {
+        return true;
+      }
+      if (hasConfirmedOptimisticTarget(lock)) {
+        this.optimisticPositionLocks.delete(entityId);
+        return false;
+      }
       // Discovery revert: `explorer_explore` rolled a treasure, the chain left
       // `explorer.coord = from`, and the tx emits an ExplorerTroops delta
       // (stamina/biomes) but no TileOpt change for the source tile. The
@@ -2031,12 +2078,21 @@ export class ArmyManager {
       return false;
     }
 
-    if (Date.now() - lock.lockedAtMs > OPTIMISTIC_POSITION_LOCK_TTL_MS) {
+    if (nowMs - lock.lockedAtMs > OPTIMISTIC_POSITION_LOCK_TTL_MS) {
       this.optimisticPositionLocks.delete(entityId);
       return false;
     }
 
     return true;
+  }
+
+  private markOptimisticTargetConfirmed(entityId: ID, lock: OptimisticPositionLockState | undefined): void {
+    if (lock && lock.targetConfirmedAtMs === undefined) {
+      lock.targetConfirmedAtMs = Date.now();
+    }
+
+    this.authoritativeReconciledArmies.add(entityId);
+    this.runAuthoritativeReconcileListeners(this.toNumericId(entityId));
   }
 
   public onAuthoritativeReconciliation(entityId: ID, callback: () => void): () => void {
@@ -2072,11 +2128,11 @@ export class ArmyManager {
 
   public rewindOptimisticMovement(entityId: ID): { col: number; row: number } | null {
     if (!this.optimisticallyMovingArmies.has(entityId)) return null;
-    // Read the lock's normalizedSource before the delete below — it's the
-    // canonical source-of-truth for the pre-tx hex, set for every optimistic
-    // move regardless of whether the source/dest share a spatial bucket.
     const lock = this.optimisticPositionLocks.get(entityId);
-    const lockedSource = lock ? { col: lock.normalizedSource.x, row: lock.normalizedSource.y } : null;
+    const sourceState = this.movingArmySourceBuckets.get(entityId);
+    // Same-bucket moves do not create source-bucket bookkeeping, so the lock is
+    // the canonical fallback for restoring the pre-tx source.
+    const rewindSource = resolveOptimisticRewindSource({ lock, sourceState });
 
     this.optimisticallyMovingArmies.delete(entityId);
     this.authoritativeReconciledArmies.delete(entityId);
@@ -2084,7 +2140,6 @@ export class ArmyManager {
     this.optimisticPositionLocks.delete(entityId);
 
     const numericEntityId = this.toNumericId(entityId);
-    const sourceState = this.movingArmySourceBuckets.get(entityId);
     const armyData = this.armies.get(entityId);
 
     // Clear the complete callback so cancelMovement's teardown doesn't fire listeners.
@@ -2099,23 +2154,14 @@ export class ArmyManager {
     this.movementStartListeners.delete(numericEntityId);
     this.movementCompleteListeners.delete(numericEntityId);
 
-    if (sourceState && armyData) {
-      const sourcePosition = new Position({ x: sourceState.col, y: sourceState.row });
+    if (rewindSource && armyData) {
+      const sourcePosition = new Position({ x: rewindSource.col, y: rewindSource.row });
       const previousHex = armyData.hexCoords;
       this.armies.set(entityId, { ...armyData, hexCoords: sourcePosition });
-      // Remove from the destination bucket we added during applyMovementPlan.
-      // Leave the source bucket intact — the army never left it.
-      const destNorm = previousHex.getNormalized();
-      const destKey = this.getSpatialKey(destNorm.x, destNorm.y);
-      if (destKey !== sourceState.bucketKey) {
-        const destBucket = this.chunkToArmies.get(destKey);
-        if (destBucket) {
-          destBucket.delete(entityId);
-          if (destBucket.size === 0) this.chunkToArmies.delete(destKey);
-        }
-      }
+      this.updateSpatialIndex(entityId, previousHex, sourcePosition);
       this.movingArmySourceBuckets.delete(entityId);
-      void this.renderArmyIntoCurrentChunkIfVisible(entityId);
+      this.lastKnownVisibleHexes.delete(entityId);
+      this.syncArmyVisualToTrackedPosition(entityId);
     }
 
     recordArmyMovementLatencyPhase({
@@ -2124,7 +2170,36 @@ export class ArmyManager {
       entityId,
     });
 
-    return lockedSource;
+    return rewindSource;
+  }
+
+  public syncArmyVisualToTrackedPosition(entityId: ID): void {
+    const army = this.armies.get(entityId);
+    if (!army) return;
+
+    const slot = this.visibleArmyIndices.get(entityId);
+    if (!this.isArmyVisibleInCurrentChunk(army)) {
+      if (slot !== undefined) {
+        this.removeVisibleArmy(entityId);
+        this.flushVisibleArmyPresentation();
+      }
+      return;
+    }
+
+    if (slot === undefined) {
+      void this.renderArmyIntoCurrentChunkIfVisible(entityId);
+      return;
+    }
+
+    this.refreshArmyInstance(army, slot, this.resolveArmyModelType(army));
+    this.flushVisibleArmyPresentation();
+  }
+
+  private flushVisibleArmyPresentation(): void {
+    this.refreshVisibleArmyCollection();
+    this.syncVisibleArmyAttachments(this.visibleArmies);
+    this.updateArmyAttachmentTransforms();
+    this.updateVisibleArmyBuffers();
   }
 
   /**

--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts
@@ -13,6 +13,7 @@ describe("processExplorerTroopsUpdate stale-position skip", () => {
     const updateArmyHexes = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => true);
+    const reconcileArmyPositionFromManager = vi.fn();
 
     processExplorerTroopsUpdate(baseUpdate, {
       cancelPendingArmyRemoval: vi.fn(),
@@ -20,17 +21,20 @@ describe("processExplorerTroopsUpdate stale-position skip", () => {
       updateArmyHexes,
       updateArmyFromExplorerTroopsUpdate,
       shouldSkipStalePositionUpdate,
+      reconcileArmyPositionFromManager,
     });
 
     expect(shouldSkipStalePositionUpdate).toHaveBeenCalledWith(7, expect.objectContaining({ x: expect.any(Number) }));
     expect(updateArmyHexes).not.toHaveBeenCalled();
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(baseUpdate);
+    expect(reconcileArmyPositionFromManager).toHaveBeenCalledWith(7);
   });
 
   it("applies both handlers when the predicate returns false", () => {
     const updateArmyHexes = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => false);
+    const reconcileArmyPositionFromManager = vi.fn();
 
     processExplorerTroopsUpdate(baseUpdate, {
       cancelPendingArmyRemoval: vi.fn(),
@@ -38,10 +42,12 @@ describe("processExplorerTroopsUpdate stale-position skip", () => {
       updateArmyHexes,
       updateArmyFromExplorerTroopsUpdate,
       shouldSkipStalePositionUpdate,
+      reconcileArmyPositionFromManager,
     });
 
     expect(updateArmyHexes).toHaveBeenCalledWith(baseUpdate);
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(baseUpdate);
+    expect(reconcileArmyPositionFromManager).not.toHaveBeenCalled();
   });
 
   it("never consults the predicate on zero-troop removal events", () => {

--- a/client/apps/game/src/three/scenes/worldmap-army-movement-submit.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-movement-submit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePendingArmyMovementSubmitAction } from "./worldmap-army-movement-submit";
+
+describe("resolvePendingArmyMovementSubmitAction", () => {
+  it("submits normally when there is no action path", () => {
+    expect(
+      resolvePendingArmyMovementSubmitAction({
+        actionPathLength: 0,
+        hasPendingMovement: true,
+        isOptimisticMovementActive: false,
+      }),
+    ).toBe("submit");
+  });
+
+  it("submits normally when the army has no pending movement", () => {
+    expect(
+      resolvePendingArmyMovementSubmitAction({
+        actionPathLength: 1,
+        hasPendingMovement: false,
+        isOptimisticMovementActive: false,
+      }),
+    ).toBe("submit");
+  });
+
+  it("queues a next move while the optimistic tween is active", () => {
+    expect(
+      resolvePendingArmyMovementSubmitAction({
+        actionPathLength: 1,
+        hasPendingMovement: true,
+        isOptimisticMovementActive: true,
+      }),
+    ).toBe("queue_next_move");
+  });
+
+  it("queues a next move after pending state hands off to the optimistic tween", () => {
+    expect(
+      resolvePendingArmyMovementSubmitAction({
+        actionPathLength: 1,
+        hasPendingMovement: false,
+        isOptimisticMovementActive: true,
+      }),
+    ).toBe("queue_next_move");
+  });
+
+  it("blocks duplicate submits while the first tx is pending but not animating yet", () => {
+    expect(
+      resolvePendingArmyMovementSubmitAction({
+        actionPathLength: 1,
+        hasPendingMovement: true,
+        isOptimisticMovementActive: false,
+      }),
+    ).toBe("block_pending_handoff");
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-army-movement-submit.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-movement-submit.ts
@@ -1,0 +1,21 @@
+type PendingArmyMovementSubmitAction = "submit" | "queue_next_move" | "block_pending_handoff";
+
+export function resolvePendingArmyMovementSubmitAction(input: {
+  actionPathLength: number;
+  hasPendingMovement: boolean;
+  isOptimisticMovementActive: boolean;
+}): PendingArmyMovementSubmitAction {
+  if (input.actionPathLength <= 0) {
+    return "submit";
+  }
+
+  if (input.isOptimisticMovementActive) {
+    return "queue_next_move";
+  }
+
+  if (input.hasPendingMovement) {
+    return "block_pending_handoff";
+  }
+
+  return "submit";
+}

--- a/client/apps/game/src/three/scenes/worldmap-army-position-repair.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-position-repair.source.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readSource(filename: string): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, filename), "utf8");
+}
+
+describe("Worldmap army position repair wiring", () => {
+  it("delegates repair planning to the shared single-pass planner", () => {
+    const source = readSource("worldmap.tsx");
+
+    const methodStart = source.indexOf("private reconcileAllArmyPositionsFromManager(");
+    expect(methodStart).toBeGreaterThan(0);
+    const methodEnd = source.indexOf("\n  private ", methodStart + 20);
+    const body = source.slice(methodStart, methodEnd);
+
+    expect(body).toContain("this.planArmyPositionRepairs(this.resolveArmyPositionRepairTargets())");
+    expect(body).toContain("this.applyArmyPositionRepair(repair, reason)");
+  });
+
+  it("defines a repair seam that reconciles worldmap caches from ArmyManager", () => {
+    const source = readSource("worldmap.tsx");
+
+    const targetStart = source.indexOf("private resolveArmyPositionRepairTarget(");
+    expect(targetStart).toBeGreaterThan(0);
+    const targetEnd = source.indexOf("\n  private ", targetStart + 20);
+    const targetBody = source.slice(targetStart, targetEnd);
+
+    expect(targetBody).toContain("this.armyManager.isArmyMovingOptimistically(entityId)");
+    expect(targetBody).toContain("this.armyManager.getArmy(entityId)");
+
+    const repairStart = source.indexOf("private applyArmyPositionRepair(");
+    expect(repairStart).toBeGreaterThan(0);
+    const repairEnd = source.indexOf("\n  private ", repairStart + 20);
+    const repairBody = source.slice(repairStart, repairEnd);
+
+    expect(repairBody).toContain("this.removeArmyHexEntries(entityId, staleEntries)");
+    expect(repairBody).toContain("this.updateArmyHexes(");
+    expect(repairBody).toContain("this.armyManager.syncArmyVisualToTrackedPosition(entityId)");
+  });
+
+  it("repairs after authoritative tile updates and stale ExplorerTroops skips", () => {
+    const source = readSource("worldmap.tsx");
+
+    const tileStart = source.indexOf("this.worldUpdateListener.Army.onTileUpdate(async");
+    expect(tileStart).toBeGreaterThan(0);
+    const tileEnd = source.indexOf("this.addWorldUpdateSubscription(", tileStart + 100);
+    const tileBody = source.slice(tileStart, tileEnd);
+    expect(tileBody).toMatch(
+      /await this\.armyManager\.onTileUpdate\(update\)[\s\S]{0,400}this\.reconcileArmyPositionFromManager\(update\.entityId, "tile_update"\)/,
+    );
+
+    const troopsStart = source.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate");
+    expect(troopsStart).toBeGreaterThan(0);
+    const troopsEnd = source.indexOf("this.addWorldUpdateSubscription(", troopsStart + 100);
+    const troopsBody = source.slice(troopsStart, troopsEnd);
+    expect(troopsBody).toContain("reconcileArmyPositionFromManager:");
+    expect(troopsBody).toContain('this.reconcileArmyPositionFromManager(entityId, "explorer_troops_update")');
+  });
+
+  it("repairs after chunk hydration so existing drift self-heals while browsing", () => {
+    const source = readSource("worldmap.tsx");
+
+    const hydrateStart = source.indexOf("private hydrateChunkForPresentation(");
+    expect(hydrateStart).toBeGreaterThan(0);
+    const hydrateBody = source.slice(hydrateStart, hydrateStart + 900);
+
+    expect(hydrateBody).toContain('this.reconcileAllArmyPositionsFromManager("chunk_hydrated")');
+  });
+
+  it("repairs before army selection reads cached action-path positions", () => {
+    const source = readSource("worldmap.tsx");
+
+    const selectionStart = source.indexOf("private onArmySelection(");
+    expect(selectionStart).toBeGreaterThan(0);
+    const selectionBody = source.slice(selectionStart, selectionStart + 2600);
+
+    const repairIndex = selectionBody.indexOf(
+      'this.reconcileArmyPositionFromManager(selectedEntityId, "army_selection")',
+    );
+    const managerCheckIndex = selectionBody.indexOf("this.armyManager.hasArmy(selectedEntityId)");
+
+    expect(repairIndex).toBeGreaterThan(0);
+    expect(managerCheckIndex).toBeGreaterThan(0);
+    expect(repairIndex).toBeLessThan(managerCheckIndex);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-army-position-repair.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-position-repair.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { planArmyPositionRepairs, type ArmyPositionRepairTarget } from "./worldmap-army-position-repair";
+
+import type { HexEntityInfo, HexPosition, ID } from "@bibliothecadao/types";
+
+class CountingMap<K, V> extends Map<K, V> {
+  public iterationCount = 0;
+
+  public override [Symbol.iterator](): MapIterator<[K, V]> {
+    this.iterationCount += 1;
+    return super[Symbol.iterator]();
+  }
+}
+
+function createTarget(entityId: ID, canonicalPosition: HexPosition): ArmyPositionRepairTarget {
+  return { entityId, canonicalPosition };
+}
+
+function createArmyHexes(entries: Array<{ col: number; row: number; entityId: ID }>) {
+  const armyHexes = new CountingMap<number, Map<number, Pick<HexEntityInfo, "id">>>();
+
+  entries.forEach(({ col, row, entityId }) => {
+    if (!armyHexes.has(col)) {
+      armyHexes.set(col, new Map());
+    }
+    armyHexes.get(col)?.set(row, { id: entityId });
+  });
+
+  return armyHexes;
+}
+
+describe("planArmyPositionRepairs", () => {
+  it("plans stale army-hex removal and canonical cache repair", () => {
+    const armyHexes = createArmyHexes([
+      { col: 2, row: 2, entityId: 1 },
+      { col: 5, row: 5, entityId: 1 },
+      { col: 8, row: 8, entityId: 2 },
+      { col: 12, row: 12, entityId: 3 },
+    ]);
+    const armiesPositions = new Map<ID, HexPosition>([
+      [1, { col: 2, row: 2 }],
+      [2, { col: 7, row: 7 }],
+      [3, { col: 12, row: 12 }],
+    ]);
+
+    const repairs = planArmyPositionRepairs({
+      armiesPositions,
+      armyHexes,
+      targets: [createTarget(1, { col: 5, row: 5 }), createTarget(2, { col: 7, row: 7 })],
+    });
+
+    expect(repairs).toEqual([
+      {
+        cachedPosition: { col: 2, row: 2 },
+        shouldUpdatePositionCache: true,
+        staleEntries: [{ col: 2, row: 2 }],
+        target: createTarget(1, { col: 5, row: 5 }),
+      },
+      {
+        cachedPosition: { col: 7, row: 7 },
+        shouldUpdatePositionCache: true,
+        staleEntries: [{ col: 8, row: 8 }],
+        target: createTarget(2, { col: 7, row: 7 }),
+      },
+    ]);
+  });
+
+  it("skips active optimistic moves so local movement is not rewound by cache repair", () => {
+    const armyHexes = createArmyHexes([
+      { col: 2, row: 2, entityId: 1 },
+      { col: 5, row: 5, entityId: 1 },
+    ]);
+
+    const repairs = planArmyPositionRepairs({
+      armiesPositions: new Map([[1, { col: 2, row: 2 }]]),
+      armyHexes,
+      skipEntityIds: new Set([1]),
+      targets: [createTarget(1, { col: 5, row: 5 })],
+    });
+
+    expect(repairs).toEqual([]);
+    expect(armyHexes.iterationCount).toBe(0);
+  });
+
+  it("scans the army-hex cache once for all repair targets", () => {
+    const armyHexes = createArmyHexes([
+      { col: 2, row: 2, entityId: 1 },
+      { col: 4, row: 4, entityId: 2 },
+      { col: 6, row: 6, entityId: 3 },
+    ]);
+
+    planArmyPositionRepairs({
+      armiesPositions: new Map<ID, HexPosition>(),
+      armyHexes,
+      targets: [
+        createTarget(1, { col: 3, row: 3 }),
+        createTarget(2, { col: 5, row: 5 }),
+        createTarget(3, { col: 7, row: 7 }),
+      ],
+    });
+
+    expect(armyHexes.iterationCount).toBe(1);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-army-position-repair.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-position-repair.ts
@@ -1,0 +1,126 @@
+import type { HexEntityInfo, HexPosition, ID } from "@bibliothecadao/types";
+
+export interface ArmyPositionRepairTarget {
+  entityId: ID;
+  canonicalPosition: HexPosition;
+}
+
+export interface ArmyPositionRepair<TTarget extends ArmyPositionRepairTarget = ArmyPositionRepairTarget> {
+  target: TTarget;
+  cachedPosition: HexPosition | undefined;
+  staleEntries: HexPosition[];
+  shouldUpdatePositionCache: boolean;
+}
+
+export function planArmyPositionRepairs<TTarget extends ArmyPositionRepairTarget>(input: {
+  targets: Iterable<TTarget>;
+  armiesPositions: ReadonlyMap<ID, HexPosition>;
+  armyHexes: ReadonlyMap<number, ReadonlyMap<number, Pick<HexEntityInfo, "id">>>;
+  skipEntityIds?: ReadonlySet<ID>;
+}): Array<ArmyPositionRepair<TTarget>> {
+  const targetsByEntityId = resolveRepairTargetsByEntityId(input.targets, input.skipEntityIds);
+  if (targetsByEntityId.size === 0) {
+    return [];
+  }
+
+  const staleEntriesByEntityId = findStaleArmyHexEntriesByEntityId(input.armyHexes, targetsByEntityId);
+
+  return Array.from(targetsByEntityId.values()).flatMap((target) =>
+    planArmyPositionRepair({
+      armyHexes: input.armyHexes,
+      armiesPositions: input.armiesPositions,
+      staleEntries: staleEntriesByEntityId.get(target.entityId) ?? [],
+      target,
+    }),
+  );
+}
+
+function resolveRepairTargetsByEntityId<TTarget extends ArmyPositionRepairTarget>(
+  targets: Iterable<TTarget>,
+  skipEntityIds: ReadonlySet<ID> | undefined,
+): Map<ID, TTarget> {
+  const targetsByEntityId = new Map<ID, TTarget>();
+
+  for (const target of targets) {
+    if (!skipEntityIds?.has(target.entityId)) {
+      targetsByEntityId.set(target.entityId, target);
+    }
+  }
+
+  return targetsByEntityId;
+}
+
+function findStaleArmyHexEntriesByEntityId<TTarget extends ArmyPositionRepairTarget>(
+  armyHexes: ReadonlyMap<number, ReadonlyMap<number, Pick<HexEntityInfo, "id">>>,
+  targetsByEntityId: ReadonlyMap<ID, TTarget>,
+): Map<ID, HexPosition[]> {
+  const staleEntriesByEntityId = new Map<ID, HexPosition[]>();
+
+  for (const [col, rowMap] of armyHexes) {
+    for (const [row, army] of rowMap) {
+      const target = targetsByEntityId.get(army.id);
+      if (!target || matchesHexPosition({ col, row }, target.canonicalPosition)) {
+        continue;
+      }
+      appendStaleEntry(staleEntriesByEntityId, army.id, { col, row });
+    }
+  }
+
+  return staleEntriesByEntityId;
+}
+
+function appendStaleEntry(staleEntriesByEntityId: Map<ID, HexPosition[]>, entityId: ID, position: HexPosition): void {
+  const entries = staleEntriesByEntityId.get(entityId);
+  if (entries) {
+    entries.push(position);
+    return;
+  }
+
+  staleEntriesByEntityId.set(entityId, [position]);
+}
+
+function planArmyPositionRepair<TTarget extends ArmyPositionRepairTarget>(input: {
+  target: TTarget;
+  armiesPositions: ReadonlyMap<ID, HexPosition>;
+  armyHexes: ReadonlyMap<number, ReadonlyMap<number, Pick<HexEntityInfo, "id">>>;
+  staleEntries: HexPosition[];
+}): Array<ArmyPositionRepair<TTarget>> {
+  const cachedPosition = input.armiesPositions.get(input.target.entityId);
+  const shouldUpdatePositionCache = !matchesTrackedArmyPosition({
+    armyHexes: input.armyHexes,
+    cachedPosition,
+    entityId: input.target.entityId,
+    position: input.target.canonicalPosition,
+  });
+
+  if (!shouldUpdatePositionCache && input.staleEntries.length === 0) {
+    return [];
+  }
+
+  return [
+    {
+      cachedPosition,
+      shouldUpdatePositionCache,
+      staleEntries: input.staleEntries,
+      target: input.target,
+    },
+  ];
+}
+
+function matchesTrackedArmyPosition(input: {
+  entityId: ID;
+  position: HexPosition;
+  cachedPosition: HexPosition | undefined;
+  armyHexes: ReadonlyMap<number, ReadonlyMap<number, Pick<HexEntityInfo, "id">>>;
+}): boolean {
+  const cachedHex = input.armyHexes.get(input.position.col)?.get(input.position.row);
+  return (
+    input.cachedPosition?.col === input.position.col &&
+    input.cachedPosition?.row === input.position.row &&
+    cachedHex?.id === input.entityId
+  );
+}
+
+function matchesHexPosition(left: HexPosition, right: HexPosition): boolean {
+  return left.col === right.col && left.row === right.row;
+}

--- a/client/apps/game/src/three/scenes/worldmap-next-move-queue-wiring.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-next-move-queue-wiring.source.test.ts
@@ -27,6 +27,25 @@ describe("Worldmap next-move queue wiring", () => {
     expect(prologue).toContain("this.enqueueNextMove(account, actionPath, selectedEntityId)");
   });
 
+  it("blocks pending handoff submits before command sound, effects, or tx submission", () => {
+    const source = readSource("worldmap.tsx");
+
+    const start = source.indexOf("private onArmyMovement(account:");
+    expect(start).toBeGreaterThan(0);
+    const body = source.slice(start, start + 9000);
+
+    const guardIndex = body.indexOf("resolvePendingArmyMovementSubmitAction");
+    const soundIndex = body.indexOf("playUnitCommandSoundForWorldmapAction(actionType)");
+    const txSubmitIndex = body.indexOf(".moveArmy(account!");
+
+    expect(guardIndex).toBeGreaterThan(0);
+    expect(soundIndex).toBeGreaterThan(guardIndex);
+    expect(txSubmitIndex).toBeGreaterThan(guardIndex);
+    expect(body).toContain('case "block_pending_handoff"');
+    expect(guardIndex).toBeLessThan(soundIndex);
+    expect(guardIndex).toBeLessThan(txSubmitIndex);
+  });
+
   it("records next_move_queued when enqueueing and replays via onMovementComplete", () => {
     const source = readSource("worldmap.tsx");
 
@@ -104,19 +123,24 @@ describe("Worldmap next-move queue wiring", () => {
     expect(body).toContain("army.currentStamina");
   });
 
-  it("runs canAffordMove at the top of onArmyMovement so every submit — not just queued — is gated", () => {
+  it("runs canAffordMove before command feedback or tx submit for non-pending moves", () => {
     const source = readSource("worldmap.tsx");
 
     const methodStart = source.indexOf(
       "private onArmyMovement(account: Account | AccountInterface, actionPath: ActionPath[], selectedEntityId: ID)",
     );
     expect(methodStart).toBeGreaterThan(0);
-    // The check must appear before the optimistic-short-circuit branch and before the
-    // tx submission path. First 400 chars of the method body comfortably cover the prologue.
-    const prologue = source.slice(methodStart, methodStart + 500);
+    const body = source.slice(methodStart, methodStart + 9000);
 
-    expect(prologue).toContain("this.canAffordMove(selectedEntityId, actionPath)");
-    expect(prologue).toContain("toast.error");
+    const guardIndex = body.indexOf("resolvePendingArmyMovementSubmitAction");
+    const staminaIndex = body.indexOf("this.canAffordMove(selectedEntityId, actionPath)");
+    const soundIndex = body.indexOf("playUnitCommandSoundForWorldmapAction(actionType)");
+    const txSubmitIndex = body.indexOf(".moveArmy(account!");
+
+    expect(staminaIndex).toBeGreaterThan(guardIndex);
+    expect(staminaIndex).toBeLessThan(soundIndex);
+    expect(staminaIndex).toBeLessThan(txSubmitIndex);
+    expect(body.slice(staminaIndex, staminaIndex + 300)).toContain("toast.error");
   });
 
   it("clears queued next-move on tx failure, submission failure, fallback timeout, and scene destroy", () => {

--- a/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
+++ b/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
@@ -7,6 +7,7 @@ type ExplorerTroopsUpdateHandlers = {
   updateArmyHexes: (update: ExplorerTroopsSystemUpdate) => void;
   updateArmyFromExplorerTroopsUpdate: (update: ExplorerTroopsSystemUpdate) => void;
   shouldSkipStalePositionUpdate?: (entityId: ID, normalized: { x: number; y: number }) => boolean;
+  reconcileArmyPositionFromManager?: (entityId: ID) => void;
 };
 
 export function processExplorerTroopsUpdate(
@@ -32,4 +33,7 @@ export function processExplorerTroopsUpdate(
   // Always apply non-positional fields (stamina/troop-count/owner). Tick-based
   // staleness resolution downstream handles any regression in those fields.
   handlers.updateArmyFromExplorerTroopsUpdate(update);
+  if (shouldSkipPosition) {
+    handlers.reconcileArmyPositionFromManager?.(update.entityId);
+  }
 }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -128,6 +128,11 @@ import {
 import { snapshotRendererFxCapabilities } from "../renderer-fx-capabilities";
 import { SceneShortcutManager } from "../utils/shortcuts";
 import { createWorldmapInteractionAdapter } from "./worldmap-interaction-adapter";
+import {
+  planArmyPositionRepairs,
+  type ArmyPositionRepair,
+  type ArmyPositionRepairTarget,
+} from "./worldmap-army-position-repair";
 import { shouldTrackHydrationUpdateForFetch } from "./worldmap-hydration-tracking";
 import {
   claimWorldmapInteractionOwner,
@@ -486,6 +491,12 @@ type DirectionalPrefetchAnchor = {
   movementSign: -1 | 1;
 };
 type WorldmapCameraTransitionStatus = "idle" | "transitioning";
+type WorldmapArmyPositionRepairReason = "tile_update" | "explorer_troops_update" | "army_selection" | "chunk_hydrated";
+interface WorldmapArmyPositionRepairTarget extends ArmyPositionRepairTarget {
+  ownerAddress: bigint;
+  ownerStructureId: ID | null;
+}
+type WorldmapArmyPositionRepair = ArmyPositionRepair<WorldmapArmyPositionRepairTarget>;
 
 /**
  * Module-level ref to the active spatial ToriiStreamManager.
@@ -1388,6 +1399,7 @@ export default class WorldmapScene extends WarpTravel {
         }
 
         await this.armyManager.onTileUpdate(update);
+        this.reconcileArmyPositionFromManager(update.entityId, "tile_update");
         recordArmyMovementLatencyPhase({
           phase: "army_manager_tile_update_applied",
           source: "worldmap",
@@ -1423,6 +1435,8 @@ export default class WorldmapScene extends WarpTravel {
           updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
           shouldSkipStalePositionUpdate: (entityId, normalized) =>
             this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
+          reconcileArmyPositionFromManager: (entityId) =>
+            this.reconcileArmyPositionFromManager(entityId, "explorer_troops_update"),
         });
       }),
     );
@@ -3343,6 +3357,7 @@ export default class WorldmapScene extends WarpTravel {
     options?: { deferDuringChunkTransition?: boolean },
   ): boolean {
     const deferDuringChunkTransition = options?.deferDuringChunkTransition ?? true;
+    this.reconcileArmyPositionFromManager(selectedEntityId, "army_selection");
 
     // Check if army has pending movement transactions
     const selectionPlan = resolvePendingArmyMovementSelectionPlan({
@@ -4223,6 +4238,107 @@ export default class WorldmapScene extends WarpTravel {
         }
       });
     });
+  }
+
+  private reconcileAllArmyPositionsFromManager(reason: WorldmapArmyPositionRepairReason): void {
+    this.planArmyPositionRepairs(this.resolveArmyPositionRepairTargets()).forEach((repair) =>
+      this.applyArmyPositionRepair(repair, reason),
+    );
+  }
+
+  private reconcileArmyPositionFromManager(entityId: ID, reason: WorldmapArmyPositionRepairReason): boolean {
+    const target = this.resolveArmyPositionRepairTarget(entityId);
+    if (!target) {
+      return false;
+    }
+
+    const repair = this.planArmyPositionRepairs([target])[0];
+    if (!repair) {
+      return false;
+    }
+
+    this.applyArmyPositionRepair(repair, reason);
+    return true;
+  }
+
+  private resolveArmyPositionRepairTargets(): WorldmapArmyPositionRepairTarget[] {
+    return this.armyManager.getArmies().flatMap((army) => this.resolveArmyPositionRepairTarget(army.entityId) ?? []);
+  }
+
+  private resolveArmyPositionRepairTarget(entityId: ID): WorldmapArmyPositionRepairTarget | null {
+    if (this.armyManager.isArmyMovingOptimistically(entityId)) {
+      return null;
+    }
+
+    const army = this.armyManager.getArmy(entityId);
+    if (!army || army.owner.address === undefined) {
+      return null;
+    }
+
+    const normalized = army.hexCoords.getNormalized();
+    return {
+      canonicalPosition: { col: normalized.x, row: normalized.y },
+      entityId,
+      ownerAddress: army.owner.address,
+      ownerStructureId: army.owningStructureId ?? this.armyStructureOwners.get(entityId) ?? null,
+    };
+  }
+
+  private planArmyPositionRepairs(targets: Iterable<WorldmapArmyPositionRepairTarget>): WorldmapArmyPositionRepair[] {
+    return planArmyPositionRepairs({
+      armiesPositions: this.armiesPositions,
+      armyHexes: this.armyHexes,
+      targets,
+    });
+  }
+
+  private applyArmyPositionRepair(repair: WorldmapArmyPositionRepair, reason: WorldmapArmyPositionRepairReason): void {
+    const {
+      cachedPosition,
+      shouldUpdatePositionCache,
+      staleEntries,
+      target: { canonicalPosition, entityId, ownerAddress, ownerStructureId },
+    } = repair;
+
+    this.removeArmyHexEntries(entityId, staleEntries);
+
+    if (shouldUpdatePositionCache) {
+      this.updateArmyHexes({
+        entityId,
+        hexCoords: canonicalPosition,
+        ownerAddress,
+        ownerStructureId,
+      });
+    }
+
+    this.armyManager.syncArmyVisualToTrackedPosition(entityId);
+    if (import.meta.env.DEV) {
+      console.debug("[WorldMap] Repaired stale army position", {
+        entityId,
+        reason,
+        cachedPosition,
+        canonicalPosition,
+        removedStaleEntries: staleEntries,
+      });
+    }
+  }
+
+  private removeArmyHexEntries(entityId: ID, positions: HexPosition[]): void {
+    positions.forEach((position) => this.removeArmyHexEntry(entityId, position));
+  }
+
+  private removeArmyHexEntry(entityId: ID, position: HexPosition): void {
+    const rowMap = this.armyHexes.get(position.col);
+    if (rowMap?.get(position.row)?.id !== entityId) {
+      return;
+    }
+
+    rowMap.delete(position.row);
+    if (rowMap.size === 0) {
+      this.armyHexes.delete(position.col);
+    }
+    gameWorkerManager.updateArmyHex(position.col, position.row, null);
+    this.invalidateAllChunkCachesContainingHex(position.col, position.row);
   }
 
   // used to track the position of the armies on the map
@@ -7374,6 +7490,7 @@ export default class WorldmapScene extends WarpTravel {
       now: () => performance.now(),
       onChunkHydrated: (hydratedChunkKey) => {
         this.hydratedChunkRefreshes.delete(hydratedChunkKey);
+        this.reconcileAllArmyPositionsFromManager("chunk_hydrated");
       },
       onPhaseTimeout: (info) => this.handleChunkPresentationTimeout(info as never),
       phaseTimeoutMs: WORLDMAP_CHUNK_PHASE_TIMEOUT_MS,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -191,6 +191,7 @@ import {
 } from "./worldmap-terrain-commit-runtime";
 import { runWorldmapArmySelectionRecovery } from "./worldmap-army-selection-recovery-runtime";
 import { retryDeferredWorldmapArmyRemovals } from "./worldmap-deferred-army-removal-runtime";
+import { resolvePendingArmyMovementSubmitAction } from "./worldmap-army-movement-submit";
 import {
   resolveArmyTabSelectionPosition,
   resolvePendingArmyMovementFallbackPlan,
@@ -2492,18 +2493,32 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private onArmyMovement(account: Account | AccountInterface, actionPath: ActionPath[], selectedEntityId: ID) {
+    const pendingSubmitAction = resolvePendingArmyMovementSubmitAction({
+      actionPathLength: actionPath.length,
+      hasPendingMovement: this.pendingArmyMovements.has(selectedEntityId),
+      isOptimisticMovementActive: this.armyManager?.isArmyMovingOptimistically(selectedEntityId) ?? false,
+    });
+
+    switch (pendingSubmitAction) {
+      case "queue_next_move":
+        this.enqueueNextMove(account, actionPath, selectedEntityId);
+        this.state.updateEntityActionHoveredHex(null);
+        this.clearSelection();
+        return;
+      case "block_pending_handoff":
+        toast.error("Move already pending. Wait for it to start before queuing another.");
+        this.state.updateEntityActionHoveredHex(null);
+        this.clearSelection();
+        return;
+      case "submit":
+        break;
+    }
+
     // Universal stamina pre-check. Blocks any submit (not just queued) when the
     // client-visible stamina can't cover the action cost — prevents "insufficient
     // stamina" server rejections from reaching the user as a tx failure toast.
     if (actionPath.length > 0 && !this.canAffordMove(selectedEntityId, actionPath)) {
       toast.error("Not enough stamina for this move");
-      this.state.updateEntityActionHoveredHex(null);
-      this.clearSelection();
-      return;
-    }
-
-    if (actionPath.length > 0 && this.armyManager?.isArmyMovingOptimistically(selectedEntityId)) {
-      this.enqueueNextMove(account, actionPath, selectedEntityId);
       this.state.updateEntityActionHoveredHex(null);
       this.clearSelection();
       return;


### PR DESCRIPTION
## Summary

- Keep optimistic army movement locks alive briefly after target confirmation so late source-position replays do not reverse units
- Repair stale worldmap army caches from ArmyManager after authoritative tile updates, stale ExplorerTroops skips, army selection, and chunk hydration using a single-pass planner
- Block duplicate movement submits while a unit has a pending tx that has not handed off to the optimistic tween yet, while preserving queued follow-up moves once the tween is active
- Add behavioral and source-wiring coverage for stale repair planning, optimistic skips, movement rollback, and pending movement submit decisions

Root cause: late source replays and stale duplicate worldmap cache entries could outlive target confirmation, and the movement submit path allowed a second tx before the first pending movement had started animating.

## Verification

- `pnpm --dir client/apps/game test src/three/scenes/worldmap-army-movement-submit.test.ts src/three/scenes/worldmap-next-move-queue-wiring.source.test.ts`
- `pnpm --dir client/apps/game test src/three/scenes/worldmap-army-movement-submit.test.ts src/three/scenes/worldmap-next-move-queue-wiring.source.test.ts src/three/scenes/worldmap-army-position-repair.test.ts src/three/scenes/worldmap-army-position-repair.source.test.ts src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts src/three/scenes/__tests__/worldmap-update-helpers.test.ts src/three/managers/army-manager.optimistic-revert-on-source.test.ts src/three/managers/army-manager.authoritative-reconciliation.test.ts src/three/managers/army-manager.optimistic-position-lock.test.ts src/three/scenes/worldmap-stale-position-filter.source.test.ts`
- `pnpm --dir client/apps/game test:three:types`
- `pnpm run format`
- `pnpm run knip`
- `git diff --check`