### PR TITLE
[codex] Fix claimable chest reward estimates

### DIFF
--- a/client/apps/game/src/services/review/chest-reward-estimate.ts
+++ b/client/apps/game/src/services/review/chest-reward-estimate.ts
@@ -1,0 +1,58 @@
+const VICTORY_POINTS_MULTIPLIER = 1_000_000n;
+const GAME_REWARD_CHEST_POINTS_THRESHOLD = 500n * VICTORY_POINTS_MULTIPLIER;
+
+interface ClaimableChestEstimateInput {
+  lootChestAddress: string | null;
+  allocatedChests: number;
+  distributedChests: number;
+  playerRegisteredPoints: bigint;
+  totalRegisteredPoints: bigint;
+}
+
+interface ClaimableChestEstimate {
+  count: number;
+  reason: string;
+}
+
+const calculateProportionalChestShare = ({
+  allocatedChests,
+  distributedChests,
+  playerRegisteredPoints,
+  totalRegisteredPoints,
+}: Omit<ClaimableChestEstimateInput, "lootChestAddress">): number => {
+  if (allocatedChests <= 0 || totalRegisteredPoints <= 0n) {
+    return 0;
+  }
+
+  const rawShare = Number((BigInt(allocatedChests) * playerRegisteredPoints) / totalRegisteredPoints);
+  const remainingAllocatedChests = Math.max(0, allocatedChests - distributedChests);
+  return Math.min(rawShare, remainingAllocatedChests);
+};
+
+export const estimateClaimableChests = ({
+  lootChestAddress,
+  allocatedChests,
+  distributedChests,
+  playerRegisteredPoints,
+  totalRegisteredPoints,
+}: ClaimableChestEstimateInput): ClaimableChestEstimate => {
+  if (!lootChestAddress) {
+    return {
+      count: 0,
+      reason: "Loot chest rewards are not configured for this game.",
+    };
+  }
+
+  const guaranteedChestBonus = playerRegisteredPoints >= GAME_REWARD_CHEST_POINTS_THRESHOLD ? 1 : 0;
+  const proportionalChestShare = calculateProportionalChestShare({
+    allocatedChests,
+    distributedChests,
+    playerRegisteredPoints,
+    totalRegisteredPoints,
+  });
+
+  return {
+    count: Math.max(0, guaranteedChestBonus + proportionalChestShare),
+    reason: "",
+  };
+};

--- a/client/apps/game/src/services/review/game-review-service.test.ts
+++ b/client/apps/game/src/services/review/game-review-service.test.ts
@@ -7,11 +7,18 @@ import type { LandingLeaderboardEntry } from "@/services/leaderboard/landing-lea
 const TEST_PLAYER_ADDRESS = "0x062ba685f1d600ac7bda27e556b787548da32c7c0aa3ff5f58dddc07b9116f33";
 const TEST_TRIAL_ID_HEX = "0x00000000000000000000000000001c6b";
 const TEST_LORDS_SHARE_HEX = "0x1bc16d674ec80000"; // 2 LORDS with 18 decimals
+const TEST_LOOT_CHEST_ADDRESS = "0x123";
+const TEST_PLAYER_REGISTERED_POINTS_HEX = "0x77359400"; // 2,000 VP with 1e6 precision
+const TEST_TOTAL_REGISTERED_POINTS_HEX = "0xEE6B2800"; // 4,000 VP with 1e6 precision
 
 const fetchLandingLeaderboardMock = vi.fn<(...args: unknown[]) => Promise<LandingLeaderboardEntry[]>>();
 const fetchLandingLeaderboardEntryByAddressMock =
   vi.fn<(...args: unknown[]) => Promise<LandingLeaderboardEntry | null>>();
 const fetchWithErrorHandlingMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>();
