### PR TITLE
Fix bottom-right HUD entity scrolling

### DIFF
--- a/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
@@ -23,7 +23,19 @@ import {
   DEFAULT_COORD_ALT,
 } from "@bibliothecadao/eternum";
 import { useDojo, useQuery } from "@bibliothecadao/react";
-import { useCallback, useMemo } from "react";
+import { type ReactNode, useCallback, useMemo } from "react";
+
+const occupiedEntityLayoutClass =
+  "grid h-full min-h-0 min-w-0 grid-cols-1 grid-rows-[minmax(0,1fr)_auto] gap-2 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:grid-rows-1";
+const entityInfoScrollPaneClass =
+  "h-full min-h-0 min-w-0 overflow-y-auto overflow-x-hidden pr-1 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent";
+const scrollableEntityDetailClass = "h-auto min-h-full min-w-0 overflow-visible";
+const scrollableEntitySectionClass = "flex h-auto min-h-full min-w-0";
+const supportingEntitySectionClass = "flex min-h-0 min-w-0";
+
+const EntityInfoScrollPane = ({ children }: { children: ReactNode }) => (
+  <div className={entityInfoScrollPaneClass}>{children}</div>
+);
 
 export const SelectedWorldmapEntity = () => {
   const selectedHex = useUIStore((state) => state.selectedHex);
@@ -106,28 +118,32 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
 
   return (
     <div
-      className="grid h-full min-h-0 grid-cols-1 gap-2 overflow-y-auto overflow-x-hidden"
+      className="grid h-full min-h-0 grid-cols-1 gap-2"
       style={{ gridTemplateColumns, gridTemplateRows, gridAutoRows }}
     >
       {isSpire ? (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
-          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
-            <SpireTravelPanel onTravelToEtherealLayer={handleTravelToEtherealLayer} />
-          </EntityDetailSection>
-          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
+        <div className={occupiedEntityLayoutClass}>
+          <EntityInfoScrollPane>
+            <EntityDetailSection compact tone="highlight" className={scrollableEntitySectionClass}>
+              <SpireTravelPanel onTravelToEtherealLayer={handleTravelToEtherealLayer} />
+            </EntityDetailSection>
+          </EntityInfoScrollPane>
+          <EntityDetailSection compact tone="highlight" className={supportingEntitySectionClass}>
             <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
           </EntityDetailSection>
         </div>
       ) : isStructure ? (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
-          <StructureBannerEntityDetail
-            structureEntityId={occupierEntityId}
-            maxInventory={14}
-            showButtons={false}
-            className="h-full min-h-0"
-            {...sharedDetailProps}
-          />
-          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
+        <div className={occupiedEntityLayoutClass}>
+          <EntityInfoScrollPane>
+            <StructureBannerEntityDetail
+              structureEntityId={occupierEntityId}
+              maxInventory={14}
+              showButtons={false}
+              className={scrollableEntityDetailClass}
+              {...sharedDetailProps}
+            />
+          </EntityInfoScrollPane>
+          <EntityDetailSection compact tone="highlight" className={supportingEntitySectionClass}>
             <SelectedStructureActionPanel
               structureEntityId={occupierEntityId}
               biome={biome}
@@ -136,25 +152,31 @@ const SelectedWorldmapEntityContent = ({ selectedHex }: { selectedHex: HexPositi
           </EntityDetailSection>
         </div>
       ) : isChest ? (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
-          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
-            <RelicCrateSummaryPanel crateEntityId={occupierEntityId} />
-          </EntityDetailSection>
-          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
+        <div className={occupiedEntityLayoutClass}>
+          <EntityInfoScrollPane>
+            <EntityDetailSection compact tone="highlight" className={scrollableEntitySectionClass}>
+              <RelicCrateSummaryPanel crateEntityId={occupierEntityId} />
+            </EntityDetailSection>
+          </EntityInfoScrollPane>
+          <EntityDetailSection compact tone="highlight" className={supportingEntitySectionClass}>
             <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
           </EntityDetailSection>
         </div>
       ) : isQuest ? (
-        <QuestEntityDetail questEntityId={occupierEntityId} className="h-full min-h-0" {...sharedDetailProps} />
+        <EntityInfoScrollPane>
+          <QuestEntityDetail questEntityId={occupierEntityId} className="min-h-full" {...sharedDetailProps} />
+        </EntityInfoScrollPane>
       ) : (
-        <div className="grid h-full min-h-0 grid-cols-1 gap-2 lg:grid-cols-[1.15fr_0.85fr]">
-          <ArmyBannerEntityDetail
-            armyEntityId={occupierEntityId}
-            showButtons={false}
-            className="h-full min-h-0"
-            {...sharedDetailProps}
-          />
-          <EntityDetailSection compact tone="highlight" className="flex h-full min-h-0">
+        <div className={occupiedEntityLayoutClass}>
+          <EntityInfoScrollPane>
+            <ArmyBannerEntityDetail
+              armyEntityId={occupierEntityId}
+              showButtons={false}
+              className={scrollableEntityDetailClass}
+              {...sharedDetailProps}
+            />
+          </EntityInfoScrollPane>
+          <EntityDetailSection compact tone="highlight" className={supportingEntitySectionClass}>
             <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
           </EntityDetailSection>
         </div>

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
@@ -86,6 +86,11 @@ interface PanelFrameProps {
   attached?: boolean;
 }
 
+interface TilePanelScrollAreaProps {
+  children: ReactNode;
+  className?: string;
+}
+
 interface ResourceAmountEntry {
   resource: number;
   amount: number;
@@ -135,6 +140,17 @@ const PanelFrame = ({ title, children, headerAction, className, attached = false
     </header>
     <div className="flex-1 min-h-0 overflow-hidden px-1.5 py-1 lg:px-2.5 lg:py-2">{children}</div>
   </section>
+);
+
+const TilePanelScrollArea = ({ children, className }: TilePanelScrollAreaProps) => (
+  <div
+    className={cn(
+      "h-full min-h-0 overflow-y-auto overflow-x-hidden pr-1 scrollbar-thin scrollbar-thumb-gold/20 scrollbar-track-transparent",
+      className,
+    )}
+  >
+    {children}
+  </div>
 );
 
 type TabDefinition = {
@@ -645,12 +661,12 @@ const LocalTilePanel = () => {
     <PanelFrame title={panelTitle} headerAction={headerAction} attached>
       {selectedBuildingHex ? (
         isCastleTile ? (
-          <div className="h-full min-h-0 overflow-auto">
+          <TilePanelScrollArea>
             <RealmUpgradeCompact />
-          </div>
+          </TilePanelScrollArea>
         ) : hasBuilding ? (
-          <div className="h-full min-h-0 overflow-hidden">
-            <div className="grid h-full min-h-0 auto-rows-min grid-cols-2 gap-2 text-[11px] text-gold">
+          <TilePanelScrollArea>
+            <div className="grid min-h-full auto-rows-min grid-cols-2 gap-2 text-[11px] text-gold">
               {isPaused && (
                 <div className="col-span-2 flex items-center justify-between gap-2 rounded border border-red-400/40 bg-red/900/25 px-2 py-1.5">
                   <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-red-200">
@@ -884,7 +900,7 @@ const LocalTilePanel = () => {
                 </div>
               )}
             </div>
-          </div>
+          </TilePanelScrollArea>
         ) : (
           <div className="flex min-h-[140px] flex-col items-center justify-center text-center">
             <p className="text-xs text-gold/70">

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-07",
+    title: "Scrollable Tile HUD",
+    description:
+      "Fixed bottom-right entity and building detail panes so oversized info scrolls without moving the biome and action summary.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-05-06",
     title: "Map Sync Recovery",
     description:


### PR DESCRIPTION
Summary:
- Scope bottom-right map tile scrolling to the entity/details pane so biome and action summaries stay fixed.
- Keep local building and castle detail scrolling where the full panel is entity/building info.
- Add the latest-features entry for the HUD overflow fix.

Checks: `pnpm run format`, `pnpm run knip`, `pnpm --dir client/apps/game typecheck`, `git diff --check`, and `pnpm --dir client/apps/game exec vitest run src/ui/features/world/latest-features.test.ts --environment node`.