### PR TITLE
feat(game): add trade route overlay

### DIFF
--- a/client/apps/game/src/hooks/store/use-ui-store.ts
+++ b/client/apps/game/src/hooks/store/use-ui-store.ts
@@ -1,4 +1,5 @@
 import { BattleViewInfo, LeftView } from "@/types";
+import type { TransferRouteOverlayRoute } from "@/lib/transfer-route-overlay";
 import { ContextMenuState } from "@/types/context-menu";
 import { SelectableArmy } from "@bibliothecadao/eternum";
 import { BiomeType, ContractAddress, Direction } from "@bibliothecadao/types";
@@ -183,6 +184,11 @@ interface UIStore {
   // map zoom controls
   enableMapZoom: boolean;
   setEnableMapZoom: (enable: boolean) => void;
+  // transfer route overlay
+  showTransferRoutes: boolean;
+  setShowTransferRoutes: (show: boolean) => void;
+  transferRouteOverlayRoutes: TransferRouteOverlayRoute[];
+  setTransferRouteOverlayRoutes: (routes: TransferRouteOverlayRoute[]) => void;
 }
 
 export type AppStore = UIStore & PopupsStore & ThreeStore & BuildModeStore & RealmStore & WorldStore;
@@ -343,5 +349,13 @@ export const useUIStore = create(
       set({ enableMapZoom: enable });
       localStorage.setItem("enableMapZoom", String(enable));
     },
+    // transfer route overlay
+    showTransferRoutes: readLocalBool("showTransferRoutes", true),
+    setShowTransferRoutes: (show: boolean) => {
+      set({ showTransferRoutes: show });
+      localStorage.setItem("showTransferRoutes", String(show));
+    },
+    transferRouteOverlayRoutes: [],
+    setTransferRouteOverlayRoutes: (routes: TransferRouteOverlayRoute[]) => set({ transferRouteOverlayRoutes: routes }),
   })),
 );

--- a/client/apps/game/src/hooks/use-active-transfers.test.ts
+++ b/client/apps/game/src/hooks/use-active-transfers.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const useQueryMock = vi.fn();
+const fetchActiveTransfersMock = vi.fn();
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: useQueryMock,
+}));
+
+vi.mock("@/services/api", () => ({
+  sqlApi: {
+    fetchActiveTransfers: fetchActiveTransfersMock,
+  },
+}));
+
+describe("useActiveTransfers", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queries active transfers through SqlApi with a stable key", async () => {
+    useQueryMock.mockReturnValue({ data: [] });
+
+    const { useActiveTransfers } = await import("./use-active-transfers");
+    useActiveTransfers(250, 1800);
+
+    expect(useQueryMock).toHaveBeenCalledTimes(1);
+    const queryOptions = useQueryMock.mock.calls[0][0];
+
+    expect(queryOptions.queryKey).toEqual(["activeTransfers", 250, 1800]);
+
+    fetchActiveTransfersMock.mockResolvedValue([{ id: "live:event-1" }]);
+    await expect(queryOptions.queryFn()).resolves.toEqual([{ id: "live:event-1" }]);
+    expect(fetchActiveTransfersMock).toHaveBeenCalledWith(250, 1800);
+  });
+});

--- a/client/apps/game/src/hooks/use-active-transfers.ts
+++ b/client/apps/game/src/hooks/use-active-transfers.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ActiveTransferData } from "@bibliothecadao/torii";
+
+import { POLLING_INTERVALS } from "@/config/polling";
+import { sqlApi } from "@/services/api";
+
+const DEFAULT_ACTIVE_TRANSFERS_LIMIT = 500;
+const DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS = 1_800;
+
+export const useActiveTransfers = (
+  limit: number = DEFAULT_ACTIVE_TRANSFERS_LIMIT,
+  lookbackSeconds: number = DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS,
+) =>
+  useQuery<ActiveTransferData[]>({
+    queryKey: ["activeTransfers", limit, lookbackSeconds],
+    queryFn: async () => sqlApi.fetchActiveTransfers(limit, lookbackSeconds),
+    staleTime: POLLING_INTERVALS.storyEventsStaleMs,
+    refetchInterval: POLLING_INTERVALS.storyEventsMs,
+  });

--- a/client/apps/game/src/lib/transfer-route-overlay-mock.test.ts
+++ b/client/apps/game/src/lib/transfer-route-overlay-mock.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import type { StructureMapData } from "@bibliothecadao/eternum";
+
+import { buildMockActiveTransfers } from "./transfer-route-overlay-mock";
+
+const createStructure = (entityId: number, coordX: number, coordY: number): StructureMapData =>
+  ({
+    entity: `0x${entityId.toString(16)}`,
+    entityId,
+    coordX,
+    coordY,
+    structureType: 1,
+    structureTypeName: "Realm",
+    level: 1,
+    ownerAddress: "1",
+    ownerName: "Owner",
+    guardArmies: [],
+    activeProductions: [],
+  }) as StructureMapData;
+
+describe("buildMockActiveTransfers", () => {
+  it("returns no mock transfers when fewer than two structures exist", () => {
+    expect(buildMockActiveTransfers([createStructure(1, 0, 0)], 100_000)).toEqual([]);
+  });
+
+  it("builds deterministic active transfers from available structures", () => {
+    const transfers = buildMockActiveTransfers(
+      [
+        createStructure(44, 4, 4),
+        createStructure(11, 1, 1),
+        createStructure(22, 2, 2),
+        createStructure(33, 3, 3),
+      ],
+      100_000,
+    );
+
+    expect(transfers).toHaveLength(4);
+    expect(transfers[0]).toMatchObject({
+      id: "live:mock-11-22-0",
+      sourceEntityId: 11,
+      destinationEntityId: 22,
+      resourceIds: [1],
+    });
+    expect(transfers.every((transfer) => transfer.startedAtMs < transfer.endsAtMs)).toBe(true);
+    expect(transfers.every((transfer) => transfer.progress > 0 && transfer.progress < 1)).toBe(true);
+  });
+});

--- a/client/apps/game/src/lib/transfer-route-overlay-mock.ts
+++ b/client/apps/game/src/lib/transfer-route-overlay-mock.ts
@@ -1,0 +1,61 @@
+import type { ActiveTransferData } from "@bibliothecadao/torii";
+import type { StructureMapData } from "@bibliothecadao/eternum";
+
+const MOCK_TRANSFER_DURATIONS_MS = [120_000, 180_000, 240_000, 90_000];
+const MOCK_TRANSFER_PROGRESS = [0.15, 0.45, 0.72, 0.33];
+const MOCK_TRANSFER_RESOURCE_IDS = [[1], [2], [3], [4, 5]];
+
+export function buildMockActiveTransfers(
+  structures: StructureMapData[],
+  currentTimeMs: number,
+): ActiveTransferData[] {
+  const selectedStructures = structures
+    .toSorted((left, right) => left.entityId - right.entityId)
+    .slice(0, 4);
+
+  if (selectedStructures.length < 2) {
+    return [];
+  }
+
+  const pairs = buildMockTransferPairs(selectedStructures);
+
+  return pairs.map(([source, destination], index) => {
+    const durationMs = MOCK_TRANSFER_DURATIONS_MS[index % MOCK_TRANSFER_DURATIONS_MS.length]!;
+    const progress = MOCK_TRANSFER_PROGRESS[index % MOCK_TRANSFER_PROGRESS.length]!;
+    const startedAtMs = currentTimeMs - durationMs * progress;
+    const endsAtMs = startedAtMs + durationMs;
+
+    return {
+      id: `live:mock-${source.entityId}-${destination.entityId}-${index}`,
+      eventId: `mock-${index}`,
+      txHash: `mock-${index}`,
+      sourceEntityId: source.entityId,
+      destinationEntityId: destination.entityId,
+      resourceIds: MOCK_TRANSFER_RESOURCE_IDS[index % MOCK_TRANSFER_RESOURCE_IDS.length]!,
+      startedAtMs,
+      endsAtMs,
+      progress,
+    };
+  });
+}
+
+function buildMockTransferPairs(structures: StructureMapData[]): Array<[StructureMapData, StructureMapData]> {
+  if (structures.length === 2) {
+    return [[structures[0]!, structures[1]!]];
+  }
+
+  if (structures.length === 3) {
+    return [
+      [structures[0]!, structures[1]!],
+      [structures[1]!, structures[2]!],
+      [structures[0]!, structures[2]!],
+    ];
+  }
+
+  return [
+    [structures[0]!, structures[1]!],
+    [structures[1]!, structures[2]!],
+    [structures[2]!, structures[3]!],
+    [structures[0]!, structures[3]!],
+  ];
+}

--- a/client/apps/game/src/lib/transfer-route-overlay.test.ts
+++ b/client/apps/game/src/lib/transfer-route-overlay.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTransferRouteOverlayRoutes,
+  mergeRetainedTransferRouteOverlayRoutes,
+  parseTransferRouteResourceIds,
+} from "./transfer-route-overlay";
+
+const resolveEntityHex = (entityId: number) => {
+  const positions = new Map([
+    [11, { col: 1, row: 2 }],
+    [22, { col: 5, row: 8 }],
+    [33, { col: -3, row: 4 }],
+    [44, { col: 9, row: -1 }],
+  ]);
+  return positions.get(entityId) ?? null;
+};
+
+describe("transfer route overlay builders", () => {
+  it("parses transfer resources from story JSON and object payloads", () => {
+    expect(parseTransferRouteResourceIds('[{"resourceId":1,"amount":10},{"resource":2,"amount":4}]')).toEqual([1, 2]);
+    expect(parseTransferRouteResourceIds([{ resourceId: 3 }, { resource: 4 }, { resourceId: Number.NaN }])).toEqual([
+      3, 4,
+    ]);
+    expect(parseTransferRouteResourceIds({ resourceId: 5, amount: 10 })).toEqual([5]);
+  });
+
+  it("builds active live transfer routes and filters mint, expired, and unresolved routes", () => {
+    const routes = buildTransferRouteOverlayRoutes({
+      currentTimeMs: 115_000,
+      liveEvents: [
+        {
+          event_id: "live-active",
+          story: "ResourceTransferStory",
+          timestamp: "0x64",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 22,
+          resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+          resource_transfer_travel_time: 30,
+          resource_transfer_is_mint: false,
+        },
+        {
+          event_id: "minted",
+          story: "ResourceTransferStory",
+          timestamp: "0x64",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 22,
+          resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+          resource_transfer_travel_time: 30,
+          resource_transfer_is_mint: true,
+        },
+        {
+          event_id: "expired",
+          story: "ResourceTransferStory",
+          timestamp: "0x32",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 22,
+          resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+          resource_transfer_travel_time: 10,
+          resource_transfer_is_mint: false,
+        },
+        {
+          event_id: "unresolved",
+          story: "ResourceTransferStory",
+          timestamp: "0x64",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 999,
+          resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+          resource_transfer_travel_time: 30,
+          resource_transfer_is_mint: false,
+        },
+      ],
+      automationEntries: [],
+      resolveEntityHex,
+    });
+
+    expect(routes).toEqual([
+      {
+        id: "live:live-active",
+        kind: "live",
+        sourceEntityId: 11,
+        destinationEntityId: 22,
+        sourceHex: { col: 1, row: 2 },
+        destinationHex: { col: 5, row: 8 },
+        resourceIds: [1],
+        startedAtMs: 100_000,
+        endsAtMs: 130_000,
+        progress: 0.5,
+      },
+    ]);
+  });
+
+  it("builds planned automation routes after live routes and applies the render cap", () => {
+    const routes = buildTransferRouteOverlayRoutes({
+      currentTimeMs: 115_000,
+      maxRoutes: 2,
+      liveEvents: [
+        {
+          event_id: "live-active",
+          story: "ResourceTransferStory",
+          timestamp: "0x64",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 22,
+          resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+          resource_transfer_travel_time: 30,
+          resource_transfer_is_mint: false,
+        },
+      ],
+      automationEntries: [
+        {
+          id: "automation-a",
+          active: true,
+          sourceEntityId: "33",
+          destinationEntityId: "44",
+          resourceIds: [5],
+          resourceConfigs: [{ resourceId: 6, amount: 10 }],
+          intervalMinutes: 5,
+        },
+        {
+          id: "automation-b",
+          active: true,
+          sourceEntityId: "11",
+          destinationEntityId: "22",
+          resourceIds: [7],
+          intervalMinutes: 5,
+        },
+        {
+          id: "automation-paused",
+          active: false,
+          sourceEntityId: "11",
+          destinationEntityId: "22",
+          resourceIds: [8],
+          intervalMinutes: 5,
+        },
+      ],
+      resolveEntityHex,
+    });
+
+    expect(routes.map((route) => route.id)).toEqual(["live:live-active", "planned:automation-a"]);
+    expect(routes[1]).toMatchObject({
+      kind: "planned",
+      sourceEntityId: 33,
+      destinationEntityId: 44,
+      sourceHex: { col: -3, row: 4 },
+      destinationHex: { col: 9, row: -1 },
+      resourceIds: [6],
+    });
+  });
+
+  it("retains still-active live routes after they fall out of the fetched event window", () => {
+    const nextRoutes = buildTransferRouteOverlayRoutes({
+      currentTimeMs: 120_000,
+      liveEvents: [],
+      automationEntries: [
+        {
+          id: "automation-a",
+          active: true,
+          sourceEntityId: "33",
+          destinationEntityId: "44",
+          resourceIds: [5],
+          intervalMinutes: 5,
+        },
+      ],
+      resolveEntityHex,
+    });
+
+    const routes = mergeRetainedTransferRouteOverlayRoutes({
+      currentTimeMs: 120_000,
+      nextRoutes,
+      previousRoutes: [
+        {
+          id: "live:still-active",
+          kind: "live",
+          sourceEntityId: 11,
+          destinationEntityId: 22,
+          sourceHex: { col: 1, row: 2 },
+          destinationHex: { col: 5, row: 8 },
+          resourceIds: [1],
+          startedAtMs: 100_000,
+          endsAtMs: 140_000,
+          progress: 0.25,
+        },
+      ],
+    });
+
+    expect(routes.map((route) => route.id)).toEqual(["live:still-active", "planned:automation-a"]);
+    expect(routes[0]).toMatchObject({
+      progress: 0.5,
+      startedAtMs: 100_000,
+      endsAtMs: 140_000,
+    });
+  });
+});

--- a/client/apps/game/src/lib/transfer-route-overlay.test.ts
+++ b/client/apps/game/src/lib/transfer-route-overlay.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildTransferRouteOverlayRoutes,
-  mergeRetainedTransferRouteOverlayRoutes,
+  buildTransferRouteOverlayRoutesFromActiveTransfers,
   parseTransferRouteResourceIds,
 } from "./transfer-route-overlay";
 
