### PR TITLE
[codex] Fix rapid building placement race

### DIFF
--- a/client/apps/game/src/three/scenes/hexception.tsx
+++ b/client/apps/game/src/three/scenes/hexception.tsx
@@ -46,6 +46,10 @@ import {
 } from "@/ui/layouts/game-loading-overlay.utils";
 
 import { ProductionModal } from "@/ui/features/settlement";
+import {
+  releaseOccupiedBuildSpot,
+  reserveOccupiedBuildSpot,
+} from "@/ui/features/settlement/construction/build-reservation-store";
 import { SetupResult } from "@bibliothecadao/dojo";
 import {
   ActionType,
@@ -634,10 +638,12 @@ export default class HexceptionScene extends HexagonScene {
       if (!this.tileManager.isHexOccupied(normalizedCoords)) {
         this.clearBuildingMode();
         const useSimpleCost = this.state.useSimpleCost;
+        const structureEntityId = useUIStore.getState().structureEntityId;
+        reserveOccupiedBuildSpot(structureEntityId, normalizedCoords);
         try {
           console.log("Placing building at:", {
             dojo: account!,
-            entityId: useUIStore.getState().structureEntityId,
+            entityId: structureEntityId,
             col: normalizedCoords.col,
             row: normalizedCoords.row,
             buildingId: buildingType.type,
@@ -645,7 +651,7 @@ export default class HexceptionScene extends HexagonScene {
 
           await this.tileManager.placeBuilding(
             account!,
-            useUIStore.getState().structureEntityId,
+            structureEntityId,
             buildingType.type,
             normalizedCoords,
             useSimpleCost,
@@ -653,6 +659,10 @@ export default class HexceptionScene extends HexagonScene {
           AudioManager.getInstance().play("ui.build_place");
         } catch (error) {
           console.log("catched error so removing building", error);
+          const message = error instanceof Error ? error.message : String(error);
+          if (!message.toLowerCase().includes("space is occupied")) {
+            releaseOccupiedBuildSpot(structureEntityId, normalizedCoords);
+          }
           this.removeBuilding(normalizedCoords.col, normalizedCoords.row);
         }
         this.updateHexceptionGrid(this.hexceptionRadius);

--- a/client/apps/game/src/ui/features/settlement/construction/build-reservation-store.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/build-reservation-store.test.ts
@@ -2,7 +2,9 @@
 
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  beginRealmBuildPlacement,
   clearAllBuildReservationState,
+  completeRealmBuildPlacement,
   getBuildReservationState,
   reserveOccupiedBuildSpot,
   reserveVacatedBuildSpot,
@@ -73,5 +75,31 @@ describe("build-reservation-store", () => {
     const state = getBuildReservationState(505);
     expect(state.occupied.has(toSpotKey({ col: 1, row: 1 }))).toBe(false);
     expect(state.vacated.has(toSpotKey({ col: 2, row: 2 }))).toBe(false);
+  });
+
+  it("blocks duplicate build placements synchronously until the placement completes", () => {
+    const firstPlacement = beginRealmBuildPlacement(606, 29, 1000);
+    const duplicatePlacement = beginRealmBuildPlacement(606, 29, 1000);
+    const otherBuildingPlacement = beginRealmBuildPlacement(606, 30, 1000);
+
+    expect(firstPlacement).toEqual({ started: true });
+    expect(duplicatePlacement).toEqual({ started: false });
+    expect(otherBuildingPlacement).toEqual({ started: true });
+
+    completeRealmBuildPlacement(606, 29);
+
+    expect(beginRealmBuildPlacement(606, 29, 1000)).toEqual({ started: true });
+  });
+
+  it("clears stale build placement locks", () => {
+    beginRealmBuildPlacement(707, 29, 1000);
+
+    reconcileBuildReservationState(707, () => false, {
+      now: 120000,
+      settleMs: 3000,
+      staleMs: 90000,
+    });
+
+    expect(beginRealmBuildPlacement(707, 29, 120000)).toEqual({ started: true });
   });
 });

--- a/client/apps/game/src/ui/features/settlement/construction/build-reservation-store.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/build-reservation-store.ts
@@ -9,6 +9,7 @@ type BuildReservationState = {
 type InternalBuildReservationState = BuildReservationState & {
   occupiedUpdatedAt: Map<string, number>;
   vacatedUpdatedAt: Map<string, number>;
+  activeBuildsByType: Map<number, number>;
 };
 
 type ReconcileOptions = {
@@ -40,6 +41,7 @@ const getOrCreateState = (realmEntityId: number): InternalBuildReservationState 
     vacated: new Set<string>(),
     occupiedUpdatedAt: new Map<string, number>(),
     vacatedUpdatedAt: new Map<string, number>(),
+    activeBuildsByType: new Map<number, number>(),
   };
   stateByRealm.set(realmEntityId, state);
   return state;
@@ -58,8 +60,37 @@ const clearVacated = (state: InternalBuildReservationState, key: string) => {
 const isSettled = (updatedAt: number, now: number, settleMs: number) => now - updatedAt >= settleMs;
 const isStale = (updatedAt: number, now: number, staleMs: number) => now - updatedAt >= staleMs;
 
+const clearStaleBuildPlacements = (state: InternalBuildReservationState, now: number, staleMs: number) => {
+  Array.from(state.activeBuildsByType.entries()).forEach(([buildingType, updatedAt]) => {
+    if (isStale(updatedAt, now, staleMs)) {
+      state.activeBuildsByType.delete(buildingType);
+    }
+  });
+};
+
 export const getBuildReservationState = (realmEntityId: number): BuildReservationState => {
   return getOrCreateState(realmEntityId);
+};
+
+export const beginRealmBuildPlacement = (
+  realmEntityId: number,
+  buildingType: number,
+  now: number = Date.now(),
+): { started: boolean } => {
+  const state = getOrCreateState(realmEntityId);
+  clearStaleBuildPlacements(state, now, RESERVATION_STALE_MS);
+
+  if (state.activeBuildsByType.has(buildingType)) {
+    return { started: false };
+  }
+
+  state.activeBuildsByType.set(buildingType, now);
+  return { started: true };
+};
+
+export const completeRealmBuildPlacement = (realmEntityId: number, buildingType: number) => {
+  const state = getOrCreateState(realmEntityId);
+  state.activeBuildsByType.delete(buildingType);
 };
 
 export const reserveOccupiedBuildSpot = (realmEntityId: number, spot: SpotInput, now: number = Date.now()) => {
@@ -98,6 +129,8 @@ export const reconcileBuildReservationState = (
   const now = options.now ?? Date.now();
   const settleMs = options.settleMs ?? RESERVATION_RECONCILE_SETTLE_MS;
   const staleMs = options.staleMs ?? RESERVATION_STALE_MS;
+
+  clearStaleBuildPlacements(state, now, staleMs);
 
   Array.from(state.occupied).forEach((key) => {
     const updatedAt = state.occupiedUpdatedAt.get(key) ?? now;

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
@@ -58,7 +58,7 @@ describe("buildRealmBuilding", () => {
     expect(onReleaseSpot).not.toHaveBeenCalled();
   });
 
-  it("releases failed occupied candidates before trying the next tile", async () => {
+  it("keeps failed occupied candidates blocked before trying the next tile", async () => {
     const onReserveSpot = vi.fn();
     const onReleaseSpot = vi.fn();
     placeBuilding.mockRejectedValueOnce(new Error("space is occupied"));
@@ -79,9 +79,29 @@ describe("buildRealmBuilding", () => {
 
     expect(result).toBe(true);
     expect(onReserveSpot).toHaveBeenNthCalledWith(1, "11,10");
-    expect(onReleaseSpot).toHaveBeenCalledWith("11,10");
     expect(onReserveSpot).toHaveBeenNthCalledWith(2, "11,11");
+    expect(onReleaseSpot).not.toHaveBeenCalledWith("11,10");
     expect(onReleaseSpot).not.toHaveBeenCalledWith("11,11");
+  });
+
+  it("blocks occupied candidates in the shared store after a contract occupancy race", async () => {
+    placeBuilding.mockRejectedValueOnce(new Error("space is occupied"));
+
+    const result = await buildRealmBuilding({
+      entityId: 101,
+      realmPosition: { x: 20, y: 30 },
+      target: { type: BuildingType.ResourceWheat },
+      useSimpleCost: true,
+      world: {
+        account: {},
+        components: {},
+        systemCalls: {},
+      },
+    });
+
+    expect(result).toBe(true);
+    expect(getBuildReservationState(101).occupied.has(toSpotKey({ col: 11, row: 10 }))).toBe(true);
+    expect(getBuildReservationState(101).occupied.has(toSpotKey({ col: 11, row: 11 }))).toBe(true);
   });
 
   it("uses the shared reservation store when callers do not provide reservation hooks", async () => {
@@ -99,6 +119,65 @@ describe("buildRealmBuilding", () => {
 
     expect(result).toBe(true);
     expect(getBuildReservationState(101).occupied.has(toSpotKey({ col: 11, row: 10 }))).toBe(true);
+  });
+
+  it("keeps provider-pending submissions reserved before transaction confirmation", async () => {
+    let resolvePlacement: (result: { transaction_hash: string }) => void = () => {};
+    placeBuilding.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePlacement = resolve;
+      }),
+    );
+
+    const resultPromise = buildRealmBuilding({
+      entityId: 101,
+      realmPosition: { x: 20, y: 30 },
+      target: { type: BuildingType.ResourceWheat },
+      useSimpleCost: true,
+      world: {
+        account: {},
+        components: {},
+        systemCalls: {},
+      },
+    });
+
+    expect(getBuildReservationState(101).occupied.has(toSpotKey({ col: 11, row: 10 }))).toBe(true);
+
+    resolvePlacement({ transaction_hash: "0x1" });
+
+    await expect(resultPromise).resolves.toBe(true);
+    expect(getBuildReservationState(101).occupied.has(toSpotKey({ col: 11, row: 10 }))).toBe(true);
+  });
+
+  it("assigns burst auto-build calls to distinct pending slots", async () => {
+    const [firstResult, secondResult] = await Promise.all([
+      buildRealmBuilding({
+        entityId: 101,
+        realmPosition: { x: 20, y: 30 },
+        target: { type: BuildingType.ResourceWheat },
+        useSimpleCost: true,
+        world: {
+          account: {},
+          components: {},
+          systemCalls: {},
+        },
+      }),
+      buildRealmBuilding({
+        entityId: 101,
+        realmPosition: { x: 20, y: 30 },
+        target: { type: BuildingType.ResourceWheat },
+        useSimpleCost: true,
+        world: {
+          account: {},
+          components: {},
+          systemCalls: {},
+        },
+      }),
+    ]);
+
+    expect([firstResult, secondResult]).toEqual([true, true]);
+    expect(placeBuilding).toHaveBeenNthCalledWith(1, {}, 101, BuildingType.ResourceWheat, { col: 11, row: 10 }, true);
+    expect(placeBuilding).toHaveBeenNthCalledWith(2, {}, 101, BuildingType.ResourceWheat, { col: 11, row: 11 }, true);
   });
 
   it("skips shared reserved tiles when picking the next build spot", async () => {

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
@@ -259,13 +259,12 @@ export const buildRealmBuilding = async ({
         });
         return true;
       } catch (error) {
-        releaseAutoBuildSpot(entityId, spotKey, onReleaseSpot);
-
         if (isOccupiedSpaceError(error)) {
           occupiedTileFailures += 1;
           continue;
         }
 
+        releaseAutoBuildSpot(entityId, spotKey, onReleaseSpot);
         throw error;
       }
     }

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -15,6 +15,8 @@ import { HintSection } from "@/ui/features/progression/hints/hint-modal";
 import { ProductionStatusBadge } from "@/ui/shared";
 import { adjustWonderLordsCost, currencyIntlFormat, getEntityIdFromKeys } from "@/ui/utils/utils";
 import {
+  beginRealmBuildPlacement,
+  completeRealmBuildPlacement,
   getBuildReservationState,
   reconcileBuildReservationState,
   releaseOccupiedBuildSpot,
@@ -194,6 +196,9 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const handleAutoBuild = useCallback(
     async (target: { type: BuildingType; resource?: ResourcesIds }) => {
       const buildingKey = target.type.toString();
+      const placement = beginRealmBuildPlacement(entityId, target.type);
+
+      if (!placement.started) return;
 
       setPendingBuilds((prev) => ({ ...prev, [buildingKey]: true }));
 
@@ -223,6 +228,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
           delete next[buildingKey];
           return next;
         });
+        completeRealmBuildPlacement(entityId, target.type);
       }
     },
     [

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-04-30",
+    title: "Safer Rapid Building",
+    description:
+      "Rapid build clicks now reserve pending building spots immediately, so auto-build and manual placement avoid duplicate occupied-space errors while the chain catches up.",
+    type: "fix",
+  },
+  {
     date: "2026-04-29",
     title: "Unblocked Spectating",
     description:

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -13,6 +13,10 @@ import {
   resolveRealmHasAvailableBuildingTile,
 } from "@/ui/features/settlement/construction/realm-build-actions";
 import {
+  beginRealmBuildPlacement,
+  completeRealmBuildPlacement,
+} from "@/ui/features/settlement/construction/build-reservation-store";
+import {
   buildRealmBuildingSummary,
   RealmBuildingSummary,
   resolveRealmBuildingSummaryBuildability,
@@ -371,6 +375,10 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
       if (!realmId) return;
 
       const buildingKey = buildingId.toString();
+      const placement = beginRealmBuildPlacement(realmId, buildingId);
+
+      if (!placement.started) return;
+
       setPendingBuilds((prev) => ({ ...prev, [buildingKey]: true }));
 
       try {
@@ -392,6 +400,7 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
           delete next[buildingKey];
           return next;
         });
+        completeRealmBuildPlacement(realmId, buildingId);
       }
     },
     [account.account, components, realm?.position, realmId, setSelectedBuildingHex, setup.systemCalls, useSimpleCost],


### PR DESCRIPTION
Fixes rapid building placement races by making build reservations synchronous across auto-build, overview shortcuts, and manual hex placement.
The root cause was that repeated clicks could start new submissions before React pending state and indexed chain state agreed on occupied slots, so stale candidates could reach Cairo and revert with "space is occupied".
Occupied contract races now keep the candidate reserved while auto-build tries the next tile, and provider-pending submissions remain blocked until reconciliation.

Checks:
- pnpm run format
- pnpm run knip
- pnpm --dir client/apps/game test src/ui/features/settlement/construction/realm-build-actions.test.ts src/ui/features/settlement/construction/build-reservation-store.test.ts src/ui/features/world/latest-features.test.ts
- pnpm --dir client/apps/game typecheck
