### PR TITLE
Fix spectating label for connected players

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/top-header/top-header-player-status.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/top-header/top-header-player-status.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { resolveTopHeaderPlayerStatus } from "./top-header-player-status";
+
+describe("top header player status", () => {
+  it("does not label connected players as spectating while leaderboard data is missing", () => {
+    const status = resolveTopHeaderPlayerStatus({
+      isSpectating: false,
+      rank: undefined,
+      points: undefined,
+    });
+
+    expect(status).toBeNull();
+  });
+
+  it("shows a rank when a connected player has leaderboard data", () => {
+    const status = resolveTopHeaderPlayerStatus({
+      isSpectating: false,
+      rank: 42,
+      points: 1234,
+    });
+
+    expect(status).toEqual({
+      type: "ranked",
+      rank: 42,
+      points: 1234,
+    });
+  });
+
+  it("only shows spectating when the game state is spectating", () => {
+    const status = resolveTopHeaderPlayerStatus({
+      isSpectating: true,
+      rank: undefined,
+      points: undefined,
+    });
+
+    expect(status).toEqual({ type: "spectating" });
+  });
+});

--- a/client/apps/game/src/ui/features/world/containers/top-header/top-header-player-status.ts
+++ b/client/apps/game/src/ui/features/world/containers/top-header/top-header-player-status.ts
@@ -1,0 +1,40 @@
+type TopHeaderPlayerStatus =
+  | {
+      type: "ranked";
+      rank: number;
+      points: number | null | undefined;
+    }
+  | {
+      type: "spectating";
+    }
+  | null;
+
+interface ResolveTopHeaderPlayerStatusInput {
+  isSpectating: boolean;
+  rank: number | null | undefined;
+  points: number | null | undefined;
+}
+
+const hasResolvedRank = (rank: number | null | undefined): rank is number => {
+  return rank !== null && rank !== undefined;
+};
+
+export const resolveTopHeaderPlayerStatus = ({
+  isSpectating,
+  rank,
+  points,
+}: ResolveTopHeaderPlayerStatusInput): TopHeaderPlayerStatus => {
+  if (isSpectating) {
+    return { type: "spectating" };
+  }
+
+  if (hasResolvedRank(rank)) {
+    return {
+      type: "ranked",
+      rank,
+      points,
+    };
+  }
+
+  return null;
+};

--- a/client/apps/game/src/ui/features/world/containers/top-header/top-header.tsx
+++ b/client/apps/game/src/ui/features/world/containers/top-header/top-header.tsx
@@ -21,6 +21,7 @@ import { motion } from "framer-motion";
 import EyeIcon from "lucide-react/dist/esm/icons/eye";
 import Swords from "lucide-react/dist/esm/icons/swords";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { resolveTopHeaderPlayerStatus } from "./top-header-player-status";
 
 const slideDown = {
   hidden: { y: "-100%" },
@@ -43,7 +44,6 @@ export const TopHeader = memo(() => {
   const setFollowArmyCombats = useUIStore((state) => state.setFollowArmyCombats);
   const lastControlledStructureEntityId = useUIStore((state) => state.lastControlledStructureEntityId);
   const isSpectating = useUIStore((state) => state.isSpectating);
-  const playerStructures = useUIStore((state) => state.playerStructures);
   const accountName = useAccountStore((state) => state.accountName);
   const mode = useGameModeConfig();
 
@@ -130,6 +130,16 @@ export const TopHeader = memo(() => {
     );
   }, [account.address, leaderboardEntries, normalizeAddress, playerEntries]);
 
+  const playerStatus = useMemo(
+    () =>
+      resolveTopHeaderPlayerStatus({
+        isSpectating,
+        rank: playerEntry?.rank,
+        points: playerEntry?.points,
+      }),
+    [isSpectating, playerEntry?.points, playerEntry?.rank],
+  );
+
   const navigateToFastTravelLayer = useCallback(() => {
     playClick();
 
@@ -175,15 +185,13 @@ export const TopHeader = memo(() => {
               <span className="truncate text-base font-semibold">
                 {accountName ?? playerEntry?.displayName ?? "Player"}
               </span>
-              {isSpectating && playerStructures.length === 0 ? (
+              {playerStatus?.type === "spectating" ? (
                 <span className="text-xs text-gold/70 font-[Cinzel]">· Spectating</span>
-              ) : playerEntry?.rank ? (
+              ) : playerStatus?.type === "ranked" ? (
                 <span className="text-xs text-gold/70 font-[Cinzel]">
-                  · Rank #{playerEntry.rank} · {formatPoints(playerEntry.points)} pts
+                  · Rank #{playerStatus.rank} · {formatPoints(playerStatus.points)} pts
                 </span>
-              ) : (
-                <span className="text-xs text-gold/70 font-[Cinzel]">· Spectating</span>
-              )}
+              ) : null}
             </div>
 
             <div className="flex flex-shrink-0 flex-nowrap items-center gap-3 text-xs md:text-base">

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-04",
+    title: "Accurate Player Header",
+    description:
+      "Fixed the in-game header so connected players are no longer labeled as spectating while their leaderboard rank is still loading.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-04-30",
     title: "Synced Army Positions",
     description:


### PR DESCRIPTION
Fixes the in-game header status so connected players are not labeled as spectating while leaderboard rank data is missing. The header now resolves player status through a small helper that only emits spectating when `isSpectating` is true, otherwise showing rank data when available. Adds focused regression coverage for missing rank data, ranked players, and real spectating state. Also adds a latest-features entry for the player-facing fix.