### PR TITLE
[codex] Guard automation resource spends

### DIFF
--- a/client/apps/game/scripts/run-renderer-scene-smoke.mjs
+++ b/client/apps/game/scripts/run-renderer-scene-smoke.mjs
@@ -11,6 +11,8 @@ const DEFAULT_WORLD_NAME = "eternum-blitz-slot-4";
 const REQUIRED_RENDERER_PARITY_FEATURES = new Set(["environmentIbl", "toneMappingControl", "bloom"]);
 const VALID_SCENES = new Set(["map", "hex", "travel"]);
 const DEFAULT_WAIT_MS = 20000;
+const AGENT_BROWSER_RETRY_DELAY_MS = 2000;
+const AGENT_BROWSER_RETRY_ATTEMPTS = 2;
 const DEFAULT_CARTRIDGE_API_BASE = "https://api.cartridge.gg";
 const FACTORY_SQL_BASE_URLS = {
   local: [],
@@ -265,6 +267,49 @@ function runAgentBrowser(session, commandArgs, { headed = false } = {}) {
   return result.stdout.trim();
 }
 
+export function isRetryableAgentBrowserFailure({ commandArgs, stderr = "", stdout = "" }) {
+  if (commandArgs[0] !== "eval") {
+    return false;
+  }
+
+  const output = `${stderr}\n${stdout}`;
+  return output.includes("CDP command timed out: Runtime.evaluate");
+}
+
+async function runAgentBrowserWithRetries(
+  session,
+  commandArgs,
+  { headed = false, retryAttempts = AGENT_BROWSER_RETRY_ATTEMPTS, retryDelayMs = AGENT_BROWSER_RETRY_DELAY_MS } = {},
+) {
+  let lastOutput = "";
+
+  for (let attempt = 0; attempt <= retryAttempts; attempt += 1) {
+    const result = invokeAgentBrowser(session, commandArgs, { headed });
+    if (result.status === 0) {
+      return (result.stdout ?? "").trim();
+    }
+
+    const stdout = (result.stdout ?? "").trim();
+    const stderr = (result.stderr ?? "").trim();
+    lastOutput = stderr || stdout || `agent-browser failed for session ${session}`;
+
+    if (
+      attempt === retryAttempts ||
+      !isRetryableAgentBrowserFailure({
+        commandArgs,
+        stderr,
+        stdout,
+      })
+    ) {
+      throw new Error(lastOutput);
+    }
+
+    await sleep(retryDelayMs * (attempt + 1));
+  }
+
+  throw new Error(lastOutput);
+}
+
 function tryRunAgentBrowser(session, commandArgs, { headed = false } = {}) {
   const result = invokeAgentBrowser(session, commandArgs, { headed });
   return {
@@ -348,9 +393,16 @@ async function runSceneSmoke({
   await sleep(waitMs);
 
   const openedUrl = runAgentBrowser(session, ["get", "url"]);
-  const canvasExists = runAgentBrowser(session, ["eval", "Boolean(document.getElementById('main-canvas'))"]) === "true";
+  const canvasExists =
+    (await runAgentBrowserWithRetries(session, ["eval", "Boolean(document.getElementById('main-canvas'))"], {
+      headed,
+    })) === "true";
   const diagnostics = normalizeRendererDiagnosticsSnapshot(
-    JSON.parse(runAgentBrowser(session, ["eval", "JSON.stringify(window.__rendererDiagnostics ?? null)"]) || "null"),
+    JSON.parse(
+      (await runAgentBrowserWithRetries(session, ["eval", "JSON.stringify(window.__rendererDiagnostics ?? null)"], {
+        headed,
+      })) || "null",
+    ),
   );
   const unableToStartCount = Number(runAgentBrowser(session, ["get", "count", "text=Unable to Start"]) || "0");
   const errors = parseErrorLines(runAgentBrowser(session, ["errors"]));

--- a/client/apps/game/scripts/run-renderer-scene-smoke.test.mjs
+++ b/client/apps/game/scripts/run-renderer-scene-smoke.test.mjs
@@ -8,6 +8,7 @@ import {
   GLOW_REPRO_TARGETS,
   evaluateRendererParitySummary,
   evaluateSceneSmokeResult,
+  isRetryableAgentBrowserFailure,
   normalizeRendererDiagnosticsSnapshot,
   normalizeSceneList,
   resolveAgentBrowserWorkingDirectory,
@@ -117,6 +118,38 @@ describe("resolveAgentBrowserWorkingDirectory", () => {
   it("runs npx outside the repository workspace to avoid npm duplicate workspace-name failures", () => {
     expect(resolveAgentBrowserWorkingDirectory({ RUNNER_TEMP: "/runner-temp", TMPDIR: "/tmp" })).toBe("/runner-temp");
     expect(resolveAgentBrowserWorkingDirectory({ TMPDIR: "/tmp" })).toBe("/tmp");
+  });
+});
+
+describe("isRetryableAgentBrowserFailure", () => {
+  it("retries transient CDP Runtime.evaluate timeouts for eval commands", () => {
+    expect(
+      isRetryableAgentBrowserFailure({
+        commandArgs: ["eval", "Boolean(document.getElementById('main-canvas'))"],
+        stderr: "Error: ✗ CDP command timed out: Runtime.evaluate",
+        stdout: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry non-eval failures", () => {
+    expect(
+      isRetryableAgentBrowserFailure({
+        commandArgs: ["get", "url"],
+        stderr: "Error: ✗ CDP command timed out: Runtime.evaluate",
+        stdout: "",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not retry regular application failures", () => {
+    expect(
+      isRetryableAgentBrowserFailure({
+        commandArgs: ["eval", "JSON.stringify(window.__rendererDiagnostics ?? null)"],
+        stderr: "Error: page reported runtime errors",
+        stdout: "",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/client/apps/game/src/hooks/automation-resource-reservations.test.ts
+++ b/client/apps/game/src/hooks/automation-resource-reservations.test.ts
@@ -1,0 +1,127 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+import { ResourcesIds } from "@bibliothecadao/types";
+import {
+  applyAutomationReservationsToSnapshot,
+  clearAutomationResourceReservationsForTests,
+  getSpendableResourceBalance,
+  releaseAutomationReservation,
+  reserveAutomationResources,
+} from "./automation-resource-reservations";
+
+describe("automation resource reservations", () => {
+  afterEach(() => {
+    clearAutomationResourceReservationsForTests();
+  });
+
+  it("subtracts pending same-entity resource spend from spendable balances", () => {
+    reserveAutomationResources({
+      entityId: 42,
+      resources: [{ resourceId: ResourcesIds.Wood, humanAmount: 60 }],
+      nowMs: 1_000,
+      ttlMs: 10_000,
+    });
+
+    expect(
+      getSpendableResourceBalance({
+        entityId: 42,
+        resourceId: ResourcesIds.Wood,
+        balanceHuman: 100,
+        nowMs: 2_000,
+      }),
+    ).toBe(40);
+  });
+
+  it("keeps unrelated entities and resources independent", () => {
+    reserveAutomationResources({
+      entityId: 42,
+      resources: [{ resourceId: ResourcesIds.Wood, humanAmount: 60 }],
+      nowMs: 1_000,
+      ttlMs: 10_000,
+    });
+
+    expect(
+      getSpendableResourceBalance({
+        entityId: 43,
+        resourceId: ResourcesIds.Wood,
+        balanceHuman: 100,
+        nowMs: 2_000,
+      }),
+    ).toBe(100);
+    expect(
+      getSpendableResourceBalance({
+        entityId: 42,
+        resourceId: ResourcesIds.Coal,
+        balanceHuman: 100,
+        nowMs: 2_000,
+      }),
+    ).toBe(100);
+  });
+
+  it("removes reservations when they expire or are released after a failed submit", () => {
+    const token = reserveAutomationResources({
+      entityId: 42,
+      resources: [{ resourceId: ResourcesIds.Wood, humanAmount: 60 }],
+      nowMs: 1_000,
+      ttlMs: 1_000,
+    });
+
+    expect(
+      getSpendableResourceBalance({
+        entityId: 42,
+        resourceId: ResourcesIds.Wood,
+        balanceHuman: 100,
+        nowMs: 2_001,
+      }),
+    ).toBe(100);
+
+    const secondToken = reserveAutomationResources({
+      entityId: 42,
+      resources: [{ resourceId: ResourcesIds.Wood, humanAmount: 25 }],
+      nowMs: 3_000,
+      ttlMs: 10_000,
+    });
+
+    releaseAutomationReservation(secondToken);
+    releaseAutomationReservation(token);
+
+    expect(
+      getSpendableResourceBalance({
+        entityId: 42,
+        resourceId: ResourcesIds.Wood,
+        balanceHuman: 100,
+        nowMs: 4_000,
+      }),
+    ).toBe(100);
+  });
+
+  it("applies reservations to production snapshots without mutating the original snapshot", () => {
+    reserveAutomationResources({
+      entityId: 42,
+      resources: [{ resourceId: ResourcesIds.Wood, humanAmount: 60 }],
+      nowMs: 1_000,
+      ttlMs: 10_000,
+    });
+
+    const snapshot = new Map([
+      [
+        ResourcesIds.Wood,
+        {
+          resourceId: ResourcesIds.Wood,
+          balanceHuman: 100,
+          hasActiveProduction: true,
+          productionPerSecond: 1,
+        },
+      ],
+    ]);
+
+    const adjusted = applyAutomationReservationsToSnapshot({
+      entityId: 42,
+      snapshot,
+      nowMs: 2_000,
+    });
+
+    expect(adjusted.get(ResourcesIds.Wood)?.balanceHuman).toBe(40);
+    expect(snapshot.get(ResourcesIds.Wood)?.balanceHuman).toBe(100);
+  });
+});

--- a/client/apps/game/src/hooks/automation-resource-reservations.test.ts
+++ b/client/apps/game/src/hooks/automation-resource-reservations.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it } from "vitest";
 import { ResourcesIds } from "@bibliothecadao/types";
+import { PROCESS_INTERVAL_MS } from "@/ui/features/infrastructure/automation/model/automation-processor";
 import {
   applyAutomationReservationsToSnapshot,
   clearAutomationResourceReservationsForTests,
@@ -123,5 +124,22 @@ describe("automation resource reservations", () => {
 
     expect(adjusted.get(ResourcesIds.Wood)?.balanceHuman).toBe(40);
     expect(snapshot.get(ResourcesIds.Wood)?.balanceHuman).toBe(100);
+  });
+
+  it("expires default reservations before the next automation pass", () => {
+    reserveAutomationResources({
+      entityId: 42,
+      resources: [{ resourceId: ResourcesIds.Wood, humanAmount: 60 }],
+      nowMs: 1_000,
+    });
+
+    expect(
+      getSpendableResourceBalance({
+        entityId: 42,
+        resourceId: ResourcesIds.Wood,
+        balanceHuman: 100,
+        nowMs: 1_000 + PROCESS_INTERVAL_MS,
+      }),
+    ).toBe(100);
   });
 });

--- a/client/apps/game/src/hooks/automation-resource-reservations.ts
+++ b/client/apps/game/src/hooks/automation-resource-reservations.ts
@@ -1,5 +1,8 @@
 import { ResourcesIds } from "@bibliothecadao/types";
-import type { RealmResourceSnapshot } from "@/ui/features/infrastructure/automation/model/automation-processor";
+import {
+  PROCESS_INTERVAL_MS,
+  type RealmResourceSnapshot,
+} from "@/ui/features/infrastructure/automation/model/automation-processor";
 
 interface AutomationResourceReservationItem {
   resourceId: ResourcesIds;
@@ -12,7 +15,10 @@ interface AutomationResourceReservation {
   expiresAtMs: number;
 }
 
-const DEFAULT_RESERVATION_TTL_MS = 90_000;
+// Keep successful reservations alive long enough to cover tx submission/indexer lag,
+// but never long enough to survive into the next scheduled automation pass.
+const NEXT_PASS_RESERVATION_BUFFER_MS = 5_000;
+const DEFAULT_RESERVATION_TTL_MS = Math.max(1_000, PROCESS_INTERVAL_MS - NEXT_PASS_RESERVATION_BUFFER_MS);
 
 let nextReservationId = 1;
 const reservations = new Map<string, AutomationResourceReservation>();

--- a/client/apps/game/src/hooks/automation-resource-reservations.ts
+++ b/client/apps/game/src/hooks/automation-resource-reservations.ts
@@ -1,0 +1,153 @@
+import { ResourcesIds } from "@bibliothecadao/types";
+import type { RealmResourceSnapshot } from "@/ui/features/infrastructure/automation/model/automation-processor";
+
+interface AutomationResourceReservationItem {
+  resourceId: ResourcesIds;
+  humanAmount: number;
+}
+
+interface AutomationResourceReservation {
+  entityId: number;
+  resources: AutomationResourceReservationItem[];
+  expiresAtMs: number;
+}
+
+const DEFAULT_RESERVATION_TTL_MS = 90_000;
+
+let nextReservationId = 1;
+const reservations = new Map<string, AutomationResourceReservation>();
+
+const normalizeEntityId = (entityId: number): number => {
+  if (!Number.isFinite(entityId) || entityId <= 0) return 0;
+  return Math.floor(entityId);
+};
+
+const normalizeReservationResources = (
+  resources: AutomationResourceReservationItem[],
+): AutomationResourceReservationItem[] => {
+  const totals = new Map<ResourcesIds, number>();
+
+  for (const resource of resources) {
+    const amount = Math.floor(resource.humanAmount);
+    if (!Number.isFinite(amount) || amount <= 0) continue;
+    totals.set(resource.resourceId, (totals.get(resource.resourceId) ?? 0) + amount);
+  }
+
+  return Array.from(totals.entries()).map(([resourceId, humanAmount]) => ({ resourceId, humanAmount }));
+};
+
+const pruneExpiredReservations = (nowMs: number) => {
+  for (const [token, reservation] of reservations) {
+    if (reservation.expiresAtMs <= nowMs) {
+      reservations.delete(token);
+    }
+  }
+};
+
+export const reserveAutomationResources = ({
+  entityId,
+  resources,
+  nowMs = Date.now(),
+  ttlMs = DEFAULT_RESERVATION_TTL_MS,
+}: {
+  entityId: number;
+  resources: AutomationResourceReservationItem[];
+  nowMs?: number;
+  ttlMs?: number;
+}): string => {
+  pruneExpiredReservations(nowMs);
+
+  const normalizedEntityId = normalizeEntityId(entityId);
+  const normalizedResources = normalizeReservationResources(resources);
+  const token = `automation-resource-reservation-${nextReservationId++}`;
+
+  if (normalizedEntityId === 0 || normalizedResources.length === 0) {
+    return token;
+  }
+
+  reservations.set(token, {
+    entityId: normalizedEntityId,
+    resources: normalizedResources,
+    expiresAtMs: nowMs + Math.max(0, ttlMs),
+  });
+
+  return token;
+};
+
+export const releaseAutomationReservation = (token: string | null | undefined) => {
+  if (!token) return;
+  reservations.delete(token);
+};
+
+const getReservedResourceAmount = ({
+  entityId,
+  resourceId,
+  nowMs = Date.now(),
+}: {
+  entityId: number;
+  resourceId: ResourcesIds;
+  nowMs?: number;
+}): number => {
+  pruneExpiredReservations(nowMs);
+
+  const normalizedEntityId = normalizeEntityId(entityId);
+  if (normalizedEntityId === 0) return 0;
+
+  let reserved = 0;
+  for (const reservation of reservations.values()) {
+    if (reservation.entityId !== normalizedEntityId) continue;
+    for (const resource of reservation.resources) {
+      if (resource.resourceId === resourceId) {
+        reserved += resource.humanAmount;
+      }
+    }
+  }
+  return reserved;
+};
+
+export const getSpendableResourceBalance = ({
+  entityId,
+  resourceId,
+  balanceHuman,
+  nowMs = Date.now(),
+}: {
+  entityId: number;
+  resourceId: ResourcesIds;
+  balanceHuman: number;
+  nowMs?: number;
+}): number => {
+  if (!Number.isFinite(balanceHuman) || balanceHuman <= 0) return 0;
+  const reserved = getReservedResourceAmount({ entityId, resourceId, nowMs });
+  return Math.max(0, Math.floor(balanceHuman - reserved));
+};
+
+export const applyAutomationReservationsToSnapshot = ({
+  entityId,
+  snapshot,
+  nowMs = Date.now(),
+}: {
+  entityId: number;
+  snapshot: RealmResourceSnapshot;
+  nowMs?: number;
+}): RealmResourceSnapshot => {
+  const adjusted: RealmResourceSnapshot = new Map();
+
+  for (const [resourceId, entry] of snapshot) {
+    adjusted.set(resourceId, {
+      ...entry,
+      balanceHuman: getSpendableResourceBalance({
+        entityId,
+        resourceId,
+        balanceHuman: entry.balanceHuman,
+        nowMs,
+      }),
+    });
+  }
+
+  return adjusted;
+};
+
+export const clearAutomationResourceReservationsForTests = () => {
+  reservations.clear();
+  nextReservationId = 1;
+};

--- a/client/apps/game/src/hooks/use-automation.source.test.ts
+++ b/client/apps/game/src/hooks/use-automation.source.test.ts
@@ -59,4 +59,22 @@ describe("useAutomation source", () => {
     expect(source).not.toContain("const executablePlans: ExecutableProductionPlan[] = [];");
     expect(source).not.toContain("executeProductionPlansSequentially");
   });
+
+  it("applies and records automation resource reservations around production submits", () => {
+    const source = readSource("src/hooks/use-automation.tsx");
+
+    expect(source).toContain("applyAutomationReservationsToSnapshot");
+    expect(source).toContain("reserveAutomationResources");
+    expect(source).toContain("releaseAutomationReservation(reservationToken)");
+    expect(source).toContain("buildProductionReservationResources(plan)");
+  });
+
+  it("scheduled transfer automation plans against spendable reserved balances", () => {
+    const source = readSource("src/hooks/use-transfer-automation-runner.ts");
+
+    expect(source).toContain("getSpendableResourceBalance");
+    expect(source).toContain("reserveAutomationResources");
+    expect(source).toContain("releaseAutomationReservation(reservationToken)");
+    expect(source).toMatch(/resources: transferList/);
+  });
 });

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -12,6 +12,11 @@ import { isSignerTransientError } from "@/ui/features/infrastructure/automation/
 import { computeAutomationConfigSignature } from "@/utils/automation-signature";
 import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import {
+  applyAutomationReservationsToSnapshot,
+  releaseAutomationReservation,
+  reserveAutomationResources,
+} from "./automation-resource-reservations";
+import {
   computeNextEligibleMs,
   computePostPassSchedulerUpdate,
   computeScheduleDelayMs,
@@ -88,6 +93,12 @@ const formatCustomPercentagesLog = (percentages: Record<number, ResourceAutomati
     resourceId: Number(resourceId),
     resource: resolveResourceLabel(Number(resourceId)),
     percentages: value,
+  }));
+
+const buildProductionReservationResources = (plan: RealmProductionPlan) =>
+  Object.entries(plan.consumptionByResource).map(([resourceId, humanAmount]) => ({
+    resourceId: Number(resourceId) as ResourcesIds,
+    humanAmount,
   }));
 
 type ProcessRealmsResult = { ran: boolean; anyExecuted: boolean };
@@ -312,7 +323,7 @@ export const useAutomation = () => {
         // Rebuild the conservative projection immediately before each realm submission so
         // projected balances reflect the freshest local state available at submit time.
         const { currentDefaultTick: conservativeTick } = getAutomationProjectionTick();
-        const snapshot =
+        const rawSnapshot: RealmResourceSnapshot =
           Number.isFinite(realmIdNum) && realmIdNum > 0
             ? buildRealmResourceSnapshot({
                 components,
@@ -320,6 +331,13 @@ export const useAutomation = () => {
                 currentTick: conservativeTick,
               })
             : new Map();
+        const snapshot =
+          Number.isFinite(realmIdNum) && realmIdNum > 0
+            ? applyAutomationReservationsToSnapshot({
+                entityId: realmIdNum,
+                snapshot: rawSnapshot,
+              })
+            : rawSnapshot;
 
         console.log("[Automation] Prepared realm snapshot", {
           realmId: activeRealmConfig.realmId,
@@ -464,7 +482,13 @@ export const useAutomation = () => {
 
         console.log("[Automation] Executing production plan", planLogPayloadWithStatus);
 
+        let reservationToken: string | null = null;
         try {
+          reservationToken = reserveAutomationResources({
+            entityId: plan.realmId,
+            resources: buildProductionReservationResources(plan),
+          });
+
           await execute_realm_production_plan({
             signer: starknetSignerAccount,
             realm_entity_id: plan.realmId,
@@ -515,6 +539,7 @@ export const useAutomation = () => {
             toast.success(`Automation executed for ${activeRealmConfig.realmName ?? `Realm ${plan.realmId}`}.`);
           }
         } catch (rawError) {
+          releaseAutomationReservation(reservationToken);
           const errorMessage = extractReadableErrorMessage(rawError, "Automation transaction failed");
           const isSignerFault = isSignerTransientError(rawError);
 

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.ts
@@ -14,6 +14,11 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { canTransferMilitaryInventoryBetweenStructureIds } from "@/ui/lib/structure-capabilities";
 import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import { useTransferAutomationStore } from "./store/use-transfer-automation-store";
+import {
+  getSpendableResourceBalance,
+  releaseAutomationReservation,
+  reserveAutomationResources,
+} from "./automation-resource-reservations";
 import { assessDonkeyCapacity, buildSendResourcesArgs, planTransferAmounts } from "./transfer-automation-planner";
 
 export const useTransferAutomationRunner = () => {
@@ -127,6 +132,7 @@ export const useTransferAutomationRunner = () => {
 
       try {
         for (const entry of due) {
+          let reservationToken: string | null = null;
           try {
             const sourceId = Number(entry.sourceEntityId);
             const destId = Number(entry.destinationEntityId);
@@ -168,12 +174,23 @@ export const useTransferAutomationRunner = () => {
             }
 
             const rm = new ResourceManager(components, sourceId);
+            const reservationNowMs = Date.now();
             const donkeyBalRaw = rm.balanceWithProduction(conservativeTick, ResourcesIds.Donkey).balance ?? 0n;
-            const donkeyBalHuman = Number(donkeyBalRaw) / RESOURCE_PRECISION;
+            const donkeyBalHuman = getSpendableResourceBalance({
+              entityId: sourceId,
+              resourceId: ResourcesIds.Donkey,
+              balanceHuman: Number(donkeyBalRaw) / RESOURCE_PRECISION,
+              nowMs: reservationNowMs,
+            });
 
             const transferList = planTransferAmounts(entry, (rid) => {
               const balRaw = rm.balanceWithProduction(conservativeTick, rid).balance ?? 0n;
-              return Number(balRaw) / RESOURCE_PRECISION;
+              return getSpendableResourceBalance({
+                entityId: sourceId,
+                resourceId: rid,
+                balanceHuman: Number(balRaw) / RESOURCE_PRECISION,
+                nowMs: reservationNowMs,
+              });
             });
 
             if (transferList.length === 0) {
@@ -189,6 +206,11 @@ export const useTransferAutomationRunner = () => {
             }
 
             const resources = buildSendResourcesArgs(transferList);
+            reservationToken = reserveAutomationResources({
+              entityId: sourceId,
+              resources: transferList,
+              nowMs: reservationNowMs,
+            });
 
             await systemCalls.send_resources_multiple({
               signer: account,
@@ -208,6 +230,7 @@ export const useTransferAutomationRunner = () => {
               .join(", ");
             toast.success(`Transfer scheduled: ${summary}`);
           } catch (err) {
+            releaseAutomationReservation(reservationToken);
             console.error("Transfer automation: execution failed", err);
             scheduleNext(entry.id, nowMs);
             toast.error("Scheduled transfer failed. Check console for details.");

--- a/client/apps/game/src/three/scenes/hexception-build-affordability.source.test.ts
+++ b/client/apps/game/src/three/scenes/hexception-build-affordability.source.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Hexception build affordability", () => {
+  it("re-checks preview affordability before placing a building from a map click", () => {
+    const source = readSource("src/three/scenes/hexception.tsx");
+
+    expect(source).toContain("canAffordPreviewBuilding");
+    expect(source).toContain(
+      "if (!this.canAffordPreviewBuilding(structureEntityId, buildingType.type, useSimpleCost))",
+    );
+    expect(source).toContain('toast.error("Insufficient resources to build here.");');
+    expect(source).toMatch(
+      /if \(!this\.canAffordPreviewBuilding\(structureEntityId, buildingType\.type, useSimpleCost\)\) \{[\s\S]*reserveOccupiedBuildSpot\(structureEntityId, normalizedCoords\);/,
+    );
+  });
+});

--- a/client/apps/game/src/three/scenes/hexception.tsx
+++ b/client/apps/game/src/three/scenes/hexception.tsx
@@ -57,6 +57,9 @@ import {
   ResourceIdToMiningType,
   ResourceManager,
   TileManager,
+  divideByPrecision,
+  getBalance,
+  getBuildingCosts,
   getEntityIdFromKeys,
   getStructureStage,
 } from "@bibliothecadao/eternum";
@@ -77,6 +80,7 @@ import {
 } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import gsap from "gsap";
+import { toast } from "sonner";
 import {
   AnimationClip,
   AnimationMixer,
@@ -382,6 +386,23 @@ export default class HexceptionScene extends HexagonScene {
     this.state.setPreviewBuilding(null);
   }
 
+  private canAffordPreviewBuilding(
+    structureEntityId: number,
+    buildingCategory: BuildingType,
+    useSimpleCost: boolean,
+  ): boolean {
+    const { currentDefaultTick } = getBlockTimestamp();
+    const buildingCosts = getBuildingCosts(structureEntityId, this.dojo.components, buildingCategory, useSimpleCost);
+    if (!buildingCosts?.length) {
+      return false;
+    }
+
+    return buildingCosts.every((resourceCost) => {
+      const balance = getBalance(structureEntityId, resourceCost.resource, currentDefaultTick, this.dojo.components);
+      return divideByPrecision(balance.balance) >= resourceCost.amount;
+    });
+  }
+
   private loadBuildingModels() {
     for (const category of Object.values(BUILDINGS_GROUPS)) {
       const categoryPaths = this.mode.assets.buildingModelPaths[category];
@@ -639,6 +660,11 @@ export default class HexceptionScene extends HexagonScene {
         this.clearBuildingMode();
         const useSimpleCost = this.state.useSimpleCost;
         const structureEntityId = useUIStore.getState().structureEntityId;
+        if (!this.canAffordPreviewBuilding(structureEntityId, buildingType.type, useSimpleCost)) {
+          toast.error("Insufficient resources to build here.");
+          this.updateHexceptionGrid(this.hexceptionRadius);
+          return;
+        }
         reserveOccupiedBuildSpot(structureEntityId, normalizedCoords);
         try {
           console.log("Placing building at:", {

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
@@ -10,12 +10,20 @@ import {
 } from "./build-reservation-store";
 import { buildRealmBuilding } from "./realm-build-actions";
 
-const placeBuilding = vi.fn();
-const isHexOccupied = vi.fn();
+const { placeBuilding, isHexOccupied, getBuildingCosts, getBalance, divideByPrecision, getBlockTimestamp, toastError } =
+  vi.hoisted(() => ({
+    placeBuilding: vi.fn(),
+    isHexOccupied: vi.fn(),
+    getBuildingCosts: vi.fn(),
+    getBalance: vi.fn(),
+    divideByPrecision: vi.fn((value: bigint | number) => Number(value)),
+    getBlockTimestamp: vi.fn(() => ({ currentDefaultTick: 123 })),
+    toastError: vi.fn(),
+  }));
 
 vi.mock("sonner", () => ({
   toast: {
-    error: vi.fn(),
+    error: toastError,
   },
 }));
 
@@ -25,6 +33,10 @@ vi.mock("@bibliothecadao/eternum", () => ({
     isHexOccupied,
     placeBuilding,
   })),
+  divideByPrecision,
+  getBlockTimestamp,
+  getBalance,
+  getBuildingCosts,
 }));
 
 describe("buildRealmBuilding", () => {
@@ -33,6 +45,28 @@ describe("buildRealmBuilding", () => {
     clearAllBuildReservationState();
     isHexOccupied.mockReturnValue(false);
     placeBuilding.mockResolvedValue({ transaction_hash: "0x1" });
+    getBuildingCosts.mockReturnValue([{ resource: 1, amount: 10 }]);
+    getBalance.mockReturnValue({ balance: 20n, resourceId: 1 });
+  });
+
+  it("re-checks resource affordability before submitting a build", async () => {
+    getBalance.mockReturnValueOnce({ balance: 5n, resourceId: 1 });
+
+    const result = await buildRealmBuilding({
+      entityId: 101,
+      realmPosition: { x: 20, y: 30 },
+      target: { type: BuildingType.ResourceWheat },
+      useSimpleCost: true,
+      world: {
+        account: {},
+        components: {},
+        systemCalls: {},
+      },
+    });
+
+    expect(result).toBe(false);
+    expect(placeBuilding).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith("Insufficient resources to build.");
   });
 
   it("keeps a successful auto-selected tile reserved until synced state confirms occupancy", async () => {

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
@@ -1,5 +1,11 @@
 import { BUILDINGS_CENTER, BuildingType, getNeighborHexes, ResourcesIds } from "@bibliothecadao/types";
-import { TileManager } from "@bibliothecadao/eternum";
+import {
+  TileManager,
+  divideByPrecision,
+  getBalance,
+  getBuildingCosts,
+  getBlockTimestamp,
+} from "@bibliothecadao/eternum";
 import { toast } from "sonner";
 import {
   getBuildReservationState,
@@ -207,6 +213,24 @@ const hasBuildableCandidate = ({
 export const resolveRealmHasAvailableBuildingTile = (options: RealmAvailableTileOptions) =>
   hasBuildableCandidate(options);
 
+const canAffordRealmBuilding = ({
+  entityId,
+  target,
+  useSimpleCost,
+  world,
+}: Pick<RealmBuildActionOptions, "entityId" | "target" | "useSimpleCost" | "world">): boolean => {
+  const { currentDefaultTick } = getBlockTimestamp();
+  const buildingCosts = getBuildingCosts(entityId, world.components, target.type, useSimpleCost);
+  if (!buildingCosts?.length) {
+    return false;
+  }
+
+  return buildingCosts.every((resourceCost) => {
+    const balance = getBalance(entityId, resourceCost.resource, currentDefaultTick, world.components);
+    return divideByPrecision(balance.balance) >= resourceCost.amount;
+  });
+};
+
 export const buildRealmBuilding = async ({
   entityId,
   realmPosition,
@@ -221,6 +245,11 @@ export const buildRealmBuilding = async ({
 }: RealmBuildActionOptions) => {
   if (!realmPosition) {
     toast.error("Select a realm before building.");
+    return false;
+  }
+
+  if (!canAffordRealmBuilding({ entityId, target, useSimpleCost, world })) {
+    toast.error("Insufficient resources to build.");
     return false;
   }
 


### PR DESCRIPTION
Adds a shared automation resource reservation ledger so submitted automation spends reduce later spendable balances before local indexed state catches up.
Production automation now adjusts realm snapshots for pending reservations and reserves planned recipe input consumption before submit, while scheduled transfer automation plans against spendable balances and reserves submitted transfer amounts.
The root cause was independent automation paths planning from the same stale local balance snapshot, allowing transfer and production work to overspend the same resources.
Validated with targeted Vitest coverage, `pnpm run format`, and `pnpm run knip`; game typecheck is still blocked by existing workspace package-resolution errors for `@bibliothecadao/*` declarations.