### PR TITLE
[codex] Fix CI pnpm setup for Node compatibility

### DIFF
--- a/.github/workflows/factory-indexer-maintenance.yml
+++ b/.github/workflows/factory-indexer-maintenance.yml
@@ -45,12 +45,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/factory-prize-funding.yml
+++ b/.github/workflows/factory-prize-funding.yml
@@ -53,12 +53,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -148,12 +148,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/grant-prize-distributor-minter-role.yml
+++ b/.github/workflows/grant-prize-distributor-minter-role.yml
@@ -18,12 +18,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/grant-village-pass-minter-role.yml
+++ b/.github/workflows/grant-village-pass-minter-role.yml
@@ -29,12 +29,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/.github/workflows/paymaster-policy-sync.yml
+++ b/.github/workflows/paymaster-policy-sync.yml
@@ -25,12 +25,10 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
+        uses: pnpm/action-setup@v4
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
## Summary
- update operational workflows from Node 20 to Node 22
- replace floating pnpm/action-setup@v2 + `version: latest` with pnpm/action-setup@v4 so CI uses the repo packageManager pin

## Root Cause
CI was installing `pnpm@latest`, which now resolves to pnpm 11. pnpm 11 requires Node 22.13+ and loads `node:sqlite`, so jobs still running Node 20 failed before dependency install.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm run format`
- `pnpm run knip`