+
+let lootChestAddress = TEST_LOOT_CHEST_ADDRESS;
+let allocatedChests = 2;
+let distributedChests = 0;
 
 vi.mock("@/services/leaderboard/landing-leaderboard-service", () => ({
   fetchLandingLeaderboard: (...args: unknown[]) => fetchLandingLeaderboardMock(...args),
@@ -78,6 +85,9 @@ const decodeQueryFromUrl = (url: string): string => {
 describe("game-review-service reward query formatting", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lootChestAddress = TEST_LOOT_CHEST_ADDRESS;
+    allocatedChests = 2;
+    distributedChests = 0;
 
     fetchLandingLeaderboardMock.mockResolvedValue([
       {
@@ -117,7 +127,14 @@ describe("game-review-service reward query formatting", () => {
       }
 
       if (normalizedQuery.includes('from "s1_eternum-worldconfig"') && normalizedQuery.includes("season_end_at")) {
-        return [{ season_end_at: 100, registration_grace_seconds: 0, registration_count: 4 }];
+        return [
+          {
+            season_end_at: 100,
+            registration_grace_seconds: 0,
+            registration_count: 4,
+            loot_chest_address: lootChestAddress,
+          },
+        ];
       }
 
       if (normalizedQuery.includes('from "s1_eternum-storyevent"') && normalizedQuery.includes("explorercreatestory")) {
@@ -132,15 +149,15 @@ describe("game-review-service reward query formatting", () => {
         normalizedQuery.includes('from "s1_eternum-playerregisteredpoints"') &&
         normalizedQuery.includes("prize_claimed")
       ) {
-        return [{ registered_points: "0x77359400", prize_claimed: 0 }];
+        return [{ registered_points: TEST_PLAYER_REGISTERED_POINTS_HEX, prize_claimed: 0 }];
       }
 
       if (normalizedQuery.includes('from "s1_eternum-gamechestreward"')) {
-        return [{ allocated_chests: 2, distributed_chests: 0 }];
+        return [{ allocated_chests: allocatedChests, distributed_chests: distributedChests }];
       }
 
       if (normalizedQuery.includes('from "s1_eternum-seasonprize"')) {
-        return [{ total_registered_points: "0xEE6B2800" }];
+        return [{ total_registered_points: TEST_TOTAL_REGISTERED_POINTS_HEX }];
       }
 
       if (normalizedQuery.includes('from "s1_eternum-playerrank" pr')) {
@@ -180,5 +197,32 @@ describe("game-review-service reward query formatting", () => {
     expect(data.rewards?.isRanked).toBe(true);
     expect(data.rewards?.lordsWonRaw).toBe(2_000_000_000_000_000_000n);
     expect(data.rewards?.lordsWonFormatted).toBe("2");
+  });
+
+  it("does not estimate loot chests when the game has no loot chest collectible configured", async () => {
+    lootChestAddress = "0x0";
+    const { fetchGameReviewClaimSummary } = await import("./game-review-service");
+
+    const summary = await fetchGameReviewClaimSummary({
+      worldName: "adam-14",
+      chain: "sepolia",
+      playerAddress: TEST_PLAYER_ADDRESS,
+    });
+
+    expect(summary.canClaimNow).toBe(true);
+    expect(summary.chestsClaimedEstimate).toBe(0);
+  });
+
+  it("caps proportional loot chests by the remaining allocated chest pool", async () => {
+    distributedChests = allocatedChests;
+    const { fetchGameReviewClaimSummary } = await import("./game-review-service");
+
+    const summary = await fetchGameReviewClaimSummary({
+      worldName: "adam-14",
+      chain: "sepolia",
+      playerAddress: TEST_PLAYER_ADDRESS,
+    });
+
+    expect(summary.chestsClaimedEstimate).toBe(1);
   });
 });

--- a/client/apps/game/src/services/review/game-review-service.ts
+++ b/client/apps/game/src/services/review/game-review-service.ts
@@ -10,6 +10,7 @@ import { commitAndClaimMMR } from "@/ui/features/prize/utils/mmr-utils";
 import { getMMRTierFromRaw, toMmrIntegerFromRaw } from "@/ui/utils/mmr-tiers";
 import { SqlApi } from "@bibliothecadao/torii";
 import {
+  normalizeNonZeroAddress,
   parseAddress,
   parseBigIntValue,
   parseBoolean,
@@ -31,13 +32,12 @@ import {
   fetchGameReviewMilestoneTimings,
   type GameReviewValueMetric,
 } from "./game-review-stats-utils";
+import { estimateClaimableChests } from "./chest-reward-estimate";
 
 const RANKING_BATCH_SIZE = 200;
 const LEADERBOARD_FETCH_LIMIT = 1000;
 const MAX_MAP_SNAPSHOT_TILES = 4200;
 const LORDS_TOKEN_DECIMALS = 18;
-const VICTORY_POINTS_MULTIPLIER = 1_000_000n;
-const GAME_REWARD_CHEST_POINTS_THRESHOLD = 500n * VICTORY_POINTS_MULTIPLIER;
 const CLAIM_ALL_REWARDS_BATCH_SIZE = 200;
 const MMR_UPDATED_SELECTOR = hash.getSelectorFromName("MMRUpdated").toLowerCase();
 const EVENT_KEY0_EXPR = "ltrim(substr(lower(keys), 1, instr(lower(keys), '/') - 1), '0x')";
@@ -94,7 +94,8 @@ const REVIEW_SEASON_TIMING_QUERY = `
     "season_config.dev_mode_on" AS dev_mode_on,
     "season_config.end_at" AS season_end_at,
     "season_config.registration_grace_seconds" AS registration_grace_seconds,
-    "blitz_registration_config.registration_count" AS registration_count
+    "blitz_registration_config.registration_count" AS registration_count,
+    "blitz_registration_config.collectibles_lootchest_address" AS loot_chest_address
   FROM "s1_eternum-WorldConfig"
   LIMIT 1;
 `;
@@ -389,6 +390,7 @@ interface SeasonTimingRow {
   season_end_at?: unknown;
   registration_grace_seconds?: unknown;
   registration_count?: unknown;
+  loot_chest_address?: unknown;
 }
 
 interface RankPrizeRow {
@@ -434,6 +436,7 @@ interface LatestMmrRow {
 interface ReviewFinalizationMeta {
   registeredPlayers: string[];
   registrationCount: number;
+  lootChestAddress: string | null;
   finalTrialId: bigint | null;
   rankingFinalized: boolean;
   devModeOn: boolean;
@@ -595,10 +598,12 @@ const fetchReviewFinalizationMeta = async (toriiSqlBaseUrl: string): Promise<Rev
   const seasonEndAt = seasonEndAtRaw > 0 ? seasonEndAtRaw : null;
   const registrationGraceSeconds = Math.max(0, parseNumeric(seasonTimingRows[0]?.registration_grace_seconds));
   const scoreSubmissionOpensAt = seasonEndAt != null ? seasonEndAt + registrationGraceSeconds : null;
+  const lootChestAddress = normalizeNonZeroAddress(seasonTimingRows[0]?.loot_chest_address);
 
   return {
     registeredPlayers,
     registrationCount,
+    lootChestAddress,
     finalTrialId,
     rankingFinalized,
     devModeOn,
@@ -894,6 +899,8 @@ const buildEliteTicketReason = ({
   return `Not eligible: elite ticket cutoff is rank #${cutoff} (you are #${playerRank}).`;
 };
 
+const parseChestCount = (value: unknown): number => Math.max(0, Math.trunc(parseNumeric(value)));
+
 const fetchReviewRewards = async ({
   toriiSqlBaseUrl,
   playerAddress,
@@ -921,15 +928,18 @@ const fetchReviewRewards = async ({
 
   const playerRegisteredPoints = parseBigIntValue(playerPointsRows[0]?.registered_points) ?? 0n;
   const playerPrizeClaimed = parseBoolean(playerPointsRows[0]?.prize_claimed);
-  const allocatedChests = Math.max(0, parseNumeric(chestRows[0]?.allocated_chests));
+  const allocatedChests = parseChestCount(chestRows[0]?.allocated_chests);
+  const distributedChests = parseChestCount(chestRows[0]?.distributed_chests);
   const totalRegisteredPoints = parseBigIntValue(seasonRows[0]?.total_registered_points) ?? 0n;
-  const guaranteedChestBonus = playerRegisteredPoints >= GAME_REWARD_CHEST_POINTS_THRESHOLD ? 1 : 0;
-  const proportionalChestShare =
-    allocatedChests > 0 && totalRegisteredPoints > 0n
-      ? Number((BigInt(allocatedChests) * playerRegisteredPoints) / totalRegisteredPoints)
-      : 0;
-  const chestsClaimedEstimate = Math.max(0, guaranteedChestBonus + proportionalChestShare);
-  const chestsClaimedReason = "";
+  const chestEstimate = estimateClaimableChests({
+    lootChestAddress: finalization.lootChestAddress,
+    allocatedChests,
+    distributedChests,
+    playerRegisteredPoints,
+    totalRegisteredPoints,
+  });
+  const chestsClaimedEstimate = chestEstimate.count;
+  const chestsClaimedReason = chestEstimate.reason;
 
   if (!finalization.rankingFinalized || finalization.finalTrialId == null) {
     return {

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -80,6 +80,15 @@ const formatLordsDisplayMaxTwoDecimals = (value: string): string => {
   return limitedDecimals.length > 0 ? `${wholeFormatted}.${limitedDecimals}` : wholeFormatted;
 };
 
+const formatClaimableRewardsText = (claimSummary: GameReviewClaimSummary): string => {
+  const lordsAmount = formatLordsDisplayMaxTwoDecimals(claimSummary.lordsWonFormatted);
+  if (claimSummary.chestsClaimedEstimate <= 0) {
+    return `Claimable: ${lordsAmount} LORDS`;
+  }
+
+  return `Claimable: ${lordsAmount} LORDS + ${claimSummary.chestsClaimedEstimate.toLocaleString()} chests`;
+};
+
 const getErrorMessage = (error: unknown): string | null => {
   if (error instanceof Error && error.message) return error.message;
   if (
@@ -808,8 +817,7 @@ const GameCard = ({
 
         {canClaimRewards && claimSummary && (
           <div className="rounded border border-gold/25 bg-gold/10 px-2 py-1.5 text-[10px] text-gold">
-            Claimable: {formatLordsDisplayMaxTwoDecimals(claimSummary.lordsWonFormatted)} LORDS +{" "}
-            {claimSummary.chestsClaimedEstimate.toLocaleString()} chests
+            {formatClaimableRewardsText(claimSummary)}
           </div>
         )}
 

--- a/client/apps/game/src/ui/features/prize/components/winners-table.tsx
+++ b/client/apps/game/src/ui/features/prize/components/winners-table.tsx
@@ -1,4 +1,6 @@
 import { getActiveWorld } from "@/runtime/world";
+import { estimateClaimableChests } from "@/services/review/chest-reward-estimate";
+import { normalizeNonZeroAddress } from "@/services/review/sql-parse-utils";
 import { displayAddress } from "@/ui/utils/utils";
 import { buildApiUrl, fetchWithErrorHandling } from "@bibliothecadao/torii";
 import { getAddressName, toHexString } from "@bibliothecadao/eternum";
@@ -11,10 +13,10 @@ import { useEffect, useMemo, useState } from "react";
 import { env } from "../../../../../env";
 
 const POINTS_PRECISION = 1_000_000n;
-const GAME_REWARD_CHEST_POINTS_THRESHOLD = 500n * POINTS_PRECISION;
 const GAME_CHEST_REWARD_QUERY = `
   SELECT
-    allocated_chests
+    allocated_chests,
+    distributed_chests
   FROM "s1_eternum-GameChestReward"
   LIMIT 1;
 `;
@@ -24,15 +26,27 @@ const SEASON_PRIZE_QUERY = `
   FROM "s1_eternum-SeasonPrize"
   LIMIT 1;
 `;
+const REWARD_CHEST_CONFIG_QUERY = `
+  SELECT
+    "blitz_registration_config.collectibles_lootchest_address" AS loot_chest_address
+  FROM "s1_eternum-WorldConfig"
+  LIMIT 1;
+`;
 
 type GameChestRewardRow = {
   allocated_chests?: unknown;
+  distributed_chests?: unknown;
 };
 type SeasonPrizeRow = {
   total_registered_points?: unknown;
 };
+type RewardChestConfigRow = {
+  loot_chest_address?: unknown;
+};
 type ChestRewardSnapshot = {
-  allocatedRewardChests: bigint;
+  lootChestAddress: string | null;
+  allocatedRewardChests: number;
+  distributedRewardChests: number;
   totalRegisteredPoints: bigint;
 };
 
@@ -49,6 +63,14 @@ const toBigIntValue = (value: unknown): bigint | undefined => {
     }
   }
   return undefined;
+};
+
+const toChestCount = (value: unknown): number => {
+  const count = toBigIntValue(value);
+  if (count == null || count <= 0n) return 0;
+
+  const asNumber = Number(count);
+  return Number.isFinite(asNumber) ? Math.trunc(asNumber) : 0;
 };
 
 type Row = {
@@ -92,7 +114,9 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
   const [chestRewardSnapshot, setChestRewardSnapshot] = useState<ChestRewardSnapshot | null>(
     () => cachedChestRewardSnapshot,
   );
-  const allocatedRewardChests = chestRewardSnapshot?.allocatedRewardChests ?? 0n;
+  const allocatedRewardChests = chestRewardSnapshot?.allocatedRewardChests ?? 0;
+  const distributedRewardChests = chestRewardSnapshot?.distributedRewardChests ?? 0;
+  const lootChestAddress = chestRewardSnapshot?.lootChestAddress ?? null;
   const totalRegisteredPoints = chestRewardSnapshot?.totalRegisteredPoints ?? 0n;
 
   useEffect(() => {
@@ -104,7 +128,7 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
         const toriiBaseUrl = activeWorld?.toriiBaseUrl ?? env.VITE_PUBLIC_TORII;
         const sqlBaseUrl = toriiBaseUrl.endsWith("/sql") ? toriiBaseUrl : `${toriiBaseUrl}/sql`;
 
-        const [chestRows, seasonRows] = await Promise.all([
+        const [chestRows, seasonRows, configRows] = await Promise.all([
           fetchWithErrorHandling<GameChestRewardRow>(
             buildApiUrl(sqlBaseUrl, GAME_CHEST_REWARD_QUERY),
             "Failed to fetch game chest reward state",
@@ -113,18 +137,23 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
             buildApiUrl(sqlBaseUrl, SEASON_PRIZE_QUERY),
             "Failed to fetch season prize state",
           ),
+          fetchWithErrorHandling<RewardChestConfigRow>(
+            buildApiUrl(sqlBaseUrl, REWARD_CHEST_CONFIG_QUERY),
+            "Failed to fetch reward chest config",
+          ),
         ]);
 
         if (cancelled) return;
 
-        const nextAllocatedRewardChests = toBigIntValue(chestRows[0]?.allocated_chests);
-        const nextTotalRegisteredPoints = toBigIntValue(seasonRows[0]?.total_registered_points);
-        if (nextAllocatedRewardChests == null || nextTotalRegisteredPoints == null) {
-          return;
-        }
+        const nextAllocatedRewardChests = toChestCount(chestRows[0]?.allocated_chests);
+        const nextDistributedRewardChests = toChestCount(chestRows[0]?.distributed_chests);
+        const nextTotalRegisteredPoints = toBigIntValue(seasonRows[0]?.total_registered_points) ?? 0n;
+        const nextLootChestAddress = normalizeNonZeroAddress(configRows[0]?.loot_chest_address);
 
         const nextSnapshot: ChestRewardSnapshot = {
+          lootChestAddress: nextLootChestAddress,
           allocatedRewardChests: nextAllocatedRewardChests,
+          distributedRewardChests: nextDistributedRewardChests,
           totalRegisteredPoints: nextTotalRegisteredPoints,
         };
         cachedChestRewardSnapshot = nextSnapshot;
@@ -190,18 +219,20 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
         const player = r!.player as unknown as bigint;
         const points = playerPointsByPlayer.get(player);
         const safePoints = typeof points === "bigint" ? points : 0n;
-        const guaranteedChestCount = safePoints >= GAME_REWARD_CHEST_POINTS_THRESHOLD ? 1n : 0n;
-        const proportionalChestCount =
-          allocatedRewardChests > 0n && totalRegisteredPoints > 0n
-            ? (allocatedRewardChests * safePoints) / totalRegisteredPoints
-            : 0n;
+        const chestEstimate = estimateClaimableChests({
+          lootChestAddress,
+          allocatedChests: allocatedRewardChests,
+          distributedChests: distributedRewardChests,
+          playerRegisteredPoints: safePoints,
+          totalRegisteredPoints,
+        });
 
         return {
           player,
           rank: Number(r!.rank),
           paid: Boolean(r!.paid),
           points,
-          earnedChests: guaranteedChestCount + proportionalChestCount,
+          earnedChests: BigInt(chestEstimate.count),
         };
       });
 
@@ -231,6 +262,8 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
     trialId,
     playerPointsByPlayer,
     allocatedRewardChests,
+    distributedRewardChests,
+    lootChestAddress,
     totalRegisteredPoints,
   ]);
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-06",
+    title: "Accurate Reward Claims",
+    description:
+      "Fixed ended game reward cards so chest rewards only appear when the game can actually mint loot chests and the shared chest pool still has claimable supply.",
+    type: "fix",
+  },
+  {
+    date: "2026-05-06",
     title: "Map Sync Recovery",
     description:
       "Improved map stream recovery so delayed spatial updates enter a reconnecting state, retry cleanly, and surface network trouble when the map cannot restore live updates.",


### PR DESCRIPTION
Fixes the ended-game reward summary so loot chests only appear when the world has a non-zero loot chest collectible address and the allocated chest pool still has remaining supply. The shared chest estimator is now reused by both the landing claim card and prize winners table, so they match the claim contract's mint gates. Added coverage for disabled loot chest config and exhausted proportional chest allocation. Validation: `pnpm run format`; `pnpm run knip`; `pnpm --dir client/apps/game typecheck`; `pnpm --dir client/apps/game exec vitest run src/services/review/game-review-service.test.ts`.