@@ -147,47 +147,39 @@ describe("transfer route overlay builders", () => {
     });
   });
 
-  it("retains still-active live routes after they fall out of the fetched event window", () => {
-    const nextRoutes = buildTransferRouteOverlayRoutes({
-      currentTimeMs: 120_000,
-      liveEvents: [],
-      automationEntries: [
+  it("builds active transfer routes from normalized server payloads", () => {
+    const routes = buildTransferRouteOverlayRoutesFromActiveTransfers({
+      currentTimeMs: 115_000,
+      liveTransfers: [
         {
-          id: "automation-a",
-          active: true,
-          sourceEntityId: "33",
-          destinationEntityId: "44",
-          resourceIds: [5],
-          intervalMinutes: 5,
-        },
-      ],
-      resolveEntityHex,
-    });
-
-    const routes = mergeRetainedTransferRouteOverlayRoutes({
-      currentTimeMs: 120_000,
-      nextRoutes,
-      previousRoutes: [
-        {
-          id: "live:still-active",
-          kind: "live",
+          id: "live:event-1",
+          eventId: "event-1",
+          txHash: "0xabc",
           sourceEntityId: 11,
           destinationEntityId: 22,
-          sourceHex: { col: 1, row: 2 },
-          destinationHex: { col: 5, row: 8 },
           resourceIds: [1],
           startedAtMs: 100_000,
-          endsAtMs: 140_000,
+          endsAtMs: 130_000,
           progress: 0.25,
         },
       ],
+      automationEntries: [],
+      resolveEntityHex,
     });
 
-    expect(routes.map((route) => route.id)).toEqual(["live:still-active", "planned:automation-a"]);
-    expect(routes[0]).toMatchObject({
-      progress: 0.5,
-      startedAtMs: 100_000,
-      endsAtMs: 140_000,
-    });
+    expect(routes).toEqual([
+      {
+        id: "live:event-1",
+        kind: "live",
+        sourceEntityId: 11,
+        destinationEntityId: 22,
+        sourceHex: { col: 1, row: 2 },
+        destinationHex: { col: 5, row: 8 },
+        resourceIds: [1],
+        startedAtMs: 100_000,
+        endsAtMs: 130_000,
+        progress: 0.5,
+      },
+    ]);
   });
 });

--- a/client/apps/game/src/lib/transfer-route-overlay.ts
+++ b/client/apps/game/src/lib/transfer-route-overlay.ts
@@ -1,3 +1,5 @@
+import type { ActiveTransferData } from "@bibliothecadao/torii";
+
 export interface TransferRouteOverlayHex {
   col: number;
   row: number;
@@ -48,10 +50,11 @@ interface BuildTransferRouteOverlayRoutesInput {
   maxRoutes?: number;
 }
 
-interface MergeRetainedTransferRouteOverlayRoutesInput {
+interface BuildTransferRouteOverlayRoutesFromActiveTransfersInput {
   currentTimeMs: number;
-  nextRoutes: TransferRouteOverlayRoute[];
-  previousRoutes: TransferRouteOverlayRoute[];
+  liveTransfers: ActiveTransferData[];
+  automationEntries: TransferAutomationRouteEntry[];
+  resolveEntityHex: (entityId: number) => TransferRouteOverlayHex | null;
   maxRoutes?: number;
 }
 
@@ -82,15 +85,17 @@ export function buildTransferRouteOverlayRoutes(
     .slice(0, input.maxRoutes ?? DEFAULT_MAX_TRANSFER_ROUTE_OVERLAY_ROUTES);
 }
 
-export function mergeRetainedTransferRouteOverlayRoutes(
-  input: MergeRetainedTransferRouteOverlayRoutesInput,
+export function buildTransferRouteOverlayRoutesFromActiveTransfers(
+  input: BuildTransferRouteOverlayRoutesFromActiveTransfersInput,
 ): TransferRouteOverlayRoute[] {
-  const nextRoutesById = new Map(input.nextRoutes.map((route) => [route.id, route]));
-  const retainedLiveRoutes = input.previousRoutes
-    .filter((route) => shouldRetainLiveTransferRoute(route, input.currentTimeMs, nextRoutesById))
-    .map((route) => refreshRetainedLiveRoute(route, input.currentTimeMs));
+  const liveRoutes = input.liveTransfers
+    .map((transfer) => buildLiveTransferRouteFromActiveTransfer(transfer, input))
+    .filter((route): route is TransferRouteOverlayRoute => route !== null);
+  const plannedRoutes = input.automationEntries
+    .map((entry) => buildPlannedTransferRoute(entry, input.resolveEntityHex))
+    .filter((route): route is TransferRouteOverlayRoute => route !== null);
 
-  return [...input.nextRoutes, ...retainedLiveRoutes]
+  return [...liveRoutes, ...plannedRoutes]
     .toSorted(compareTransferRoutes)
     .slice(0, input.maxRoutes ?? DEFAULT_MAX_TRANSFER_ROUTE_OVERLAY_ROUTES);
 }
@@ -180,38 +185,34 @@ function buildPlannedTransferRoute(
   };
 }
 
-function shouldRetainLiveTransferRoute(
-  route: TransferRouteOverlayRoute,
-  currentTimeMs: number,
-  nextRoutesById: Map<string, TransferRouteOverlayRoute>,
-): boolean {
-  if (route.kind !== "live") {
-    return false;
+function buildLiveTransferRouteFromActiveTransfer(
+  transfer: ActiveTransferData,
+  input: BuildTransferRouteOverlayRoutesFromActiveTransfersInput,
+): TransferRouteOverlayRoute | null {
+  const sourceHex = input.resolveEntityHex(transfer.sourceEntityId);
+  const destinationHex = input.resolveEntityHex(transfer.destinationEntityId);
+  if (!sourceHex || !destinationHex) {
+    return null;
   }
 
-  if (nextRoutesById.has(route.id)) {
-    return false;
+  if (input.currentTimeMs >= transfer.endsAtMs) {
+    return null;
   }
 
-  return route.endsAtMs !== undefined && currentTimeMs < route.endsAtMs;
-}
-
-function refreshRetainedLiveRoute(route: TransferRouteOverlayRoute, currentTimeMs: number): TransferRouteOverlayRoute {
-  if (route.startedAtMs === undefined || route.endsAtMs === undefined) {
-    return route;
-  }
-
-  const durationMs = route.endsAtMs - route.startedAtMs;
-  if (durationMs <= 0) {
-    return {
-      ...route,
-      progress: 1,
-    };
-  }
+  const durationMs = transfer.endsAtMs - transfer.startedAtMs;
+  const progress = durationMs > 0 ? clampProgress((input.currentTimeMs - transfer.startedAtMs) / durationMs) : 1;
 
   return {
-    ...route,
-    progress: clampProgress((currentTimeMs - route.startedAtMs) / durationMs),
+    id: transfer.id,
+    kind: "live",
+    sourceEntityId: transfer.sourceEntityId,
+    destinationEntityId: transfer.destinationEntityId,
+    sourceHex,
+    destinationHex,
+    resourceIds: transfer.resourceIds,
+    startedAtMs: transfer.startedAtMs,
+    endsAtMs: transfer.endsAtMs,
+    progress,
   };
 }
 

--- a/client/apps/game/src/lib/transfer-route-overlay.ts
+++ b/client/apps/game/src/lib/transfer-route-overlay.ts
@@ -1,0 +1,357 @@
+export interface TransferRouteOverlayHex {
+  col: number;
+  row: number;
+}
+
+export interface TransferRouteOverlayRoute {
+  id: string;
+  kind: "live" | "planned";
+  sourceEntityId: number;
+  destinationEntityId: number;
+  sourceHex: TransferRouteOverlayHex;
+  destinationHex: TransferRouteOverlayHex;
+  resourceIds: number[];
+  startedAtMs?: number;
+  endsAtMs?: number;
+  progress?: number;
+}
+
+interface TransferRouteStoryEvent {
+  event_id?: string | null;
+  id?: string | null;
+  tx_hash?: string | null;
+  story?: string | null;
+  timestamp?: string | number | bigint | null;
+  timestampMs?: number;
+  resource_transfer_from_entity_id?: string | number | bigint | null;
+  resource_transfer_to_entity_id?: string | number | bigint | null;
+  resource_transfer_resources?: unknown;
+  resource_transfer_travel_time?: string | number | bigint | null;
+  resource_transfer_is_mint?: boolean | string | number | null;
+}
+
+interface TransferAutomationRouteEntry {
+  id: string;
+  active: boolean;
+  sourceEntityId: string | number | bigint;
+  destinationEntityId: string | number | bigint;
+  resourceIds: number[];
+  resourceConfigs?: Array<{ resourceId: number; amount: number }>;
+  intervalMinutes: number;
+}
+
+interface BuildTransferRouteOverlayRoutesInput {
+  currentTimeMs: number;
+  liveEvents: TransferRouteStoryEvent[];
+  automationEntries: TransferAutomationRouteEntry[];
+  resolveEntityHex: (entityId: number) => TransferRouteOverlayHex | null;
+  maxRoutes?: number;
+}
+
+interface MergeRetainedTransferRouteOverlayRoutesInput {
+  currentTimeMs: number;
+  nextRoutes: TransferRouteOverlayRoute[];
+  previousRoutes: TransferRouteOverlayRoute[];
+  maxRoutes?: number;
+}
+
+const DEFAULT_MAX_TRANSFER_ROUTE_OVERLAY_ROUTES = 96;
+
+export function parseTransferRouteResourceIds(raw: unknown): number[] {
+  const parsed = parseMaybeJson(raw);
+  const resourceCandidates = resolveTransferResourceCandidates(parsed);
+  const resourceIds = resourceCandidates
+    .map(resolveResourceId)
+    .filter((resourceId): resourceId is number => resourceId !== null);
+
+  return Array.from(new Set(resourceIds));
+}
+
+export function buildTransferRouteOverlayRoutes(
+  input: BuildTransferRouteOverlayRoutesInput,
+): TransferRouteOverlayRoute[] {
+  const liveRoutes = input.liveEvents
+    .map((event) => buildLiveTransferRoute(event, input))
+    .filter((route): route is TransferRouteOverlayRoute => route !== null);
+  const plannedRoutes = input.automationEntries
+    .map((entry) => buildPlannedTransferRoute(entry, input.resolveEntityHex))
+    .filter((route): route is TransferRouteOverlayRoute => route !== null);
+
+  return [...liveRoutes, ...plannedRoutes]
+    .toSorted(compareTransferRoutes)
+    .slice(0, input.maxRoutes ?? DEFAULT_MAX_TRANSFER_ROUTE_OVERLAY_ROUTES);
+}
+
+export function mergeRetainedTransferRouteOverlayRoutes(
+  input: MergeRetainedTransferRouteOverlayRoutesInput,
+): TransferRouteOverlayRoute[] {
+  const nextRoutesById = new Map(input.nextRoutes.map((route) => [route.id, route]));
+  const retainedLiveRoutes = input.previousRoutes
+    .filter((route) => shouldRetainLiveTransferRoute(route, input.currentTimeMs, nextRoutesById))
+    .map((route) => refreshRetainedLiveRoute(route, input.currentTimeMs));
+
+  return [...input.nextRoutes, ...retainedLiveRoutes]
+    .toSorted(compareTransferRoutes)
+    .slice(0, input.maxRoutes ?? DEFAULT_MAX_TRANSFER_ROUTE_OVERLAY_ROUTES);
+}
+
+function buildLiveTransferRoute(
+  event: TransferRouteStoryEvent,
+  input: BuildTransferRouteOverlayRoutesInput,
+): TransferRouteOverlayRoute | null {
+  if (event.story !== undefined && event.story !== "ResourceTransferStory") {
+    return null;
+  }
+
+  if (isMintTransfer(event.resource_transfer_is_mint)) {
+    return null;
+  }
+
+  const sourceEntityId = parsePositiveInteger(event.resource_transfer_from_entity_id);
+  const destinationEntityId = parsePositiveInteger(event.resource_transfer_to_entity_id);
+  const startedAtMs = parseEventTimestampMs(event);
+  const travelTimeMs = parseDurationMs(event.resource_transfer_travel_time);
+  const resourceIds = parseTransferRouteResourceIds(event.resource_transfer_resources);
+
+  if (
+    sourceEntityId === null ||
+    destinationEntityId === null ||
+    startedAtMs === null ||
+    travelTimeMs === null ||
+    resourceIds.length === 0
+  ) {
+    return null;
+  }
+
+  const endsAtMs = startedAtMs + travelTimeMs;
+  if (input.currentTimeMs >= endsAtMs) {
+    return null;
+  }
+
+  const sourceHex = input.resolveEntityHex(sourceEntityId);
+  const destinationHex = input.resolveEntityHex(destinationEntityId);
+  if (!sourceHex || !destinationHex) {
+    return null;
+  }
+
+  return {
+    id: `live:${resolveLiveRouteId(event, sourceEntityId, destinationEntityId, startedAtMs)}`,
+    kind: "live",
+    sourceEntityId,
+    destinationEntityId,
+    sourceHex,
+    destinationHex,
+    resourceIds,
+    startedAtMs,
+    endsAtMs,
+    progress: clampProgress((input.currentTimeMs - startedAtMs) / travelTimeMs),
+  };
+}
+
+function buildPlannedTransferRoute(
+  entry: TransferAutomationRouteEntry,
+  resolveEntityHex: BuildTransferRouteOverlayRoutesInput["resolveEntityHex"],
+): TransferRouteOverlayRoute | null {
+  if (!entry.active) {
+    return null;
+  }
+
+  const sourceEntityId = parsePositiveInteger(entry.sourceEntityId);
+  const destinationEntityId = parsePositiveInteger(entry.destinationEntityId);
+  const resourceIds = resolveAutomationResourceIds(entry);
+  if (!sourceEntityId || !destinationEntityId || resourceIds.length === 0) {
+    return null;
+  }
+
+  const sourceHex = resolveEntityHex(sourceEntityId);
+  const destinationHex = resolveEntityHex(destinationEntityId);
+  if (!sourceHex || !destinationHex) {
+    return null;
+  }
+
+  return {
+    id: `planned:${entry.id}`,
+    kind: "planned",
+    sourceEntityId,
+    destinationEntityId,
+    sourceHex,
+    destinationHex,
+    resourceIds,
+  };
+}
+
+function shouldRetainLiveTransferRoute(
+  route: TransferRouteOverlayRoute,
+  currentTimeMs: number,
+  nextRoutesById: Map<string, TransferRouteOverlayRoute>,
+): boolean {
+  if (route.kind !== "live") {
+    return false;
+  }
+
+  if (nextRoutesById.has(route.id)) {
+    return false;
+  }
+
+  return route.endsAtMs !== undefined && currentTimeMs < route.endsAtMs;
+}
+
+function refreshRetainedLiveRoute(route: TransferRouteOverlayRoute, currentTimeMs: number): TransferRouteOverlayRoute {
+  if (route.startedAtMs === undefined || route.endsAtMs === undefined) {
+    return route;
+  }
+
+  const durationMs = route.endsAtMs - route.startedAtMs;
+  if (durationMs <= 0) {
+    return {
+      ...route,
+      progress: 1,
+    };
+  }
+
+  return {
+    ...route,
+    progress: clampProgress((currentTimeMs - route.startedAtMs) / durationMs),
+  };
+}
+
+function resolveAutomationResourceIds(entry: TransferAutomationRouteEntry): number[] {
+  const configuredIds = entry.resourceConfigs?.map((resource) => resource.resourceId) ?? entry.resourceIds;
+  return Array.from(new Set(configuredIds.filter((resourceId) => Number.isFinite(resourceId) && resourceId > 0)));
+}
+
+function parseMaybeJson(raw: unknown): unknown {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+    return raw;
+  }
+
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return raw;
+  }
+}
+
+function resolveTransferResourceCandidates(parsed: unknown): unknown[] {
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+
+  if (parsed && typeof parsed === "object") {
+    const candidate = parsed as { resource?: unknown; resourceId?: unknown };
+    return candidate.resourceId !== undefined || candidate.resource !== undefined
+      ? [parsed]
+      : Object.values(parsed as Record<string, unknown>);
+  }
+
+  return [];
+}
+
+function resolveResourceId(entry: unknown): number | null {
+  if (Array.isArray(entry)) {
+    return parsePositiveInteger(entry[0]);
+  }
+
+  if (!entry || typeof entry !== "object") {
+    return null;
+  }
+
+  const candidate = entry as { resource?: unknown; resourceId?: unknown };
+  return parsePositiveInteger(candidate.resourceId ?? candidate.resource);
+}
+
+function isMintTransfer(value: TransferRouteStoryEvent["resource_transfer_is_mint"]): boolean {
+  if (value === true || value === 1) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.toLowerCase() === "true" || value === "1";
+  }
+
+  return false;
+}
+
+function parsePositiveInteger(value: unknown): number | null {
+  const parsed = parseFiniteNumber(value);
+  if (parsed === null) {
+    return null;
+  }
+
+  const integer = Math.floor(parsed);
+  return integer > 0 ? integer : null;
+}
+
+function parseFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.startsWith("0x")) {
+    return Number(BigInt(trimmed));
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseEventTimestampMs(event: TransferRouteStoryEvent): number | null {
+  if (typeof event.timestampMs === "number" && Number.isFinite(event.timestampMs)) {
+    return event.timestampMs;
+  }
+
+  const timestampSeconds = parseFiniteNumber(event.timestamp);
+  return timestampSeconds === null ? null : timestampSeconds * 1000;
+}
+
+function parseDurationMs(value: unknown): number | null {
+  const seconds = parseFiniteNumber(value);
+  if (seconds === null || seconds <= 0) {
+    return null;
+  }
+
+  return seconds * 1000;
+}
+
+function clampProgress(progress: number): number {
+  if (!Number.isFinite(progress)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(progress, 1));
+}
+
+function resolveLiveRouteId(
+  event: TransferRouteStoryEvent,
+  sourceEntityId: number,
+  destinationEntityId: number,
+  startedAtMs: number,
+): string {
+  return event.event_id ?? event.id ?? event.tx_hash ?? `${sourceEntityId}-${destinationEntityId}-${startedAtMs}`;
+}
+
+function compareTransferRoutes(left: TransferRouteOverlayRoute, right: TransferRouteOverlayRoute): number {
+  if (left.kind !== right.kind) {
+    return left.kind === "live" ? -1 : 1;
+  }
+
+  if (left.kind === "live" && right.kind === "live") {
+    return (right.progress ?? 0) - (left.progress ?? 0);
+  }
+
+  return left.id.localeCompare(right.id);
+}

--- a/client/apps/game/src/three/managers/transfer-route-overlay-manager.test.ts
+++ b/client/apps/game/src/three/managers/transfer-route-overlay-manager.test.ts
@@ -1,0 +1,126 @@
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+
+import { TransferRouteOverlayManager } from "./transfer-route-overlay-manager";
+import type { TransferRouteOverlayRoute } from "@/lib/transfer-route-overlay";
+
+const createRoute = (overrides: Partial<TransferRouteOverlayRoute> = {}): TransferRouteOverlayRoute => ({
+  id: "live:1",
+  kind: "live",
+  sourceEntityId: 11,
+  destinationEntityId: 22,
+  sourceHex: { col: 1, row: 2 },
+  destinationHex: { col: 8, row: 5 },
+  resourceIds: [1],
+  startedAtMs: 100_000,
+  endsAtMs: 130_000,
+  progress: 0.4,
+  ...overrides,
+});
+
+describe("TransferRouteOverlayManager", () => {
+  it("owns a named scene group and renders one group per route", () => {
+    const scene = new THREE.Scene();
+    const manager = new TransferRouteOverlayManager(scene);
+
+    manager.setRoutes([createRoute(), createRoute({ id: "planned:2", kind: "planned", progress: undefined })]);
+
+    const group = scene.getObjectByName("TransferRouteOverlayGroup") as THREE.Group;
+    expect(group).toBeDefined();
+    expect(group.children).toHaveLength(2);
+    expect(manager.getRouteCount()).toBe(2);
+  });
+
+  it("animates route pulses and live progress markers", () => {
+    const scene = new THREE.Scene();
+    const manager = new TransferRouteOverlayManager(scene);
+
+    manager.setRoutes([createRoute()]);
+
+    const routeGroup = manager.getGroup().children[0] as THREE.Group;
+    const pulse = routeGroup.getObjectByName("transfer-route-pulse-0") as THREE.Mesh;
+    const marker = routeGroup.getObjectByName("transfer-route-progress-marker") as THREE.Mesh;
+    const initialPulsePosition = pulse.position.clone();
+    const initialMarkerPosition = marker.position.clone();
+    const initialMarkerScale = marker.scale.x;
+
+    manager.update(0.5);
+
+    expect(pulse.position.equals(initialPulsePosition)).toBe(false);
+    expect(marker.position.equals(initialMarkerPosition)).toBe(false);
+    expect(marker.scale.x).not.toBe(initialMarkerScale);
+  });
+
+  it("hides and skips animation work when disabled", () => {
+    const scene = new THREE.Scene();
+    const manager = new TransferRouteOverlayManager(scene);
+
+    manager.setRoutes([createRoute()]);
+    manager.setEnabled(false);
+
+    const pulse = manager.getGroup().children[0].getObjectByName("transfer-route-pulse-0") as THREE.Mesh;
+    const initialPulsePosition = pulse.position.clone();
+
+    manager.update(0.5);
+
+    expect(manager.getGroup().visible).toBe(false);
+    expect(pulse.position.equals(initialPulsePosition)).toBe(true);
+  });
+
+  it("updates route progress without recreating stable visuals", () => {
+    const scene = new THREE.Scene();
+    const manager = new TransferRouteOverlayManager(scene);
+
+    manager.setRoutes([createRoute({ progress: 0.2 })]);
+
+    const routeGroup = manager.getGroup().children[0] as THREE.Group;
+    const marker = routeGroup.getObjectByName("transfer-route-progress-marker") as THREE.Mesh;
+    const initialMarkerPosition = marker.position.clone();
+
+    manager.setRoutes([createRoute({ progress: 0.6 })]);
+
+    expect(manager.getGroup().children[0]).toBe(routeGroup);
+    expect(marker.position.equals(initialMarkerPosition)).toBe(false);
+  });
+
+  it("keeps concurrent routes on stable lanes when route ordering changes", () => {
+    const scene = new THREE.Scene();
+    const manager = new TransferRouteOverlayManager(scene);
+
+    const leadingRoute = createRoute({ id: "live:b", progress: 0.8 });
+    const trailingRoute = createRoute({ id: "live:a", progress: 0.3 });
+
+    manager.setRoutes([leadingRoute, trailingRoute]);
+
+    const initialGroups = Object.fromEntries(
+      manager.getGroup().children.map((child) => [(child as THREE.Group).userData.routeId, child]),
+    );
+
+    manager.setRoutes([
+      { ...trailingRoute, progress: 0.9 },
+      { ...leadingRoute, progress: 0.1 },
+    ]);
+
+    const nextGroups = Object.fromEntries(
+      manager.getGroup().children.map((child) => [(child as THREE.Group).userData.routeId, child]),
+    );
+
+    expect(nextGroups["live:a"]).toBe(initialGroups["live:a"]);
+    expect(nextGroups["live:b"]).toBe(initialGroups["live:b"]);
+  });
+
+  it("reconciles removed routes and disposes all visuals on destroy", () => {
+    const scene = new THREE.Scene();
+    const manager = new TransferRouteOverlayManager(scene);
+
+    manager.setRoutes([createRoute(), createRoute({ id: "planned:2", kind: "planned", progress: undefined })]);
+    manager.setRoutes([createRoute()]);
+
+    expect(manager.getRouteCount()).toBe(1);
+
+    manager.destroy();
+
+    expect(scene.getObjectByName("TransferRouteOverlayGroup")).toBeUndefined();
+    expect(manager.getRouteCount()).toBe(0);
+  });
+});

--- a/client/apps/game/src/three/managers/transfer-route-overlay-manager.ts
+++ b/client/apps/game/src/three/managers/transfer-route-overlay-manager.ts
@@ -1,0 +1,329 @@
+import type { TransferRouteOverlayRoute } from "@/lib/transfer-route-overlay";
+import * as THREE from "three";
+
+import { getWorldPositionForHex } from "../utils/utils";
+
+interface RouteVisual {
+  curve: THREE.QuadraticBezierCurve3;
+  group: THREE.Group;
+  kind: TransferRouteOverlayRoute["kind"];
+  marker?: THREE.Mesh;
+  progress?: number;
+  progressRatePerSecond?: number;
+  pulses: THREE.Mesh[];
+  signature: string;
+}
+
+const GROUP_NAME = "TransferRouteOverlayGroup";
+const ROUTE_BASE_Y = 1.05;
+const LIVE_PULSE_COUNT = 3;
+const PLANNED_PULSE_COUNT = 2;
+
+export class TransferRouteOverlayManager {
+  private readonly group: THREE.Group;
+  private readonly routeVisuals = new Map<string, RouteVisual>();
+  private enabled = true;
+  private elapsedSeconds = 0;
+
+  constructor(private readonly scene: THREE.Scene) {
+    this.group = new THREE.Group();
+    this.group.name = GROUP_NAME;
+    this.group.renderOrder = 42;
+    this.scene.add(this.group);
+  }
+
+  public getGroup(): THREE.Group {
+    return this.group;
+  }
+
+  public getRouteCount(): number {
+    return this.routeVisuals.size;
+  }
+
+  public setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+    this.group.visible = enabled;
+  }
+
+  public setRoutes(routes: TransferRouteOverlayRoute[]): void {
+    const nextRouteIds = new Set<string>();
+    const parallelRouteIndices = resolveParallelRouteIndices(routes);
+
+    routes.forEach((route) => {
+      const parallelIndex = parallelRouteIndices.get(route.id) ?? 0;
+      nextRouteIds.add(route.id);
+      this.upsertRouteVisual(route, parallelIndex);
+    });
+
+    this.removeStaleRouteVisuals(nextRouteIds);
+  }
+
+  public update(deltaTime: number): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    this.elapsedSeconds += deltaTime;
+    this.routeVisuals.forEach((visual) => this.updateRouteVisual(visual, deltaTime));
+  }
+
+  public destroy(): void {
+    this.clearRoutes();
+    this.group.parent?.remove(this.group);
+  }
+
+  private upsertRouteVisual(route: TransferRouteOverlayRoute, parallelIndex: number): void {
+    const signature = buildRouteVisualSignature(route, parallelIndex);
+    const existingVisual = this.routeVisuals.get(route.id);
+
+    if (existingVisual?.signature === signature) {
+      updateRouteVisualProgress(existingVisual, route);
+      return;
+    }
+
+    if (existingVisual) {
+      disposeRouteVisual(existingVisual);
+      this.routeVisuals.delete(route.id);
+    }
+
+    this.addRouteVisual(route, parallelIndex, signature);
+  }
+
+  private addRouteVisual(route: TransferRouteOverlayRoute, parallelIndex: number, signature: string): void {
+    const curve = buildRouteCurve(route, parallelIndex);
+    const group = new THREE.Group();
+    group.name = `transfer-route:${route.id}`;
+    group.userData.routeId = route.id;
+    group.renderOrder = 42;
+
+    const path = createRoutePath(curve, route.kind);
+    group.add(path);
+
+    const pulses = createRoutePulses(route.kind);
+    pulses.forEach((pulse) => group.add(pulse));
+
+    const marker =
+      route.kind === "live" && route.progress !== undefined
+        ? createLiveProgressMarker(route.kind, curve, route.progress)
+        : undefined;
+    if (marker) {
+      group.add(marker);
+    }
+
+    this.group.add(group);
+    this.routeVisuals.set(route.id, {
+      curve,
+      group,
+      kind: route.kind,
+      marker,
+      progress: route.progress,
+      progressRatePerSecond: resolveProgressRatePerSecond(route),
+      pulses,
+      signature,
+    });
+  }
+
+  private updateRouteVisual(visual: RouteVisual, deltaTime: number): void {
+    const speed = visual.kind === "live" ? 0.24 : 0.1;
+
+    visual.pulses.forEach((pulse, index) => {
+      const phase = index / Math.max(visual.pulses.length, 1);
+      const progress = (this.elapsedSeconds * speed + phase) % 1;
+      pulse.position.copy(visual.curve.getPointAt(progress));
+      const scale = visual.kind === "live" ? 0.85 + Math.sin((progress + phase) * Math.PI * 2) * 0.18 : 0.7;
+      pulse.scale.setScalar(scale);
+    });
+
+    if (visual.marker && visual.progress !== undefined) {
+      visual.progress = advanceRouteProgress(visual.progress, visual.progressRatePerSecond, deltaTime);
+      visual.marker.position.copy(visual.curve.getPointAt(visual.progress));
+      const markerScale = 1 + Math.sin(this.elapsedSeconds * Math.PI * 2.6) * 0.18;
+      visual.marker.scale.setScalar(markerScale);
+    }
+  }
+
+  private clearRoutes(): void {
+    this.routeVisuals.forEach((visual) => disposeRouteVisual(visual));
+    this.routeVisuals.clear();
+  }
+
+  private removeStaleRouteVisuals(nextRouteIds: Set<string>): void {
+    this.routeVisuals.forEach((visual, routeId) => {
+      if (nextRouteIds.has(routeId)) {
+        return;
+      }
+
+      disposeRouteVisual(visual);
+      this.routeVisuals.delete(routeId);
+    });
+  }
+}
+
+function resolveParallelRouteIndices(routes: TransferRouteOverlayRoute[]): Map<string, number> {
+  const routeIdsByPairKey = new Map<string, TransferRouteOverlayRoute[]>();
+  const parallelRouteIndices = new Map<string, number>();
+
+  routes.forEach((route) => {
+    const pairKey = buildParallelRoutePairKey(route);
+    const pairRoutes = routeIdsByPairKey.get(pairKey) ?? [];
+    pairRoutes.push(route);
+    routeIdsByPairKey.set(pairKey, pairRoutes);
+  });
+
+  routeIdsByPairKey.forEach((pairRoutes) => {
+    pairRoutes
+      .toSorted(compareParallelRouteStability)
+      .forEach((route, index) => parallelRouteIndices.set(route.id, index));
+  });
+
+  return parallelRouteIndices;
+}
+
+function buildParallelRoutePairKey(route: TransferRouteOverlayRoute): string {
+  return [route.sourceEntityId, route.destinationEntityId].toSorted((left, right) => left - right).join(":");
+}
+
+function compareParallelRouteStability(left: TransferRouteOverlayRoute, right: TransferRouteOverlayRoute): number {
+  return left.id.localeCompare(right.id);
+}
+
+function buildRouteCurve(route: TransferRouteOverlayRoute, parallelIndex: number): THREE.QuadraticBezierCurve3 {
+  const start = getWorldPositionForHex(route.sourceHex).clone();
+  const end = getWorldPositionForHex(route.destinationHex).clone();
+  start.y += ROUTE_BASE_Y;
+  end.y += ROUTE_BASE_Y;
+
+  const direction = new THREE.Vector3().subVectors(end, start);
+  const distance = Math.max(direction.length(), 1);
+  const midpoint = new THREE.Vector3().addVectors(start, end).multiplyScalar(0.5);
+  const lateralOffset = resolveParallelLateralOffset(start, end, parallelIndex);
+  const height = Math.max(2.8, Math.min(distance * 0.18, 18));
+
+  midpoint.add(lateralOffset);
+  midpoint.y += height;
+
+  return new THREE.QuadraticBezierCurve3(start, midpoint, end);
+}
+
+function buildRouteVisualSignature(route: TransferRouteOverlayRoute, parallelIndex: number): string {
+  return [
+    route.kind,
+    route.sourceHex.col,
+    route.sourceHex.row,
+    route.destinationHex.col,
+    route.destinationHex.row,
+    parallelIndex,
+  ].join(":");
+}
+
+function resolveParallelLateralOffset(start: THREE.Vector3, end: THREE.Vector3, parallelIndex: number): THREE.Vector3 {
+  if (parallelIndex === 0) {
+    return new THREE.Vector3();
+  }
+
+  const direction = new THREE.Vector3(end.x - start.x, 0, end.z - start.z).normalize();
+  const perpendicular = new THREE.Vector3(-direction.z, 0, direction.x);
+  const side = parallelIndex % 2 === 0 ? -1 : 1;
+  const lane = Math.ceil(parallelIndex / 2);
+  return perpendicular.multiplyScalar(side * lane * 0.9);
+}
+
+function createRoutePath(curve: THREE.QuadraticBezierCurve3, kind: TransferRouteOverlayRoute["kind"]): THREE.Mesh {
+  const geometry = new THREE.TubeGeometry(curve, 36, kind === "live" ? 0.055 : 0.035, 6, false);
+  const material = new THREE.MeshBasicMaterial({
+    blending: THREE.AdditiveBlending,
+    color: kind === "live" ? 0xffcf72 : 0x6bd9cf,
+    depthWrite: false,
+    opacity: kind === "live" ? 0.72 : 0.38,
+    transparent: true,
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.name = "transfer-route-arc";
+  mesh.frustumCulled = false;
+  mesh.renderOrder = 42;
+  return mesh;
+}
+
+function createRoutePulses(kind: TransferRouteOverlayRoute["kind"]): THREE.Mesh[] {
+  const pulseCount = kind === "live" ? LIVE_PULSE_COUNT : PLANNED_PULSE_COUNT;
+  return Array.from({ length: pulseCount }, (_, index) => {
+    const geometry = new THREE.SphereGeometry(kind === "live" ? 0.22 : 0.16, 12, 8);
+    const material = new THREE.MeshBasicMaterial({
+      blending: THREE.AdditiveBlending,
+      color: kind === "live" ? 0xfff0b8 : 0x9ff8ee,
+      depthWrite: false,
+      opacity: kind === "live" ? 0.92 : 0.56,
+      transparent: true,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.name = `transfer-route-pulse-${index}`;
+    mesh.frustumCulled = false;
+    mesh.renderOrder = 43;
+    return mesh;
+  });
+}
+
+function createLiveProgressMarker(
+  kind: TransferRouteOverlayRoute["kind"],
+  curve: THREE.QuadraticBezierCurve3,
+  progress: number,
+): THREE.Mesh {
+  const geometry = new THREE.SphereGeometry(0.32, 16, 10);
+  const material = new THREE.MeshBasicMaterial({
+    blending: THREE.AdditiveBlending,
+    color: kind === "live" ? 0xffffff : 0x9ff8ee,
+    depthWrite: false,
+    opacity: 0.96,
+    transparent: true,
+  });
+  const marker = new THREE.Mesh(geometry, material);
+  marker.name = "transfer-route-progress-marker";
+  marker.position.copy(curve.getPointAt(progress));
+  marker.frustumCulled = false;
+  marker.renderOrder = 44;
+  return marker;
+}
+
+function resolveProgressRatePerSecond(route: TransferRouteOverlayRoute): number | undefined {
+  if (route.startedAtMs === undefined || route.endsAtMs === undefined) {
+    return undefined;
+  }
+
+  const durationSeconds = (route.endsAtMs - route.startedAtMs) / 1000;
+  return durationSeconds > 0 ? 1 / durationSeconds : undefined;
+}
+
+function updateRouteVisualProgress(visual: RouteVisual, route: TransferRouteOverlayRoute): void {
+  visual.progress = route.progress;
+  visual.progressRatePerSecond = resolveProgressRatePerSecond(route);
+  if (visual.marker && route.progress !== undefined) {
+    visual.marker.position.copy(visual.curve.getPointAt(route.progress));
+  }
+}
+
+function advanceRouteProgress(progress: number, progressRatePerSecond: number | undefined, deltaTime: number): number {
+  if (progressRatePerSecond === undefined) {
+    return progress;
+  }
+
+  return Math.min(progress + progressRatePerSecond * deltaTime, 1);
+}
+
+function disposeRouteVisual(visual: RouteVisual): void {
+  visual.group.traverse((object) => {
+    if (object instanceof THREE.Mesh) {
+      object.geometry.dispose();
+      disposeMaterial(object.material);
+    }
+  });
+  visual.group.parent?.remove(visual.group);
+}
+
+function disposeMaterial(material: THREE.Material | THREE.Material[]): void {
+  if (Array.isArray(material)) {
+    material.forEach((entry) => entry.dispose());
+    return;
+  }
+
+  material.dispose();
+}

--- a/client/apps/game/src/three/scenes/worldmap-ownership-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/worldmap-ownership-lifecycle.ts
@@ -9,6 +9,7 @@ interface WorldmapOwnedManagers {
   chestManager?: Destroyable | null;
   fxManager?: Destroyable | null;
   resourceFXManager?: Destroyable | null;
+  transferRouteOverlayManager?: Destroyable | null;
 }
 
 export function destroyWorldmapOwnedManagers(managers: WorldmapOwnedManagers): void {
@@ -18,4 +19,5 @@ export function destroyWorldmapOwnedManagers(managers: WorldmapOwnedManagers): v
   managers.chestManager?.destroy();
   managers.fxManager?.destroy();
   managers.resourceFXManager?.destroy();
+  managers.transferRouteOverlayManager?.destroy();
 }

--- a/client/apps/game/src/three/scenes/worldmap-store-bridge.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-store-bridge.test.ts
@@ -19,6 +19,8 @@ const createWorldmapStoreState = (overrides: Partial<WorldmapStoreState> = {}): 
     selectableArmies: [],
     playerStructures: [],
     publicIncomingTroopArrivalsByStructure: {},
+    showTransferRoutes: true,
+    transferRouteOverlayRoutes: [],
     entityActions: {
       actionPaths: new Map(),
       hoveredHex: null,
@@ -63,6 +65,8 @@ describe("worldmap store bridge", () => {
       onSelectableArmiesChanged: vi.fn(),
       onPlayerStructuresChanged: vi.fn(),
       onIncomingTroopArrivalsChanged: vi.fn(),
+      onShowTransferRoutesChanged: vi.fn(),
+      onTransferRouteOverlayRoutesChanged: vi.fn(),
       onEntityActionsChanged: vi.fn(),
       onSelectedHexChanged: vi.fn(),
       onMapZoomPolicyChanged: vi.fn(),
@@ -73,19 +77,23 @@ describe("worldmap store bridge", () => {
       ...callbacks,
     });
 
-    expect(subscriptions).toHaveLength(6);
-    expect(listeners).toHaveLength(6);
+    expect(subscriptions).toHaveLength(8);
+    expect(listeners).toHaveLength(8);
 
     listeners[0].listener([{ entityId: 7 }] as never, [] as never);
     listeners[1].listener([{ entityId: 11 }] as never, [] as never);
     listeners[2].listener({ 99: [] } as never, {} as never);
-    listeners[3].listener({ selectedEntityId: 42 } as never, { selectedEntityId: null } as never);
-    listeners[4].listener({ col: 1, row: 2 } as never, null as never);
-    listeners[5].listener(true as never, false as never);
+    listeners[3].listener(false as never, true as never);
+    listeners[4].listener([{ id: "live:1" }] as never, [] as never);
+    listeners[5].listener({ selectedEntityId: 42 } as never, { selectedEntityId: null } as never);
+    listeners[6].listener({ col: 1, row: 2 } as never, null as never);
+    listeners[7].listener(true as never, false as never);
 
     expect(callbacks.onSelectableArmiesChanged).toHaveBeenCalledWith([{ entityId: 7 }], []);
     expect(callbacks.onPlayerStructuresChanged).toHaveBeenCalledWith([{ entityId: 11 }], []);
     expect(callbacks.onIncomingTroopArrivalsChanged).toHaveBeenCalledWith({ 99: [] }, {});
+    expect(callbacks.onShowTransferRoutesChanged).toHaveBeenCalledWith(false, true);
+    expect(callbacks.onTransferRouteOverlayRoutesChanged).toHaveBeenCalledWith([{ id: "live:1" }], []);
     expect(callbacks.onEntityActionsChanged).toHaveBeenCalledWith({ selectedEntityId: 42 }, { selectedEntityId: null });
     expect(callbacks.onSelectedHexChanged).toHaveBeenCalledWith({ col: 1, row: 2 }, null);
     expect(callbacks.onMapZoomPolicyChanged).toHaveBeenCalledTimes(1);
@@ -122,6 +130,8 @@ describe("worldmap store bridge", () => {
       onSelectableArmiesChanged,
       onPlayerStructuresChanged: vi.fn(),
       onIncomingTroopArrivalsChanged: vi.fn(),
+      onShowTransferRoutesChanged: vi.fn(),
+      onTransferRouteOverlayRoutesChanged: vi.fn(),
       onEntityActionStateSynced: vi.fn(),
       hasMissingActionPathOwnership: () => false,
       clearEntitySelection: vi.fn(),
@@ -156,6 +166,8 @@ describe("worldmap store bridge", () => {
       onSelectableArmiesChanged: vi.fn(),
       onPlayerStructuresChanged: vi.fn(),
       onIncomingTroopArrivalsChanged: vi.fn(),
+      onShowTransferRoutesChanged: vi.fn(),
+      onTransferRouteOverlayRoutesChanged: vi.fn(),
       onEntityActionStateSynced: vi.fn(),
       hasMissingActionPathOwnership: () => true,
       clearEntitySelection,
@@ -175,6 +187,8 @@ describe("worldmap store bridge", () => {
       selectableArmies: [{ entityId: 1 }] as never,
       playerStructures: [{ entityId: 2 }] as never,
       publicIncomingTroopArrivalsByStructure: { 3: [{ count: 4 }] } as never,
+      showTransferRoutes: true,
+      transferRouteOverlayRoutes: [{ id: "live:route" }] as never,
       entityActions: {
         actionPaths: new Map([["1,1", { action: "move" }]]),
         hoveredHex: { col: 1, row: 1 },
@@ -187,6 +201,8 @@ describe("worldmap store bridge", () => {
       onSelectableArmiesChanged: vi.fn(),
       onPlayerStructuresChanged: vi.fn(),
       onIncomingTroopArrivalsChanged: vi.fn(),
+      onShowTransferRoutesChanged: vi.fn(),
+      onTransferRouteOverlayRoutesChanged: vi.fn(),
       onEntityActionStateSynced: vi.fn(),
       clearEntitySelection: vi.fn(),
       onSelectedHexChanged: vi.fn(),
@@ -205,6 +221,8 @@ describe("worldmap store bridge", () => {
     expect(callbacks.onSelectableArmiesChanged).toHaveBeenCalledWith([{ entityId: 1 }]);
     expect(callbacks.onPlayerStructuresChanged).toHaveBeenCalledWith([{ entityId: 2 }]);
     expect(callbacks.onIncomingTroopArrivalsChanged).toHaveBeenCalledWith({ 3: [{ count: 4 }] });
+    expect(callbacks.onShowTransferRoutesChanged).toHaveBeenCalledWith(true);
+    expect(callbacks.onTransferRouteOverlayRoutesChanged).toHaveBeenCalledWith([{ id: "live:route" }]);
     expect(callbacks.onEntityActionStateSynced).toHaveBeenCalledWith(state.entityActions);
     expect(callbacks.onSelectedHexChanged).toHaveBeenCalledWith({ col: 5, row: 6 });
     expect(callbacks.onMapZoomPolicyChanged).toHaveBeenCalledTimes(1);

--- a/client/apps/game/src/three/scenes/worldmap-store-bridge.ts
+++ b/client/apps/game/src/three/scenes/worldmap-store-bridge.ts
@@ -19,6 +19,10 @@ interface RegisterWorldmapStoreBridgeInput {
   onIncomingTroopArrivalsChanged: (
     publicIncomingTroopArrivalsByStructure: WorldmapStoreState["publicIncomingTroopArrivalsByStructure"],
   ) => void;
+  onShowTransferRoutesChanged: (showTransferRoutes: WorldmapStoreState["showTransferRoutes"]) => void;
+  onTransferRouteOverlayRoutesChanged: (
+    transferRouteOverlayRoutes: WorldmapStoreState["transferRouteOverlayRoutes"],
+  ) => void;
   onEntityActionsChanged: (
     nextEntityActions: WorldmapStoreState["entityActions"],
     previousEntityActions: WorldmapStoreState["entityActions"] | undefined,
@@ -41,6 +45,10 @@ interface SyncWorldmapStoreBridgeStateInput {
   onIncomingTroopArrivalsChanged: (
     publicIncomingTroopArrivalsByStructure: WorldmapStoreState["publicIncomingTroopArrivalsByStructure"],
   ) => void;
+  onShowTransferRoutesChanged: (showTransferRoutes: WorldmapStoreState["showTransferRoutes"]) => void;
+  onTransferRouteOverlayRoutesChanged: (
+    transferRouteOverlayRoutes: WorldmapStoreState["transferRouteOverlayRoutes"],
+  ) => void;
   onEntityActionStateSynced: (entityActions: WorldmapStoreState["entityActions"]) => void;
   hasMissingActionPathOwnership: () => boolean;
   clearEntitySelection: () => void;
@@ -59,6 +67,8 @@ export function registerWorldmapStoreBridge({
   onSelectableArmiesChanged,
   onPlayerStructuresChanged,
   onIncomingTroopArrivalsChanged,
+  onShowTransferRoutesChanged,
+  onTransferRouteOverlayRoutesChanged,
   onEntityActionsChanged,
   onSelectedHexChanged,
   onMapZoomPolicyChanged,
@@ -67,6 +77,8 @@ export function registerWorldmapStoreBridge({
     store.subscribe((state) => state.selectableArmies, onSelectableArmiesChanged),
     store.subscribe((state) => state.playerStructures, onPlayerStructuresChanged),
     store.subscribe((state) => state.publicIncomingTroopArrivalsByStructure, onIncomingTroopArrivalsChanged),
+    store.subscribe((state) => state.showTransferRoutes, onShowTransferRoutesChanged),
+    store.subscribe((state) => state.transferRouteOverlayRoutes, onTransferRouteOverlayRoutesChanged),
     store.subscribe((state) => state.entityActions, onEntityActionsChanged),
     store.subscribe((state) => state.selectedHex, onSelectedHexChanged),
     store.subscribe(
@@ -95,6 +107,8 @@ export function syncWorldmapStoreBridgeState({
   onSelectableArmiesChanged,
   onPlayerStructuresChanged,
   onIncomingTroopArrivalsChanged,
+  onShowTransferRoutesChanged,
+  onTransferRouteOverlayRoutesChanged,
   onEntityActionStateSynced,
   hasMissingActionPathOwnership,
   clearEntitySelection,
@@ -112,6 +126,8 @@ export function syncWorldmapStoreBridgeState({
   onSelectableArmiesChanged(uiState.selectableArmies);
   onPlayerStructuresChanged(uiState.playerStructures);
   onIncomingTroopArrivalsChanged(uiState.publicIncomingTroopArrivalsByStructure);
+  onShowTransferRoutesChanged(uiState.showTransferRoutes);
+  onTransferRouteOverlayRoutesChanged(uiState.transferRouteOverlayRoutes);
   onEntityActionStateSynced(uiState.entityActions);
 
   if (hasMissingActionPathOwnership()) {

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -114,6 +114,7 @@ import { FXManager } from "../managers/fx-manager";
 import { HoverLabelManager } from "../managers/hover-label-manager";
 import { ResourceFXManager } from "../managers/resource-fx-manager";
 import { ArrivalGhostManager } from "../managers/arrival-ghost-manager";
+import { TransferRouteOverlayManager } from "../managers/transfer-route-overlay-manager";
 import { resolveHoverVisualPalette, resolveSelectionPulsePalette } from "../managers/worldmap-interaction-palette";
 import { SceneName, type ArmyData } from "../types/common";
 import { getWorldPositionForHex, isAddressEqualToAccount } from "../utils";
@@ -955,6 +956,7 @@ export default class WorldmapScene extends WarpTravel {
   private fxManager!: FXManager;
   private arrivalGhostManager!: ArrivalGhostManager;
   private resourceFXManager!: ResourceFXManager;
+  private transferRouteOverlayManager!: TransferRouteOverlayManager;
   private armyIndex: number = 0;
   private selectableArmies: SelectableArmy[] = [];
   private structureIndex: number = 0;
@@ -1064,6 +1066,7 @@ export default class WorldmapScene extends WarpTravel {
   private initializeWorldmapSceneServices(dojoContext: SetupResult): void {
     this.fxManager = new FXManager(this.scene, 1);
     this.resourceFXManager = new ResourceFXManager(this.scene, 1.2);
+    this.transferRouteOverlayManager = new TransferRouteOverlayManager(this.scene);
 
     if (MEMORY_MONITORING_ENABLED) {
       this.memoryMonitor = new MemoryMonitor({
@@ -8038,6 +8041,7 @@ export default class WorldmapScene extends WarpTravel {
     this.arrivalGhostManager.update(deltaTime);
     this.fxManager.update(deltaTime);
     this.resourceFXManager.update(deltaTime);
+    this.transferRouteOverlayManager.update(deltaTime);
     this.selectionPulseManager.update(deltaTime);
     this.selectedHexManager.update(deltaTime);
     this.structureManager.updateAnimations(deltaTime, animationContext);
@@ -8576,6 +8580,7 @@ export default class WorldmapScene extends WarpTravel {
       chestManager: this.chestManager,
       fxManager: this.fxManager,
       resourceFXManager: this.resourceFXManager,
+      transferRouteOverlayManager: this.transferRouteOverlayManager,
     });
     this.updateCameraTargetHexThrottled?.cancel();
     this.minimapCameraMoveThrottled?.cancel();
@@ -8892,6 +8897,12 @@ export default class WorldmapScene extends WarpTravel {
       onIncomingTroopArrivalsChanged: (publicIncomingTroopArrivalsByStructure) => {
         this.structureManager.setIncomingTroopArrivalsByStructure(publicIncomingTroopArrivalsByStructure);
       },
+      onShowTransferRoutesChanged: (showTransferRoutes) => {
+        this.transferRouteOverlayManager.setEnabled(showTransferRoutes);
+      },
+      onTransferRouteOverlayRoutesChanged: (transferRouteOverlayRoutes) => {
+        this.transferRouteOverlayManager.setRoutes(transferRouteOverlayRoutes);
+      },
       onEntityActionsChanged: (nextEntityActions, previousEntityActions) =>
         this.handleEntityActionsStoreUpdate(nextEntityActions, previousEntityActions),
       onSelectedHexChanged: (selectedHex) => {
@@ -8974,6 +8985,12 @@ export default class WorldmapScene extends WarpTravel {
       onPlayerStructuresChanged: (playerStructures) => this.updatePlayerStructures(playerStructures),
       onIncomingTroopArrivalsChanged: (publicIncomingTroopArrivalsByStructure) => {
         this.structureManager.setIncomingTroopArrivalsByStructure(publicIncomingTroopArrivalsByStructure);
+      },
+      onShowTransferRoutesChanged: (showTransferRoutes) => {
+        this.transferRouteOverlayManager.setEnabled(showTransferRoutes);
+      },
+      onTransferRouteOverlayRoutesChanged: (transferRouteOverlayRoutes) => {
+        this.transferRouteOverlayManager.setRoutes(transferRouteOverlayRoutes);
       },
       onEntityActionStateSynced: () => this.syncEntityActionPathsTransitionToken(),
       hasMissingActionPathOwnership: () => this.isMissingActionPathOwnershipState(),

--- a/client/apps/game/src/ui/debug/mock-transfer-routes-overlay.test.ts
+++ b/client/apps/game/src/ui/debug/mock-transfer-routes-overlay.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { isMockTransferRoutesEnabled } from "./mock-transfer-routes-overlay";
+
+describe("isMockTransferRoutesEnabled", () => {
+  it("defaults to disabled", () => {
+    expect(isMockTransferRoutesEnabled("")).toBe(false);
+    expect(isMockTransferRoutesEnabled("?foo=bar")).toBe(false);
+  });
+
+  it("enables mock mode for explicit mock values", () => {
+    expect(isMockTransferRoutesEnabled("?debugTransferRoutes=mock")).toBe(true);
+    expect(isMockTransferRoutesEnabled("?debugTransferRoutes=1")).toBe(true);
+  });
+
+  it("disables mock mode for falsey values", () => {
+    expect(isMockTransferRoutesEnabled("?debugTransferRoutes=0")).toBe(false);
+    expect(isMockTransferRoutesEnabled("?debugTransferRoutes=false")).toBe(false);
+  });
+});

--- a/client/apps/game/src/ui/debug/mock-transfer-routes-overlay.tsx
+++ b/client/apps/game/src/ui/debug/mock-transfer-routes-overlay.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from "react";
+
+import { useUIStore } from "@/hooks/store/use-ui-store";
+
+const QUERY_PARAM = "debugTransferRoutes";
+
+export function isMockTransferRoutesEnabled(search: string = window.location.search): boolean {
+  const params = new URLSearchParams(search);
+  const value = params.get(QUERY_PARAM);
+  if (value === null) {
+    return false;
+  }
+  return value.toLowerCase() === "mock" || (value !== "0" && value.toLowerCase() !== "false");
+}
+
+export function MockTransferRoutesOverlay(): JSX.Element | null {
+  const enabled = useMemo(() => isMockTransferRoutesEnabled(), []);
+  const routeCount = useUIStore((state) => state.transferRouteOverlayRoutes.length);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed right-4 top-16 z-[9999] rounded-md border border-cyan-300/50 bg-slate-950/85 px-3 py-2 font-mono text-xs text-cyan-50 shadow-xl"
+      data-testid="mock-transfer-routes-overlay"
+    >
+      <div className="font-semibold text-cyan-300">Mock Transfer Routes</div>
+      <div className="mt-1 text-cyan-50/80">mode: query param</div>
+      <div className="text-cyan-50/80">routes: {routeCount}</div>
+      <div className="text-cyan-50/60">?debugTransferRoutes=mock</div>
+    </div>
+  );
+}

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
@@ -47,6 +47,7 @@ import Info from "lucide-react/dist/esm/icons/info";
 import Loader from "lucide-react/dist/esm/icons/loader";
 import MapIcon from "lucide-react/dist/esm/icons/map";
 import RefreshCw from "lucide-react/dist/esm/icons/refresh-cw";
+import RouteIcon from "lucide-react/dist/esm/icons/route";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
 import { toast } from "sonner";
 
@@ -182,6 +183,28 @@ const PanelTabs = ({
     })}
   </div>
 );
+
+const TransferRouteToggleButton = () => {
+  const showTransferRoutes = useUIStore((state) => state.showTransferRoutes);
+  const setShowTransferRoutes = useUIStore((state) => state.setShowTransferRoutes);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setShowTransferRoutes(!showTransferRoutes)}
+      aria-pressed={showTransferRoutes}
+      className={cn(
+        "pointer-events-auto flex h-11 w-11 items-center justify-center rounded-md border transition",
+        showTransferRoutes
+          ? "border-gold/80 bg-black/80 text-gold shadow-[0_6px_18px_rgba(255,209,128,0.25)] ring-1 ring-gold/40"
+          : "border-gold/30 bg-black/70 text-gold/70 hover:border-gold/60 hover:text-gold",
+      )}
+      title="Show Trade Routes"
+    >
+      <RouteIcon className="h-4 w-4" />
+    </button>
+  );
+};
 
 const MapTilePanel = () => {
   const selectedHex = useUIStore((state) => state.selectedHex);
@@ -1014,6 +1037,11 @@ export const BottomRightPanel = memo(() => {
           onSelect={handleTabToggle}
           className="absolute right-2 bottom-full pb-2"
         />
+        {isMapView ? (
+          <div className="absolute right-[104px] bottom-full pb-2">
+            <TransferRouteToggleButton />
+          </div>
+        ) : null}
         <div className="pointer-events-auto">
           <div className={cn(activeTab === "tile" && isPanelOpen ? "block" : "hidden")}>
             {isMapView ? <MapTilePanel /> : <LocalTilePanel />}

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-06",
+    title: "Trade Route Overlay",
+    description:
+      "Added pulsing map arcs for live transfers and planned automation routes, with a quick toggle so active trade movement is visible across the world.",
+    type: "feature",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-05-06",
     title: "Map Sync Recovery",
     description:
       "Improved map stream recovery so delayed spatial updates enter a reconnecting state, retry cleanly, and surface network trouble when the map cannot restore live updates.",

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -25,6 +25,7 @@ import { dojoConfig } from "../../../dojo-config";
 import { env } from "../../../env";
 import { useUIStore } from "../../hooks/store/use-ui-store";
 import { ArmyMovementLatencyOverlay } from "../debug/army-movement-latency-overlay";
+import { MockTransferRoutesOverlay } from "../debug/mock-transfer-routes-overlay";
 import { Tooltip } from "../design-system/molecules/tooltip";
 import { NetworkStatusBanner } from "../features/world/components/network-status-banner";
 import { triggerConnectionForceReconnect } from "../features/world/components/network-status-retry";
@@ -75,6 +76,7 @@ export const World = ({ backgroundImage }: { backgroundImage: string }) => {
         <Tooltip />
         <VersionDisplay />
         <ArmyMovementLatencyOverlay />
+        <MockTransferRoutesOverlay />
         <div id="labelrenderer" className="absolute top-0 pointer-events-none z-10" />
       </div>
     </>

--- a/client/apps/game/src/ui/modules/settings/settings.tsx
+++ b/client/apps/game/src/ui/modules/settings/settings.tsx
@@ -82,6 +82,8 @@ export const SettingsWindow = () => {
   const { trackName, next: nextTrack } = useMusicPlayer();
   const enableMapZoom = useUIStore((state) => state.enableMapZoom);
   const setEnableMapZoom = useUIStore((state) => state.setEnableMapZoom);
+  const showTransferRoutes = useUIStore((state) => state.showTransferRoutes);
+  const setShowTransferRoutes = useUIStore((state) => state.setShowTransferRoutes);
 
   const playToggleOn = useUISound("ui.toggle_on");
   const playToggleOff = useUISound("ui.toggle_off");
@@ -322,6 +324,20 @@ export const SettingsWindow = () => {
             >
               <Checkbox enabled={enableMapZoom} />
               <div>Enable Map Zoom</div>
+            </div>
+            <div
+              className="flex items-center space-x-2 text-xs cursor-pointer text-gray-gold"
+              onClick={() => {
+                if (showTransferRoutes) {
+                  playToggleOff();
+                } else {
+                  playToggleOn();
+                }
+                setShowTransferRoutes(!showTransferRoutes);
+              }}
+            >
+              <Checkbox enabled={showTransferRoutes} />
+              <div>Show Trade Routes</div>
             </div>
           </section>
 

--- a/client/apps/game/src/ui/store-managers.transfer-route-overlay.source.test.ts
+++ b/client/apps/game/src/ui/store-managers.transfer-route-overlay.source.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("StoreManagers transfer route overlay source", () => {
+  it("uses the active transfers hook instead of the generic story events feed", () => {
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const source = readFileSync(resolve(currentDir, "./store-managers.tsx"), "utf8");
+
+    expect(source).toContain('import { useActiveTransfers } from "@/hooks/use-active-transfers";');
+    expect(source).toContain("const { data: activeTransfers = [] } = useActiveTransfers(");
+    expect(source).not.toContain("const { data: storyEvents = [] } = useStoryEvents(350);");
+  });
+});

--- a/client/apps/game/src/ui/store-managers.transfer-route-overlay.source.test.ts
+++ b/client/apps/game/src/ui/store-managers.transfer-route-overlay.source.test.ts
@@ -9,7 +9,10 @@ describe("StoreManagers transfer route overlay source", () => {
     const source = readFileSync(resolve(currentDir, "./store-managers.tsx"), "utf8");
 
     expect(source).toContain('import { useActiveTransfers } from "@/hooks/use-active-transfers";');
+    expect(source).toContain('import { buildMockActiveTransfers } from "@/lib/transfer-route-overlay-mock";');
+    expect(source).toContain('import { isMockTransferRoutesEnabled } from "@/ui/debug/mock-transfer-routes-overlay";');
     expect(source).toContain("const { data: activeTransfers = [] } = useActiveTransfers(");
+    expect(source).toContain("const liveTransfers = isMockTransferRoutesEnabled()");
     expect(source).not.toContain("const { data: storyEvents = [] } = useStoryEvents(350);");
   });
 });

--- a/client/apps/game/src/ui/store-managers.tsx
+++ b/client/apps/game/src/ui/store-managers.tsx
@@ -1,15 +1,11 @@
 import { POLLING_INTERVALS } from "@/config/polling";
 import { usePlayerStructureSync } from "@/hooks/helpers/use-player-structure-sync";
+import { useActiveTransfers } from "@/hooks/use-active-transfers";
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
 import { usePlayerStore } from "@/hooks/store/use-player-store";
-import { useStoryEvents } from "@/hooks/store/use-story-events-store";
 import { useTransferAutomationStore } from "@/hooks/store/use-transfer-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
-import {
-  buildTransferRouteOverlayRoutes,
-  mergeRetainedTransferRouteOverlayRoutes,
-  type TransferRouteOverlayRoute,
-} from "@/lib/transfer-route-overlay";
+import { buildTransferRouteOverlayRoutesFromActiveTransfers } from "@/lib/transfer-route-overlay";
 import { sqlApi } from "@/services/api";
 import { RESOURCE_ARRIVAL_AUTO_CLAIM_RETRY_DELAY_SECONDS, RESOURCE_ARRIVAL_READY_BUFFER_SECONDS } from "@/ui/constants";
 import { resolveFiniteSeasonEndAt, resolveSeasonStartTimestamp } from "@/ui/features/world/utils/season-timing";
@@ -282,10 +278,9 @@ const TransferRouteOverlayStoreManager = () => {
   const chainNowMs = useChainTimeStore((state) => state.nowMs);
   const setTransferRouteOverlayRoutes = useUIStore((state) => state.setTransferRouteOverlayRoutes);
   const transferAutomationEntriesById = useTransferAutomationStore((state) => state.entries);
-  const { data: storyEvents = [] } = useStoryEvents(350);
+  const { data: activeTransfers = [] } = useActiveTransfers(500, 1800);
   const mapDataStore = useMemo(() => MapDataStore.getInstance(MAP_DATA_REFRESH_INTERVAL, sqlApi), []);
   const [mapDataVersion, setMapDataVersion] = useState(0);
-  const previousRoutesRef = useRef<TransferRouteOverlayRoute[]>([]);
 
   const transferAutomationEntries = useMemo(
     () => Object.values(transferAutomationEntriesById),
@@ -310,28 +305,21 @@ const TransferRouteOverlayStoreManager = () => {
 
   useEffect(() => {
     const currentTimeMs = chainNowMs > 0 ? chainNowMs : Date.now();
-    const nextRoutes = buildTransferRouteOverlayRoutes({
+    const routes = buildTransferRouteOverlayRoutesFromActiveTransfers({
       currentTimeMs,
-      liveEvents: storyEvents,
+      liveTransfers: activeTransfers,
       automationEntries: transferAutomationEntries,
       resolveEntityHex: (entityId) => resolveTransferRouteEntityHex(mapDataStore, entityId),
     });
-    const routes = mergeRetainedTransferRouteOverlayRoutes({
-      currentTimeMs,
-      nextRoutes,
-      previousRoutes: previousRoutesRef.current,
-    });
-
-    previousRoutesRef.current = routes;
     setTransferRouteOverlayRoutes(routes);
-  }, [chainNowMs, mapDataStore, mapDataVersion, setTransferRouteOverlayRoutes, storyEvents, transferAutomationEntries]);
-
-  useEffect(
-    () => () => {
-      previousRoutesRef.current = [];
-    },
-    [],
-  );
+  }, [
+    activeTransfers,
+    chainNowMs,
+    mapDataStore,
+    mapDataVersion,
+    setTransferRouteOverlayRoutes,
+    transferAutomationEntries,
+  ]);
 
   return null;
 };

--- a/client/apps/game/src/ui/store-managers.tsx
+++ b/client/apps/game/src/ui/store-managers.tsx
@@ -5,8 +5,10 @@ import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
 import { usePlayerStore } from "@/hooks/store/use-player-store";
 import { useTransferAutomationStore } from "@/hooks/store/use-transfer-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import { buildMockActiveTransfers } from "@/lib/transfer-route-overlay-mock";
 import { buildTransferRouteOverlayRoutesFromActiveTransfers } from "@/lib/transfer-route-overlay";
 import { sqlApi } from "@/services/api";
+import { isMockTransferRoutesEnabled } from "@/ui/debug/mock-transfer-routes-overlay";
 import { RESOURCE_ARRIVAL_AUTO_CLAIM_RETRY_DELAY_SECONDS, RESOURCE_ARRIVAL_READY_BUFFER_SECONDS } from "@/ui/constants";
 import { resolveFiniteSeasonEndAt, resolveSeasonStartTimestamp } from "@/ui/features/world/utils/season-timing";
 import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
@@ -305,9 +307,12 @@ const TransferRouteOverlayStoreManager = () => {
 
   useEffect(() => {
     const currentTimeMs = chainNowMs > 0 ? chainNowMs : Date.now();
+    const liveTransfers = isMockTransferRoutesEnabled()
+      ? buildMockActiveTransfers(mapDataStore.getAllStructures(), currentTimeMs)
+      : activeTransfers;
     const routes = buildTransferRouteOverlayRoutesFromActiveTransfers({
       currentTimeMs,
-      liveTransfers: activeTransfers,
+      liveTransfers,
       automationEntries: transferAutomationEntries,
       resolveEntityHex: (entityId) => resolveTransferRouteEntityHex(mapDataStore, entityId),
     });

--- a/client/apps/game/src/ui/store-managers.tsx
+++ b/client/apps/game/src/ui/store-managers.tsx
@@ -2,7 +2,14 @@ import { POLLING_INTERVALS } from "@/config/polling";
 import { usePlayerStructureSync } from "@/hooks/helpers/use-player-structure-sync";
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
 import { usePlayerStore } from "@/hooks/store/use-player-store";
+import { useStoryEvents } from "@/hooks/store/use-story-events-store";
+import { useTransferAutomationStore } from "@/hooks/store/use-transfer-automation-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import {
+  buildTransferRouteOverlayRoutes,
+  mergeRetainedTransferRouteOverlayRoutes,
+  type TransferRouteOverlayRoute,
+} from "@/lib/transfer-route-overlay";
 import { sqlApi } from "@/services/api";
 import { RESOURCE_ARRIVAL_AUTO_CLAIM_RETRY_DELAY_SECONDS, RESOURCE_ARRIVAL_READY_BUFFER_SECONDS } from "@/ui/constants";
 import { resolveFiniteSeasonEndAt, resolveSeasonStartTimestamp } from "@/ui/features/world/utils/season-timing";
@@ -16,6 +23,9 @@ import {
   getEntityIdFromKeys,
   getGuildFromPlayerAddress,
   LeaderboardManager,
+  MAP_DATA_REFRESH_INTERVAL,
+  MapDataStore,
+  Position,
   ResourceArrivalManager,
   SelectableArmy,
   summarizeIncomingTroopArrivals,
@@ -264,6 +274,80 @@ const PublicTroopArrivalsStoreManager = () => {
 
     setPublicIncomingTroopArrivalsByStructure(summarizeIncomingTroopArrivals(formatArrivals(rawArrivals), nowSeconds));
   }, [chainNowMs, components.ResourceArrival, resourceArrivals, setPublicIncomingTroopArrivalsByStructure]);
+
+  return null;
+};
+
+const TransferRouteOverlayStoreManager = () => {
+  const chainNowMs = useChainTimeStore((state) => state.nowMs);
+  const setTransferRouteOverlayRoutes = useUIStore((state) => state.setTransferRouteOverlayRoutes);
+  const transferAutomationEntriesById = useTransferAutomationStore((state) => state.entries);
+  const { data: storyEvents = [] } = useStoryEvents(350);
+  const mapDataStore = useMemo(() => MapDataStore.getInstance(MAP_DATA_REFRESH_INTERVAL, sqlApi), []);
+  const [mapDataVersion, setMapDataVersion] = useState(0);
+  const previousRoutesRef = useRef<TransferRouteOverlayRoute[]>([]);
+
+  const transferAutomationEntries = useMemo(
+    () => Object.values(transferAutomationEntriesById),
+    [transferAutomationEntriesById],
+  );
+
+  useEffect(() => {
+    const handleRefresh = () => setMapDataVersion((version) => version + 1);
+    mapDataStore.onRefresh(handleRefresh);
+    return () => mapDataStore.offRefresh(handleRefresh);
+  }, [mapDataStore]);
+
+  useEffect(() => {
+    if (mapDataStore.getStructureCount() > 0 || mapDataStore.getArmyCount() > 0) {
+      return;
+    }
+
+    void mapDataStore.refresh().catch((error) => {
+      console.error("[TransferRouteOverlay] Failed to hydrate map data", error);
+    });
+  }, [mapDataStore]);
+
+  useEffect(() => {
+    const currentTimeMs = chainNowMs > 0 ? chainNowMs : Date.now();
+    const nextRoutes = buildTransferRouteOverlayRoutes({
+      currentTimeMs,
+      liveEvents: storyEvents,
+      automationEntries: transferAutomationEntries,
+      resolveEntityHex: (entityId) => resolveTransferRouteEntityHex(mapDataStore, entityId),
+    });
+    const routes = mergeRetainedTransferRouteOverlayRoutes({
+      currentTimeMs,
+      nextRoutes,
+      previousRoutes: previousRoutesRef.current,
+    });
+
+    previousRoutesRef.current = routes;
+    setTransferRouteOverlayRoutes(routes);
+  }, [chainNowMs, mapDataStore, mapDataVersion, setTransferRouteOverlayRoutes, storyEvents, transferAutomationEntries]);
+
+  useEffect(
+    () => () => {
+      previousRoutesRef.current = [];
+    },
+    [],
+  );
+
+  return null;
+};
+
+const resolveTransferRouteEntityHex = (mapDataStore: MapDataStore, entityId: number) => {
+  const structure = mapDataStore.getStructureById(entityId);
+  if (structure) {
+    const normalized = new Position({ x: structure.coordX, y: structure.coordY }).getNormalized();
+    return { col: Number(normalized.x), row: Number(normalized.y) };
+  }
+
+  const army = mapDataStore.getArmyById(entityId);
+  if (army) {
+    const normalized = new Position({ x: army.coordX, y: army.coordY }).getNormalized();
+    return { col: Number(normalized.x), row: Number(normalized.y) };
+  }
 
   return null;
 };
@@ -640,6 +724,7 @@ export const StoreManagers = () => {
     <>
       <ResourceArrivalsStoreManager />
       <PublicTroopArrivalsStoreManager />
+      <TransferRouteOverlayStoreManager />
       <RelicsStoreManager />
       <AutoRegisterPointsStoreManager />
       <PlayerStructuresStoreManager />

--- a/client/apps/realtime-server/src/http/routes/__tests__/cache.test.ts
+++ b/client/apps/realtime-server/src/http/routes/__tests__/cache.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+import cacheRoutes from "../cache";
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("cache routes", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("1970-01-01T00:00:30.000Z"));
+    app = new Hono();
+    app.route("/api/cache", cacheRoutes);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("GET /active-transfers returns normalized active transfers and caches by request shape", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse([
+        {
+          id: "row-1",
+          event_id: "event-1",
+          tx_hash: "0xabc",
+          timestamp: "0x10",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 22,
+          resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+          resource_transfer_travel_time: 30,
+          resource_transfer_is_mint: 0,
+        },
+        {
+          id: "row-2",
+          event_id: "event-2",
+          tx_hash: "0xdef",
+          timestamp: "0x5",
+          resource_transfer_from_entity_id: 11,
+          resource_transfer_to_entity_id: 22,
+          resource_transfer_resources: '[{"resourceId":2,"amount":10}]',
+          resource_transfer_travel_time: 10,
+          resource_transfer_is_mint: 0,
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const url = "/api/cache/active-transfers?toriiSqlBaseUrl=https://torii.example/sql&lookbackSeconds=1800&limit=500";
+    const first = await app.request(url);
+    const second = await app.request(url);
+
+    expect(first.status).toBe(200);
+    expect(first.headers.get("x-cache")).toBe("miss");
+    expect(second.headers.get("x-cache")).toBe("hit");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const body = await first.json();
+    expect(body).toEqual([
+      {
+        id: "live:event-1",
+        eventId: "event-1",
+        txHash: "0xabc",
+        sourceEntityId: 11,
+        destinationEntityId: 22,
+        resourceIds: [1],
+        startedAtMs: 16_000,
+        endsAtMs: 46_000,
+        progress: 14 / 30,
+      },
+    ]);
+  });
+
+  it("GET /active-transfers respects limit=0 without querying Torii", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await app.request("/api/cache/active-transfers?toriiSqlBaseUrl=https://torii.example/sql&limit=0");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-cache")).toBe("hit");
+    expect(await response.json()).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/client/apps/realtime-server/src/http/routes/cache.ts
+++ b/client/apps/realtime-server/src/http/routes/cache.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "../middleware/auth";
 import { createCachedJsonResponse, createJsonPayload, type CachedJsonPayload } from "./cache-response";
 import {
   ALL_TILES_QUERY,
+  buildActiveTransfersQuery,
   buildLeaderboardQuery,
   buildStoryEventsQuery,
   HYPERSTRUCTURE_LEADERBOARD_CONFIG_QUERY,
@@ -33,6 +34,30 @@ type LeaderboardCachePayload = {
   hyperstructureConfigRow?: unknown;
 };
 
+type ActiveTransferCacheRow = {
+  id?: string | null;
+  event_id?: string | null;
+  tx_hash?: string | null;
+  timestamp?: string | number | bigint | null;
+  resource_transfer_from_entity_id?: string | number | bigint | null;
+  resource_transfer_to_entity_id?: string | number | bigint | null;
+  resource_transfer_resources?: unknown;
+  resource_transfer_is_mint?: boolean | string | number | null;
+  resource_transfer_travel_time?: string | number | bigint | null;
+};
+
+type ActiveTransferCachePayload = {
+  id: string;
+  eventId?: string;
+  txHash?: string;
+  sourceEntityId: number;
+  destinationEntityId: number;
+  resourceIds: number[];
+  startedAtMs: number;
+  endsAtMs: number;
+  progress: number;
+};
+
 const DEFAULT_LEADERBOARD_TTL_MS = 60_000;
 const DEFAULT_LEADERBOARD_STALE_MS = 5 * 60_000;
 const DEFAULT_LEADERBOARD_MAX_ENTRIES = 5;
@@ -44,6 +69,14 @@ const DEFAULT_STORY_EVENTS_STALE_MS = 2 * 60_000;
 const DEFAULT_STORY_EVENTS_MAX_ENTRIES = 25;
 const DEFAULT_STORY_EVENTS_LIMIT = 50;
 const DEFAULT_STORY_EVENTS_LIMIT_MAX = 2_000;
+
+const DEFAULT_ACTIVE_TRANSFERS_TTL_MS = 5_000;
+const DEFAULT_ACTIVE_TRANSFERS_STALE_MS = 30_000;
+const DEFAULT_ACTIVE_TRANSFERS_MAX_ENTRIES = 25;
+const DEFAULT_ACTIVE_TRANSFERS_LIMIT = 500;
+const DEFAULT_ACTIVE_TRANSFERS_LIMIT_MAX = 5_000;
+const DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS = 1_800;
+const DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS_MAX = 86_400;
 
 const DEFAULT_TILES_TTL_MS = 5_000;
 const DEFAULT_TILES_STALE_MS = 30_000;
@@ -114,6 +147,38 @@ const storyEventsLimitDefault = parseEnvInt(
 );
 const storyEventsLimitMax = parseEnvInt(process.env.STORY_EVENTS_CACHE_LIMIT_MAX, DEFAULT_STORY_EVENTS_LIMIT_MAX, 1);
 
+const activeTransfersTtlMs = parseEnvNumber(process.env.ACTIVE_TRANSFERS_CACHE_TTL_MS, DEFAULT_ACTIVE_TRANSFERS_TTL_MS);
+const activeTransfersStaleMs = parseEnvNumber(
+  process.env.ACTIVE_TRANSFERS_CACHE_STALE_MS,
+  DEFAULT_ACTIVE_TRANSFERS_STALE_MS,
+  activeTransfersTtlMs,
+);
+const activeTransfersMaxEntries = parseEnvInt(
+  process.env.ACTIVE_TRANSFERS_CACHE_MAX_ENTRIES,
+  DEFAULT_ACTIVE_TRANSFERS_MAX_ENTRIES,
+  1,
+);
+const activeTransfersLimitDefault = parseEnvInt(
+  process.env.ACTIVE_TRANSFERS_CACHE_LIMIT_DEFAULT,
+  DEFAULT_ACTIVE_TRANSFERS_LIMIT,
+  1,
+);
+const activeTransfersLimitMax = parseEnvInt(
+  process.env.ACTIVE_TRANSFERS_CACHE_LIMIT_MAX,
+  DEFAULT_ACTIVE_TRANSFERS_LIMIT_MAX,
+  1,
+);
+const activeTransfersLookbackSecondsDefault = parseEnvInt(
+  process.env.ACTIVE_TRANSFERS_CACHE_LOOKBACK_SECONDS_DEFAULT,
+  DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS,
+  1,
+);
+const activeTransfersLookbackSecondsMax = parseEnvInt(
+  process.env.ACTIVE_TRANSFERS_CACHE_LOOKBACK_SECONDS_MAX,
+  DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS_MAX,
+  1,
+);
+
 const tilesTtlMs = parseEnvNumber(process.env.TILES_CACHE_TTL_MS, DEFAULT_TILES_TTL_MS);
 const tilesStaleMs = parseEnvNumber(process.env.TILES_CACHE_STALE_MS, DEFAULT_TILES_STALE_MS, tilesTtlMs);
 const tilesMaxEntries = parseEnvInt(process.env.TILES_CACHE_MAX_ENTRIES, DEFAULT_TILES_MAX_ENTRIES, 1);
@@ -149,6 +214,8 @@ const leaderboardCache = new Map<string, CacheEntry<CachedJsonPayload>>();
 const leaderboardInFlight = new Map<string, Promise<CachedJsonPayload>>();
 const storyEventsCache = new Map<string, CacheEntry<CachedJsonPayload>>();
 const storyEventsInFlight = new Map<string, Promise<CachedJsonPayload>>();
+const activeTransfersCache = new Map<string, CacheEntry<CachedJsonPayload>>();
+const activeTransfersInFlight = new Map<string, Promise<CachedJsonPayload>>();
 const tilesCache = new Map<string, CacheEntry<CachedJsonPayload>>();
 const tilesInFlight = new Map<string, Promise<CachedJsonPayload>>();
 const hyperstructuresCache = new Map<string, CacheEntry<CachedJsonPayload>>();
@@ -198,6 +265,7 @@ const startCacheCleanup = () => {
     () => {
       cleanupExpiredEntries(leaderboardCache, leaderboardStaleMs);
       cleanupExpiredEntries(storyEventsCache, storyEventsStaleMs);
+      cleanupExpiredEntries(activeTransfersCache, activeTransfersStaleMs);
       cleanupExpiredEntries(tilesCache, tilesStaleMs);
       cleanupExpiredEntries(hyperstructuresCache, hyperstructuresStaleMs);
       cleanupExpiredEntries(structureExplorerDetailsCache, structureExplorerDetailsStaleMs);
@@ -268,6 +336,131 @@ const fetchToriiRows = async <T>(baseUrl: string, query: string, context: string
 
   return result as T[];
 };
+
+const parseActiveTransferNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("0x")) {
+    return Number(BigInt(trimmed));
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseActiveTransferPositiveInteger = (value: unknown): number | null => {
+  const parsed = parseActiveTransferNumber(value);
+  if (parsed === null) {
+    return null;
+  }
+
+  const integer = Math.floor(parsed);
+  return integer > 0 ? integer : null;
+};
+
+const parseActiveTransferResourceIds = (raw: unknown): number[] => {
+  const parseMaybeJson = (value: unknown): unknown => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+      return value;
+    }
+
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return value;
+    }
+  };
+
+  const parsed = parseMaybeJson(raw);
+  const resourceCandidates = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object"
+      ? Object.values(parsed as Record<string, unknown>)
+      : [];
+
+  const resourceIds = resourceCandidates
+    .map((entry) => {
+      if (Array.isArray(entry)) {
+        return parseActiveTransferPositiveInteger(entry[0]);
+      }
+
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+
+      const candidate = entry as { resourceId?: unknown; resource?: unknown };
+      return parseActiveTransferPositiveInteger(candidate.resourceId ?? candidate.resource);
+    })
+    .filter((resourceId): resourceId is number => resourceId !== null);
+
+  return Array.from(new Set(resourceIds));
+};
+
+const normalizeActiveTransfers = (
+  rows: ActiveTransferCacheRow[],
+  currentTimeMs: number,
+): ActiveTransferCachePayload[] =>
+  rows
+    .map((row): ActiveTransferCachePayload | null => {
+      const sourceEntityId = parseActiveTransferPositiveInteger(row.resource_transfer_from_entity_id);
+      const destinationEntityId = parseActiveTransferPositiveInteger(row.resource_transfer_to_entity_id);
+      const startedAtSeconds = parseActiveTransferNumber(row.timestamp);
+      const travelTimeSeconds = parseActiveTransferNumber(row.resource_transfer_travel_time);
+      const resourceIds = parseActiveTransferResourceIds(row.resource_transfer_resources);
+
+      if (
+        sourceEntityId === null ||
+        destinationEntityId === null ||
+        startedAtSeconds === null ||
+        travelTimeSeconds === null ||
+        travelTimeSeconds <= 0 ||
+        resourceIds.length === 0
+      ) {
+        return null;
+      }
+
+      const startedAtMs = startedAtSeconds * 1000;
+      const endsAtMs = startedAtMs + travelTimeSeconds * 1000;
+      if (currentTimeMs >= endsAtMs) {
+        return null;
+      }
+
+      const transferId =
+        row.event_id ?? row.id ?? row.tx_hash ?? `${sourceEntityId}-${destinationEntityId}-${startedAtMs}`;
+
+      return {
+        id: `live:${transferId}`,
+        eventId: row.event_id ?? undefined,
+        txHash: row.tx_hash ?? undefined,
+        sourceEntityId,
+        destinationEntityId,
+        resourceIds,
+        startedAtMs,
+        endsAtMs,
+        progress: Math.max(0, Math.min((currentTimeMs - startedAtMs) / (travelTimeSeconds * 1000), 1)),
+      };
+    })
+    .filter((transfer): transfer is ActiveTransferCachePayload => transfer !== null);
 
 const getCachedValue = async <T>({
   cache,
@@ -533,6 +726,75 @@ cacheRoutes.get("/story-events", async (c) => {
   } catch (error) {
     console.error("Failed to fetch story events cache", error);
     return c.json({ error: "Failed to fetch story events cache." }, 500);
+  }
+});
+
+cacheRoutes.get("/active-transfers", async (c) => {
+  const start = Date.now();
+  const toriiBaseUrl = resolveToriiSqlBaseUrl(c);
+  if (!toriiBaseUrl) {
+    return c.json({ error: "Torii SQL base URL missing. Provide toriiSqlBaseUrl or set TORII_SQL_BASE_URL." }, 400);
+  }
+
+  const limitRaw = c.req.query("limit");
+  const limitParsed = limitRaw ? Number.parseInt(limitRaw, 10) : activeTransfersLimitDefault;
+  if (limitParsed <= 0) {
+    logCacheMetrics({
+      name: "active-transfers",
+      status: "hit",
+      totalMs: Date.now() - start,
+      fetchMs: null,
+      ageMs: null,
+      extra: "limit=0",
+    });
+    c.header("x-cache", "hit");
+    return sendJsonBody(c, createJsonPayload([]));
+  }
+
+  const limit = clampNumber(limitParsed, 1, activeTransfersLimitMax);
+  const lookbackRaw = c.req.query("lookbackSeconds");
+  const lookbackParsed = lookbackRaw ? Number.parseInt(lookbackRaw, 10) : activeTransfersLookbackSecondsDefault;
+  const lookbackSeconds = clampNumber(lookbackParsed, 1, activeTransfersLookbackSecondsMax);
+  const cacheKey = `${toriiBaseUrl}|limit:${limit}|lookbackSeconds:${lookbackSeconds}`;
+
+  try {
+    let fetchMs: number | null = null;
+    const result = await getCachedValue({
+      cache: activeTransfersCache,
+      inFlight: activeTransfersInFlight,
+      key: cacheKey,
+      ttlMs: activeTransfersTtlMs,
+      staleMs: activeTransfersStaleMs,
+      maxEntries: activeTransfersMaxEntries,
+      fetcher: async () => {
+        const fetchStart = Date.now();
+        try {
+          const currentTimeMs = Date.now();
+          const query = buildActiveTransfersQuery({
+            limit,
+            minTimestampSeconds: Math.max(0, Math.floor(currentTimeMs / 1000) - lookbackSeconds),
+          });
+          const rows = await fetchToriiRows<ActiveTransferCacheRow>(toriiBaseUrl, query, "active transfers");
+          return createJsonPayload(normalizeActiveTransfers(rows, currentTimeMs));
+        } finally {
+          fetchMs = Date.now() - fetchStart;
+        }
+      },
+    });
+
+    logCacheMetrics({
+      name: "active-transfers",
+      status: result.status,
+      totalMs: Date.now() - start,
+      fetchMs,
+      ageMs: Date.now() - result.fetchedAt,
+      extra: `limit=${limit} lookbackSeconds=${lookbackSeconds}`,
+    });
+    c.header("x-cache", result.status);
+    return sendJsonBody(c, result.value);
+  } catch (error) {
+    console.error("Failed to fetch active transfers cache", error);
+    return c.json({ error: "Failed to fetch active transfers cache." }, 500);
   }
 });
 

--- a/client/apps/realtime-server/src/services/__tests__/torii-queries.test.ts
+++ b/client/apps/realtime-server/src/services/__tests__/torii-queries.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { buildActiveTransfersQuery } from "../torii-queries";
+
+describe("buildActiveTransfersQuery", () => {
+  it("filters to non-mint resource transfers within the requested lookback window", () => {
+    const query = buildActiveTransfersQuery({
+      limit: 250,
+      minTimestampSeconds: 1_700_000_000,
+    });
+
+    expect(query).toContain('FROM "s1_eternum-StoryEvent"');
+    expect(query).toContain("WHERE story = 'ResourceTransferStory'");
+    expect(query).toContain(
+      `COALESCE(CAST("story.ResourceTransferStory.is_mint" AS TEXT), '0') NOT IN ('1', 'true', 'TRUE')`,
+    );
+    expect(query).toContain("timestamp >= 1700000000");
+    expect(query).toContain("LIMIT 250");
+  });
+});

--- a/client/apps/realtime-server/src/services/torii-queries.ts
+++ b/client/apps/realtime-server/src/services/torii-queries.ts
@@ -334,6 +334,31 @@ ${STORY_EVENT_SELECT_FIELDS}
     OFFSET ${offset}
 `;
 
+export const buildActiveTransfersQuery = ({
+  limit,
+  minTimestampSeconds,
+}: {
+  limit: number;
+  minTimestampSeconds: number;
+}): string => `
+    SELECT
+      id as id,
+      internal_event_id as event_id,
+      tx_hash,
+      timestamp,
+      "story.ResourceTransferStory.from_entity_id" as resource_transfer_from_entity_id,
+      "story.ResourceTransferStory.to_entity_id" as resource_transfer_to_entity_id,
+      "story.ResourceTransferStory.resources" as resource_transfer_resources,
+      "story.ResourceTransferStory.is_mint" as resource_transfer_is_mint,
+      "story.ResourceTransferStory.travel_time" as resource_transfer_travel_time
+    FROM "s1_eternum-StoryEvent"
+    WHERE story = 'ResourceTransferStory'
+      AND COALESCE(CAST("story.ResourceTransferStory.is_mint" AS TEXT), '0') NOT IN ('1', 'true', 'TRUE')
+      AND timestamp >= ${Math.max(0, Math.floor(minTimestampSeconds))}
+    ORDER BY timestamp DESC
+    LIMIT ${Math.max(0, Math.floor(limit))}
+`;
+
 export const HYPERSTRUCTURE_LEADERBOARD_CONFIG_QUERY = `
     SELECT
       "victory_points_grant_config.hyp_points_per_second" AS points_per_second,

--- a/packages/client/src/views/index.ts
+++ b/packages/client/src/views/index.ts
@@ -46,6 +46,7 @@ export interface SqlApiLike {
   fetchPlayerLeaderboard(limit?: number, offset?: number): Promise<any[]>;
   fetchPlayerLeaderboardByAddress?(address: string): Promise<any | null>;
   fetchStoryEvents(limit?: number, offset?: number): Promise<any[]>;
+  fetchActiveTransfers?(limit?: number, lookbackSeconds?: number): Promise<any[]>;
   fetchStoryEventsByEntity(entityId: ID, limit?: number, offset?: number): Promise<any[]>;
   fetchStoryEventsByOwner(owner: string, limit?: number, offset?: number): Promise<any[]>;
   fetchStoryEventsCount(): Promise<number>;

--- a/packages/torii/src/queries/sql/api.test.ts
+++ b/packages/torii/src/queries/sql/api.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SqlApi } from "./api";
+
+const jsonResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("SqlApi.fetchActiveTransfers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the realtime cache endpoint when configured", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse([
+        {
+          id: "live:event-1",
+          eventId: "event-1",
+          txHash: "0xabc",
+          sourceEntityId: 11,
+          destinationEntityId: 22,
+          resourceIds: [1],
+          startedAtMs: 10_000,
+          endsAtMs: 20_000,
+          progress: 0.5,
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sqlApi = new SqlApi("https://torii.example/sql", "https://realtime.example");
+    const result = await sqlApi.fetchActiveTransfers(250, 1800);
+
+    expect(result).toEqual([
+      {
+        id: "live:event-1",
+        eventId: "event-1",
+        txHash: "0xabc",
+        sourceEntityId: 11,
+        destinationEntityId: 22,
+        resourceIds: [1],
+        startedAtMs: 10_000,
+        endsAtMs: 20_000,
+        progress: 0.5,
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://realtime.example/api/cache/active-transfers?limit=250&lookbackSeconds=1800&toriiSqlBaseUrl=https%3A%2F%2Ftorii.example%2Fsql",
+      expect.anything(),
+    );
+  });
+
+  it("falls back to direct SQL and normalizes transfer rows when the cache is unavailable", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("cache down"))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: "row-1",
+            event_id: "event-1",
+            tx_hash: "0xabc",
+            timestamp: "0x64",
+            resource_transfer_from_entity_id: 11,
+            resource_transfer_to_entity_id: 22,
+            resource_transfer_resources: '[{"resourceId":1,"amount":10}]',
+            resource_transfer_travel_time: 30,
+            resource_transfer_is_mint: 0,
+          },
+        ]),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sqlApi = new SqlApi("https://torii.example/sql", "https://realtime.example");
+    const result = await sqlApi.fetchActiveTransfers(250, 1800, 115_000);
+
+    expect(result).toEqual([
+      {
+        id: "live:event-1",
+        eventId: "event-1",
+        txHash: "0xabc",
+        sourceEntityId: 11,
+        destinationEntityId: 22,
+        resourceIds: [1],
+        startedAtMs: 100_000,
+        endsAtMs: 130_000,
+        progress: 0.5,
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/torii/src/queries/sql/api.ts
+++ b/packages/torii/src/queries/sql/api.ts
@@ -38,6 +38,7 @@ import {
   SeasonEnded,
   SettlementPlannerSnapshot,
   SettlementPlannerTile,
+  ActiveTransferData,
   StoryEventData,
   StructureDetails,
   StructureLocation,
@@ -74,6 +75,7 @@ import { RESOURCE_QUERIES } from "./resource";
 import { extractRelicsFromResourceData } from "./relics-utils";
 import { SEASON_QUERIES } from "./season";
 import { STORY_QUERIES } from "./story";
+import { buildActiveTransfersStoryEventsQuery } from "./story";
 import { STRUCTURE_QUERIES } from "./structure";
 import { TILES_QUERIES } from "./tiles";
 import { TRADING_QUERIES } from "./trading";
@@ -108,6 +110,147 @@ const buildCacheUrl = (baseUrl: string, path: string): URL => {
 // within a few hundred ms. gRPC subscription reconciles any staleness within a block.
 const STRUCTURES_BY_OWNER_TTL_MS = 500;
 const structuresByOwnerCache = new Map<string, { promise: Promise<StructureLocation[]>; expiresAt: number }>();
+const DEFAULT_ACTIVE_TRANSFERS_LIMIT = 500;
+const DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS = 1_800;
+
+type ActiveTransferStoryRow = Pick<
+  StoryEventData,
+  | "id"
+  | "event_id"
+  | "tx_hash"
+  | "timestamp"
+  | "resource_transfer_from_entity_id"
+  | "resource_transfer_to_entity_id"
+  | "resource_transfer_resources"
+  | "resource_transfer_is_mint"
+  | "resource_transfer_travel_time"
+>;
+
+const parseActiveTransferNumber = (value: unknown): number | null => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (trimmed.startsWith("0x")) {
+    return Number(BigInt(trimmed));
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const parseActiveTransferPositiveInteger = (value: unknown): number | null => {
+  const parsed = parseActiveTransferNumber(value);
+  if (parsed === null) {
+    return null;
+  }
+
+  const integer = Math.floor(parsed);
+  return integer > 0 ? integer : null;
+};
+
+const parseActiveTransferResourceIds = (raw: unknown): number[] => {
+  const parseMaybeJson = (value: unknown): unknown => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+      return value;
+    }
+
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      return value;
+    }
+  };
+
+  const parsed = parseMaybeJson(raw);
+  const candidates = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object"
+      ? Object.values(parsed as Record<string, unknown>)
+      : [];
+
+  const resourceIds = candidates
+    .map((entry) => {
+      if (Array.isArray(entry)) {
+        return parseActiveTransferPositiveInteger(entry[0]);
+      }
+
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+
+      const candidate = entry as { resourceId?: unknown; resource?: unknown };
+      return parseActiveTransferPositiveInteger(candidate.resourceId ?? candidate.resource);
+    })
+    .filter((resourceId): resourceId is number => resourceId !== null);
+
+  return Array.from(new Set(resourceIds));
+};
+
+const resolveActiveTransferId = (
+  row: ActiveTransferStoryRow,
+  sourceEntityId: number,
+  destinationEntityId: number,
+  startedAtMs: number,
+): string => row.event_id ?? row.id ?? row.tx_hash ?? `${sourceEntityId}-${destinationEntityId}-${startedAtMs}`;
+
+const normalizeActiveTransferRows = (rows: ActiveTransferStoryRow[], currentTimeMs: number): ActiveTransferData[] =>
+  rows
+    .map((row): ActiveTransferData | null => {
+      const sourceEntityId = parseActiveTransferPositiveInteger(row.resource_transfer_from_entity_id);
+      const destinationEntityId = parseActiveTransferPositiveInteger(row.resource_transfer_to_entity_id);
+      const startedAtSeconds = parseActiveTransferNumber(row.timestamp);
+      const travelTimeSeconds = parseActiveTransferNumber(row.resource_transfer_travel_time);
+      const resourceIds = parseActiveTransferResourceIds(row.resource_transfer_resources);
+
+      if (
+        sourceEntityId === null ||
+        destinationEntityId === null ||
+        startedAtSeconds === null ||
+        travelTimeSeconds === null ||
+        travelTimeSeconds <= 0 ||
+        resourceIds.length === 0
+      ) {
+        return null;
+      }
+
+      const startedAtMs = startedAtSeconds * 1000;
+      const endsAtMs = startedAtMs + travelTimeSeconds * 1000;
+      if (currentTimeMs >= endsAtMs) {
+        return null;
+      }
+
+      return {
+        id: `live:${resolveActiveTransferId(row, sourceEntityId, destinationEntityId, startedAtMs)}`,
+        eventId: row.event_id ?? undefined,
+        txHash: row.tx_hash ?? undefined,
+        sourceEntityId,
+        destinationEntityId,
+        resourceIds,
+        startedAtMs,
+        endsAtMs,
+        progress: Math.max(0, Math.min((currentTimeMs - startedAtMs) / (travelTimeSeconds * 1000), 1)),
+      };
+    })
+    .filter((transfer): transfer is ActiveTransferData => transfer !== null);
 
 export class SqlApi {
   constructor(
@@ -852,6 +995,40 @@ export class SqlApi {
     const results = await fetchWithErrorHandling<{ total_count: number }>(url, "Failed to count story events");
     const firstResult = extractFirstOrNull(results);
     return firstResult?.total_count ?? 0;
+  }
+
+  async fetchActiveTransfers(
+    limit: number = DEFAULT_ACTIVE_TRANSFERS_LIMIT,
+    lookbackSeconds: number = DEFAULT_ACTIVE_TRANSFERS_LOOKBACK_SECONDS,
+    currentTimeMs: number = Date.now(),
+  ): Promise<ActiveTransferData[]> {
+    const normalizedLimit = Math.max(0, Math.floor(limit));
+    if (normalizedLimit === 0) {
+      return [];
+    }
+
+    const normalizedLookbackSeconds = Math.max(1, Math.floor(lookbackSeconds));
+    const cacheBase = this.cacheBaseUrl?.trim();
+    if (cacheBase) {
+      try {
+        const cacheUrl = buildCacheUrl(cacheBase, "/api/cache/active-transfers");
+        cacheUrl.searchParams.set("limit", normalizedLimit.toString());
+        cacheUrl.searchParams.set("lookbackSeconds", normalizedLookbackSeconds.toString());
+        cacheUrl.searchParams.set("toriiSqlBaseUrl", this.baseUrl);
+        return await fetchJsonWithErrorHandling<ActiveTransferData[]>(
+          cacheUrl.toString(),
+          "Failed to fetch cached active transfers",
+        );
+      } catch (error) {
+        console.warn("Cached active transfers fetch failed; falling back to direct SQL.", error);
+      }
+    }
+
+    const minTimestampSeconds = Math.max(0, Math.floor(currentTimeMs / 1000) - normalizedLookbackSeconds);
+    const query = buildActiveTransfersStoryEventsQuery(normalizedLimit, minTimestampSeconds);
+    const url = buildApiUrl(this.baseUrl, query);
+    const rows = await fetchWithErrorHandling<ActiveTransferStoryRow>(url, "Failed to fetch active transfers");
+    return normalizeActiveTransferRows(rows, currentTimeMs);
   }
 
   /**

--- a/packages/torii/src/queries/sql/story.ts
+++ b/packages/torii/src/queries/sql/story.ts
@@ -122,6 +122,29 @@ const STORY_EVENT_SELECT_FIELDS = `
       "story.PrizeDistributionFinalStory.trial_id" as prize_trial_id
 `;
 
+const ACTIVE_TRANSFER_SELECT_FIELDS = `
+      id as id,
+      internal_event_id as event_id,
+      tx_hash,
+      timestamp,
+      "story.ResourceTransferStory.from_entity_id" as resource_transfer_from_entity_id,
+      "story.ResourceTransferStory.to_entity_id" as resource_transfer_to_entity_id,
+      "story.ResourceTransferStory.resources" as resource_transfer_resources,
+      "story.ResourceTransferStory.is_mint" as resource_transfer_is_mint,
+      "story.ResourceTransferStory.travel_time" as resource_transfer_travel_time
+`;
+
+export const buildActiveTransfersStoryEventsQuery = (limit: number, minTimestampSeconds: number): string => `
+    SELECT
+${ACTIVE_TRANSFER_SELECT_FIELDS}
+    FROM "s1_eternum-StoryEvent"
+    WHERE story = 'ResourceTransferStory'
+      AND COALESCE(CAST("story.ResourceTransferStory.is_mint" AS TEXT), '0') NOT IN ('1', 'true', 'TRUE')
+      AND timestamp >= ${Math.max(0, Math.floor(minTimestampSeconds))}
+    ORDER BY timestamp DESC
+    LIMIT ${Math.max(0, Math.floor(limit))}
+`;
+
 export const STORY_QUERIES = {
   /**
    * Fetches all story events ordered by timestamp descending (newest first)

--- a/packages/torii/src/types/sql.ts
+++ b/packages/torii/src/types/sql.ts
@@ -294,6 +294,18 @@ export interface StoryEventData {
   prize_trial_id?: string;
 }
 
+export interface ActiveTransferData {
+  id: string;
+  eventId?: string;
+  txHash?: string;
+  sourceEntityId: number;
+  destinationEntityId: number;
+  resourceIds: number[];
+  startedAtMs: number;
+  endsAtMs: number;
+  progress: number;
+}
+
 export interface PlayersData {
   explorer_ids: string | number;
   structure_ids: string;


### PR DESCRIPTION
## Summary
Adds a trade route overlay to the Eternum world map with a persisted toggle in the map panel and settings.
The scene now renders live transfer arcs and planned automation routes through new store bridge, route builder, and Three.js overlay manager wiring.
Includes focused tests for the route builder, overlay manager, and worldmap store bridge.
Also fixes two correctness edges: active live routes stay visible after they fall out of the recent event window, and concurrent routes keep stable lanes instead of swapping as progress changes.