### PR TITLE
[codex] Ignore bot env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ client/apps/game/minimap
 .claude/tsc-cache/
 **/.claude/tsc-cache/
 thoughts/
+client/apps/bot/.env


### PR DESCRIPTION
Adds client/apps/bot/.env to .gitignore so local bot environment secrets stay out of the working tree. This is a repository hygiene change with no runtime behavior impact. Validated with pnpm run format and pnpm run knip after restoring workspace dependencies with pnpm install.