### PR TITLE
[codex] Fix Eternum launch season timing

### DIFF
--- a/config/deployer/clean/config/config-loader.ts
+++ b/config/deployer/clean/config/config-loader.ts
@@ -187,16 +187,51 @@ function applyModeOverrides(
       on: resolvedOverrides.devModeOn,
     },
   };
-  config.season = {
-    ...(config.season ?? {}),
-    startMainAt: overrides.startMainAt,
-    ...(resolvedOverrides.durationSeconds !== undefined ? { durationSeconds: resolvedOverrides.durationSeconds } : {}),
-  };
+  config.season = buildSeasonConfigWithLaunchTiming(config, resolvedOverrides, overrides);
   config.settlement = {
     ...(config.settlement ?? {}),
     single_realm_mode: resolvedOverrides.singleRealmMode,
     two_player_mode: resolvedOverrides.twoPlayerMode,
   };
+}
+
+function buildSeasonConfigWithLaunchTiming(
+  config: EternumConfig,
+  resolvedOverrides: ResolvedConfigOverrides,
+  overrides: ConfigOverrides,
+): EternumConfig["season"] {
+  return {
+    ...(config.season ?? {}),
+    startMainAt: overrides.startMainAt,
+    ...resolveStartSettlingAtOverride(config, overrides.startMainAt),
+    ...(resolvedOverrides.durationSeconds !== undefined ? { durationSeconds: resolvedOverrides.durationSeconds } : {}),
+  };
+}
+
+function resolveStartSettlingAtOverride(
+  config: EternumConfig,
+  startMainAt: number,
+): Partial<Pick<EternumConfig["season"], "startSettlingAt">> {
+  if (!shouldDeriveStartSettlingAt(config, startMainAt)) {
+    return {};
+  }
+
+  return { startSettlingAt: startMainAt - resolveStartSettlingLeadSeconds(config) };
+}
+
+function shouldDeriveStartSettlingAt(config: EternumConfig, startMainAt: number): boolean {
+  return startMainAt > 0 && !hasExplicitStartSettlingAt(config);
+}
+
+function hasExplicitStartSettlingAt(config: EternumConfig): boolean {
+  return Boolean(config.season?.startSettlingAt && config.season.startSettlingAt > 0);
+}
+
+function resolveStartSettlingLeadSeconds(config: EternumConfig): number {
+  const startMainAfterSeconds = config.season?.startMainAfterSeconds ?? 0;
+  const startSettlingAfterSeconds = config.season?.startSettlingAfterSeconds ?? 0;
+
+  return Math.max(1, startMainAfterSeconds - startSettlingAfterSeconds);
 }
 
 function applyFactoryAddressOverride(config: EternumConfig, factoryAddress: string): void {

--- a/config/deployer/clean/tests/config-loader.test.ts
+++ b/config/deployer/clean/tests/config-loader.test.ts
@@ -214,7 +214,7 @@ describe("applyDeploymentConfigOverrides", () => {
     ).toThrow("blitzRegistrationOverrides.fee_amount must be a non-negative integer string");
   });
 
-  test("ignores duration overrides for eternum environments", () => {
+  test("ignores duration overrides and derives launch settling for eternum environments", () => {
     const baseConfig = loadEnvironmentConfiguration("slot.eternum");
 
     const result = applyDeploymentConfigOverrides(baseConfig, {
@@ -224,6 +224,7 @@ describe("applyDeploymentConfigOverrides", () => {
     });
 
     expect(result.season.startMainAt).toBe(1_763_112_600);
+    expect(result.season.startSettlingAt).toBe(1_763_112_599);
     expect(result.season.durationSeconds).toBe(0);
     expect(result.blitz.mode.on).toBe(false);
   });

--- a/config/deployer/clean/tests/native-config-steps.test.ts
+++ b/config/deployer/clean/tests/native-config-steps.test.ts
@@ -245,6 +245,40 @@ describe("native config steps", () => {
     expect(capturedCalls[0]?.end_at).toBe((capturedCalls[0]?.start_main_at as number) + 3_600);
   });
 
+  test("keeps standard launch settling before the pinned main start", async () => {
+    const baseConfig = loadEnvironmentConfiguration("slot.eternum");
+    const config = applyDeploymentConfigOverrides(baseConfig, {
+      startMainAt: 1_700_000_030,
+      factoryAddress: "0xabc",
+    });
+
+    const capturedCalls: Array<Record<string, unknown>> = [];
+    const provider = {
+      manifest: getGameManifest("slot") as any,
+      set_season_config: async (payload: Record<string, unknown>) => {
+        capturedCalls.push(payload);
+        return { statusReceipt: "ok" };
+      },
+    };
+
+    const originalDateNow = Date.now;
+    Date.now = () => 1_700_000_000_000;
+
+    try {
+      await setSeasonConfig({
+        account: { address: "0x1" } as any,
+        provider: provider as any,
+        config,
+      });
+    } finally {
+      Date.now = originalDateNow;
+    }
+
+    expect(capturedCalls).toHaveLength(1);
+    expect(capturedCalls[0]?.start_settling_at).toBe(1_700_000_029);
+    expect(capturedCalls[0]?.start_main_at).toBe(1_700_000_030);
+  });
+
   test("fills missing simple recipe outputs with zero in resource factory payloads", async () => {
     const baseConfig = loadEnvironmentConfiguration("mainnet.blitz");
     const config = applyDeploymentConfigOverrides(baseConfig, {


### PR DESCRIPTION
## Summary
Derive Eternum launch settling time from the pinned main start time so near-immediate launches do not send `start_settling_at` after `start_main_at`.
The deploy failure was caused by `startMainAt` being overridden from the launch request while `startSettlingAt` stayed relative to wall-clock time.
This keeps explicit settling timestamps intact, preserves Blitz duration behavior, and adds regression coverage for both config override output and the final season payload.

## Verification
- `bun test deployer/clean/tests/native-config-steps.test.ts deployer/clean/tests/config-loader.test.ts`
- `pnpm run format`
- `pnpm run knip`
