### PR TITLE
[codex] Harden transaction submission

### DIFF
--- a/client/apps/game/src/game-route.test.tsx
+++ b/client/apps/game/src/game-route.test.tsx
@@ -13,6 +13,18 @@ vi.mock("./hooks/context/dojo-context", () => ({
   DojoProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("./hooks/context/transaction-submit-guard", () => ({
+  waitForSafeTransactionSubmit: vi.fn(),
+}));
+
+vi.mock("./hooks/store/use-account-store", () => ({
+  useAccountStore: {
+    getState: () => ({
+      connector: null,
+    }),
+  },
+}));
+
 vi.mock("./hooks/use-transaction-listener", () => ({
   useTransactionListener: vi.fn(),
 }));

--- a/client/apps/game/src/game-route.tsx
+++ b/client/apps/game/src/game-route.tsx
@@ -7,6 +7,8 @@ import { useEffect } from "react";
 import { Navigate, useNavigate } from "react-router-dom";
 import type { Account, AccountInterface } from "starknet";
 import { env } from "../env";
+import { waitForSafeTransactionSubmit } from "./hooks/context/transaction-submit-guard";
+import { useAccountStore } from "./hooks/store/use-account-store";
 import { usePlayRouteBootController } from "./game-entry/play-route-boot";
 import { DojoProvider } from "./hooks/context/dojo-context";
 import { useTransactionListener } from "./hooks/use-transaction-listener";
@@ -30,12 +32,32 @@ const TransactionListenerBridge = () => {
   return null;
 };
 
+const TransactionSubmitGuardBridge = ({ setupResult, account }: Pick<ReadyAppProps, "setupResult" | "account">) => {
+  useEffect(() => {
+    const provider = setupResult.network.provider;
+    provider.setTransactionSubmitGuard((context) =>
+      waitForSafeTransactionSubmit({
+        account,
+        connector: useAccountStore.getState().connector,
+        context,
+      }),
+    );
+
+    return () => {
+      provider.setTransactionSubmitGuard(undefined);
+    };
+  }, [account, setupResult]);
+
+  return null;
+};
+
 const ReadyApp = ({ backgroundImage, setupResult, account }: ReadyAppProps) => {
   return (
     <DojoProvider value={setupResult} account={account}>
       <ErrorBoundary>
         <StoryEventToastBridge />
         <NewsHeadlineBridge />
+        <TransactionSubmitGuardBridge setupResult={setupResult} account={account} />
         <TransactionListenerBridge />
         <TransactionNotification />
         <World backgroundImage={backgroundImage} />

--- a/client/apps/game/src/hooks/context/session-policy-refresh.ts
+++ b/client/apps/game/src/hooks/context/session-policy-refresh.ts
@@ -25,6 +25,7 @@ import { buildPolicies } from "./policies";
  */
 let _lastPolicyHash = "";
 let _isRefreshingPolicies = false;
+const refreshWaiters = new Set<() => void>();
 
 function hashPolicies(manifest: unknown): string {
   try {
@@ -42,6 +43,23 @@ const hasPoliciesChanged = (): boolean => {
 };
 
 export const isSessionPolicyRefreshInProgress = (): boolean => _isRefreshingPolicies;
+
+const resolveSessionPolicyRefreshWaiters = (): void => {
+  for (const resolve of refreshWaiters) {
+    resolve();
+  }
+  refreshWaiters.clear();
+};
+
+export const waitForSessionPolicyRefresh = async (): Promise<void> => {
+  if (!_isRefreshingPolicies) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    refreshWaiters.add(resolve);
+  });
+};
 
 /**
  * Refresh the controller's session policies in-place and recreate the
@@ -129,5 +147,6 @@ export const refreshSessionPolicies = async (
     return true;
   } finally {
     _isRefreshingPolicies = false;
+    resolveSessionPolicyRefreshWaiters();
   }
 };

--- a/client/apps/game/src/hooks/context/transaction-submit-guard.ts
+++ b/client/apps/game/src/hooks/context/transaction-submit-guard.ts
@@ -1,0 +1,68 @@
+import type { ControllerConnector } from "@cartridge/connector";
+import type { TransactionSubmitGuardContext } from "@bibliothecadao/provider";
+import type { AccountInterface } from "starknet";
+import { waitForSessionPolicyRefresh } from "./session-policy-refresh";
+
+type ControllerProvider = {
+  account?: { address?: string };
+  probe?: () => Promise<unknown>;
+  waitForKeychain?: (options?: { timeout?: number }) => Promise<unknown>;
+};
+
+type TransactionSubmitGuardInput = {
+  account: AccountInterface | null;
+  connector: ControllerConnector | null;
+  context: TransactionSubmitGuardContext;
+};
+
+const isMissingAddress = (address: string | undefined): boolean => !address || address === "0x0";
+
+const resolveControllerProvider = (connector: ControllerConnector | null): ControllerProvider | null => {
+  if (!connector) {
+    return null;
+  }
+
+  const connectorRecord = connector as unknown as ControllerProvider & { controller?: ControllerProvider };
+  return connectorRecord.controller ?? connectorRecord;
+};
+
+const waitForControllerKeychain = async (provider: ControllerProvider | null): Promise<void> => {
+  if (typeof provider?.waitForKeychain !== "function") {
+    return;
+  }
+
+  await provider.waitForKeychain({ timeout: 10_000 });
+};
+
+const probeControllerAccount = async (provider: ControllerProvider | null): Promise<void> => {
+  if (typeof provider?.probe !== "function") {
+    return;
+  }
+
+  await provider.probe();
+};
+
+const resolveSubmitAddress = (
+  account: AccountInterface | null,
+  controllerProvider: ControllerProvider | null,
+  context: TransactionSubmitGuardContext,
+): string | undefined => {
+  return account?.address ?? controllerProvider?.account?.address ?? context.signerAddress;
+};
+
+export const waitForSafeTransactionSubmit = async ({
+  account,
+  connector,
+  context,
+}: TransactionSubmitGuardInput): Promise<void> => {
+  await waitForSessionPolicyRefresh();
+
+  const controllerProvider = resolveControllerProvider(connector);
+  await waitForControllerKeychain(controllerProvider);
+  await probeControllerAccount(controllerProvider);
+
+  const submitAddress = resolveSubmitAddress(account, controllerProvider, context);
+  if (isMissingAddress(submitAddress)) {
+    throw new Error("No account connected");
+  }
+};

--- a/client/apps/game/src/hooks/use-transaction-listener.test.tsx
+++ b/client/apps/game/src/hooks/use-transaction-listener.test.tsx
@@ -1,6 +1,11 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  rememberUncertainClaimSharePointsSubmission,
+  resetUncertainSubmissionRegistryForTests,
+  shouldSkipAutomaticClaimSharePointsSubmission,
+} from "../ui/utils/uncertain-transaction-registry";
 
 import { useTransactionListener } from "./use-transaction-listener";
 
@@ -84,6 +89,7 @@ describe("useTransactionListener", () => {
     root = createRoot(container);
     provider.removeAllListeners();
     storeState.transactions = [];
+    resetUncertainSubmissionRegistryForTests();
     storeState.addTransaction.mockClear();
     storeState.updateTransaction.mockClear();
     observabilityMocks.addClientTransactionBreadcrumb.mockClear();
@@ -198,5 +204,53 @@ describe("useTransactionListener", () => {
     );
     expect(storeState.addTransaction).not.toHaveBeenCalled();
     expect(storeState.updateTransaction).not.toHaveBeenCalled();
+  });
+
+  it("clears the unresolved claim-share-points marker after a recovered late completion", async () => {
+    rememberUncertainClaimSharePointsSubmission({
+      walletAddress: "0xabc",
+      failureKind: "submission_timeout_no_hash",
+    });
+    expect(shouldSkipAutomaticClaimSharePointsSubmission("0xabc")).toBe(true);
+
+    await act(async () => {
+      root.render(<HookHarness />);
+    });
+
+    await act(async () => {
+      provider.emit("transactionComplete", {
+        details: { transaction_hash: "0xtx" },
+        type: "claim_share_points",
+        recoveredFromSubmissionTimeout: true,
+        signerAddress: "0xabc",
+      });
+    });
+
+    expect(shouldSkipAutomaticClaimSharePointsSubmission("0xabc")).toBe(false);
+  });
+
+  it("clears the unresolved claim-share-points marker after a recovered late failure with a hash", async () => {
+    rememberUncertainClaimSharePointsSubmission({
+      walletAddress: "0xabc",
+      failureKind: "submission_timeout_no_hash",
+    });
+    expect(shouldSkipAutomaticClaimSharePointsSubmission("0xabc")).toBe(true);
+
+    await act(async () => {
+      root.render(<HookHarness />);
+    });
+
+    await act(async () => {
+      provider.emit("transactionFailed", {
+        message: "Transaction reverted",
+        stage: "revert",
+        transactionHash: "0xfail",
+        type: "claim_share_points",
+        recoveredFromSubmissionTimeout: true,
+        signerAddress: "0xabc",
+      });
+    });
+
+    expect(shouldSkipAutomaticClaimSharePointsSubmission("0xabc")).toBe(false);
   });
 });

--- a/client/apps/game/src/hooks/use-transaction-listener.test.tsx
+++ b/client/apps/game/src/hooks/use-transaction-listener.test.tsx
@@ -165,4 +165,38 @@ describe("useTransactionListener", () => {
       }),
     );
   });
+
+  it("passes submit failure classification through to transaction reporting without a hash", async () => {
+    await act(async () => {
+      root.render(<HookHarness />);
+    });
+
+    await act(async () => {
+      provider.emit("transactionFailed", {
+        message: "Transaction submission timed out after 20s before a transaction hash was returned",
+        stage: "submit",
+        type: "claim_share_points",
+        failureKind: "submission_timeout_no_hash",
+        providerState: "unknown",
+        hasTxHash: false,
+        retrySafety: "unsafe_until_wallet_checked",
+      });
+    });
+
+    expect(observabilityMocks.reportClientTransactionFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          surface: "dojo_provider",
+          stage: "submit",
+          transactionHash: undefined,
+          failureKind: "submission_timeout_no_hash",
+          providerState: "unknown",
+          hasTxHash: false,
+          retrySafety: "unsafe_until_wallet_checked",
+        }),
+      }),
+    );
+    expect(storeState.addTransaction).not.toHaveBeenCalled();
+    expect(storeState.updateTransaction).not.toHaveBeenCalled();
+  });
 });

--- a/client/apps/game/src/hooks/use-transaction-listener.ts
+++ b/client/apps/game/src/hooks/use-transaction-listener.ts
@@ -151,6 +151,10 @@ export const useTransactionListener = () => {
           batchDetails: payload.batchDetails,
           entrypoints: payload.entrypoints,
           contractAddresses: payload.contractAddresses,
+          failureKind: payload.failureKind,
+          providerState: payload.providerState,
+          hasTxHash: payload.hasTxHash ?? Boolean(payload.transactionHash),
+          retrySafety: payload.retrySafety,
         },
       });
 

--- a/client/apps/game/src/hooks/use-transaction-listener.ts
+++ b/client/apps/game/src/hooks/use-transaction-listener.ts
@@ -7,6 +7,7 @@ import {
 } from "@/observability/transaction-failure-reporting";
 import { useTransactionStore } from "@/hooks/store/use-transaction-store";
 import { getTxMessage } from "@/ui/components/transaction-center/types";
+import { clearUncertainClaimSharePointsSubmission } from "@/ui/utils/uncertain-transaction-registry";
 import { extractReadableErrorMessage } from "@/utils/error-message";
 
 interface TransactionSubmittedPayload extends TransactionLifecycleMeta {
@@ -38,6 +39,16 @@ export const useTransactionListener = () => {
   const updateTransaction = useTransactionStore((state) => state.updateTransaction);
 
   useEffect(() => {
+    const clearRecoveredClaimSharePointsMarker = (payload: TransactionLifecycleMeta) => {
+      if (
+        payload.recoveredFromSubmissionTimeout &&
+        payload.type === TransactionType.CLAIM_SHARE_POINTS &&
+        payload.signerAddress
+      ) {
+        clearUncertainClaimSharePointsSubmission(payload.signerAddress);
+      }
+    };
+
     // Called immediately when transaction is submitted to the network
     const handleTransactionSubmitted = (payload: TransactionSubmittedPayload) => {
       addClientTransactionBreadcrumb({
@@ -98,6 +109,7 @@ export const useTransactionListener = () => {
 
     const handleTransactionComplete = (payload: TransactionCompletePayload) => {
       const hash = payload.details.transaction_hash;
+      clearRecoveredClaimSharePointsMarker(payload);
       addClientTransactionBreadcrumb({
         stage: "completed",
         message: payload.type ? getTxMessage(payload.type) : "Transaction completed",
@@ -139,6 +151,7 @@ export const useTransactionListener = () => {
 
     const handleTransactionFailed = (payload: TransactionFailedPayload) => {
       const message = extractReadableErrorMessage(payload.message, "Transaction failed");
+      clearRecoveredClaimSharePointsMarker(payload);
       void reportClientTransactionFailure({
         error: new Error(message),
         context: {

--- a/client/apps/game/src/observability/transaction-failure-reporting.test.ts
+++ b/client/apps/game/src/observability/transaction-failure-reporting.test.ts
@@ -128,4 +128,72 @@ describe("transaction failure reporting", () => {
     expect(sentryMocks.addBreadcrumb).toHaveBeenCalledTimes(1);
     expect(sentryMocks.captureException).not.toHaveBeenCalled();
   });
+
+  it("tags provider disconnects separately from no-hash submission timeouts", async () => {
+    const { reportClientTransactionFailure } = await loadModule();
+
+    await reportClientTransactionFailure({
+      error: new Error("Unable to send execute() call due to destroyed connection"),
+      context: {
+        surface: "dojo_provider",
+        operation: "claim_share_points",
+        stage: "submit",
+        walletAddress: "0x123",
+        failureKind: "provider_connection_destroyed",
+        providerState: "destroyed",
+        hasTxHash: false,
+        retrySafety: "safe_after_reconnect",
+      } as any,
+    });
+
+    await reportClientTransactionFailure({
+      error: new Error("Transaction submission timed out after 20s before a transaction hash was returned"),
+      context: {
+        surface: "dojo_provider",
+        operation: "claim_share_points",
+        stage: "submit",
+        walletAddress: "0x123",
+        failureKind: "submission_timeout_no_hash",
+        providerState: "unknown",
+        hasTxHash: false,
+        retrySafety: "unsafe_until_wallet_checked",
+      } as any,
+    });
+
+    expect(sentryMocks.captureException).toHaveBeenCalledTimes(2);
+
+    const [, disconnectContext] = sentryMocks.captureException.mock.calls[0];
+    const [, timeoutContext] = sentryMocks.captureException.mock.calls[1];
+
+    expect(disconnectContext.tags).toMatchObject({
+      "tx.failure_kind": "provider_connection_destroyed",
+      provider_state: "destroyed",
+      has_tx_hash: "false",
+    });
+    expect(timeoutContext.tags).toMatchObject({
+      "tx.failure_kind": "submission_timeout_no_hash",
+      provider_state: "unknown",
+      has_tx_hash: "false",
+    });
+    expect(disconnectContext.contexts.transaction).toMatchObject({
+      failureKind: "provider_connection_destroyed",
+      retrySafety: "safe_after_reconnect",
+    });
+    expect(timeoutContext.contexts.transaction).toMatchObject({
+      failureKind: "submission_timeout_no_hash",
+      retrySafety: "unsafe_until_wallet_checked",
+    });
+    expect(disconnectContext.fingerprint).toEqual([
+      "client-transaction-submission",
+      "provider_connection_destroyed",
+      "dojo_provider",
+      "claim_share_points",
+    ]);
+    expect(timeoutContext.fingerprint).toEqual([
+      "client-transaction-submission",
+      "submission_timeout_no_hash",
+      "dojo_provider",
+      "claim_share_points",
+    ]);
+  });
 });

--- a/client/apps/game/src/observability/transaction-failure-reporting.ts
+++ b/client/apps/game/src/observability/transaction-failure-reporting.ts
@@ -2,6 +2,9 @@ import * as Sentry from "@sentry/react";
 import {
   type BatchedTransactionDetail,
   type TransactionFailureStage,
+  type TransactionProviderState,
+  type TransactionRetrySafety,
+  type TransactionSubmitFailureKind,
   type TransactionType,
 } from "@bibliothecadao/provider";
 import { env } from "../../env";
@@ -41,6 +44,10 @@ export interface ClientTransactionFailureContext {
   worldName?: string;
   worldAddress?: string;
   rpcHost?: string;
+  failureKind?: TransactionSubmitFailureKind;
+  providerState?: TransactionProviderState;
+  hasTxHash?: boolean;
+  retrySafety?: TransactionRetrySafety;
 }
 
 type ClientTransactionBreadcrumbStage = "submitted" | "pending" | "completed" | ClientTransactionFailureStage;
@@ -194,13 +201,22 @@ const buildFingerprint = ({
   transactionType,
   operation,
   normalizedReason,
+  failureKind,
 }: {
   surface: ClientTransactionSurface;
   stage: ClientTransactionFailureStage;
   transactionType?: TransactionType;
   operation: string;
   normalizedReason: string;
+  failureKind?: TransactionSubmitFailureKind;
 }) => {
+  if (
+    stage === "submit" &&
+    (failureKind === "provider_connection_destroyed" || failureKind === "submission_timeout_no_hash")
+  ) {
+    return ["client-transaction-submission", failureKind, surface, transactionType ?? operation];
+  }
+
   return ["client-transaction-failure", surface, stage, transactionType ?? operation, normalizedReason];
 };
 
@@ -240,6 +256,10 @@ const buildBreadcrumbData = (context: Partial<Omit<ClientTransactionFailureConte
     worldName: context.worldName ?? defaultContext.worldName,
     worldAddress: context.worldAddress ?? defaultContext.worldAddress,
     rpcHost: context.rpcHost,
+    failureKind: context.failureKind,
+    providerState: context.providerState,
+    hasTxHash: context.hasTxHash,
+    retrySafety: context.retrySafety,
   });
 };
 
@@ -352,14 +372,17 @@ export const reportClientTransactionFailure = async ({
   const walletIdentity = await resolveUserIdentity(failureContext.walletAddress);
   const sanitizedError = error instanceof Error ? error : new Error(readableMessage);
   const vrfNotConsumed = isVrfNotConsumedError(error);
+  const hasTransactionHash = failureContext.hasTxHash ?? Boolean(failureContext.transactionHash);
   const tags = {
     feature: "transactions",
     "tx.surface": failureContext.surface,
     "tx.stage": stage,
     ...(failureContext.transactionType ? { "tx.type": failureContext.transactionType } : {}),
+    ...(failureContext.failureKind ? { "tx.failure_kind": failureContext.failureKind } : {}),
+    ...(failureContext.providerState ? { provider_state: failureContext.providerState } : {}),
     ...(failureContext.chain ? { chain: failureContext.chain } : {}),
     ...(failureContext.worldName ? { world: failureContext.worldName } : {}),
-    has_tx_hash: failureContext.transactionHash ? "true" : "false",
+    has_tx_hash: hasTransactionHash ? "true" : "false",
     ...(vrfNotConsumed ? { "tx.vrf_not_consumed": "true" } : {}),
   };
   const transactionContext = sanitizeValue({
@@ -367,6 +390,10 @@ export const reportClientTransactionFailure = async ({
     stage,
     transactionType: failureContext.transactionType,
     transactionHash: failureContext.transactionHash,
+    failureKind: failureContext.failureKind,
+    providerState: failureContext.providerState,
+    hasTxHash: hasTransactionHash,
+    retrySafety: failureContext.retrySafety,
     transactionCount: failureContext.transactionCount,
     entrypoints: failureContext.entrypoints,
     contractAddresses: failureContext.contractAddresses,
@@ -411,6 +438,7 @@ export const reportClientTransactionFailure = async ({
       transactionType: failureContext.transactionType,
       operation: failureContext.operation,
       normalizedReason,
+      failureKind: failureContext.failureKind,
     }),
   });
 };

--- a/client/apps/game/src/ui/features/social/components/register-points-button.tsx
+++ b/client/apps/game/src/ui/features/social/components/register-points-button.tsx
@@ -2,6 +2,11 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { LEADERBOARD_UPDATE_INTERVAL } from "@/ui/constants";
 import Button from "@/ui/design-system/atoms/button";
 import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
+import {
+  clearUncertainClaimSharePointsSubmission,
+  isNoHashSubmissionTimeout,
+  rememberUncertainClaimSharePointsSubmission,
+} from "@/ui/utils/uncertain-transaction-registry";
 import { getRealmCountPerHyperstructure } from "@/ui/utils/utils";
 import { LeaderboardManager } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
@@ -98,7 +103,6 @@ export const RegisterPointsButton = ({ className }: RegisterPointsButtonProps) =
         playerAddress,
         { ignorePendingClaimOverride: true },
       );
-
       const transactionResult = await claim_share_points({
         signer: account,
         hyperstructure_ids: hyperstructuresEntityIds,
@@ -126,12 +130,19 @@ export const RegisterPointsButton = ({ className }: RegisterPointsButtonProps) =
       }
 
       leaderboardManager.confirmPendingSharePointsClaim(playerAddress, txHash ?? undefined);
+      clearUncertainClaimSharePointsSubmission(playerAddress);
       leaderboardManager.forceRefresh();
       leaderboardManager.updatePoints();
 
       setPlayersByRank(leaderboardManager.playersByRank);
       logPointsSummary("claim confirmed and refreshed", { txHash });
     } catch (error) {
+      if (isNoHashSubmissionTimeout(error)) {
+        rememberUncertainClaimSharePointsSubmission({
+          walletAddress: playerAddress,
+          failureKind: "submission_timeout_no_hash",
+        });
+      }
       leaderboardManager.clearPendingSharePointsClaim(playerAddress, txHash ?? undefined);
       leaderboardManager.updatePoints();
       setPlayersByRank(leaderboardManager.playersByRank);

--- a/client/apps/game/src/ui/shared/components/tx-emit.test.tsx
+++ b/client/apps/game/src/ui/shared/components/tx-emit.test.tsx
@@ -1,0 +1,96 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TransactionNotification } from "./tx-emit";
+
+const provider = vi.hoisted(() => {
+  const listeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  return {
+    emit(event: string, payload: unknown) {
+      listeners.get(event)?.forEach((listener) => listener(payload));
+    },
+    on(event: string, listener: (payload: unknown) => void) {
+      const eventListeners = listeners.get(event) ?? new Set<(payload: unknown) => void>();
+      eventListeners.add(listener);
+      listeners.set(event, eventListeners);
+    },
+    off(event: string, listener: (payload: unknown) => void) {
+      listeners.get(event)?.delete(listener);
+    },
+    removeAllListeners() {
+      listeners.clear();
+    },
+  };
+});
+
+const toastMock = vi.hoisted(() => vi.fn());
+const playMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@bibliothecadao/react", () => ({
+  useDojo: () => ({
+    setup: {
+      network: {
+        provider,
+      },
+    },
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("@/audio/core/AudioManager", () => ({
+  AudioManager: {
+    getInstance: () => ({
+      play: playMock,
+    }),
+  },
+}));
+
+describe("TransactionNotification", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    provider.removeAllListeners();
+    toastMock.mockClear();
+    playMock.mockClear();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    provider.removeAllListeners();
+    container.remove();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("shows explicit uncertainty guidance for no-hash submit timeouts", async () => {
+    await act(async () => {
+      root.render(<TransactionNotification />);
+    });
+
+    await act(async () => {
+      provider.emit("transactionFailed", {
+        message: "Transaction submission timed out after 20s before a transaction hash was returned",
+        stage: "submit",
+        type: "claim_share_points",
+        failureKind: "submission_timeout_no_hash",
+      });
+    });
+
+    expect(toastMock).toHaveBeenCalledWith("⚠️ Transaction status uncertain", {
+      description: expect.stringContaining(
+        "Submission timed out before a tx hash was returned. Check wallet/activity before retrying.",
+      ),
+    });
+    expect(playMock).toHaveBeenCalledWith("ui.tx_fail");
+  });
+});

--- a/client/apps/game/src/ui/shared/components/tx-emit.tsx
+++ b/client/apps/game/src/ui/shared/components/tx-emit.tsx
@@ -1,4 +1,4 @@
-import { TransactionType } from "@bibliothecadao/provider";
+import { SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE, TransactionType } from "@bibliothecadao/provider";
 import { useDojo } from "@bibliothecadao/react";
 import { useEffect } from "react";
 import { toast } from "sonner";
@@ -18,6 +18,7 @@ type TransactionFailurePayload = {
   stage?: string;
   transactionCount?: number;
   transactionHash?: string;
+  failureKind?: string;
 };
 
 export function TransactionNotification() {
@@ -50,9 +51,11 @@ export function TransactionNotification() {
       const transactionCount = typeof payload?.transactionCount === "number" ? payload.transactionCount : null;
       const action = type ? getTxMessage(type) : "Action failed";
       const txCount = transactionCount ? ` (${transactionCount} transactions)` : "";
-      const description = `${action}${txCount} - ${message}`;
+      const isNoHashTimeout = payload.failureKind === "submission_timeout_no_hash";
+      const title = isNoHashTimeout ? "⚠️ Transaction status uncertain" : "❌ Transaction failed";
+      const description = `${action}${txCount} - ${isNoHashTimeout ? SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE : message}`;
       console.error("Transaction failed:", message);
-      toast("❌ Transaction failed", { description });
+      toast(title, { description });
       AudioManager.getInstance().play("ui.tx_fail");
     };
 

--- a/client/apps/game/src/ui/store-managers.tsx
+++ b/client/apps/game/src/ui/store-managers.tsx
@@ -7,6 +7,12 @@ import { sqlApi } from "@/services/api";
 import { RESOURCE_ARRIVAL_AUTO_CLAIM_RETRY_DELAY_SECONDS, RESOURCE_ARRIVAL_READY_BUFFER_SECONDS } from "@/ui/constants";
 import { resolveFiniteSeasonEndAt, resolveSeasonStartTimestamp } from "@/ui/features/world/utils/season-timing";
 import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
+import {
+  clearUncertainClaimSharePointsSubmission,
+  isNoHashSubmissionTimeout,
+  rememberUncertainClaimSharePointsSubmission,
+  shouldSkipAutomaticClaimSharePointsSubmission,
+} from "@/ui/utils/uncertain-transaction-registry";
 import { getRealmCountPerHyperstructure } from "@/ui/utils/utils";
 import {
   formatArmies,
@@ -436,6 +442,10 @@ const AutoRegisterPointsStoreManager = () => {
       let txHash: string | null = null;
       try {
         const playerAddress = ContractAddress(account.address);
+        if (shouldSkipAutomaticClaimSharePointsSubmission(playerAddress)) {
+          log("Skipped: unresolved no-hash claim submission");
+          return;
+        }
         const claimedPointsAtSubmit = leaderboardManager.getPlayerHyperstructureUnregisteredShareholderPoints(
           playerAddress,
           { ignorePendingClaimOverride: true },
@@ -463,6 +473,7 @@ const AutoRegisterPointsStoreManager = () => {
         }
 
         leaderboardManager.confirmPendingSharePointsClaim(playerAddress, txHash ?? undefined);
+        clearUncertainClaimSharePointsSubmission(playerAddress);
         log("Points registered successfully");
 
         // Refresh leaderboard
@@ -470,6 +481,12 @@ const AutoRegisterPointsStoreManager = () => {
         leaderboardManager.updatePoints();
         log("Leaderboard refreshed");
       } catch (error) {
+        if (isNoHashSubmissionTimeout(error)) {
+          rememberUncertainClaimSharePointsSubmission({
+            walletAddress: ContractAddress(account.address),
+            failureKind: "submission_timeout_no_hash",
+          });
+        }
         leaderboardManager.clearPendingSharePointsClaim(ContractAddress(account.address), txHash ?? undefined);
         leaderboardManager.updatePoints();
         console.error("[AutoRegisterPoints] Failed:", error);

--- a/client/apps/game/src/ui/utils/uncertain-transaction-registry.test.ts
+++ b/client/apps/game/src/ui/utils/uncertain-transaction-registry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClaimSharePointsSubmissionKey,
+  clearUncertainSubmission,
+  clearUncertainClaimSharePointsSubmission,
+  hasUnresolvedUncertainSubmission,
+  isNoHashSubmissionTimeout,
+  rememberUncertainClaimSharePointsSubmission,
+  rememberUncertainSubmission,
+  resetUncertainSubmissionRegistryForTests,
+  shouldSkipAutomaticClaimSharePointsSubmission,
+} from "./uncertain-transaction-registry";
+
+describe("uncertain transaction registry", () => {
+  it("records unresolved claim share-points no-hash submissions and skips automatic retry until cleared", () => {
+    resetUncertainSubmissionRegistryForTests();
+    const walletAddress = "0xabc";
+    const key = buildClaimSharePointsSubmissionKey(walletAddress);
+
+    expect(hasUnresolvedUncertainSubmission(key)).toBe(false);
+    expect(shouldSkipAutomaticClaimSharePointsSubmission(walletAddress)).toBe(false);
+
+    rememberUncertainClaimSharePointsSubmission({
+      walletAddress,
+      failureKind: "submission_timeout_no_hash",
+    });
+
+    expect(hasUnresolvedUncertainSubmission(key)).toBe(true);
+    expect(shouldSkipAutomaticClaimSharePointsSubmission(walletAddress)).toBe(true);
+
+    clearUncertainClaimSharePointsSubmission(walletAddress);
+
+    expect(hasUnresolvedUncertainSubmission(key)).toBe(false);
+    expect(shouldSkipAutomaticClaimSharePointsSubmission(walletAddress)).toBe(false);
+  });
+
+  it("does not block automatic retries for provider disconnects that failed before submit", () => {
+    resetUncertainSubmissionRegistryForTests();
+    const key = "claim_share_points:0xabc";
+
+    rememberUncertainSubmission({
+      key,
+      failureKind: "provider_connection_destroyed",
+    });
+
+    expect(hasUnresolvedUncertainSubmission(key)).toBe(false);
+  });
+
+  it("classifies no-hash timeout errors from provider messages", () => {
+    const timeout = new Error("Transaction submission timed out after 20s before a transaction hash was returned");
+
+    expect(isNoHashSubmissionTimeout(timeout)).toBe(true);
+    expect(isNoHashSubmissionTimeout(new Error("connection destroyed"))).toBe(false);
+  });
+});

--- a/client/apps/game/src/ui/utils/uncertain-transaction-registry.ts
+++ b/client/apps/game/src/ui/utils/uncertain-transaction-registry.ts
@@ -1,0 +1,69 @@
+import type { TransactionSubmitFailureKind } from "@bibliothecadao/provider";
+
+const unresolvedSubmissionKeys = new Set<string>();
+const CLAIM_SHARE_POINTS_OPERATION = "claim_share_points";
+
+export const isNoHashSubmissionTimeout = (error: unknown): boolean => {
+  return error instanceof Error && error.message.includes("before a transaction hash was returned");
+};
+
+const buildUncertainSubmissionKey = ({
+  operation,
+  walletAddress,
+}: {
+  operation: string;
+  walletAddress: string | bigint;
+}): string => `${operation}:${walletAddress.toString()}`;
+
+export const buildClaimSharePointsSubmissionKey = (walletAddress: string | bigint): string => {
+  return buildUncertainSubmissionKey({
+    operation: CLAIM_SHARE_POINTS_OPERATION,
+    walletAddress,
+  });
+};
+
+export const rememberUncertainSubmission = ({
+  key,
+  failureKind,
+}: {
+  key: string;
+  failureKind?: TransactionSubmitFailureKind;
+}): void => {
+  if (failureKind === "submission_timeout_no_hash") {
+    unresolvedSubmissionKeys.add(key);
+    return;
+  }
+
+  unresolvedSubmissionKeys.delete(key);
+};
+
+export const hasUnresolvedUncertainSubmission = (key: string): boolean => unresolvedSubmissionKeys.has(key);
+
+export const clearUncertainSubmission = (key: string): void => {
+  unresolvedSubmissionKeys.delete(key);
+};
+
+export const rememberUncertainClaimSharePointsSubmission = ({
+  walletAddress,
+  failureKind,
+}: {
+  walletAddress: string | bigint;
+  failureKind?: TransactionSubmitFailureKind;
+}): void => {
+  rememberUncertainSubmission({
+    key: buildClaimSharePointsSubmissionKey(walletAddress),
+    failureKind,
+  });
+};
+
+export const shouldSkipAutomaticClaimSharePointsSubmission = (walletAddress: string | bigint): boolean => {
+  return hasUnresolvedUncertainSubmission(buildClaimSharePointsSubmissionKey(walletAddress));
+};
+
+export const clearUncertainClaimSharePointsSubmission = (walletAddress: string | bigint): void => {
+  clearUncertainSubmission(buildClaimSharePointsSubmissionKey(walletAddress));
+};
+
+export const resetUncertainSubmissionRegistryForTests = (): void => {
+  unresolvedSubmissionKeys.clear();
+};

--- a/client/apps/game/vitest.config.ts
+++ b/client/apps/game/vitest.config.ts
@@ -39,6 +39,8 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
       "@config": path.resolve(__dirname, "../../../config/utils/utils"),
+      "@config-deployer": path.resolve(__dirname, "../../../config/deployer"),
+      "@contracts": path.resolve(__dirname, "../../../contracts/utils/utils"),
       "@bibliothecadao/amm-sdk": path.resolve(__dirname, "../../../packages/amm-sdk/src/index.ts"),
       "@bibliothecadao/ammv2-sdk": path.resolve(__dirname, "../../../packages/ammv2-sdk/src/index.ts"),
       "@bibliothecadao/client": path.resolve(__dirname, "../../../packages/client/src/index.ts"),
@@ -48,6 +50,8 @@ export default defineConfig({
       "@bibliothecadao/torii": path.resolve(__dirname, "../../../packages/torii/src/index.ts"),
       "@bibliothecadao/types": path.resolve(__dirname, "../../../packages/types/src/index.ts"),
       "@manifests": path.resolve(__dirname, "../../../contracts/game"),
+      "@pm": path.resolve(__dirname, "./src/pm"),
+      "@videos": path.resolve(__dirname, "./src/assets/videos"),
     },
   },
 });

--- a/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
+++ b/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
@@ -578,6 +578,105 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
     );
   });
 
+  it("keeps the VRF submission lock until a timed-out submission reaches a terminal state", async () => {
+    vi.useFakeTimers();
+    const provider = makeProvider();
+    provider.TRANSACTION_SUBMIT_TIMEOUT_MS = 50;
+    provider.VRF_PROVIDER_ADDRESS = "0x999";
+
+    let resolveFirstExecute!: (value: { transaction_hash: string }) => void;
+    let resolveFirstWait!: (value: any) => void;
+    const firstWaitPromise = new Promise<any>((resolve) => {
+      resolveFirstWait = resolve;
+    });
+
+    provider.execute = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ transaction_hash: string }>((resolve) => {
+            resolveFirstExecute = resolve;
+          }),
+      )
+      .mockResolvedValueOnce({ transaction_hash: "0x2" });
+    provider.waitForTransactionWithCheckInternal = vi.fn().mockImplementation((transactionHash: string) => {
+      if (transactionHash === "0x1") {
+        return firstWaitPromise;
+      }
+      return Promise.resolve({ isReverted: () => false });
+    });
+
+    const signer = {
+      address: "0xabc",
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const calls: Call[] = [
+      {
+        contractAddress: "0x999",
+        entrypoint: "request_random",
+        calldata: ["0x123", 0, "0xabc"],
+      },
+      {
+        contractAddress: "0x123",
+        entrypoint: "open_chest",
+        calldata: [],
+      },
+    ];
+
+    const firstResult = provider.executeAndCheckTransaction(signer, calls, undefined, {
+      waitForConfirmation: false,
+    });
+    const timedOutResult = firstResult.then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(timedOutResult).resolves.toBeInstanceOf(Error);
+
+    const secondResult = provider.executeAndCheckTransaction(signer, calls, undefined, {
+      waitForConfirmation: false,
+    });
+
+    const releasedBeforeLateHash = await vi
+      .waitFor(
+        () => {
+          expect(provider.execute).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 25, interval: 1 },
+      )
+      .then(
+        () => true,
+        () => false,
+      );
+    expect(releasedBeforeLateHash).toBe(false);
+
+    resolveFirstExecute({ transaction_hash: "0x1" });
+
+    const releasedBeforeTerminalState = await vi
+      .waitFor(
+        () => {
+          expect(provider.execute).toHaveBeenCalledTimes(2);
+        },
+        { timeout: 25, interval: 1 },
+      )
+      .then(
+        () => true,
+        () => false,
+      );
+    expect(releasedBeforeTerminalState).toBe(false);
+
+    resolveFirstWait({ isReverted: () => false });
+
+    await expect(secondResult).resolves.toMatchObject({
+      statusReceipt: "PENDING",
+      transaction_hash: "0x2",
+    });
+    expect(provider.execute).toHaveBeenCalledTimes(2);
+  });
+
   it("waits for a registered pre-submit guard before calling execute", async () => {
     const provider = makeProvider();
     let releaseGuard!: () => void;

--- a/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
+++ b/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
@@ -489,7 +489,133 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
     expect(findTransactionFailedPayload(provider)).toMatchObject({
       stage: "submit",
       message: expect.stringContaining("Transaction submission timed out"),
+      failureKind: "submission_timeout_no_hash",
+      hasTxHash: false,
+      retrySafety: "unsafe_until_wallet_checked",
     });
+  });
+
+  it("classifies destroyed provider connections before a transaction hash", async () => {
+    const provider = makeProvider();
+    provider.execute = vi
+      .fn()
+      .mockRejectedValue(new Error("Unable to send execute() call due to destroyed connection"));
+
+    const signer = {
+      address: "0xabc",
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "claim_share_points",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toThrow("destroyed connection");
+
+    expect(findTransactionFailedPayload(provider)).toMatchObject({
+      stage: "submit",
+      failureKind: "provider_connection_destroyed",
+      providerState: "destroyed",
+      hasTxHash: false,
+      retrySafety: "safe_after_reconnect",
+    });
+  });
+
+  it("emits a late submitted and pending event when a timed-out submission later returns a hash", async () => {
+    vi.useFakeTimers();
+    const provider = makeProvider();
+    provider.TRANSACTION_SUBMIT_TIMEOUT_MS = 50;
+
+    let resolveExecute!: (value: { transaction_hash: string }) => void;
+    provider.execute = vi.fn(() => {
+      return new Promise<{ transaction_hash: string }>((resolve) => {
+        resolveExecute = resolve;
+      });
+    });
+
+    const signer = {
+      address: "0xabc",
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "set_entity_name",
+      calldata: [],
+    };
+
+    const timedOutSubmission = provider
+      .executeAndCheckTransaction(signer, call, undefined, { waitForConfirmation: false })
+      .then(
+        () => "resolved",
+        (error: unknown) => error,
+      );
+
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(timedOutSubmission).resolves.toBeInstanceOf(Error);
+
+    resolveExecute({ transaction_hash: "0xlate" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(provider.emit).toHaveBeenCalledWith(
+      "transactionSubmitted",
+      expect.objectContaining({
+        transactionHash: "0xlate",
+        recoveredFromSubmissionTimeout: true,
+      }),
+    );
+    expect(provider.emit).toHaveBeenCalledWith(
+      "transactionPending",
+      expect.objectContaining({
+        transactionHash: "0xlate",
+        recoveredFromSubmissionTimeout: true,
+      }),
+    );
+  });
+
+  it("waits for a registered pre-submit guard before calling execute", async () => {
+    const provider = makeProvider();
+    let releaseGuard!: () => void;
+    provider.transactionSubmitGuard = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseGuard = resolve;
+        }),
+    );
+
+    const signer = {
+      address: "0xabc",
+      estimateInvokeFee: vi.fn().mockResolvedValue({
+        resourceBounds: makeResourceBounds(1_000_000_000n),
+      }),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "claim_share_points",
+      calldata: [],
+    };
+
+    const result = provider.executeAndCheckTransaction(signer, call, undefined, { waitForConfirmation: false });
+    await Promise.resolve();
+
+    expect(provider.transactionSubmitGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transactionType: TransactionType.CLAIM_SHARE_POINTS,
+      }),
+    );
+    expect(provider.execute).not.toHaveBeenCalled();
+
+    releaseGuard();
+    await expect(result).resolves.toMatchObject({
+      statusReceipt: "PENDING",
+      transaction_hash: "0xabc",
+    });
+    expect(provider.execute).toHaveBeenCalledTimes(1);
   });
 
   it("uses default v3 execution details when fee estimation stalls before submission", async () => {

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -825,7 +825,10 @@ export class EternumProvider extends EnhancedDojoProvider {
 
   private buildTransactionLifecycleMeta(
     transactionDetails: AllowArray<Call>,
-    meta: Pick<TransactionLifecycleMeta, "type" | "transactionCount" | "batchDetails" | "transactionHash">,
+    meta: Pick<
+      TransactionLifecycleMeta,
+      "type" | "transactionHash" | "signerAddress" | "transactionCount" | "batchDetails"
+    >,
   ): TransactionLifecycleMeta {
     const entrypoints = this.getTransactionEntrypoints(transactionDetails);
     const contractAddresses = this.getTransactionContractAddresses(transactionDetails);
@@ -933,6 +936,7 @@ export class EternumProvider extends EnhancedDojoProvider {
   private observeLateSubmittedTransaction(
     submitPromise: Promise<{ transaction_hash: string }>,
     transactionMeta: TransactionLifecycleMeta,
+    releaseVrfExecutionLock?: () => void,
   ): void {
     void submitPromise
       .then((tx) => {
@@ -948,7 +952,7 @@ export class EternumProvider extends EnhancedDojoProvider {
         this.emitTransactionSubmitted(tx.transaction_hash, recoveredTransactionMeta);
         this.emitTransactionPending(tx.transaction_hash, recoveredTransactionMeta);
 
-        void this.waitForTransactionWithCheckInternal(tx.transaction_hash, recoveredTransactionMetaWithHash)
+        return this.waitForTransactionWithCheckInternal(tx.transaction_hash, recoveredTransactionMetaWithHash)
           .then((receipt) => {
             this.emit("transactionComplete", {
               details: receipt,
@@ -965,6 +969,9 @@ export class EternumProvider extends EnhancedDojoProvider {
       })
       .catch(() => {
         // The original timeout path already emitted the submit failure.
+      })
+      .finally(() => {
+        releaseVrfExecutionLock?.();
       });
   }
 
@@ -1086,6 +1093,7 @@ export class EternumProvider extends EnhancedDojoProvider {
 
     const transactionMeta = this.buildTransactionLifecycleMeta(sanitizedTransactionDetails, {
       type: txType,
+      signerAddress: this.getSignerAddress(signer),
       ...(isMultipleTransactions ? { transactionCount: sanitizedTransactionDetails.length } : {}),
       ...(batchDetails && batchDetails.length > 0 ? { batchDetails } : {}),
     });
@@ -1107,12 +1115,14 @@ export class EternumProvider extends EnhancedDojoProvider {
       submitPromise = this.submitTransaction(signer, sanitizedTransactionDetails, executionDetails);
       tx = await this.waitForTransactionSubmission(submitPromise);
     } catch (error) {
-      releaseVrfExecutionLock?.();
-      releaseVrfExecutionLock = undefined;
       const message = extractErrorMessage(error);
       const submitFailure = classifySubmitFailure(error);
       if (submitPromise && submitFailure.failureKind === "submission_timeout_no_hash") {
-        this.observeLateSubmittedTransaction(submitPromise, transactionMeta);
+        this.observeLateSubmittedTransaction(submitPromise, transactionMeta, releaseVrfExecutionLock);
+        releaseVrfExecutionLock = undefined;
+      } else {
+        releaseVrfExecutionLock?.();
+        releaseVrfExecutionLock = undefined;
       }
       this.emitTransactionFailure({
         ...transactionMeta,

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -31,6 +31,11 @@ import {
   TransactionFailedPayload,
   TransactionFailureStage,
   TransactionLifecycleMeta,
+  TransactionProviderState,
+  TransactionRetrySafety,
+  TransactionSubmitFailureKind,
+  TransactionSubmitGuard,
+  TransactionSubmitGuardContext,
   TransactionType,
 } from "./types";
 import { createVrfRequestRandomCall, isVrfEnabled, isVrfRequestRandomCall, type VrfSource } from "./vrf";
@@ -54,6 +59,11 @@ export type {
   TransactionFailedPayload,
   TransactionFailureStage,
   TransactionLifecycleMeta,
+  TransactionProviderState,
+  TransactionRetrySafety,
+  TransactionSubmitFailureKind,
+  TransactionSubmitGuard,
+  TransactionSubmitGuardContext,
 } from "./types";
 export type { VrfSource } from "./vrf";
 
@@ -63,6 +73,8 @@ const V3_L2_GAS_OVERHEAD_PERCENT = 50n;
 const HUNDRED_PERCENT = 100n;
 const DEFAULT_FEE_ESTIMATE_TIMEOUT_MS = 5_000;
 const DEFAULT_TRANSACTION_SUBMIT_TIMEOUT_MS = 20_000;
+export const SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE =
+  "Submission timed out before a tx hash was returned. Check wallet/activity before retrying.";
 const NON_MEANINGFUL_ERROR_MESSAGES = new Set(["", "[object Object]", "undefined", "null"]);
 const GENERIC_ERROR_MESSAGES = new Set([
   "transaction execution error",
@@ -362,6 +374,49 @@ const extractErrorMessage = (error: unknown, fallback = "Unknown error"): string
 
 const matchesNonceError = (error: unknown): boolean => extractErrorMessage(error, "").toLowerCase().includes("nonce");
 
+const isTransactionSubmissionTimeoutError = (error: unknown): boolean => {
+  return error instanceof TransactionSubmissionTimeoutError;
+};
+
+const matchesDestroyedConnectionError = (error: unknown): boolean => {
+  const message = extractErrorMessage(error, "").toLowerCase();
+  return message.includes("destroyed connection") || message.includes("connection destroyed");
+};
+
+const classifySubmitFailure = (
+  error: unknown,
+): {
+  failureKind: TransactionSubmitFailureKind;
+  providerState: TransactionProviderState;
+  hasTxHash: boolean;
+  retrySafety: TransactionRetrySafety;
+} => {
+  if (isTransactionSubmissionTimeoutError(error)) {
+    return {
+      failureKind: "submission_timeout_no_hash",
+      providerState: "unknown",
+      hasTxHash: false,
+      retrySafety: "unsafe_until_wallet_checked",
+    };
+  }
+
+  if (matchesDestroyedConnectionError(error)) {
+    return {
+      failureKind: "provider_connection_destroyed",
+      providerState: "destroyed",
+      hasTxHash: false,
+      retrySafety: "safe_after_reconnect",
+    };
+  }
+
+  return {
+    failureKind: "submit_failed",
+    providerState: "unknown",
+    hasTxHash: false,
+    retrySafety: "unknown",
+  };
+};
+
 const withL2GasHeadroom = (resourceBounds?: ResourceBoundsBN): ResourceBoundsBN | undefined => {
   if (!resourceBounds?.l2_gas || typeof resourceBounds.l2_gas.max_amount !== "bigint") {
     return resourceBounds;
@@ -517,6 +572,7 @@ export class EternumProvider extends EnhancedDojoProvider {
   private pendingTransactionSpans = new Map<string, Span>();
   private pendingVrfExecutionLocks = new Map<string, VrfExecutionLock>();
   private readonly retryConfig?: RetryConfig;
+  private transactionSubmitGuard?: TransactionSubmitGuard;
   /**
    * Create a new EternumProvider instance
    *
@@ -698,13 +754,39 @@ export class EternumProvider extends EnhancedDojoProvider {
     return await this.execute(signer as any, transactionDetails, NAMESPACE, executionDetails);
   }
 
-  private async submitTransactionWithTimeout(
+  public setTransactionSubmitGuard(transactionSubmitGuard?: TransactionSubmitGuard): void {
+    this.transactionSubmitGuard = transactionSubmitGuard;
+  }
+
+  private getSignerAddress(signer: Account | AccountInterface): string | undefined {
+    const address = (signer as { address?: unknown }).address;
+    return typeof address === "string" && address.length > 0 ? address : undefined;
+  }
+
+  private async runTransactionSubmitGuard(
     signer: Account | AccountInterface,
-    transactionDetails: AllowArray<Call>,
-    executionDetails: UniversalDetails,
+    transactionMeta: TransactionLifecycleMeta,
+  ): Promise<void> {
+    const guard = this.transactionSubmitGuard;
+    if (!guard) {
+      return;
+    }
+
+    const context: TransactionSubmitGuardContext = {
+      ...transactionMeta,
+      transactionType: transactionMeta.type,
+      signerAddress: this.getSignerAddress(signer),
+      providerState: "ready",
+    };
+
+    await guard(context);
+  }
+
+  private async waitForTransactionSubmission(
+    submitPromise: Promise<{ transaction_hash: string }>,
   ): Promise<{ transaction_hash: string }> {
     return await this.withTimeout(
-      this.submitTransaction(signer, transactionDetails, executionDetails),
+      submitPromise,
       this.TRANSACTION_SUBMIT_TIMEOUT_MS,
       () => new TransactionSubmissionTimeoutError(this.TRANSACTION_SUBMIT_TIMEOUT_MS),
     );
@@ -834,6 +916,58 @@ export class EternumProvider extends EnhancedDojoProvider {
     this.emit("transactionFailed", payload);
   }
 
+  private emitTransactionSubmitted(transactionHash: string, transactionMeta: TransactionLifecycleMeta): void {
+    this.emit("transactionSubmitted", {
+      transactionHash,
+      ...transactionMeta,
+    });
+  }
+
+  private emitTransactionPending(transactionHash: string, transactionMeta: TransactionLifecycleMeta): void {
+    this.emit("transactionPending", {
+      transactionHash,
+      ...transactionMeta,
+    });
+  }
+
+  private observeLateSubmittedTransaction(
+    submitPromise: Promise<{ transaction_hash: string }>,
+    transactionMeta: TransactionLifecycleMeta,
+  ): void {
+    void submitPromise
+      .then((tx) => {
+        const recoveredTransactionMeta = {
+          ...transactionMeta,
+          recoveredFromSubmissionTimeout: true,
+        };
+        const recoveredTransactionMetaWithHash = {
+          ...recoveredTransactionMeta,
+          transactionHash: tx.transaction_hash,
+        };
+
+        this.emitTransactionSubmitted(tx.transaction_hash, recoveredTransactionMeta);
+        this.emitTransactionPending(tx.transaction_hash, recoveredTransactionMeta);
+
+        void this.waitForTransactionWithCheckInternal(tx.transaction_hash, recoveredTransactionMetaWithHash)
+          .then((receipt) => {
+            this.emit("transactionComplete", {
+              details: receipt,
+              ...recoveredTransactionMeta,
+            });
+          })
+          .catch((error) => {
+            this.emitTransactionFailure({
+              ...recoveredTransactionMetaWithHash,
+              message: extractErrorMessage(error),
+              stage: resolveTransactionFailureStage(error, "background_confirmation"),
+            });
+          });
+      })
+      .catch(() => {
+        // The original timeout path already emitted the submit failure.
+      });
+  }
+
   // ============ Optional client-side batching API ============
   public beginBatch(options: { signer: Account | AccountInterface; immediateEntrypoints?: string[] }) {
     if (this._batchCalls) return; // already batching
@@ -956,6 +1090,7 @@ export class EternumProvider extends EnhancedDojoProvider {
       ...(batchDetails && batchDetails.length > 0 ? { batchDetails } : {}),
     });
 
+    await this.runTransactionSubmitGuard(signer, transactionMeta);
     const span = this.startTransactionSpan(sanitizedTransactionDetails, transactionMeta);
 
     const executionDetails = await this.getV3ExecutionDetails(signer, sanitizedTransactionDetails);
@@ -967,16 +1102,23 @@ export class EternumProvider extends EnhancedDojoProvider {
     }
 
     let tx;
+    let submitPromise: Promise<{ transaction_hash: string }> | undefined;
     try {
-      tx = await this.submitTransactionWithTimeout(signer, sanitizedTransactionDetails, executionDetails);
+      submitPromise = this.submitTransaction(signer, sanitizedTransactionDetails, executionDetails);
+      tx = await this.waitForTransactionSubmission(submitPromise);
     } catch (error) {
       releaseVrfExecutionLock?.();
       releaseVrfExecutionLock = undefined;
       const message = extractErrorMessage(error);
+      const submitFailure = classifySubmitFailure(error);
+      if (submitPromise && submitFailure.failureKind === "submission_timeout_no_hash") {
+        this.observeLateSubmittedTransaction(submitPromise, transactionMeta);
+      }
       this.emitTransactionFailure({
         ...transactionMeta,
         message: `Transaction failed to submit: ${message}`,
         stage: "submit",
+        ...submitFailure,
       });
       this.failTransactionSpan(span, undefined, error);
       throw error;
@@ -986,10 +1128,7 @@ export class EternumProvider extends EnhancedDojoProvider {
     span.addEvent("transaction.submitted", { "transaction.hash": tx.transaction_hash });
 
     // Emit immediately so UI can show pending state
-    this.emit("transactionSubmitted", {
-      transactionHash: tx.transaction_hash,
-      ...transactionMeta,
-    });
+    this.emitTransactionSubmitted(tx.transaction_hash, transactionMeta);
 
     const waitForConfirmation = options?.waitForConfirmation ?? true;
     const transactionMetaWithHash = {
@@ -1008,10 +1147,7 @@ export class EternumProvider extends EnhancedDojoProvider {
       : waitPromiseWithoutLockRelease;
 
     if (!waitForConfirmation) {
-      this.emit("transactionPending", {
-        transactionHash: tx.transaction_hash,
-        ...transactionMeta,
-      });
+      this.emitTransactionPending(tx.transaction_hash, transactionMeta);
       span.setAttribute("transaction.status", "pending");
       span.addEvent("transaction.pending", { "transaction.hash": tx.transaction_hash });
       this.pendingTransactionSpans.set(tx.transaction_hash, span);
@@ -1056,10 +1192,7 @@ export class EternumProvider extends EnhancedDojoProvider {
     }
 
     if (waitResult.status === "pending") {
-      this.emit("transactionPending", {
-        transactionHash: tx.transaction_hash,
-        ...transactionMeta,
-      });
+      this.emitTransactionPending(tx.transaction_hash, transactionMeta);
       span.setAttribute("transaction.status", "pending");
       span.addEvent("transaction.pending", { "transaction.hash": tx.transaction_hash });
       this.pendingTransactionSpans.set(tx.transaction_hash, span);

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -9,6 +9,15 @@ export interface BatchedTransactionDetail {
 
 export type TransactionFailureStage = "submit" | "confirmation" | "revert" | "background_confirmation";
 
+export type TransactionSubmitFailureKind =
+  | "provider_connection_destroyed"
+  | "submission_timeout_no_hash"
+  | "submit_failed";
+
+export type TransactionProviderState = "ready" | "destroyed" | "unavailable" | "unknown";
+
+export type TransactionRetrySafety = "safe_after_reconnect" | "unsafe_until_wallet_checked" | "unknown";
+
 export interface TransactionLifecycleMeta {
   type?: TransactionType;
   transactionHash?: string;
@@ -16,12 +25,25 @@ export interface TransactionLifecycleMeta {
   batchDetails?: BatchedTransactionDetail[];
   entrypoints?: string[];
   contractAddresses?: string[];
+  recoveredFromSubmissionTimeout?: boolean;
 }
 
 export interface TransactionFailedPayload extends TransactionLifecycleMeta {
   message: string;
   stage: TransactionFailureStage;
+  failureKind?: TransactionSubmitFailureKind;
+  providerState?: TransactionProviderState;
+  hasTxHash?: boolean;
+  retrySafety?: TransactionRetrySafety;
 }
+
+export interface TransactionSubmitGuardContext extends TransactionLifecycleMeta {
+  transactionType?: TransactionType;
+  signerAddress?: string;
+  providerState?: TransactionProviderState;
+}
+
+export type TransactionSubmitGuard = (context: TransactionSubmitGuardContext) => Promise<void> | void;
 
 export enum TransactionType {
   // Exploration & Movement

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -21,6 +21,7 @@ export type TransactionRetrySafety = "safe_after_reconnect" | "unsafe_until_wall
 export interface TransactionLifecycleMeta {
   type?: TransactionType;
   transactionHash?: string;
+  signerAddress?: string;
   transactionCount?: number;
   batchDetails?: BatchedTransactionDetail[];
   entrypoints?: string[];


### PR DESCRIPTION
## Summary
Hardens the provider submit path by classifying destroyed Cartridge connections and no-hash submission timeouts, carrying retry-safety metadata, and continuing to observe late hashes so recovered transactions still reach the transaction center.
Adds a client submit guard that waits for session-policy refresh and warms/probes the controller before execute(), addressing the race where keychain iframe recreation could destroy the wallet connection as claim_share_points submits.
Updates Sentry grouping/tags, no-hash timeout copy, and share-points automation so unresolved no-hash submissions block automatic retries while manual retry remains possible with an uncertainty warning.

## Verification
- pnpm run format
- pnpm run knip
- pnpm --dir packages/provider test --run execute-and-check-transaction.l2-gas.test.ts
- pnpm --dir client/apps/game test src/hooks/use-transaction-listener.test.tsx src/observability/transaction-failure-reporting.test.ts src/ui/shared/components/tx-emit.test.tsx src/ui/utils/uncertain-transaction-registry.test.ts
- node ./scripts/run-vitest.mjs src/game-route.test.tsx
- pnpm --dir client/apps/game typecheck

Known existing limitation: repo-wide pnpm run typecheck still fails in client/apps/onchain-agent manifest typing outside this PR.
