### PR TITLE
[codex] Stabilize spatial stream recovery

### DIFF
--- a/client/apps/game/src/dojo/torii-stream-manager.test.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/observability/network-health-reporting", () => ({
 
 import { syncEntitiesDebounced } from "./sync";
 import { ToriiStreamManager, type BoundsDescriptor } from "./torii-stream-manager";
+import { useConnectionStore } from "@/hooks/store/use-connection-store";
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
@@ -78,7 +79,15 @@ const descriptor = (minCol: number): BoundsDescriptor => ({
 describe("ToriiStreamManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(syncEntitiesDebounced).mockReset();
     envMock.env.VITE_PUBLIC_TORII_SPATIAL_SUBSCRIPTION_UPDATE_ENABLED = true;
+    useConnectionStore.setState({
+      status: "connected",
+      spatialStatus: "connected",
+      globalStatus: "connected",
+      lastDisconnectedAt: null,
+      reconnectAttempts: 0,
+    });
   });
 
   it("reports skipped outcome when switching to an unchanged signature", async () => {
@@ -153,7 +162,49 @@ describe("ToriiStreamManager", () => {
     expect(cancelFresh).toHaveBeenCalledTimes(1);
   });
 
-  it("reports fallback recreate failure and leaves the old subscription live", async () => {
+  it("backs off and retries fallback recreate before replacing the old subscription", async () => {
+    vi.useFakeTimers();
+    const syncMock = vi.mocked(syncEntitiesDebounced);
+    const updateClause = vi.fn(async () => {
+      throw new Error("update failed");
+    });
+    const cancelOld = vi.fn();
+    const cancelFresh = vi.fn();
+    syncMock
+      .mockImplementationOnce(async () => syncSubscription(cancelOld, Promise.resolve(), updateClause))
+      .mockRejectedValueOnce(new Error("recreate failed once"))
+      .mockResolvedValueOnce(syncSubscription(cancelFresh));
+
+    const manager = new ToriiStreamManager({
+      client: {} as any,
+      setup: {} as any,
+      logging: false,
+    });
+
+    await manager.switchBounds(descriptor(0));
+
+    const pendingSwitch = manager.switchBounds(descriptor(24));
+    await vi.runOnlyPendingTimersAsync();
+
+    await expect(pendingSwitch).resolves.toEqual({ outcome: "applied" });
+
+    expect(syncMock).toHaveBeenCalledTimes(3);
+    expect(cancelOld).toHaveBeenCalledTimes(1);
+    expect(useConnectionStore.getState().spatialStatus).toBe("connected");
+    expect(reportToriiSubscriptionLifecycleMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        streamType: "spatial",
+        kind: "fallback_recreate",
+        outcome: "failed",
+      }),
+    );
+
+    manager.cancelCurrentSubscription();
+    vi.useRealTimers();
+  });
+
+  it("reports fallback recreate failure after retry attempts and leaves the old subscription live", async () => {
+    vi.useFakeTimers();
     const syncMock = vi.mocked(syncEntitiesDebounced);
     const updateClause = vi.fn(async () => {
       throw new Error("update failed");
@@ -161,6 +212,7 @@ describe("ToriiStreamManager", () => {
     const cancelOld = vi.fn();
     syncMock
       .mockImplementationOnce(async () => syncSubscription(cancelOld, Promise.resolve(), updateClause))
+      .mockRejectedValueOnce(new Error("recreate failed once"))
       .mockRejectedValueOnce(new Error("recreate failed"));
 
     const manager = new ToriiStreamManager({
@@ -171,9 +223,14 @@ describe("ToriiStreamManager", () => {
 
     await manager.switchBounds(descriptor(0));
 
-    await expect(manager.switchBounds(descriptor(24))).rejects.toThrow("recreate failed");
+    const pendingSwitch = manager.switchBounds(descriptor(24));
+    const pendingExpectation = expect(pendingSwitch).rejects.toThrow("recreate failed");
+    await vi.runOnlyPendingTimersAsync();
+
+    await pendingExpectation;
 
     expect(cancelOld).not.toHaveBeenCalled();
+    expect(useConnectionStore.getState().spatialStatus).toBe("failed");
     expect(reportToriiSubscriptionLifecycleMock).toHaveBeenCalledWith(
       expect.objectContaining({
         streamType: "spatial",
@@ -185,6 +242,7 @@ describe("ToriiStreamManager", () => {
     );
 
     manager.cancelCurrentSubscription();
+    vi.useRealTimers();
   });
 
   it("uses the recreate path when spatial subscription updates are disabled", async () => {
@@ -309,6 +367,37 @@ describe("ToriiStreamManager", () => {
     vi.useRealTimers();
   });
 
+  it("enters reconnecting state and resubscribes after spatial readiness timeout backoff", async () => {
+    vi.useFakeTimers();
+    const syncMock = vi.mocked(syncEntitiesDebounced);
+    const cancelFirst = vi.fn();
+    const cancelRecovered = vi.fn();
+    syncMock
+      .mockImplementationOnce(async () => syncSubscription(cancelFirst, new Promise<void>(() => {})))
+      .mockImplementationOnce(async () => syncSubscription(cancelRecovered));
+
+    const manager = new ToriiStreamManager({
+      client: {} as any,
+      setup: {} as any,
+      logging: false,
+      subscriptionSetupTimeoutMs: 25,
+    });
+
+    await manager.switchBounds(descriptor(0));
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(useConnectionStore.getState().spatialStatus).toBe("reconnecting");
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(syncMock).toHaveBeenCalledTimes(2);
+    expect(cancelFirst).toHaveBeenCalledTimes(1);
+    expect(useConnectionStore.getState().spatialStatus).toBe("connected");
+
+    manager.cancelCurrentSubscription();
+    vi.useRealTimers();
+  });
+
   it("uses in-bounds TileOpt as the spatial stream readiness entity", async () => {
     const syncMock = vi.mocked(syncEntitiesDebounced);
     syncMock.mockImplementationOnce(async (...args) => {
@@ -384,8 +473,9 @@ describe("ToriiStreamManager", () => {
   });
 
   it("passes the subscription setup timeout through to syncEntitiesDebounced", async () => {
+    vi.useFakeTimers();
     const syncMock = vi.mocked(syncEntitiesDebounced);
-    syncMock.mockImplementationOnce(async (...args) => {
+    syncMock.mockImplementation(async (...args) => {
       const options = args[5] as { subscriptionSetupTimeoutMs?: number } | undefined;
       throw new Error(`timeout:${options?.subscriptionSetupTimeoutMs ?? "missing"}`);
     });
@@ -397,14 +487,24 @@ describe("ToriiStreamManager", () => {
       subscriptionSetupTimeoutMs: 25,
     });
 
-    await expect(manager.switchBounds(descriptor(0))).rejects.toThrow("timeout:25");
+    const pendingSwitch = manager.switchBounds(descriptor(0));
+    const pendingExpectation = expect(pendingSwitch).rejects.toThrow("timeout:25");
+    await vi.runOnlyPendingTimersAsync();
+
+    await pendingExpectation;
+    expect(syncMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it("allows a later bounds switch to recover after a timed out setup", async () => {
+    vi.useFakeTimers();
     const syncMock = vi.mocked(syncEntitiesDebounced);
     const cancelRecovered = vi.fn();
 
-    syncMock.mockRejectedValueOnce(new Error("timeout:25")).mockResolvedValueOnce(syncSubscription(cancelRecovered));
+    syncMock
+      .mockRejectedValueOnce(new Error("timeout:25"))
+      .mockRejectedValueOnce(new Error("timeout:25"))
+      .mockResolvedValueOnce(syncSubscription(cancelRecovered));
 
     const manager = new ToriiStreamManager({
       client: {} as any,
@@ -413,7 +513,11 @@ describe("ToriiStreamManager", () => {
       subscriptionSetupTimeoutMs: 25,
     });
 
-    await expect(manager.switchBounds(descriptor(0))).rejects.toThrow("timeout:25");
+    const pendingSwitch = manager.switchBounds(descriptor(0));
+    const pendingExpectation = expect(pendingSwitch).rejects.toThrow("timeout:25");
+    await vi.runOnlyPendingTimersAsync();
+
+    await pendingExpectation;
 
     const recovered = await manager.switchBounds(descriptor(24));
 
@@ -421,13 +525,15 @@ describe("ToriiStreamManager", () => {
 
     expect(recovered.outcome).toBe("applied");
     expect(cancelRecovered).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 
   it("reports subscription setup timeouts with the switch request id", async () => {
+    vi.useFakeTimers();
     const syncMock = vi.mocked(syncEntitiesDebounced);
     const onSubscriptionSetupTimeout = vi.fn();
 
-    syncMock.mockImplementationOnce(async (...args) => {
+    syncMock.mockImplementation(async (...args) => {
       const options = args[5] as
         | {
             onSubscriptionSetupTimeout?: (info: { label: string; timeoutMs: number }) => void;
@@ -448,11 +554,16 @@ describe("ToriiStreamManager", () => {
       onSubscriptionSetupTimeout,
     });
 
-    await expect(manager.switchBounds(descriptor(0))).rejects.toThrow("timeout:25");
+    const pendingSwitch = manager.switchBounds(descriptor(0));
+    const pendingExpectation = expect(pendingSwitch).rejects.toThrow("timeout:25");
+    await vi.runOnlyPendingTimersAsync();
+
+    await pendingExpectation;
     expect(onSubscriptionSetupTimeout).toHaveBeenCalledWith({
       label: "event subscription",
       timeoutMs: 25,
       requestId: 1,
     });
+    vi.useRealTimers();
   });
 });

--- a/client/apps/game/src/dojo/torii-stream-manager.test.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.test.ts
@@ -372,9 +372,17 @@ describe("ToriiStreamManager", () => {
     const syncMock = vi.mocked(syncEntitiesDebounced);
     const cancelFirst = vi.fn();
     const cancelRecovered = vi.fn();
+    let recoveredOptions:
+      | {
+          onReadyEntityApplied?: (info: { entityId: string; models: string[] }) => void;
+        }
+      | undefined;
     syncMock
       .mockImplementationOnce(async () => syncSubscription(cancelFirst, new Promise<void>(() => {})))
-      .mockImplementationOnce(async () => syncSubscription(cancelRecovered));
+      .mockImplementationOnce(async (...args) => {
+        recoveredOptions = args[5] as typeof recoveredOptions;
+        return syncSubscription(cancelRecovered, new Promise<void>(() => {}));
+      });
 
     const manager = new ToriiStreamManager({
       client: {} as any,
@@ -392,6 +400,13 @@ describe("ToriiStreamManager", () => {
 
     expect(syncMock).toHaveBeenCalledTimes(2);
     expect(cancelFirst).toHaveBeenCalledTimes(1);
+    expect(useConnectionStore.getState().spatialStatus).toBe("reconnecting");
+
+    recoveredOptions?.onReadyEntityApplied?.({
+      entityId: "tile-1",
+      models: ["s1_eternum-TileOpt"],
+    });
+
     expect(useConnectionStore.getState().spatialStatus).toBe("connected");
 
     manager.cancelCurrentSubscription();
@@ -564,6 +579,44 @@ describe("ToriiStreamManager", () => {
       timeoutMs: 25,
       requestId: 1,
     });
+    vi.useRealTimers();
+  });
+
+  it("suppresses setup timeout callbacks when an internal create retry succeeds", async () => {
+    vi.useFakeTimers();
+    const syncMock = vi.mocked(syncEntitiesDebounced);
+    const onSubscriptionSetupTimeout = vi.fn();
+
+    syncMock
+      .mockImplementationOnce(async (...args) => {
+        const options = args[5] as
+          | {
+              onSubscriptionSetupTimeout?: (info: { label: string; timeoutMs: number }) => void;
+            }
+          | undefined;
+        options?.onSubscriptionSetupTimeout?.({
+          label: "event subscription",
+          timeoutMs: 25,
+        });
+        throw new Error("timeout:25");
+      })
+      .mockResolvedValueOnce(syncSubscription(vi.fn()));
+
+    const manager = new ToriiStreamManager({
+      client: {} as any,
+      setup: {} as any,
+      logging: false,
+      subscriptionSetupTimeoutMs: 25,
+      onSubscriptionSetupTimeout,
+    });
+
+    const pendingSwitch = manager.switchBounds(descriptor(0));
+    await vi.runOnlyPendingTimersAsync();
+
+    await expect(pendingSwitch).resolves.toEqual({ outcome: "applied" });
+    expect(onSubscriptionSetupTimeout).not.toHaveBeenCalled();
+
+    manager.cancelCurrentSubscription();
     vi.useRealTimers();
   });
 });

--- a/client/apps/game/src/dojo/torii-stream-manager.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.ts
@@ -520,6 +520,10 @@ export class ToriiStreamManager {
   private markSpatialSubscriptionApplied(): void {
     const store = useConnectionStore.getState();
     store.recordSpatialHandshake();
+    if (this.isRecoveringSpatialReadiness()) {
+      return;
+    }
+
     store.setSpatialStatus("connected");
   }
 
@@ -531,6 +535,10 @@ export class ToriiStreamManager {
   private resetReadinessRecoveryAttempts(): void {
     this.readinessRecoveryAttempts = 0;
     this.clearReadinessRecoveryTimer();
+  }
+
+  private isRecoveringSpatialReadiness(): boolean {
+    return this.readinessRecoveryAttempts > 0;
   }
 
   private clearReadinessRecoveryTimer(): void {
@@ -550,7 +558,9 @@ export class ToriiStreamManager {
 
     while (true) {
       try {
-        return await this.createSpatialSubscription(clause, requestId);
+        return await this.createSpatialSubscription(clause, requestId, {
+          reportSetupTimeouts: attempt >= SPATIAL_SUBSCRIPTION_CREATE_MAX_ATTEMPTS,
+        });
       } catch (error) {
         if (attempt >= SPATIAL_SUBSCRIPTION_CREATE_MAX_ATTEMPTS) {
           throw error;
@@ -563,7 +573,11 @@ export class ToriiStreamManager {
     }
   }
 
-  private async createSpatialSubscription(clause: Clause | null, requestId: number): Promise<ToriiEntitySubscription> {
+  private async createSpatialSubscription(
+    clause: Clause | null,
+    requestId: number,
+    options: { reportSetupTimeouts?: boolean } = {},
+  ): Promise<ToriiEntitySubscription> {
     return syncEntitiesDebounced(this.client, this.setup, clause, this.logging, this.onUpdate, {
       isReadyEntity: this.isSpatialReadyEntity,
       onReadyEntityApplied: (info) => {
@@ -575,6 +589,9 @@ export class ToriiStreamManager {
       },
       subscriptionSetupTimeoutMs: this.subscriptionSetupTimeoutMs,
       onSubscriptionSetupTimeout: (info) => {
+        if (options.reportSetupTimeouts === false) {
+          return;
+        }
         this.onSubscriptionSetupTimeout?.({ ...info, requestId });
       },
       streamType: "spatial",

--- a/client/apps/game/src/dojo/torii-stream-manager.ts
+++ b/client/apps/game/src/dojo/torii-stream-manager.ts
@@ -76,6 +76,9 @@ export interface GlobalModelStreamConfig {
 }
 
 const DEFAULT_SUBSCRIPTION_SETUP_TIMEOUT_MS = 8_000;
+const SPATIAL_SUBSCRIPTION_CREATE_MAX_ATTEMPTS = 2;
+const SPATIAL_SUBSCRIPTION_CREATE_RETRY_BACKOFF_MS = 750;
+const SPATIAL_READINESS_RECOVERY_BACKOFF_MS = [1_000, 2_500, 5_000] as const;
 const TILE_OPT_MODEL = "s1_eternum-TileOpt";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -117,6 +120,16 @@ function hashSignature(signature: string): string {
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function getBackoffDelay(attempt: number, delays: readonly number[]): number {
+  return delays[Math.min(Math.max(attempt - 1, 0), delays.length - 1)] ?? 0;
+}
+
+function waitForBackoff(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
 }
 
 function getPaddedBounds(descriptor: BoundsDescriptor): {
@@ -276,6 +289,9 @@ export class ToriiStreamManager {
   private readonly onSubscriptionSetupTimeout?: (info: BoundsSubscriptionSetupTimeoutInfo) => void;
   private activeReadinessDescriptor: BoundsDescriptor | null = null;
   private activeReadinessContext: { requestId: number; startedAt: number } | null = null;
+  private readinessRecoveryAttempts = 0;
+  private readinessRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+  private shutdownRequested = false;
 
   constructor({
     client,
@@ -306,6 +322,7 @@ export class ToriiStreamManager {
   }
 
   async switchBounds(descriptor: BoundsDescriptor): Promise<BoundsSwitchResult> {
+    this.clearReadinessRecoveryTimer();
     this.lastDescriptor = descriptor;
 
     const signature = JSON.stringify({
@@ -356,7 +373,7 @@ export class ToriiStreamManager {
 
           this.monitorSpatialStreamReadiness(updateCurrentSubscription.subscription, requestId);
           this.currentSignature = signature;
-          useConnectionStore.getState().recordSpatialHandshake();
+          this.markSpatialSubscriptionApplied();
           addToriiStreamBreadcrumb({
             event: "subscription_update_succeeded",
             streamType: "spatial",
@@ -397,8 +414,9 @@ export class ToriiStreamManager {
       const recreateStartedAt = performance.now();
       let subscription: ToriiEntitySubscription;
       try {
-        subscription = await this.createSpatialSubscription(clause, requestId);
+        subscription = await this.createSpatialSubscriptionWithRetry(clause, requestId);
       } catch (error) {
+        useConnectionStore.getState().setSpatialStatus("failed");
         if (attemptedUpdate) {
           reportToriiSubscriptionLifecycle({
             streamType: "spatial",
@@ -428,7 +446,7 @@ export class ToriiStreamManager {
       this.currentSignature = signature;
       // Handshake succeeded — restart the staleness clock so the monitor
       // tracks subscription transport separately from quiet data updates.
-      useConnectionStore.getState().recordSpatialHandshake();
+      this.markSpatialSubscriptionApplied();
       if (attemptedUpdate) {
         addToriiStreamBreadcrumb({
           event: "fallback_recreate_succeeded",
@@ -499,10 +517,57 @@ export class ToriiStreamManager {
     });
   }
 
+  private markSpatialSubscriptionApplied(): void {
+    const store = useConnectionStore.getState();
+    store.recordSpatialHandshake();
+    store.setSpatialStatus("connected");
+  }
+
+  private markSpatialReadyEntityApplied(): void {
+    this.resetReadinessRecoveryAttempts();
+    useConnectionStore.getState().setSpatialStatus("connected");
+  }
+
+  private resetReadinessRecoveryAttempts(): void {
+    this.readinessRecoveryAttempts = 0;
+    this.clearReadinessRecoveryTimer();
+  }
+
+  private clearReadinessRecoveryTimer(): void {
+    if (this.readinessRecoveryTimer === null) {
+      return;
+    }
+
+    clearTimeout(this.readinessRecoveryTimer);
+    this.readinessRecoveryTimer = null;
+  }
+
+  private async createSpatialSubscriptionWithRetry(
+    clause: Clause | null,
+    requestId: number,
+  ): Promise<ToriiEntitySubscription> {
+    let attempt = 1;
+
+    while (true) {
+      try {
+        return await this.createSpatialSubscription(clause, requestId);
+      } catch (error) {
+        if (attempt >= SPATIAL_SUBSCRIPTION_CREATE_MAX_ATTEMPTS) {
+          throw error;
+        }
+
+        useConnectionStore.getState().setSpatialStatus("reconnecting");
+        attempt += 1;
+        await waitForBackoff(SPATIAL_SUBSCRIPTION_CREATE_RETRY_BACKOFF_MS);
+      }
+    }
+  }
+
   private async createSpatialSubscription(clause: Clause | null, requestId: number): Promise<ToriiEntitySubscription> {
     return syncEntitiesDebounced(this.client, this.setup, clause, this.logging, this.onUpdate, {
       isReadyEntity: this.isSpatialReadyEntity,
       onReadyEntityApplied: (info) => {
+        this.markSpatialReadyEntityApplied();
         this.onSpatialReadyEntityApplied?.(this.buildSpatialReadyEntityInfo(info));
       },
       onReadyEntityReceived: (info) => {
@@ -522,23 +587,82 @@ export class ToriiStreamManager {
         return;
       }
 
-      this.onSpatialReadyTimeout?.(
-        buildSpatialReadinessTimeoutInfo({
-          elapsedMs: readinessResult.durationMs,
-          requestId,
-          timeoutMs: this.subscriptionSetupTimeoutMs,
-        }),
-      );
-      reportToriiReadinessTimeout({
-        streamType: "spatial",
-        elapsedMs: readinessResult.durationMs,
-        requestId,
+      this.handleSpatialStreamReadinessTimeout(requestId, readinessResult.durationMs);
+    });
+  }
+
+  private handleSpatialStreamReadinessTimeout(requestId: number, elapsedMs: number): void {
+    if (this.shutdownRequested || requestId !== this.latestSwitchRequestId) {
+      return;
+    }
+
+    const timeoutInfo = buildSpatialReadinessTimeoutInfo({
+      elapsedMs,
+      requestId,
+      timeoutMs: this.subscriptionSetupTimeoutMs,
+    });
+
+    this.onSpatialReadyTimeout?.(timeoutInfo);
+    reportToriiReadinessTimeout({
+      streamType: "spatial",
+      elapsedMs: timeoutInfo.elapsedMs,
+      requestId,
+      timeoutMs: timeoutInfo.timeoutMs,
+    });
+    this.scheduleSpatialReadinessRecovery(timeoutInfo);
+  }
+
+  private scheduleSpatialReadinessRecovery(info: ToriiSpatialReadinessTimeoutInfo): void {
+    if (!this.lastDescriptor) {
+      useConnectionStore.getState().setSpatialStatus("failed");
+      return;
+    }
+
+    if (this.readinessRecoveryAttempts >= SPATIAL_READINESS_RECOVERY_BACKOFF_MS.length) {
+      this.markSpatialReadinessRecoveryFailed("readiness recovery exhausted", info);
+      return;
+    }
+
+    this.readinessRecoveryAttempts += 1;
+    const delayMs = getBackoffDelay(this.readinessRecoveryAttempts, SPATIAL_READINESS_RECOVERY_BACKOFF_MS);
+    useConnectionStore.getState().setSpatialStatus("reconnecting");
+
+    this.readinessRecoveryTimer = setTimeout(() => {
+      this.readinessRecoveryTimer = null;
+      void this.runSpatialReadinessRecovery(info.requestId);
+    }, delayMs);
+  }
+
+  private async runSpatialReadinessRecovery(timedOutRequestId: number): Promise<void> {
+    if (this.shutdownRequested || timedOutRequestId !== this.latestSwitchRequestId) {
+      return;
+    }
+
+    try {
+      await this.resubscribe({ resetReadinessRecovery: false });
+    } catch (error) {
+      this.markSpatialReadinessRecoveryFailed(getErrorMessage(error), {
+        elapsedMs: 0,
+        requestId: timedOutRequestId,
         timeoutMs: this.subscriptionSetupTimeoutMs,
       });
+    }
+  }
+
+  private markSpatialReadinessRecoveryFailed(reason: string, info: ToriiSpatialReadinessTimeoutInfo): void {
+    useConnectionStore.getState().setSpatialStatus("failed");
+    reportToriiSubscriptionLifecycle({
+      streamType: "spatial",
+      kind: "readiness",
+      outcome: "failed",
+      requestId: info.requestId,
+      durationMs: info.elapsedMs,
+      reason,
     });
   }
 
   cancelCurrentSubscription() {
+    this.clearReadinessRecoveryTimer();
     if (this.currentSubscription) {
       this.currentSubscription.cancel();
       this.currentSubscription = null;
@@ -552,10 +676,15 @@ export class ToriiStreamManager {
   }
 
   shutdown() {
+    this.shutdownRequested = true;
+    this.clearReadinessRecoveryTimer();
     this.cancelCurrentSubscription();
   }
 
-  async resubscribe(): Promise<BoundsSwitchResult | null> {
+  async resubscribe(options: { resetReadinessRecovery?: boolean } = {}): Promise<BoundsSwitchResult | null> {
+    if (options.resetReadinessRecovery ?? true) {
+      this.resetReadinessRecoveryAttempts();
+    }
     this.currentSignature = null;
     if (this.lastDescriptor) {
       return this.switchBounds(this.lastDescriptor);

--- a/client/apps/game/src/observability/network-health-reporting.test.ts
+++ b/client/apps/game/src/observability/network-health-reporting.test.ts
@@ -100,13 +100,24 @@ describe("network-health-reporting", () => {
   });
 
   it("reportSubscriptionSetupTimeout captures and dedups by label", () => {
-    reportSubscriptionSetupTimeout({ label: "entity subscription", timeoutMs: 8000, requestId: 42 });
-    reportSubscriptionSetupTimeout({ label: "entity subscription", timeoutMs: 8000, requestId: 43 });
+    reportSubscriptionSetupTimeout({
+      label: "entity subscription",
+      streamType: "spatial",
+      timeoutMs: 8000,
+      requestId: 42,
+    });
+    reportSubscriptionSetupTimeout({
+      label: "entity subscription",
+      streamType: "spatial",
+      timeoutMs: 8000,
+      requestId: 43,
+    });
 
     expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(1);
     const [message, opts] = sentryMocks.captureMessage.mock.calls[0];
     expect(message).toContain("entity subscription");
     expect(opts.tags["network.kind"]).toBe("subscription_setup_timeout");
+    expect(opts.tags["network.stream_type"]).toBe("spatial");
     expect(opts.contexts.network.label).toBe("entity subscription");
   });
 
@@ -207,6 +218,27 @@ describe("network-health-reporting", () => {
     expect(message).toContain("readiness timed out");
     expect(opts.tags["network.kind"]).toBe("readiness_timeout");
     expect(opts.contexts.network.timeout_ms).toBe(8000);
+  });
+
+  it("groups spatial Torii lifecycle failures under the world-level Sentry fingerprint", () => {
+    reportToriiSubscriptionLifecycle({
+      streamType: "spatial",
+      kind: "fallback_recreate",
+      outcome: "failed",
+      reason: "recreate failed",
+    });
+    reportToriiReadinessTimeout({
+      streamType: "spatial",
+      requestId: 8,
+      timeoutMs: 8000,
+      elapsedMs: 8012.8,
+    });
+
+    expect(sentryMocks.captureMessage).toHaveBeenCalledTimes(2);
+    const [, lifecycleOpts] = sentryMocks.captureMessage.mock.calls[0];
+    const [, readinessOpts] = sentryMocks.captureMessage.mock.calls[1];
+    expect(lifecycleOpts.fingerprint).toEqual(["torii_spatial:spatial_lifecycle:spatial:eternum"]);
+    expect(readinessOpts.fingerprint).toEqual(lifecycleOpts.fingerprint);
   });
 
   it("reportToriiQueuePressure dedups by stream and queue bucket", () => {

--- a/client/apps/game/src/observability/network-health-reporting.ts
+++ b/client/apps/game/src/observability/network-health-reporting.ts
@@ -40,6 +40,7 @@ interface OutageReport {
 
 interface SetupTimeoutReport {
   label: string;
+  streamType?: NetworkStreamType;
   timeoutMs: number;
   requestId?: number | string;
 }
@@ -88,6 +89,7 @@ interface NetworkScopeTags {
 
 const DUPLICATE_TTL_MS = 5 * 60 * 1000;
 const MAX_CONTEXT_TEXT_LENGTH = 180;
+const TORII_SPATIAL_LIFECYCLE_GROUP = "spatial_lifecycle";
 const reportedKeys = new Map<string, number>();
 let eventsThisSession = 0;
 let enabledOverride: boolean | null = null;
@@ -151,6 +153,19 @@ const sanitizeContextText = (value: string): string => {
   }
   return `${redacted.slice(0, MAX_CONTEXT_TEXT_LENGTH - 3)}...`;
 };
+
+const getActiveWorldName = (): string => getActiveWorld()?.name ?? "unknown-world";
+
+const buildToriiLifecycleFingerprint = (streamType: NetworkStreamType | undefined, fallback: string[]): string[] => {
+  if (streamType !== "spatial") {
+    return fallback;
+  }
+
+  return [`torii_spatial:${TORII_SPATIAL_LIFECYCLE_GROUP}:${streamType}:${getActiveWorldName()}`];
+};
+
+const buildToriiLifecycleGroupTags = (streamType: NetworkStreamType | undefined): Record<string, string> =>
+  streamType === "spatial" ? { "network.lifecycle_group": TORII_SPATIAL_LIFECYCLE_GROUP } : {};
 
 export const setNetworkHealthScopeTags = async ({ toriiBaseUrl, walletAddress }: NetworkScopeTags): Promise<void> => {
   if (!isEnabled()) return;
@@ -268,11 +283,16 @@ export const reportNetworkOutageResolved = (report: OutageReport): void => repor
 
 export const reportNetworkOutageDeadEnd = (report: OutageReport): void => reportOutage(report, false);
 
-export const reportSubscriptionSetupTimeout = ({ label, timeoutMs, requestId }: SetupTimeoutReport): void => {
+export const reportSubscriptionSetupTimeout = ({
+  label,
+  streamType,
+  timeoutMs,
+  requestId,
+}: SetupTimeoutReport): void => {
   if (!isEnabled()) return;
   if (!canEmitMore()) return;
 
-  const dedupeKey = `setup-timeout:${label}`;
+  const dedupeKey = `setup-timeout:${streamType ?? "unknown"}:${label}`;
   if (shouldSkipDuplicate(dedupeKey)) return;
 
   eventsThisSession += 1;
@@ -283,15 +303,18 @@ export const reportSubscriptionSetupTimeout = ({ label, timeoutMs, requestId }: 
       feature: "network-health",
       "network.kind": "subscription_setup_timeout",
       "network.subscription_label": label,
+      ...(streamType ? { "network.stream_type": streamType } : {}),
+      ...buildToriiLifecycleGroupTags(streamType),
     },
     contexts: {
       network: {
         label,
+        ...(streamType ? { stream_type: streamType } : {}),
         timeout_ms: timeoutMs,
         ...(typeof requestId !== "undefined" ? { request_id: String(requestId) } : {}),
       },
     },
-    fingerprint: ["network-health", "setup-timeout", label],
+    fingerprint: buildToriiLifecycleFingerprint(streamType, ["network-health", "setup-timeout", label]),
   });
 };
 
@@ -321,6 +344,7 @@ export const reportToriiSubscriptionLifecycle = ({
       "network.stream_type": streamType,
       "network.kind": kind,
       "network.outcome": outcome,
+      ...buildToriiLifecycleGroupTags(streamType),
     },
     contexts: {
       network: {
@@ -331,7 +355,7 @@ export const reportToriiSubscriptionLifecycle = ({
         ...(signatureHash ? { signature_hash: signatureHash } : {}),
       },
     },
-    fingerprint: ["network-health", "torii", streamType, kind, outcome],
+    fingerprint: buildToriiLifecycleFingerprint(streamType, ["network-health", "torii", streamType, kind, outcome]),
   });
 };
 
@@ -356,6 +380,7 @@ export const reportToriiReadinessTimeout = ({
       "network.stream_type": streamType,
       "network.kind": "readiness_timeout",
       "network.outcome": "timeout",
+      ...buildToriiLifecycleGroupTags(streamType),
     },
     contexts: {
       network: {
@@ -364,7 +389,12 @@ export const reportToriiReadinessTimeout = ({
         timeout_ms: timeoutMs,
       },
     },
-    fingerprint: ["network-health", "torii", streamType, "readiness-timeout"],
+    fingerprint: buildToriiLifecycleFingerprint(streamType, [
+      "network-health",
+      "torii",
+      streamType,
+      "readiness-timeout",
+    ]),
   });
 };
 

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -5984,6 +5984,7 @@ export default class WorldmapScene extends WarpTravel {
       toast("Map sync delayed", { description: "Retrying…" });
       reportSubscriptionSetupTimeout({
         label: info.label,
+        streamType: "spatial",
         timeoutMs: info.timeoutMs,
         requestId: info.requestId,
       });

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-06",
+    title: "Map Sync Recovery",
+    description:
+      "Improved map stream recovery so delayed spatial updates enter a reconnecting state, retry cleanly, and surface network trouble when the map cannot restore live updates.",
+    type: "fix",
+  },
+  {
     date: "2026-04-30",
     title: "Synced Army Positions",
     description:


### PR DESCRIPTION
Fixes #4749.

Adds capped backoff recovery for spatial readiness timeouts and a retry around fallback subscription recreation so the map enters a controlled reconnecting or failed state instead of silently staying stale.

Groups spatial readiness, setup timeout, and fallback lifecycle reports under one world-level Sentry fingerprint, tags map setup timeouts as spatial, and adds a latest-features note for the user-visible map sync recovery.

Validation: pnpm --dir client/apps/game test -- src/dojo/torii-stream-manager.test.ts src/observability/network-health-reporting.test.ts src/ui/features/world/latest-features.test.ts; pnpm run format; pnpm run knip; git diff --check.