### PR TITLE
Focus landing views on selected chain

### DIFF
--- a/client/apps/game/src/ui/features/cosmetics/config/networks.ts
+++ b/client/apps/game/src/ui/features/cosmetics/config/networks.ts
@@ -87,8 +87,6 @@ export const COSMETICS_NETWORK_CONFIG: Record<
   },
 };
 
-export const COSMETICS_NETWORKS: CosmeticsNetwork[] = ["mainnet", "sepolia"];
-
 const normalizeChainId = (value: bigint | string | null | undefined): string | null => {
   if (value === null || value === undefined) return null;
 

--- a/client/apps/game/src/ui/features/cosmetics/cosmetics-view.tsx
+++ b/client/apps/game/src/ui/features/cosmetics/cosmetics-view.tsx
@@ -20,15 +20,14 @@ import {
 import { COSMETIC_ITEMS, type CosmeticItem } from "@/ui/features/cosmetics/config/cosmetics.data";
 import {
   COSMETICS_NETWORK_CONFIG,
-  COSMETICS_NETWORKS,
-  type CosmeticsNetwork,
-  DEFAULT_COSMETICS_NETWORK,
   resolveConnectedTxNetworkFromRuntime,
 } from "@/ui/features/cosmetics/config/networks";
 import { buildDevPreviewCatalogItems } from "@/ui/features/cosmetics/lib/dev-preview-cosmetics";
+import { resolveCosmeticsLoadoutNetworkForChain } from "@/ui/features/cosmetics/lib/loadout-scope";
 import { useToriiCosmetics, useTotalCosmeticsSupply } from "@/ui/features/cosmetics/lib/use-torii-cosmetics";
 import { describeBlitzLoadoutSummary, useCosmeticLoadoutStore } from "@/ui/features/cosmetics/model";
-import { switchWalletToChain, type WalletChainControllerLike } from "@/ui/utils/network-switch";
+import { useLandingNetworkState } from "@/ui/features/landing/hooks/use-landing-network-state";
+import { getChainLabel, switchWalletToChain, type WalletChainControllerLike } from "@/ui/utils/network-switch";
 import { useAccount } from "@starknet-react/core";
 import { useCallback, useMemo, useState } from "react";
 
@@ -46,7 +45,8 @@ export const LandingCosmetics = () => {
   const { chainId, connector } = useAccount();
   const controller = (connector as { controller?: WalletChainControllerLike } | undefined)?.controller;
   const connectedTxNetwork = resolveConnectedTxNetworkFromRuntime({ chainId, controller });
-  const [selectedNetwork, setSelectedNetwork] = useState<CosmeticsNetwork>(DEFAULT_COSMETICS_NETWORK);
+  const { preferredChain } = useLandingNetworkState();
+  const selectedNetwork = resolveCosmeticsLoadoutNetworkForChain(preferredChain);
   const [showWrongNetworkPrompt, setShowWrongNetworkPrompt] = useState(false);
   const { data: toriiCosmetics, isLoading, isError } = useToriiCosmetics({ network: selectedNetwork });
   const { data: totalSupply, isLoading: isLoadingSupply } = useTotalCosmeticsSupply({ network: selectedNetwork });
@@ -72,6 +72,7 @@ export const LandingCosmetics = () => {
   const { showLootChestOpening, setShowLootChestOpening } = useLootChestOpeningStore();
   const { ownedChests, isLoading: isLoadingChests, refetch: refetchChests } = useOwnedChests(selectedNetwork);
   const canOpenSelectedNetworkChests = connectedTxNetwork !== null && selectedNetwork === connectedTxNetwork;
+  const selectedLandingChainLabel = getChainLabel(preferredChain);
   const selectedNetworkLabel = COSMETICS_NETWORK_CONFIG[selectedNetwork].label;
   const openDisabledReason = canOpenSelectedNetworkChests
     ? undefined
@@ -236,25 +237,13 @@ export const LandingCosmetics = () => {
               </Tabs.Tab>
             </Tabs.List>
 
-            <div className="inline-flex w-fit rounded-xl border border-gold/20 bg-black/40 p-1">
-              {COSMETICS_NETWORKS.map((network) => {
-                const isActive = selectedNetwork === network;
-                return (
-                  <button
-                    key={network}
-                    type="button"
-                    onClick={() => setSelectedNetwork(network)}
-                    className={[
-                      "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
-                      isActive
-                        ? "bg-gold/25 text-gold border border-gold/40"
-                        : "text-gold/65 border border-transparent hover:text-gold hover:bg-gold/10",
-                    ].join(" ")}
-                  >
-                    {COSMETICS_NETWORK_CONFIG[network].label}
-                  </button>
-                );
-              })}
+            <div
+              className="inline-flex w-fit rounded-xl border border-gold/20 bg-black/40 p-1"
+              title={`Cosmetics data: ${selectedNetworkLabel}`}
+            >
+              <span className="rounded-lg border border-gold/40 bg-gold/25 px-3 py-1.5 text-xs font-medium text-gold">
+                {selectedLandingChainLabel}
+              </span>
             </div>
           </div>
 

--- a/client/apps/game/src/ui/features/landing/components/dashboard-network-switch.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/dashboard-network-switch.source.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("DashboardNetworkSwitch source", () => {
+  it("shows Mainnet before Slot in the landing chain selector", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/landing/components/dashboard-network-switch.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain('const DASHBOARD_CHAIN_OPTIONS: LandingNetworkChain[] = ["mainnet", "slot"];');
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/dashboard-network-switch.test.tsx
+++ b/client/apps/game/src/ui/features/landing/components/dashboard-network-switch.test.tsx
@@ -6,31 +6,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DashboardNetworkSwitch } from "./dashboard-network-switch";
 
 const mocks = vi.hoisted(() => ({
-  useAccount: vi.fn(),
-  useSelectedRuntimeChain: vi.fn(),
-  setSelectedChain: vi.fn(),
-  switchWalletToChain: vi.fn(),
+  selectPreferredChain: vi.fn(),
+  switchToPreferredChain: vi.fn(),
+  useLandingNetworkState: vi.fn(),
 }));
 
-vi.mock("@starknet-react/core", () => ({
-  useAccount: mocks.useAccount,
-}));
-
-vi.mock("@/runtime/world", () => ({
-  useSelectedRuntimeChain: mocks.useSelectedRuntimeChain,
-  setSelectedChain: mocks.setSelectedChain,
+vi.mock("../hooks/use-landing-network-state", () => ({
+  useLandingNetworkState: mocks.useLandingNetworkState,
 }));
 
 vi.mock("@/ui/utils/network-switch", () => ({
   getChainLabel: (chain: string) => (chain === "mainnet" ? "Mainnet" : "Slot"),
-  resolveConnectedTxChainFromRuntime: () => "slot",
-  switchWalletToChain: mocks.switchWalletToChain,
 }));
 
-const controller = {
-  switchStarknetChain: vi.fn(),
-  openSettings: vi.fn(),
-  rpcUrl: vi.fn(),
+const buildLandingNetworkState = (overrides: Partial<ReturnType<typeof mocks.useLandingNetworkState>> = {}) => {
+  return {
+    connectedChain: "slot",
+    connectedLandingChain: "slot",
+    hasConnectedWallet: true,
+    preferredChain: "mainnet",
+    selectPreferredChain: mocks.selectPreferredChain,
+    status: "mismatched",
+    switchToPreferredChain: mocks.switchToPreferredChain,
+    ...overrides,
+  };
 };
 
 const waitForAsyncWork = async () => {
@@ -45,15 +44,11 @@ describe("DashboardNetworkSwitch", () => {
   beforeEach(() => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-    mocks.useSelectedRuntimeChain.mockReturnValue("slot");
-    mocks.setSelectedChain.mockReset();
-    mocks.switchWalletToChain.mockReset();
-    mocks.switchWalletToChain.mockResolvedValue(true);
-    mocks.useAccount.mockReturnValue({
-      address: "0xabc",
-      chainId: "0xslot",
-      connector: { controller },
-    });
+    mocks.selectPreferredChain.mockReset();
+    mocks.switchToPreferredChain.mockReset();
+    mocks.switchToPreferredChain.mockResolvedValue(true);
+    mocks.useLandingNetworkState.mockReset();
+    mocks.useLandingNetworkState.mockReturnValue(buildLandingNetworkState());
 
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -71,36 +66,46 @@ describe("DashboardNetworkSwitch", () => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
   });
 
+  it("renders Mainnet before Slot", async () => {
+    await act(async () => {
+      root.render(<DashboardNetworkSwitch />);
+      await waitForAsyncWork();
+    });
+
+    const buttonLabels = Array.from(container.querySelectorAll("button")).map((button) => button.textContent);
+
+    expect(buttonLabels).toEqual(["Mainnet", "Slot"]);
+  });
+
   it("swaps the preferred game chain and wallet network when the user picks another chain", async () => {
     await act(async () => {
       root.render(<DashboardNetworkSwitch />);
       await waitForAsyncWork();
     });
 
-    const mainnetButton = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.includes("Mainnet"),
+    const slotButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Slot"),
     );
 
-    expect(mainnetButton).toBeDefined();
+    expect(slotButton).toBeDefined();
 
     await act(async () => {
-      mainnetButton?.click();
+      slotButton?.click();
       await waitForAsyncWork();
     });
 
-    expect(mocks.setSelectedChain).toHaveBeenCalledWith("mainnet");
-    expect(mocks.switchWalletToChain).toHaveBeenCalledWith({
-      controller,
-      targetChain: "mainnet",
-    });
+    expect(mocks.switchToPreferredChain).toHaveBeenCalledWith("slot");
   });
 
   it("updates the selected button immediately after changing the preferred chain without waiting for wallet state", async () => {
-    mocks.useAccount.mockReturnValue({
-      address: null,
-      chainId: null,
-      connector: undefined,
-    });
+    mocks.useLandingNetworkState.mockReturnValue(
+      buildLandingNetworkState({
+        connectedChain: null,
+        connectedLandingChain: null,
+        hasConnectedWallet: false,
+        status: "disconnected",
+      }),
+    );
 
     await act(async () => {
       root.render(<DashboardNetworkSwitch />);
@@ -111,16 +116,16 @@ describe("DashboardNetworkSwitch", () => {
     const slotButton = buttons.find((button) => button.textContent?.includes("Slot"));
     const mainnetButton = buttons.find((button) => button.textContent?.includes("Mainnet"));
 
-    expect(slotButton?.getAttribute("aria-pressed")).toBe("true");
-    expect(mainnetButton?.getAttribute("aria-pressed")).toBe("false");
+    expect(mainnetButton?.getAttribute("aria-pressed")).toBe("true");
+    expect(slotButton?.getAttribute("aria-pressed")).toBe("false");
 
     await act(async () => {
-      mainnetButton?.click();
+      slotButton?.click();
       await waitForAsyncWork();
     });
 
-    expect(mocks.setSelectedChain).toHaveBeenCalledWith("mainnet");
-    expect(mainnetButton?.getAttribute("aria-pressed")).toBe("true");
-    expect(slotButton?.getAttribute("aria-pressed")).toBe("false");
+    expect(mocks.selectPreferredChain).toHaveBeenCalledWith("slot");
+    expect(slotButton?.getAttribute("aria-pressed")).toBe("true");
+    expect(mainnetButton?.getAttribute("aria-pressed")).toBe("false");
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/dashboard-network-switch.tsx
+++ b/client/apps/game/src/ui/features/landing/components/dashboard-network-switch.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useLandingNetworkState } from "../hooks/use-landing-network-state";
 import type { LandingNetworkChain, LandingNetworkStatus } from "../lib/landing-network-state";
 
-const DASHBOARD_CHAIN_OPTIONS: LandingNetworkChain[] = ["slot", "mainnet"];
+const DASHBOARD_CHAIN_OPTIONS: LandingNetworkChain[] = ["mainnet", "slot"];
 
 const resolveIndicatorTone = (status: LandingNetworkStatus) => {
   switch (status) {

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.network-switch-replay.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.network-switch-replay.source.test.ts
@@ -9,9 +9,8 @@ describe("Game card network switch replay", () => {
     const source = readFileSync(fileURLToPath(new URL("./game-card-grid.tsx", import.meta.url)), "utf8");
 
     expect(source).toContain('import { useLandingNetworkState } from "../../hooks/use-landing-network-state";');
-    expect(source).toContain(
-      'import { canInteractWithLandingChain, resolvePreferredLandingChain } from "../../lib/landing-network-state";',
-    );
+    expect(source).toContain("canInteractWithLandingChain");
+    expect(source).toContain("resolvePreferredLandingChain");
     expect(source).toContain("const [isSwitchNetworkPending, setIsSwitchNetworkPending] = useState(false);");
     expect(source).toContain("resolvePendingNetworkSwitchOutcome");
     expect(source).toContain(

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -20,7 +20,11 @@ import { WorldCountdownDetailed, useGameTimeStatus } from "@/ui/components/world
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { useLandingNetworkState } from "../../hooks/use-landing-network-state";
-import { canInteractWithLandingChain, resolvePreferredLandingChain } from "../../lib/landing-network-state";
+import {
+  canInteractWithLandingChain,
+  resolvePreferredLandingChain,
+  type LandingNetworkChain,
+} from "../../lib/landing-network-state";
 import { MarketDetailsModal } from "@/ui/features/landing/views/market-details-modal";
 import { normalizeHexAddress, transformMarketRowToClass } from "@/ui/features/market/hooks/transform-market-row";
 import { MaybeController } from "@/ui/features/market/landing-markets/maybe-controller";
@@ -171,6 +175,9 @@ interface GameMarketState {
   isLoading: boolean;
   error: string | null;
 }
+
+const isLiveSummaryForLandingChain = (summary: WorldSummary, selectedChain: LandingNetworkChain): boolean =>
+  summary.alive && summary.chain === selectedChain;
 
 const formatOddsPercentage = (raw: string | number) => {
   const value = Number(raw);
@@ -1133,6 +1140,7 @@ export const UnifiedGameGrid = ({
   const playerAddress = account?.address && account.address !== "0x0" ? account.address : null;
   const playerFeltLiteral = playerAddress ? toPaddedFeltAddress(playerAddress) : null;
   const landingNetworkState = useLandingNetworkState();
+  const selectedLandingChain = landingNetworkState.preferredChain;
   const autoSettleEntries = useAutoSettleStore((state) => state.entries);
   const markOpening = useAutoSettleStore((state) => state.markOpening);
 
@@ -1165,14 +1173,11 @@ export const UnifiedGameGrid = ({
     refetch: refetchSummary,
   } = useWorldsSummary();
 
-  // Only show live worlds on supported chains. Dead (alive=false) worlds
-  // are excluded from the card grid — they surface separately via the modal.
+  // Only show live worlds for the chain selected in the landing network switch.
+  // Dead (alive=false) worlds are excluded from the card grid — they surface separately via the modal.
   const liveSummaries = useMemo<WorldSummary[]>(
-    () =>
-      (worldsSummaryData ?? []).filter(
-        (summary) => summary.alive && (summary.chain === "mainnet" || summary.chain === "slot"),
-      ),
-    [worldsSummaryData],
+    () => (worldsSummaryData ?? []).filter((summary) => isLiveSummaryForLandingChain(summary, selectedLandingChain)),
+    [selectedLandingChain, worldsSummaryData],
   );
 
   // Player-scoped fields (registration, settled realm) layered on top of the

--- a/client/apps/game/src/ui/features/landing/components/mmr-leaderboard.test.tsx
+++ b/client/apps/game/src/ui/features/landing/components/mmr-leaderboard.test.tsx
@@ -5,8 +5,22 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MMR_TOKEN_BY_CHAIN } from "@/config/global-chain";
 import { MMRLeaderboard } from "./mmr-leaderboard";
 
+const landingNetworkStateMock = vi.hoisted(() => ({
+  preferredChain: "mainnet" as "mainnet" | "slot",
+}));
+
 vi.mock("@starknet-react/core", () => ({
   useAccount: vi.fn(() => ({ address: null })),
+}));
+
+vi.mock("@/ui/features/landing/hooks/use-landing-network-state", () => ({
+  useLandingNetworkState: () => ({
+    preferredChain: landingNetworkStateMock.preferredChain,
+  }),
+}));
+
+vi.mock("@/ui/utils/network-switch", () => ({
+  getChainLabel: (chain: string) => (chain === "mainnet" ? "Mainnet" : "Slot"),
 }));
 
 vi.mock("@/ui/utils/utils", () => ({
@@ -77,6 +91,7 @@ describe("MMRLeaderboard", () => {
   beforeEach(() => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     vi.useFakeTimers();
+    landingNetworkStateMock.preferredChain = "mainnet";
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -137,20 +152,14 @@ describe("MMRLeaderboard", () => {
     expect(fetchMock.mock.calls.length).toBe(initialCallCount);
   });
 
-  it("defaults to mainnet and allows switching to slot", async () => {
+  it("follows the selected landing chain", async () => {
     await act(async () => {
       root.render(<MMRLeaderboard />);
       await waitForAsyncWork();
     });
 
-    const buttons = Array.from(container.querySelectorAll("button"));
-    const slotButton = buttons.find((button) => button.textContent?.toLowerCase().includes("slot"));
-    const mainnetButton = buttons.find((button) => button.textContent?.toLowerCase().includes("mainnet"));
-
-    expect(slotButton).toBeDefined();
-    expect(mainnetButton).toBeDefined();
-    expect(mainnetButton?.textContent?.toLowerCase()).not.toContain("coming soon");
-    expect((mainnetButton as HTMLButtonElement).disabled).toBe(false);
+    expect(container.textContent).toContain("Chain:");
+    expect(container.textContent).toContain("Mainnet");
 
     const fetchMock = vi.mocked(fetch);
     const fetchedUrls = fetchMock.mock.calls.map(([input]) => (typeof input === "string" ? input : input.toString()));
@@ -171,9 +180,12 @@ describe("MMRLeaderboard", () => {
     expect(mainnetQuery.toLowerCase()).toContain(`${EVENT_CONTRACT_EXPR} = '${mainnetToken}'`);
 
     await act(async () => {
-      (slotButton as HTMLButtonElement).click();
+      landingNetworkStateMock.preferredChain = "slot";
+      root.render(<MMRLeaderboard />);
       await waitForAsyncWork();
     });
+
+    expect(container.textContent).toContain("Slot");
 
     await vi.waitFor(() => {
       const urls = vi.mocked(fetch).mock.calls.map(([input]) => (typeof input === "string" ? input : input.toString()));

--- a/client/apps/game/src/ui/features/landing/components/mmr-leaderboard.tsx
+++ b/client/apps/game/src/ui/features/landing/components/mmr-leaderboard.tsx
@@ -8,7 +8,9 @@ import { hash } from "starknet";
 
 import { GLOBAL_TORII_BY_CHAIN, MMR_TOKEN_BY_CHAIN } from "@/config/global-chain";
 import { getAvatarUrl, normalizeAvatarAddress, useAvatarProfiles } from "@/hooks/use-player-avatar";
+import { useLandingNetworkState } from "@/ui/features/landing/hooks/use-landing-network-state";
 import { MMRTierBadge } from "@/ui/shared/components/mmr-tier-badge";
+import { getChainLabel } from "@/ui/utils/network-switch";
 import {
   getMMRTier,
   getMMRTierFromRaw,
@@ -32,8 +34,6 @@ const EVENT_CONTRACT_EXPR =
 const SHIMMER_DELTA_THRESHOLD = 100;
 
 type SortBy = "rank" | "timestamp" | "delta";
-
-const CHAIN_OPTIONS: Chain[] = ["mainnet", "slot"];
 
 interface GlobalMMRRow {
   player_address?: string;
@@ -652,12 +652,13 @@ const ExpandedRowDetail = ({ entry }: { entry: GlobalMMREntry }) => {
 
 export const MMRLeaderboard = () => {
   const { address: connectedAddress } = useAccount();
+  const { preferredChain } = useLandingNetworkState();
 
   const [state, setState] = useState<LeaderboardState>({
     entries: [],
     isLoading: false,
     error: null,
-    selectedChain: "mainnet",
+    selectedChain: preferredChain,
     sortBy: "rank",
     searchInput: "",
     searchTerm: "",
@@ -672,6 +673,10 @@ export const MMRLeaderboard = () => {
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const currentUserRowRef = useRef<HTMLTableRowElement>(null);
   const pendingScrollToUser = useRef(false);
+
+  useEffect(() => {
+    setState((prev) => (prev.selectedChain === preferredChain ? prev : { ...prev, selectedChain: preferredChain }));
+  }, [preferredChain]);
 
   const currentUserAddress = useMemo(() => {
     if (!connectedAddress) return null;
@@ -930,28 +935,13 @@ export const MMRLeaderboard = () => {
           </div>
         </div>
 
-        {/* Toolbar: Chain, Sort, Search */}
+        {/* Toolbar: selected chain, sort, search */}
         <div className="flex flex-wrap items-center gap-6">
           <div className="flex items-center gap-2">
             <span className="text-sm text-gold/60">Chain:</span>
-            <div className="flex gap-1">
-              {CHAIN_OPTIONS.map((chain) => {
-                const isSelected = state.selectedChain === chain;
-
-                return (
-                  <button
-                    key={chain}
-                    type="button"
-                    onClick={() => setState((prev) => ({ ...prev, selectedChain: chain }))}
-                    className={`rounded-lg px-3 py-1.5 text-sm font-medium capitalize transition ${
-                      isSelected ? "bg-gold/20 text-gold" : "text-gold/60 hover:bg-gold/10 hover:text-gold"
-                    }`}
-                  >
-                    <span>{chain}</span>
-                  </button>
-                );
-              })}
-            </div>
+            <span className="rounded-lg border border-gold/20 bg-gold/10 px-3 py-1.5 text-sm font-medium text-gold">
+              {getChainLabel(state.selectedChain)}
+            </span>
           </div>
 
           <div className="flex items-center gap-2">

--- a/client/apps/game/src/ui/features/landing/components/player-profile.tsx
+++ b/client/apps/game/src/ui/features/landing/components/player-profile.tsx
@@ -20,9 +20,11 @@ import { MMR_TOKEN_BY_CHAIN } from "@/config/global-chain";
 import { Button } from "@/ui/design-system/atoms";
 import { Tabs } from "@/ui/design-system/atoms/tab";
 import { AvatarImageGrid } from "@/ui/features/avatars/avatar-image-grid";
+import { useLandingNetworkState } from "@/ui/features/landing/hooks/use-landing-network-state";
 import { MMRTierBadge } from "@/ui/shared/components/mmr-tier-badge";
 import { copyElementAsPng, openShareOnX } from "@/ui/shared/lib/share-image";
 import { buildProfileShareMessage } from "@/ui/shared/lib/x-share-messages";
+import { getChainLabel } from "@/ui/utils/network-switch";
 import type { MMRTier } from "@/ui/utils/mmr-tiers";
 import {
   getMMRTierFromRaw,
@@ -49,13 +51,18 @@ import { env } from "../../../../../env";
 
 // MMR fetching utilities
 const GET_PLAYER_MMR_SELECTOR = hash.getSelectorFromName("get_player_mmr");
-const CHAIN_OPTIONS: Chain[] = ["mainnet", "slot"];
-const DEFAULT_CHAIN: Chain = "mainnet";
-const MMR_CHAIN_STORAGE_KEY = "landing-player-mmr-chain-mainnet-priority";
 
 const RPC_FALLBACK_BY_CHAIN: Partial<Record<Chain, string>> = {
   mainnet: "https://api.cartridge.gg/x/starknet/mainnet",
   slot: "https://api.cartridge.gg/x/eternum-blitz-slot-4/katana/rpc/v0_9",
+};
+
+const resolveProfileMmrRpcUrl = (chain: Chain): string | undefined => {
+  if (chain === "slot" && env.VITE_PUBLIC_CHAIN === "slot") {
+    return dojoConfig.rpcUrl || env.VITE_PUBLIC_NODE_URL || RPC_FALLBACK_BY_CHAIN.slot;
+  }
+
+  return RPC_FALLBACK_BY_CHAIN[chain];
 };
 
 // Map tier color classes to actual hex values for gradients/glows
@@ -157,6 +164,8 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
   const normalizedSelectedAddress = getNormalizedProfileAddress(selectedPlayerAddress);
   const viewedPlayerAddress = normalizedSelectedAddress ?? normalizedConnectedAddress;
   const isOwnProfile = viewedPlayerAddress != null && viewedPlayerAddress === normalizedConnectedAddress;
+  const { preferredChain } = useLandingNetworkState();
+  const selectedChain = preferredChain;
 
   const { username: cartridgeUsername, isLoading: isCartridgeUsernameLoading } = useCartridgeUsername();
   const ownDisplayName = accountName || cartridgeUsername || "";
@@ -171,20 +180,13 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
     : externalPlayerName || (viewedPlayerAddress ? displayAddress(viewedPlayerAddress) : "Anonymous");
   const isTrimmed = variant === "trimmed";
 
-  const [selectedChain, setSelectedChain] = useState<Chain>(DEFAULT_CHAIN);
-
   // MMR state
   const [playerMMR, setPlayerMMR] = useState<bigint | null>(null);
   const [isLoadingMMR, setIsLoadingMMR] = useState(false);
   const profileCardRef = useRef<HTMLDivElement>(null);
   const [isCopyingProfileCard, setIsCopyingProfileCard] = useState(false);
 
-  const rpcUrl = useMemo(() => {
-    if (selectedChain === "slot") {
-      return dojoConfig.rpcUrl || env.VITE_PUBLIC_NODE_URL || RPC_FALLBACK_BY_CHAIN.slot;
-    }
-    return RPC_FALLBACK_BY_CHAIN[selectedChain];
-  }, [selectedChain]);
+  const rpcUrl = useMemo(() => resolveProfileMmrRpcUrl(selectedChain), [selectedChain]);
 
   const mmrTokenAddress = useMemo(() => MMR_TOKEN_BY_CHAIN[selectedChain], [selectedChain]);
 
@@ -212,19 +214,6 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
       cancelled = true;
     };
   }, [isOwnProfile, selectedPlayerNameTrimmed, viewedPlayerAddress]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const storedChain = window.localStorage.getItem(MMR_CHAIN_STORAGE_KEY);
-    if (storedChain && CHAIN_OPTIONS.includes(storedChain as Chain)) {
-      setSelectedChain(storedChain as Chain);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(MMR_CHAIN_STORAGE_KEY, selectedChain);
-  }, [selectedChain]);
 
   // Avatar management
   const [avatarPrompt, setAvatarPrompt] = useState("");
@@ -617,22 +606,9 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
                     {displayName || "Anonymous"}
                   </motion.h2>
                   <div className="flex items-center gap-1.5 justify-center sm:justify-start">
-                    {CHAIN_OPTIONS.map((chain) => {
-                      const isSelected = selectedChain === chain;
-
-                      return (
-                        <button
-                          key={chain}
-                          type="button"
-                          onClick={() => setSelectedChain(chain)}
-                          className={`rounded-md px-2 py-0.5 text-[10px] font-medium capitalize transition-all duration-150 ${
-                            isSelected ? "bg-white/[0.08] text-white/70" : "text-white/30 hover:text-white/50"
-                          }`}
-                        >
-                          {chain}
-                        </button>
-                      );
-                    })}
+                    <span className="rounded-md bg-white/[0.08] px-2 py-0.5 text-[10px] font-medium text-white/70">
+                      {getChainLabel(selectedChain)}
+                    </span>
                   </div>
                 </div>
 

--- a/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.source.test.ts
@@ -15,4 +15,18 @@ describe("useLandingNetworkState source", () => {
     expect(source).toContain("const connectedChain = resolveConnectedTxChainFromRuntime({ chainId, controller });");
     expect(source).not.toContain("useMemo(\n    () => resolveConnectedTxChainFromRuntime({ chainId, controller })");
   });
+
+  it("defaults every landing page open to mainnet before applying stored preferences", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/landing/hooks/use-landing-network-state.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('const DEFAULT_LANDING_CHAIN: Chain = "mainnet";');
+    expect(source).toContain("let hasDefaultedLandingChainOnPageOpen = false;");
+    expect(source).toContain(
+      "const selectedChain = shouldStartOnDefaultLandingChain ? DEFAULT_LANDING_CHAIN : storedSelectedChain;",
+    );
+    expect(source).toContain("setSelectedChain(DEFAULT_LANDING_CHAIN);");
+  });
 });

--- a/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.ts
+++ b/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.ts
@@ -1,4 +1,3 @@
-import { env } from "../../../../../env";
 import { setSelectedChain, useSelectedRuntimeChain } from "@/runtime/world";
 import {
   resolveConnectedTxChainFromRuntime,
@@ -7,7 +6,7 @@ import {
 } from "@/ui/utils/network-switch";
 import type { Chain } from "@contracts";
 import { useAccount } from "@starknet-react/core";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import {
   resolveLandingNetworkState,
@@ -26,11 +25,30 @@ interface LandingNetworkControllerState {
   switchToPreferredChain: (chain: LandingNetworkChain) => Promise<boolean>;
 }
 
+const DEFAULT_LANDING_CHAIN: Chain = "mainnet";
+
+// Landing should start on Mainnet for each full page open, while still allowing
+// normal Slot/Mainnet switching during the current page session.
+let hasDefaultedLandingChainOnPageOpen = false;
+
+const defaultLandingChainOnPageOpen = () => {
+  if (hasDefaultedLandingChainOnPageOpen) return;
+
+  hasDefaultedLandingChainOnPageOpen = true;
+  setSelectedChain(DEFAULT_LANDING_CHAIN);
+};
+
 export const useLandingNetworkState = (): LandingNetworkControllerState => {
-  const fallbackChain = env.VITE_PUBLIC_CHAIN as Chain;
-  const selectedChain = useSelectedRuntimeChain(fallbackChain);
+  const storedSelectedChain = useSelectedRuntimeChain(DEFAULT_LANDING_CHAIN);
+  const shouldStartOnDefaultLandingChain = !hasDefaultedLandingChainOnPageOpen;
+  const selectedChain = shouldStartOnDefaultLandingChain ? DEFAULT_LANDING_CHAIN : storedSelectedChain;
   const { address, chainId, connector } = useAccount();
   const controller = (connector as { controller?: WalletChainControllerLike } | undefined)?.controller ?? null;
+
+  useEffect(() => {
+    if (!shouldStartOnDefaultLandingChain) return;
+    defaultLandingChainOnPageOpen();
+  }, [shouldStartOnDefaultLandingChain]);
 
   const connectedChain = resolveConnectedTxChainFromRuntime({ chainId, controller });
 

--- a/client/apps/game/src/ui/features/landing/landing-network-state-adoption.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/landing-network-state-adoption.source.test.ts
@@ -12,11 +12,15 @@ describe("Landing network state adoption", () => {
     const dashboardSource = readSource("src/ui/features/landing/components/dashboard-network-switch.tsx");
     const gameGridSource = readSource("src/ui/features/landing/components/game-selector/game-card-grid.tsx");
     const marketsSource = readSource("src/ui/features/landing/views/markets-view.tsx");
+    const profileSource = readSource("src/ui/features/landing/components/player-profile.tsx");
     const factorySource = readSource("src/ui/features/factory-v2/hooks/use-factory-v2-developer-config.ts");
 
     expect(dashboardSource).toContain('import { useLandingNetworkState } from "../hooks/use-landing-network-state";');
     expect(gameGridSource).toContain('import { useLandingNetworkState } from "../../hooks/use-landing-network-state";');
     expect(marketsSource).toContain('import { useLandingNetworkState } from "../hooks/use-landing-network-state";');
+    expect(profileSource).toContain(
+      'import { useLandingNetworkState } from "@/ui/features/landing/hooks/use-landing-network-state";',
+    );
     expect(factorySource).toContain(
       'import { useLandingNetworkState } from "@/ui/features/landing/hooks/use-landing-network-state";',
     );

--- a/client/apps/game/src/ui/features/landing/views/markets-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/markets-view.tsx
@@ -33,7 +33,6 @@ import {
   useMultiChainMarketCounts,
   useMultiChainMarkets,
   type EnrichedMarket,
-  type MarketChainFilter,
   type MarketSortKey,
   type MarketStatusKey,
 } from "@/ui/features/market/landing-markets/use-multi-chain-markets";
@@ -177,12 +176,6 @@ const STATUS_OPTIONS: Array<{
   { key: "all", label: "All" },
 ];
 
-const CHAIN_OPTIONS: Array<{ key: MarketChainFilter; label: string }> = [
-  { key: "all", label: "All Chains" },
-  { key: "slot", label: "Slot" },
-  { key: "mainnet", label: "Mainnet" },
-];
-
 const SORT_OPTIONS: Array<{ key: MarketSortKey; label: string }> = [
   { key: "creation-date", label: "Creation Date" },
   { key: "end-time", label: "End Time" },
@@ -196,11 +189,6 @@ const getStatusFromParam = (value: string | null): MarketStatusKey => {
   }
 
   return "live";
-};
-
-const getChainFromParam = (value: string | null): MarketChainFilter => {
-  if (value === "slot" || value === "mainnet") return value;
-  return "all";
 };
 
 const getSortFromParam = (value: string | null): MarketSortKey => {
@@ -568,7 +556,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
   );
 
   const selectedStatus = getStatusFromParam(searchParams.get("status"));
-  const selectedChain = getChainFromParam(searchParams.get("chain"));
+  const selectedChain = landingNetworkState.preferredChain;
   const selectedSort = getSortFromParam(searchParams.get("sort"));
   const filterKey = `${selectedStatus}|${selectedChain}|${selectedSort}`;
 
@@ -580,7 +568,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
     const blockedAddresses = new Set<string>();
 
     for (const summary of worldsSummary ?? []) {
-      if (!summary.devModeOn) continue;
+      if (!summary.devModeOn || summary.chain !== selectedChain) continue;
 
       const prizeDistributionAddress = normalizeHexAddress(summary.prizeDistributionAddress ?? "");
       if (prizeDistributionAddress) {
@@ -589,7 +577,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
     }
 
     return Array.from(blockedAddresses);
-  }, [worldsSummary]);
+  }, [selectedChain, worldsSummary]);
 
   const { counts, isLoading: isCountsLoading, isFetching: isCountsFetching } = useMultiChainMarketCounts(selectedChain);
   const hasLiveMarkets = counts.live > 0;
@@ -648,19 +636,6 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
     [selectedChain, selectedSort, setSearchParams],
   );
 
-  const handleChainChange = useCallback(
-    (nextChain: MarketChainFilter) => {
-      setSearchParams((previous) => {
-        const next = new URLSearchParams(previous);
-        if (nextChain === "all") next.delete("chain");
-        else next.set("chain", nextChain);
-        return next;
-      });
-      setPagesByFilter((previous) => ({ ...previous, [`${selectedStatus}|${nextChain}|${selectedSort}`]: 1 }));
-    },
-    [selectedSort, selectedStatus, setSearchParams],
-  );
-
   const handleSortChange = useCallback(
     (nextSort: MarketSortKey) => {
       setSearchParams((previous) => {
@@ -680,8 +655,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
   const isInitialLoad = (isLoading || isFetching) && markets.length === 0;
 
   const sourceWarnings = useMemo(() => {
-    const selected = selectedChain === "all" ? (["slot", "mainnet"] as MarketDataChain[]) : [selectedChain];
-    return selected
+    return [selectedChain]
       .filter((chain) => !sourceStatus[chain]?.ok)
       .map((chain) => {
         const message = sourceStatus[chain]?.error ?? "Unavailable";
@@ -727,7 +701,9 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
     <div className={cn("flex h-full flex-col gap-5", className)}>
       <div className="space-y-3">
         <h2 className="font-cinzel text-xl font-semibold text-gold md:text-2xl">Prediction Markets</h2>
-        <p className="text-sm text-gold/70">Track live odds, liquidity, and market activity across Slot and Mainnet.</p>
+        <p className="text-sm text-gold/70">
+          Track live odds, liquidity, and market activity on {getChainLabel(selectedChain)}.
+        </p>
       </div>
 
       <div className={cn(PM_SURFACE_CLASS, "border-gold/15 bg-black/30 p-4")}>
@@ -800,25 +776,8 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
           })}
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          {CHAIN_OPTIONS.map((option) => {
-            const isActive = selectedChain === option.key;
-            return (
-              <button
-                key={option.key}
-                type="button"
-                onClick={() => handleChainChange(option.key)}
-                className={cn(
-                  "rounded-full border px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition-colors",
-                  isActive
-                    ? "border-gold/70 bg-gold/15 text-gold"
-                    : "border-gold/25 bg-black/40 text-gold/75 hover:border-gold/45 hover:bg-gold/10",
-                )}
-              >
-                {option.label}
-              </button>
-            );
-          })}
+        <div className="rounded-full border border-gold/70 bg-gold/15 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-gold">
+          {getChainLabel(selectedChain)}
         </div>
       </div>
 
@@ -965,8 +924,12 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
   );
 };
 
-export const MarketsView = ({ className }: MarketsViewProps) => (
-  <MarketsProviders>
-    <MarketsViewContent className={className} />
-  </MarketsProviders>
-);
+export const MarketsView = ({ className }: MarketsViewProps) => {
+  const { preferredChain } = useLandingNetworkState();
+
+  return (
+    <MarketsProviders chain={preferredChain}>
+      <MarketsViewContent className={className} />
+    </MarketsProviders>
+  );
+};

--- a/client/apps/game/src/ui/features/landing/views/play-view.market-provider-gating.test.ts
+++ b/client/apps/game/src/ui/features/landing/views/play-view.market-provider-gating.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -8,6 +10,8 @@ describe("PlayView market provider gating", () => {
     const source = readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/play-view.tsx"), "utf8");
 
     expect(source).toContain('const shouldMountMarketsProviders = activeTab === "play" || activeTab === "learn"');
-    expect(source).toContain("shouldMountMarketsProviders ? <MarketsProviders>{content}</MarketsProviders> : content");
+    expect(source).toContain(
+      "shouldMountMarketsProviders ? <MarketsProviders chain={preferredChain}>{content}</MarketsProviders> : content",
+    );
   });
 });

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -33,6 +33,7 @@ import { GameReviewModal } from "../components/game-review-modal";
 import type { LandingModeFilter, LandingEntryRouteState } from "../lib/landing-entry-state";
 import { isGameReviewDismissed, setGameReviewDismissed } from "../lib/game-review-storage";
 import { useLandingContext } from "../context/landing-context";
+import { useLandingNetworkState } from "../hooks/use-landing-network-state";
 
 interface PlayViewProps {
   className?: string;
@@ -866,6 +867,7 @@ export const PlayView = ({
   const queryClient = useQueryClient();
   const location = useLocation();
   const navigate = useNavigate();
+  const { preferredChain } = useLandingNetworkState();
 
   // Review flow state
   const [reviewWorld, setReviewWorld] = useState<WorldSelection | null>(null);
@@ -1148,7 +1150,7 @@ export const PlayView = ({
 
   return (
     <>
-      {shouldMountMarketsProviders ? <MarketsProviders>{content}</MarketsProviders> : content}
+      {shouldMountMarketsProviders ? <MarketsProviders chain={preferredChain}>{content}</MarketsProviders> : content}
 
       {reviewWorld && !disableReviewFlow && (
         <GameReviewModal

--- a/client/apps/game/src/ui/features/world/latest-features.test.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from "vitest";
 
 import { latestFeatures } from "./latest-features";

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-06",
+    title: "Focused Chain Views",
+    description:
+      "Landing games, profile ranks, MMR, prediction markets, and cosmetics now follow the selected landing chain, with each page open starting on Mainnet.",
+    type: "fix",
+  },
+  {
+    date: "2026-05-06",
     title: "Map Sync Recovery",
     description:
       "Improved map stream recovery so delayed spatial updates enter a reconnecting state, retry cleanly, and surface network trouble when the map cannot restore live updates.",


### PR DESCRIPTION
## Summary
This PR makes the landing chain selector the source of truth for game cards, global MMR, profile MMR, prediction markets, and cosmetics.
It starts each full page open on Mainnet, orders the selector as Mainnet then Slot, and scopes market providers plus dev-mode exclusions to the selected chain.
It also adds focused source/component coverage and a latest-features entry for the UX change.

## Verification
- `pnpm run format`
- `pnpm run knip`
- `pnpm --dir client/apps/game typecheck`
- `pnpm --dir client/apps/game test -- src/ui/features/landing/components/dashboard-network-switch.source.test.ts src/ui/features/landing/views/play-view.market-provider-gating.test.ts src/ui/features/landing/landing-network-state-adoption.source.test.ts src/ui/features/landing/hooks/use-landing-network-state.source.test.ts src/ui/features/world/latest-features.test.ts`
- `npx -y node@22.12.0 $(which pnpm) --dir /Users/aymericdelabrousse/conductor/workspaces/eternum/chicago-v2/client/apps/game test -- src/ui/features/landing/components/dashboard-network-switch.test.tsx`