### PR TITLE
[NEED TO TRY ON MAINNET] Fix confirmation-gated army movement

### DIFF
--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts
@@ -9,16 +9,18 @@ const baseUpdate = {
 } as any;
 
 describe("processExplorerTroopsUpdate stale-position skip", () => {
-  it("skips updateArmyHexes but still applies updateArmyFromExplorerTroopsUpdate when stale", () => {
+  it("skips position work but still applies updateArmyFromExplorerTroopsUpdate when stale", async () => {
     const updateArmyHexes = vi.fn();
+    const moveArmyToAuthoritativeExplorerTroopsPosition = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => true);
     const onAuthoritativePositionApplied = vi.fn();
 
-    processExplorerTroopsUpdate(baseUpdate, {
+    await processExplorerTroopsUpdate(baseUpdate, {
       cancelPendingArmyRemoval: vi.fn(),
       scheduleArmyRemoval: vi.fn(),
       updateArmyHexes,
+      moveArmyToAuthoritativeExplorerTroopsPosition,
       updateArmyFromExplorerTroopsUpdate,
       onAuthoritativePositionApplied,
       shouldSkipStalePositionUpdate,
@@ -26,43 +28,49 @@ describe("processExplorerTroopsUpdate stale-position skip", () => {
 
     expect(shouldSkipStalePositionUpdate).toHaveBeenCalledWith(7, expect.objectContaining({ x: expect.any(Number) }));
     expect(updateArmyHexes).not.toHaveBeenCalled();
+    expect(moveArmyToAuthoritativeExplorerTroopsPosition).not.toHaveBeenCalled();
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(baseUpdate);
     expect(onAuthoritativePositionApplied).not.toHaveBeenCalled();
   });
 
-  it("applies both handlers when the predicate returns false", () => {
+  it("animates and applies state when the predicate returns false", async () => {
     const updateArmyHexes = vi.fn();
+    const moveArmyToAuthoritativeExplorerTroopsPosition = vi.fn(async () => {});
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => false);
     const onAuthoritativePositionApplied = vi.fn();
 
-    processExplorerTroopsUpdate(baseUpdate, {
+    await processExplorerTroopsUpdate(baseUpdate, {
       cancelPendingArmyRemoval: vi.fn(),
       scheduleArmyRemoval: vi.fn(),
       updateArmyHexes,
+      moveArmyToAuthoritativeExplorerTroopsPosition,
       updateArmyFromExplorerTroopsUpdate,
       onAuthoritativePositionApplied,
       shouldSkipStalePositionUpdate,
     });
 
     expect(updateArmyHexes).toHaveBeenCalledWith(baseUpdate);
+    expect(moveArmyToAuthoritativeExplorerTroopsPosition).toHaveBeenCalledWith(baseUpdate);
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(baseUpdate);
     expect(onAuthoritativePositionApplied).toHaveBeenCalledWith(baseUpdate);
   });
 
-  it("never consults the predicate on zero-troop removal events", () => {
+  it("never consults the predicate on zero-troop removal events", async () => {
     const updateArmyHexes = vi.fn();
+    const moveArmyToAuthoritativeExplorerTroopsPosition = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
     const scheduleArmyRemoval = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => true);
     const onAuthoritativePositionApplied = vi.fn();
 
-    processExplorerTroopsUpdate(
+    await processExplorerTroopsUpdate(
       { ...baseUpdate, troopCount: 0 },
       {
         cancelPendingArmyRemoval: vi.fn(),
         scheduleArmyRemoval,
         updateArmyHexes,
+        moveArmyToAuthoritativeExplorerTroopsPosition,
         updateArmyFromExplorerTroopsUpdate,
         onAuthoritativePositionApplied,
         shouldSkipStalePositionUpdate,
@@ -70,6 +78,7 @@ describe("processExplorerTroopsUpdate stale-position skip", () => {
     );
 
     expect(shouldSkipStalePositionUpdate).not.toHaveBeenCalled();
+    expect(moveArmyToAuthoritativeExplorerTroopsPosition).not.toHaveBeenCalled();
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalled();
     expect(onAuthoritativePositionApplied).not.toHaveBeenCalled();
     expect(scheduleArmyRemoval).toHaveBeenCalledWith(7, "zero");

--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { processExplorerTroopsUpdate } from "../worldmap-update-helpers";
+import { enqueueExplorerTroopsUpdate, processExplorerTroopsUpdate } from "../worldmap-update-helpers";
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+};
 
 describe("processExplorerTroopsUpdate", () => {
   it("updates army data before scheduling zero-count removal", async () => {
@@ -81,5 +97,65 @@ describe("processExplorerTroopsUpdate", () => {
     });
 
     expect(callOrder).toEqual(["hexes", "movement", "army", "pending-clear"]);
+  });
+});
+
+describe("enqueueExplorerTroopsUpdate", () => {
+  it("serializes async updates for the same army", async () => {
+    const queue = new Map();
+    const firstUpdate = { entityId: 7, troopCount: 12, hexCoords: { col: 2101, row: 2101 } } as any;
+    const secondUpdate = { entityId: 7, troopCount: 12, hexCoords: { col: 2102, row: 2102 } } as any;
+    const firstDeferred = createDeferred();
+    const secondDeferred = createDeferred();
+    const started: number[] = [];
+    const completed: number[] = [];
+    const processUpdate = vi.fn(async (update: any) => {
+      started.push(update.hexCoords.col);
+      await (update === firstUpdate ? firstDeferred.promise : secondDeferred.promise);
+      completed.push(update.hexCoords.col);
+    });
+
+    enqueueExplorerTroopsUpdate(firstUpdate, queue, { processUpdate });
+    enqueueExplorerTroopsUpdate(secondUpdate, queue, { processUpdate });
+    const queuedCompletion = queue.get(7)!;
+
+    await flushMicrotasks();
+    expect(started).toEqual([2101]);
+    expect(processUpdate).toHaveBeenCalledTimes(1);
+
+    firstDeferred.resolve();
+    await flushMicrotasks();
+    expect(started).toEqual([2101, 2102]);
+    expect(completed).toEqual([2101]);
+
+    secondDeferred.resolve();
+    await queuedCompletion;
+    expect(completed).toEqual([2101, 2102]);
+    expect(queue.has(7)).toBe(false);
+  });
+
+  it("keeps independent army queues from blocking each other", async () => {
+    const queue = new Map();
+    const firstDeferred = createDeferred();
+    const secondDeferred = createDeferred();
+    const started: number[] = [];
+    const processUpdate = vi.fn(async (update: any) => {
+      started.push(update.entityId);
+      await (update.entityId === 7 ? firstDeferred.promise : secondDeferred.promise);
+    });
+
+    enqueueExplorerTroopsUpdate({ entityId: 7, troopCount: 12, hexCoords: { col: 1, row: 1 } } as any, queue, {
+      processUpdate,
+    });
+    enqueueExplorerTroopsUpdate({ entityId: 8, troopCount: 12, hexCoords: { col: 2, row: 2 } } as any, queue, {
+      processUpdate,
+    });
+
+    await flushMicrotasks();
+    expect(started).toEqual([7, 8]);
+
+    firstDeferred.resolve();
+    secondDeferred.resolve();
+    await Promise.all(Array.from(queue.values()));
   });
 });

--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
@@ -3,10 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import { processExplorerTroopsUpdate } from "../worldmap-update-helpers";
 
 describe("processExplorerTroopsUpdate", () => {
-  it("updates army data before scheduling zero-count removal", () => {
+  it("updates army data before scheduling zero-count removal", async () => {
     const cancelPendingArmyRemoval = vi.fn();
     const scheduleArmyRemoval = vi.fn();
     const updateArmyHexes = vi.fn();
+    const moveArmyToAuthoritativeExplorerTroopsPosition = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
 
     const update = {
@@ -14,23 +15,26 @@ describe("processExplorerTroopsUpdate", () => {
       troopCount: 0,
     } as any;
 
-    processExplorerTroopsUpdate(update, {
+    await processExplorerTroopsUpdate(update, {
       cancelPendingArmyRemoval,
       scheduleArmyRemoval,
       updateArmyHexes,
+      moveArmyToAuthoritativeExplorerTroopsPosition,
       updateArmyFromExplorerTroopsUpdate,
     });
 
     expect(cancelPendingArmyRemoval).toHaveBeenCalledWith(42);
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(update);
     expect(updateArmyHexes).not.toHaveBeenCalled();
+    expect(moveArmyToAuthoritativeExplorerTroopsPosition).not.toHaveBeenCalled();
     expect(scheduleArmyRemoval).toHaveBeenCalledWith(42, "zero");
   });
 
-  it("updates hexes and army state for living armies", () => {
+  it("animates the authoritative position before updating army state for living armies", async () => {
     const cancelPendingArmyRemoval = vi.fn();
     const scheduleArmyRemoval = vi.fn();
     const updateArmyHexes = vi.fn();
+    const moveArmyToAuthoritativeExplorerTroopsPosition = vi.fn(async () => {});
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
     const onAuthoritativePositionApplied = vi.fn();
 
@@ -40,22 +44,24 @@ describe("processExplorerTroopsUpdate", () => {
       hexCoords: { col: 2100, row: 2100 },
     } as any;
 
-    processExplorerTroopsUpdate(update, {
+    await processExplorerTroopsUpdate(update, {
       cancelPendingArmyRemoval,
       scheduleArmyRemoval,
       updateArmyHexes,
+      moveArmyToAuthoritativeExplorerTroopsPosition,
       updateArmyFromExplorerTroopsUpdate,
       onAuthoritativePositionApplied,
     });
 
     expect(cancelPendingArmyRemoval).toHaveBeenCalledWith(7);
     expect(updateArmyHexes).toHaveBeenCalledWith(update);
+    expect(moveArmyToAuthoritativeExplorerTroopsPosition).toHaveBeenCalledWith(update);
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(update);
     expect(onAuthoritativePositionApplied).toHaveBeenCalledWith(update);
     expect(scheduleArmyRemoval).not.toHaveBeenCalled();
   });
 
-  it("notifies after applying the authoritative army update", () => {
+  it("notifies after animating and applying the authoritative army update", async () => {
     const callOrder: string[] = [];
     const update = {
       entityId: 9,
@@ -63,14 +69,17 @@ describe("processExplorerTroopsUpdate", () => {
       hexCoords: { col: 2103, row: 2104 },
     } as any;
 
-    processExplorerTroopsUpdate(update, {
+    await processExplorerTroopsUpdate(update, {
       cancelPendingArmyRemoval: vi.fn(),
       scheduleArmyRemoval: vi.fn(),
       updateArmyHexes: vi.fn(() => callOrder.push("hexes")),
+      moveArmyToAuthoritativeExplorerTroopsPosition: vi.fn(async () => {
+        callOrder.push("movement");
+      }),
       updateArmyFromExplorerTroopsUpdate: vi.fn(() => callOrder.push("army")),
       onAuthoritativePositionApplied: vi.fn(() => callOrder.push("pending-clear")),
     });
 
-    expect(callOrder).toEqual(["hexes", "army", "pending-clear"]);
+    expect(callOrder).toEqual(["hexes", "movement", "army", "pending-clear"]);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
@@ -59,7 +59,7 @@ describe("worldmap army suppression integration", () => {
   it("troop updates do not recover visuals before tile state catches up", () => {
     const src = readSource("worldmap.tsx");
 
-    const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {");
+    const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate(async (update) => {");
     expect(listenerStart).toBeGreaterThan(-1);
 
     const listenerBody = src.slice(listenerStart, listenerStart + 1200);

--- a/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
@@ -59,12 +59,12 @@ describe("worldmap army suppression integration", () => {
   it("troop updates do not recover visuals before tile state catches up", () => {
     const src = readSource("worldmap.tsx");
 
-    const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate(async (update) => {");
-    expect(listenerStart).toBeGreaterThan(-1);
+    const handlerStart = src.indexOf("private async applyExplorerTroopsUpdate(");
+    expect(handlerStart).toBeGreaterThan(-1);
 
-    const listenerBody = src.slice(listenerStart, listenerStart + 1200);
-    expect(listenerBody).not.toContain("this.cancelPendingArmyRemoval(update.entityId)");
-    expect(listenerBody).not.toContain("restoreArmyVisualIfVisible(update.entityId)");
-    expect(listenerBody).toContain("this.armyManager.updateArmyFromExplorerTroopsUpdate(update)");
+    const handlerBody = src.slice(handlerStart, handlerStart + 1200);
+    expect(handlerBody).not.toContain("this.cancelPendingArmyRemoval(update.entityId)");
+    expect(handlerBody).not.toContain("restoreArmyVisualIfVisible(update.entityId)");
+    expect(handlerBody).toContain("this.armyManager.updateArmyFromExplorerTroopsUpdate(update)");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
@@ -34,11 +34,11 @@ describe("worldmap army tile-sync recovery", () => {
   it("does not advance tile-sync recovery from troop updates", () => {
     const src = readSource("worldmap.tsx");
 
-    const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate(async (update) => {");
-    expect(listenerStart).toBeGreaterThan(-1);
+    const handlerStart = src.indexOf("private async applyExplorerTroopsUpdate(");
+    expect(handlerStart).toBeGreaterThan(-1);
 
-    const listenerBody = src.slice(listenerStart, listenerStart + 1400);
-    expect(listenerBody).not.toContain("this.armyLastTileSyncAt.set(update.entityId");
+    const handlerBody = src.slice(handlerStart, handlerStart + 1400);
+    expect(handlerBody).not.toContain("this.armyLastTileSyncAt.set(update.entityId");
   });
 
   it("uses tile-sync timestamps for scheduled removal cancellation and deferred retry", () => {

--- a/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
@@ -34,7 +34,7 @@ describe("worldmap army tile-sync recovery", () => {
   it("does not advance tile-sync recovery from troop updates", () => {
     const src = readSource("worldmap.tsx");
 
-    const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {");
+    const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate(async (update) => {");
     expect(listenerStart).toBeGreaterThan(-1);
 
     const listenerBody = src.slice(listenerStart, listenerStart + 1400);

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-biome.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-biome.source.test.ts
@@ -10,9 +10,9 @@ function readSource(filename: string): string {
 
 /**
  * Close the "empty hex for a few seconds" gap between tx submission and the
- * authoritative TileOpt delivery. Biome.getBiome is deterministic and mirrors
- * the Cairo biome_library, so we can render the destination biome immediately
- * once the submitted tx hash starts the optimistic tween.
+ * authoritative TileOpt delivery after confirmation. Biome.getBiome is
+ * deterministic and mirrors the Cairo biome_library, so we can render the
+ * destination biome immediately once the optimistic tween is allowed to start.
  */
 describe("Worldmap optimistic destination biome", () => {
   it("imports Biome from @bibliothecadao/eternum", () => {

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-mirror-gated.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-mirror-gated.source.test.ts
@@ -53,10 +53,10 @@ describe("Worldmap optimistic mirror gated on applyMovementPlan result", () => {
     expect(body).toMatch(/return true;/);
   });
 
-  it("the submitted optimistic-plan helper gates the mirror on applyMovementPlan's return", () => {
+  it("the confirmed optimistic-plan helper gates the mirror on applyMovementPlan's return", () => {
     const source = readSource("worldmap.tsx");
 
-    const handlerStart = source.indexOf("private async applySubmittedArmyMovementOptimisticPlan(");
+    const handlerStart = source.indexOf("private async applyConfirmedArmyMovementOptimisticPlan(");
     expect(handlerStart).toBeGreaterThan(0);
     const handlerEnd = source.indexOf("\n  private ", handlerStart + 20);
     expect(handlerEnd).toBeGreaterThan(handlerStart);
@@ -78,7 +78,7 @@ describe("Worldmap optimistic mirror gated on applyMovementPlan result", () => {
   it("emits optimistic_animation_skipped latency phase when the plan no-ops", () => {
     const source = readSource("worldmap.tsx");
 
-    const handlerStart = source.indexOf("private async applySubmittedArmyMovementOptimisticPlan(");
+    const handlerStart = source.indexOf("private async applyConfirmedArmyMovementOptimisticPlan(");
     const handlerEnd = source.indexOf("\n  private ", handlerStart + 20);
     const handler = source.slice(handlerStart, handlerEnd);
 

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-movement-wiring.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-movement-wiring.source.test.ts
@@ -22,7 +22,7 @@ describe("Worldmap optimistic movement wiring", () => {
     expect(source).toMatch(/this\.pendingMovementPlans\.set/);
   });
 
-  it("starts the optimistic plan from the submitted transaction hash", () => {
+  it("records submitted transaction hashes without starting movement", () => {
     const source = readSource("worldmap.tsx");
 
     const submitStart = source.indexOf("private handleSubmittedArmyMovementTx(");
@@ -32,10 +32,12 @@ describe("Worldmap optimistic movement wiring", () => {
     const submitHandler = source.slice(submitStart, submitEnd);
 
     expect(submitHandler).toContain('"tx_submitted"');
-    expect(submitHandler).toContain("startSubmittedArmyMovementOptimisticPlan");
+    expect(submitHandler).toContain("this.pendingArmyMovementTxMap.set(txHash, entityId)");
+    expect(submitHandler).not.toContain("startConfirmedArmyMovementOptimisticPlan");
+    expect(submitHandler).not.toContain("applyMovementPlan");
   });
 
-  it("records confirmation without waiting to start the optimistic tween", () => {
+  it("starts the optimistic plan from transaction confirmation", () => {
     const source = readSource("worldmap.tsx");
 
     const handlerStart = source.indexOf("this.handleTransactionComplete = ");
@@ -45,7 +47,37 @@ describe("Worldmap optimistic movement wiring", () => {
 
     const handler = source.slice(handlerStart, handlerEnd);
     expect(handler).toContain('"tx_confirmed"');
-    expect(handler).not.toContain("applyMovementPlan");
+    expect(handler).toContain("this.startConfirmedArmyMovementOptimisticPlan(entityId, txHash)");
+  });
+
+  it("applies confirmed movement plans at most once", () => {
+    const source = readSource("worldmap.tsx");
+
+    const helperStart = source.indexOf("private startConfirmedArmyMovementOptimisticPlan(");
+    expect(helperStart).toBeGreaterThan(0);
+    const helperEnd = source.indexOf("\n  private ", helperStart + 20);
+    expect(helperEnd).toBeGreaterThan(helperStart);
+    const helper = source.slice(helperStart, helperEnd);
+
+    expect(helper).toContain("this.pendingMovementPlans.get(entityId)");
+    expect(helper).toContain("if (!planPromise) return");
+    expect(helper).toContain("this.pendingMovementPlans.delete(entityId)");
+    expect(helper).toContain("this.applyConfirmedArmyMovementOptimisticPlan(entityId, txHash, plan)");
+    expect(helper.indexOf("this.pendingMovementPlans.delete(entityId)")).toBeLessThan(
+      helper.indexOf("this.applyConfirmedArmyMovementOptimisticPlan"),
+    );
+  });
+
+  it("lets authoritative movement clear pending plans before confirmation", () => {
+    const source = readSource("worldmap.tsx");
+
+    const clearStart = source.indexOf("private clearPendingArmyMovementFromAuthoritativePosition(");
+    expect(clearStart).toBeGreaterThan(0);
+    const clearEnd = source.indexOf("\n  private ", clearStart + 20);
+    expect(clearEnd).toBeGreaterThan(clearStart);
+    const clearBody = source.slice(clearStart, clearEnd);
+
+    expect(clearBody).toContain("this.pendingMovementPlans.delete(entityId)");
   });
 
   it("rewinds optimistic movement when the tx fails", () => {

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
@@ -43,15 +43,31 @@ describe("Worldmap pending movement visual handoff wiring", () => {
 
   it("clears pending movement from authoritative ExplorerTroops updates", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
-    const callStart = source.indexOf("processExplorerTroopsUpdate(update, {");
+    const callStart = source.indexOf("await processExplorerTroopsUpdate(update, {");
     expect(callStart).toBeGreaterThan(-1);
 
     const callEnd = source.indexOf("});", callStart);
     const body = source.slice(callStart, callEnd);
 
     expect(source).toContain("private clearPendingArmyMovementFromAuthoritativePosition(");
+    expect(body).toContain("moveArmyToAuthoritativeExplorerTroopsPosition:");
     expect(body).toContain("onAuthoritativePositionApplied:");
     expect(body).toContain("this.clearPendingArmyMovementFromAuthoritativePosition(update)");
+  });
+
+  it("animates authoritative ExplorerTroops movement before clearing pending movement", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const callStart = source.indexOf("await processExplorerTroopsUpdate(update, {");
+    expect(callStart).toBeGreaterThan(-1);
+
+    const callEnd = source.indexOf("});", callStart);
+    const body = source.slice(callStart, callEnd);
+    const movement = body.indexOf("moveArmyToAuthoritativeExplorerTroopsPosition:");
+    const pendingClear = body.indexOf("onAuthoritativePositionApplied:");
+
+    expect(movement).toBeGreaterThan(-1);
+    expect(pendingClear).toBeGreaterThan(-1);
+    expect(movement).toBeLessThan(pendingClear);
   });
 
   it("does not register tx hashes after authoritative updates already cleared pending movement", () => {
@@ -71,9 +87,9 @@ describe("Worldmap pending movement visual handoff wiring", () => {
     expect(pendingGuard).toBeLessThan(submittedTxRegistration);
   });
 
-  it("does not apply submitted movement plans after authoritative updates already cleared pending movement", () => {
+  it("does not apply confirmed movement plans after authoritative updates already cleared pending movement", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
-    const applyStart = source.indexOf("private async applySubmittedArmyMovementOptimisticPlan(");
+    const applyStart = source.indexOf("private async applyConfirmedArmyMovementOptimisticPlan(");
     expect(applyStart).toBeGreaterThan(-1);
 
     const applyEnd = source.indexOf("private mirrorOptimisticArmyDestinationIntoWorldmapCache", applyStart);

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
@@ -55,6 +55,16 @@ describe("Worldmap pending movement visual handoff wiring", () => {
     expect(body).toContain("this.clearPendingArmyMovementFromAuthoritativePosition(update)");
   });
 
+  it("routes ExplorerTroops listener work through the per-entity queue", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const listenerStart = source.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {");
+    expect(listenerStart).toBeGreaterThan(-1);
+
+    const listenerBody = source.slice(listenerStart, listenerStart + 300);
+    expect(source).toContain("private explorerTroopsUpdateQueue: Map<ID, Promise<void>> = new Map()");
+    expect(listenerBody).toContain("this.queueExplorerTroopsUpdate(update)");
+  });
+
   it("animates authoritative ExplorerTroops movement before clearing pending movement", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
     const callStart = source.indexOf("await processExplorerTroopsUpdate(update, {");

--- a/client/apps/game/src/three/scenes/worldmap-stale-position-filter.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-stale-position-filter.source.test.ts
@@ -28,7 +28,7 @@ describe("Worldmap stale-position filter wiring", () => {
   it("passes shouldSkipStalePositionUpdate into processExplorerTroopsUpdate", () => {
     const source = readSource("worldmap.tsx");
 
-    const callStart = source.indexOf("processExplorerTroopsUpdate(update, {");
+    const callStart = source.indexOf("await processExplorerTroopsUpdate(update, {");
     expect(callStart).toBeGreaterThan(0);
     const callEnd = source.indexOf("});", callStart);
     const body = source.slice(callStart, callEnd);

--- a/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
+++ b/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
@@ -5,15 +5,16 @@ type ExplorerTroopsUpdateHandlers = {
   cancelPendingArmyRemoval: (entityId: ID) => void;
   scheduleArmyRemoval: (entityId: ID, reason: "tile" | "zero") => void;
   updateArmyHexes: (update: ExplorerTroopsSystemUpdate) => void;
+  moveArmyToAuthoritativeExplorerTroopsPosition: (update: ExplorerTroopsSystemUpdate) => Promise<void>;
   updateArmyFromExplorerTroopsUpdate: (update: ExplorerTroopsSystemUpdate) => void;
   onAuthoritativePositionApplied?: (update: ExplorerTroopsSystemUpdate) => void;
   shouldSkipStalePositionUpdate?: (entityId: ID, normalized: { x: number; y: number }) => boolean;
 };
 
-export function processExplorerTroopsUpdate(
+export async function processExplorerTroopsUpdate(
   update: ExplorerTroopsSystemUpdate,
   handlers: ExplorerTroopsUpdateHandlers,
-): void {
+): Promise<void> {
   handlers.cancelPendingArmyRemoval(update.entityId);
 
   if (update.troopCount <= 0) {
@@ -29,6 +30,7 @@ export function processExplorerTroopsUpdate(
 
   if (!shouldSkipPosition) {
     handlers.updateArmyHexes(update);
+    await handlers.moveArmyToAuthoritativeExplorerTroopsPosition(update);
   }
   // Always apply non-positional fields (stamina/troop-count/owner). Tick-based
   // staleness resolution downstream handles any regression in those fields.

--- a/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
+++ b/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
@@ -11,6 +11,34 @@ type ExplorerTroopsUpdateHandlers = {
   shouldSkipStalePositionUpdate?: (entityId: ID, normalized: { x: number; y: number }) => boolean;
 };
 
+type ExplorerTroopsUpdateQueueHandlers = {
+  processUpdate: (update: ExplorerTroopsSystemUpdate) => Promise<void>;
+  onError?: (error: unknown, update: ExplorerTroopsSystemUpdate) => void;
+};
+
+export function enqueueExplorerTroopsUpdate(
+  update: ExplorerTroopsSystemUpdate,
+  queue: Map<ID, Promise<void>>,
+  handlers: ExplorerTroopsUpdateQueueHandlers,
+): void {
+  const entityId = update.entityId;
+  const previousUpdate = queue.get(entityId) ?? Promise.resolve();
+  const queuedUpdate = previousUpdate
+    .catch(() => undefined)
+    .then(() => handlers.processUpdate(update))
+    .catch((error) => {
+      handlers.onError?.(error, update);
+    });
+
+  queue.set(entityId, queuedUpdate);
+
+  void queuedUpdate.then(() => {
+    if (queue.get(entityId) === queuedUpdate) {
+      queue.delete(entityId);
+    }
+  });
+}
+
 export async function processExplorerTroopsUpdate(
   update: ExplorerTroopsSystemUpdate,
   handlers: ExplorerTroopsUpdateHandlers,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -66,6 +66,7 @@ import {
   BattleEventSystemUpdate,
   ChestSystemUpdate,
   ExplorerRewardSystemUpdate,
+  ExplorerTroopsSystemUpdate,
   ExplorerTroopsTileSystemUpdate,
   getBlockTimestamp,
   getTileAt,
@@ -639,9 +640,9 @@ export default class WorldmapScene extends WarpTravel {
   private pendingArmyMovementTxMap: Map<string, ID> = new Map();
   private pendingArmyMovementTargetKeys: Map<ID, string> = new Map();
   private pendingArmyMovementVisualLifecycleDisposers: Map<ID, () => void> = new Map();
-  // Pre-computed optimistic movement plans keyed by entityId. Planned at submit
-  // time in parallel with the tx, applied as soon as the tx hash is submitted
-  // so the army moves during provider confirmation instead of waiting on Torii.
+  // Pre-computed movement plans keyed by entityId. Planned at submit time in
+  // parallel with the tx, then applied after provider confirmation unless Torii
+  // reconciles the authoritative position first.
   private pendingMovementPlans: Map<ID, Promise<ArmyMovementPlan | null>> = new Map();
   private get hydratedChunkRefreshes(): Set<string> {
     return this.hydratedRefreshQueueState.queuedChunkKeys;
@@ -992,7 +993,7 @@ export default class WorldmapScene extends WarpTravel {
     this.logWorldmapSceneConstruction();
     this.initializeToriiStreamManager(dojoContext);
     this.initializeWorldmapSceneServices(dojoContext);
-    this.bindTransactionFailureLifecycle(dojoContext);
+    this.bindTransactionLifecycle(dojoContext);
     this.initializeWorldmapManagers();
     this.configureWorldmapRecoveryLifecycle();
     this.initializeWorldmapSupportManagers();
@@ -1091,7 +1092,7 @@ export default class WorldmapScene extends WarpTravel {
     this.loadBiomeModels(this.renderChunkSize.width * this.renderChunkSize.height);
   }
 
-  private bindTransactionFailureLifecycle(dojoContext: SetupResult): void {
+  private bindTransactionLifecycle(dojoContext: SetupResult): void {
     this.handleTransactionComplete = (payload: { details?: { transaction_hash?: string } }) => {
       const txHash = payload?.details?.transaction_hash;
       if (!txHash) {
@@ -1110,6 +1111,7 @@ export default class WorldmapScene extends WarpTravel {
         txHash,
       });
 
+      this.startConfirmedArmyMovementOptimisticPlan(entityId, txHash);
       this.pendingArmyMovementTxMap.delete(txHash);
     };
 
@@ -1150,18 +1152,17 @@ export default class WorldmapScene extends WarpTravel {
       entityId,
       txHash,
     });
-    this.startSubmittedArmyMovementOptimisticPlan(entityId, txHash);
   }
 
-  private startSubmittedArmyMovementOptimisticPlan(entityId: ID, txHash: string): void {
+  private startConfirmedArmyMovementOptimisticPlan(entityId: ID, txHash: string): void {
     const planPromise = this.pendingMovementPlans.get(entityId);
     if (!planPromise) return;
 
     this.pendingMovementPlans.delete(entityId);
-    void planPromise.then((plan) => this.applySubmittedArmyMovementOptimisticPlan(entityId, txHash, plan));
+    void planPromise.then((plan) => this.applyConfirmedArmyMovementOptimisticPlan(entityId, txHash, plan));
   }
 
-  private async applySubmittedArmyMovementOptimisticPlan(
+  private async applyConfirmedArmyMovementOptimisticPlan(
     entityId: ID,
     txHash: string,
     plan: ArmyMovementPlan | null,
@@ -1460,11 +1461,13 @@ export default class WorldmapScene extends WarpTravel {
     );
 
     this.addWorldUpdateSubscription(
-      this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {
-        processExplorerTroopsUpdate(update, {
+      this.worldUpdateListener.Army.onExplorerTroopsUpdate(async (update) => {
+        await processExplorerTroopsUpdate(update, {
           cancelPendingArmyRemoval: (entityId) => this.cancelPendingArmyRemoval(entityId),
           scheduleArmyRemoval: (entityId, reason) => this.scheduleArmyRemoval(entityId, reason),
           updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
+          moveArmyToAuthoritativeExplorerTroopsPosition: (update) =>
+            this.moveArmyToAuthoritativeExplorerTroopsPosition(update),
           updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
           onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
           shouldSkipStalePositionUpdate: (entityId, normalized) =>
@@ -1479,6 +1482,13 @@ export default class WorldmapScene extends WarpTravel {
         this.removeEntityFromTracking(entityId);
         this.requestChunkRefresh(false, "army_dead");
       }),
+    );
+  }
+
+  private async moveArmyToAuthoritativeExplorerTroopsPosition(update: ExplorerTroopsSystemUpdate): Promise<void> {
+    await this.armyManager.moveArmy(
+      update.entityId,
+      new Position({ x: update.hexCoords.col, y: update.hexCoords.row }),
     );
   }
 
@@ -2693,9 +2703,8 @@ export default class WorldmapScene extends WarpTravel {
         },
       });
 
-      // Pre-compute the optimistic movement plan in parallel with the tx so the
-      // submitted tx hash can start animation without waiting for provider
-      // confirmation or Torii's authoritative TileOpt update.
+      // Pre-compute the movement plan in parallel with the tx so confirmation
+      // can start animation promptly if Torii has not already reconciled it.
       const destPosition = new Position({ x: targetHex.col, y: targetHex.row });
       this.pendingMovementPlans.set(
         selectedEntityId,
@@ -2965,6 +2974,7 @@ export default class WorldmapScene extends WarpTravel {
         source: "worldmap",
         entityId,
       });
+      this.pendingMovementPlans.delete(entityId);
       this.clearPendingArmyMovement(entityId, "movement_started");
     });
     const disposeMovementComplete = this.armyManager.onMovementComplete(entityId, () => {

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -44,7 +44,7 @@ import { SceneManager } from "@/three/scene-manager";
 import { CameraView } from "@/three/scenes/camera-view";
 import { CAMERA_CONFIG } from "@/three/constants";
 import { HexagonScene } from "@/three/scenes/hexagon-scene";
-import { processExplorerTroopsUpdate } from "@/three/scenes/worldmap-update-helpers";
+import { enqueueExplorerTroopsUpdate, processExplorerTroopsUpdate } from "@/three/scenes/worldmap-update-helpers";
 import { WorldmapPerfSimulation } from "@/three/scenes/worldmap-perf-simulation";
 import { playResourceSound } from "@/three/sound/utils";
 import { LeftView } from "@/types";
@@ -644,6 +644,7 @@ export default class WorldmapScene extends WarpTravel {
   // parallel with the tx, then applied after provider confirmation unless Torii
   // reconciles the authoritative position first.
   private pendingMovementPlans: Map<ID, Promise<ArmyMovementPlan | null>> = new Map();
+  private explorerTroopsUpdateQueue: Map<ID, Promise<void>> = new Map();
   private get hydratedChunkRefreshes(): Set<string> {
     return this.hydratedRefreshQueueState.queuedChunkKeys;
   }
@@ -1461,18 +1462,8 @@ export default class WorldmapScene extends WarpTravel {
     );
 
     this.addWorldUpdateSubscription(
-      this.worldUpdateListener.Army.onExplorerTroopsUpdate(async (update) => {
-        await processExplorerTroopsUpdate(update, {
-          cancelPendingArmyRemoval: (entityId) => this.cancelPendingArmyRemoval(entityId),
-          scheduleArmyRemoval: (entityId, reason) => this.scheduleArmyRemoval(entityId, reason),
-          updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
-          moveArmyToAuthoritativeExplorerTroopsPosition: (update) =>
-            this.moveArmyToAuthoritativeExplorerTroopsPosition(update),
-          updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
-          onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
-          shouldSkipStalePositionUpdate: (entityId, normalized) =>
-            this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
-        });
+      this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {
+        this.queueExplorerTroopsUpdate(update);
       }),
     );
 
@@ -1483,6 +1474,31 @@ export default class WorldmapScene extends WarpTravel {
         this.requestChunkRefresh(false, "army_dead");
       }),
     );
+  }
+
+  private queueExplorerTroopsUpdate(update: ExplorerTroopsSystemUpdate): void {
+    enqueueExplorerTroopsUpdate(update, this.explorerTroopsUpdateQueue, {
+      processUpdate: (queuedUpdate) => this.applyExplorerTroopsUpdate(queuedUpdate),
+      onError: (error, failedUpdate) => this.handleExplorerTroopsUpdateError(error, failedUpdate),
+    });
+  }
+
+  private async applyExplorerTroopsUpdate(update: ExplorerTroopsSystemUpdate): Promise<void> {
+    await processExplorerTroopsUpdate(update, {
+      cancelPendingArmyRemoval: (entityId) => this.cancelPendingArmyRemoval(entityId),
+      scheduleArmyRemoval: (entityId, reason) => this.scheduleArmyRemoval(entityId, reason),
+      updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
+      moveArmyToAuthoritativeExplorerTroopsPosition: (update) =>
+        this.moveArmyToAuthoritativeExplorerTroopsPosition(update),
+      updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
+      onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
+      shouldSkipStalePositionUpdate: (entityId, normalized) =>
+        this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
+    });
+  }
+
+  private handleExplorerTroopsUpdateError(error: unknown, update: ExplorerTroopsSystemUpdate): void {
+    console.error("[worldmap] ExplorerTroops update failed", { entityId: update.entityId, error });
   }
 
   private async moveArmyToAuthoritativeExplorerTroopsPosition(update: ExplorerTroopsSystemUpdate): Promise<void> {
@@ -8565,6 +8581,7 @@ export default class WorldmapScene extends WarpTravel {
     this.pendingArmyMovementVisualLifecycleDisposers.clear();
     this.pendingArmyMovements.clear();
     this.pendingMovementPlans.clear();
+    this.explorerTroopsUpdateQueue.clear();
     if (this.handleTransactionComplete) {
       this.dojo.network?.provider?.off("transactionComplete", this.handleTransactionComplete);
     }

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-08",
+    title: "Confirmed Army Movement",
+    description:
+      "Army movement now waits for confirmation or synced world state, then animates from its source while pending markers show where explore or travel is resolving.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
     date: "2026-05-07",
     title: "Scrollable Tile HUD",
     description:
@@ -68,7 +76,7 @@ const allLatestFeatures: LatestFeature[] = [
     date: "2026-04-29",
     title: "Smoother Army Movement",
     description:
-      "Army movement now starts as soon as the transaction is submitted, blocks follow-up commands until authoritative world state catches up, and rewinds cleanly if the transaction fails.",
+      "Army movement now blocks follow-up commands while submitted moves resolve, keeps pending feedback visible, and rewinds cleanly if the transaction fails.",
     type: "fix",
   },
   {


### PR DESCRIPTION
## Summary
- Keep armies at their source while move transactions are only submitted.
- Start movement on provider confirmation or the first indexed ExplorerTroops update, preserving the origin-to-destination animation.
- Keep pending markers/arrival ghosts visible and update latest-features copy.

## Verification
- `pnpm --dir client/apps/game test src/three/scenes/__tests__/worldmap-update-helpers.test.ts src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts src/three/scenes/worldmap-stale-position-filter.source.test.ts src/three/scenes/worldmap-army-suppression.test.ts src/three/scenes/worldmap-army-tile-sync-recovery.test.ts src/three/scenes/worldmap-optimistic-movement-wiring.source.test.ts src/three/scenes/worldmap-optimistic-mirror-gated.source.test.ts src/three/scenes/worldmap-arrival-ghost.source.test.ts src/three/scenes/worldmap-optimistic-biome.source.test.ts`
- `pnpm --dir client/apps/game test:three:types`
- `pnpm run format`
- `pnpm run knip`