### PR TITLE
[codex] Record live indexer snapshots after launch

### DIFF
--- a/config/deployer/clean/run-store/indexer-live-snapshot.ts
+++ b/config/deployer/clean/run-store/indexer-live-snapshot.ts
@@ -1,5 +1,6 @@
 import { requireGitHubBranchStoreConfig, readGitHubBranchJsonFile, updateGitHubBranchJsonFile } from "./github";
-import type { IndexerLiveState } from "../types";
+import type { IndexerLiveState, IndexerTier, SeriesLaunchGameArtifacts } from "../types";
+import type { FactoryRunArtifacts } from "./types";
 
 const FACTORY_LIVE_INDEXER_SNAPSHOT_PATH = "indexes/indexers/live.json";
 
@@ -13,6 +14,11 @@ export interface FactoryLiveIndexerSnapshot {
   version: 1;
   updatedAt: string;
   entries: Record<string, FactoryLiveIndexerSnapshotEntry>;
+}
+
+interface FactoryLiveIndexerArtifactSource {
+  gameName: string;
+  artifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts;
 }
 
 function buildEmptyFactoryLiveIndexerSnapshot(): FactoryLiveIndexerSnapshot {
@@ -33,6 +39,41 @@ function buildSnapshotEntry(
     liveState,
     updatedAt,
   };
+}
+
+function isIndexerTier(value: string | undefined): value is IndexerTier {
+  return value === "basic" || value === "pro" || value === "legendary" || value === "epic";
+}
+
+function resolveLiveIndexerTier(artifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts): IndexerTier | undefined {
+  return isIndexerTier(artifacts.indexerTier) ? artifacts.indexerTier : undefined;
+}
+
+function buildLiveIndexerStateFromArtifacts(
+  artifacts: FactoryRunArtifacts | SeriesLaunchGameArtifacts,
+): IndexerLiveState | null {
+  if (!artifacts.indexerCreated) {
+    return null;
+  }
+
+  return {
+    state: "existing",
+    stateSource: "describe",
+    currentTier: resolveLiveIndexerTier(artifacts),
+    url: artifacts.indexerUrl,
+    version: artifacts.indexerVersion,
+    branch: artifacts.indexerBranch,
+    describedAt: artifacts.lastIndexerDescribeAt,
+  };
+}
+
+function buildLiveIndexerSnapshotEntriesFromArtifacts(
+  sources: FactoryLiveIndexerArtifactSource[],
+): Array<{ gameName: string; liveState: IndexerLiveState }> {
+  return sources.flatMap((source) => {
+    const liveState = buildLiveIndexerStateFromArtifacts(source.artifacts);
+    return liveState ? [{ gameName: source.gameName, liveState }] : [];
+  });
 }
 
 export function resolveFactoryLiveIndexerSnapshotPath() {
@@ -91,4 +132,17 @@ export async function updateFactoryLiveIndexerSnapshotEntries(
     }),
     message,
   );
+}
+
+export async function recordFactoryLiveIndexerSnapshotEntriesFromArtifacts(
+  config: ReturnType<typeof requireGitHubBranchStoreConfig>,
+  sources: FactoryLiveIndexerArtifactSource[],
+  message: string,
+) {
+  const entries = buildLiveIndexerSnapshotEntriesFromArtifacts(sources);
+  if (entries.length === 0) {
+    return;
+  }
+
+  await updateFactoryLiveIndexerSnapshotEntries(config, entries, message);
 }

--- a/config/deployer/clean/run-store/rotation-store.ts
+++ b/config/deployer/clean/run-store/rotation-store.ts
@@ -15,6 +15,7 @@ import {
   requireGitHubBranchStoreConfig,
   type ResolveGitHubBranchStoreConfigOptions,
 } from "./github";
+import { recordFactoryLiveIndexerSnapshotEntriesFromArtifacts } from "./indexer-live-snapshot";
 import { recordFactoryRotationMaintenanceIndex } from "./maintenance-index";
 import { resolveFactoryRotationRunId, resolveFactoryRotationRunRecordPath } from "./paths";
 import { buildPersistedRotationLaunchRequest } from "./persisted-launch-request";
@@ -500,6 +501,22 @@ async function updateRotationRunRecord(
   return nextRun;
 }
 
+async function recordLiveIndexerSnapshotForCompletedRotationStep(
+  run: FactoryRotationRunRecord,
+  request: FactoryRotationLaunchEventRequest,
+  options: RecordFactoryRotationLaunchOptions,
+): Promise<void> {
+  if (request.stepId !== "create-indexers") {
+    return;
+  }
+
+  await recordFactoryLiveIndexerSnapshotEntriesFromArtifacts(
+    requireGitHubBranchStoreConfig(options),
+    run.summary.games.map((game) => ({ gameName: game.gameName, artifacts: game.artifacts })),
+    buildCommitMessage("record live indexer snapshot", request),
+  );
+}
+
 async function resolvePlannedRotationSummary(request: FactoryRotationRunRequestContext["request"]) {
   const hydratedSummary = await hydrateRotationLaunchSummary(request);
   return persistRotationLaunchSummary(reconcileRotationLaunchSummary(request, hydratedSummary));
@@ -634,7 +651,7 @@ export async function recordFactoryRotationLaunchStepSucceeded(
 
   const context = createFactoryRotationRunStoreEventContext(request);
 
-  return updateRotationRunRecord(
+  const run = await updateRotationRunRecord(
     context,
     await resolvePlannedRotationSummary(request.request),
     options,
@@ -680,6 +697,9 @@ export async function recordFactoryRotationLaunchStepSucceeded(
     },
     `complete ${request.stepId}`,
   );
+
+  await recordLiveIndexerSnapshotForCompletedRotationStep(run, request, options);
+  return run;
 }
 
 export async function recordFactoryRotationLaunchStepFailed(

--- a/config/deployer/clean/run-store/series-store.ts
+++ b/config/deployer/clean/run-store/series-store.ts
@@ -13,6 +13,7 @@ import {
   requireGitHubBranchStoreConfig,
   type ResolveGitHubBranchStoreConfigOptions,
 } from "./github";
+import { recordFactoryLiveIndexerSnapshotEntriesFromArtifacts } from "./indexer-live-snapshot";
 import { recordFactorySeriesMaintenanceIndex } from "./maintenance-index";
 import { resolveFactorySeriesRunId, resolveFactorySeriesRunRecordPath } from "./paths";
 import { buildPersistedSeriesLaunchRequest } from "./persisted-launch-request";
@@ -450,6 +451,22 @@ async function updateSeriesRunRecord(
   return nextRun;
 }
 
+async function recordLiveIndexerSnapshotForCompletedSeriesStep(
+  run: FactorySeriesRunRecord,
+  request: FactorySeriesLaunchEventRequest,
+  options: RecordFactorySeriesLaunchOptions,
+): Promise<void> {
+  if (request.stepId !== "create-indexers") {
+    return;
+  }
+
+  await recordFactoryLiveIndexerSnapshotEntriesFromArtifacts(
+    requireGitHubBranchStoreConfig(options),
+    run.summary.games.map((game) => ({ gameName: game.gameName, artifacts: game.artifacts })),
+    buildCommitMessage("record live indexer snapshot", request),
+  );
+}
+
 export async function recordFactorySeriesLaunchStarted(
   request: FactorySeriesRunRequestContext,
   options: RecordFactorySeriesLaunchOptions = {},
@@ -541,7 +558,7 @@ export async function recordFactorySeriesLaunchStepSucceeded(
 
   const context = createFactorySeriesRunStoreEventContext(request);
 
-  return updateSeriesRunRecord(
+  const run = await updateSeriesRunRecord(
     context,
     buildInitialSeriesLaunchSummary(request.request),
     options,
@@ -580,6 +597,9 @@ export async function recordFactorySeriesLaunchStepSucceeded(
     },
     `complete ${request.stepId}`,
   );
+
+  await recordLiveIndexerSnapshotForCompletedSeriesStep(run, request, options);
+  return run;
 }
 
 export async function recordFactorySeriesLaunchStepFailed(

--- a/config/deployer/clean/run-store/store.ts
+++ b/config/deployer/clean/run-store/store.ts
@@ -8,6 +8,7 @@ import {
   requireGitHubBranchStoreConfig,
   type ResolveGitHubBranchStoreConfigOptions,
 } from "./github";
+import { recordFactoryLiveIndexerSnapshotEntriesFromArtifacts } from "./indexer-live-snapshot";
 import { recordFactoryRunMaintenanceIndex } from "./maintenance-index";
 import { resolveFactoryRunId, resolveFactoryRunRecordPath } from "./paths";
 import { buildPersistedGameLaunchRequest } from "./persisted-launch-request";
@@ -384,6 +385,22 @@ async function updateRunRecord(
   return nextRun;
 }
 
+async function recordLiveIndexerSnapshotForCompletedStep(
+  run: FactoryRunRecord,
+  request: FactoryLaunchEventRequest,
+  options: RecordFactoryLaunchOptions,
+): Promise<void> {
+  if (request.stepId !== "create-indexer") {
+    return;
+  }
+
+  await recordFactoryLiveIndexerSnapshotEntriesFromArtifacts(
+    requireGitHubBranchStoreConfig(options),
+    [{ gameName: run.gameName, artifacts: run.artifacts }],
+    buildCommitMessage("record live indexer snapshot", request),
+  );
+}
+
 export async function recordFactoryLaunchStarted(
   request: FactoryRunRequestContext,
   options: RecordFactoryLaunchOptions = {},
@@ -451,7 +468,7 @@ export async function recordFactoryLaunchStepSucceeded(
 
   const context = createFactoryRunStoreEventContext(request);
 
-  return updateRunRecord(
+  const run = await updateRunRecord(
     context,
     options,
     (current) =>
@@ -475,6 +492,9 @@ export async function recordFactoryLaunchStepSucceeded(
       ),
     `complete ${request.stepId}`,
   );
+
+  await recordLiveIndexerSnapshotForCompletedStep(run, request, options);
+  return run;
 }
 
 export async function recordFactoryLaunchStepFailed(

--- a/config/deployer/clean/tests/run-store.test.ts
+++ b/config/deployer/clean/tests/run-store.test.ts
@@ -329,6 +329,68 @@ describe("factory run store", () => {
     expect(runRecord.steps.find((step: { id: string }) => step.id === "create-world")?.status).toBe("succeeded");
   });
 
+  test("records successful indexer output into the live indexer snapshot", async () => {
+    const branchStore = createBranchStoreFetch();
+    globalThis.fetch = branchStore.fetch;
+
+    await recordFactoryLaunchStarted({
+      environmentId: "slot.eternum",
+      gameName: "etrn-season-730",
+      requestedLaunchStep: "full",
+      request: {
+        environmentId: "slot.eternum",
+        gameName: "etrn-season-730",
+        startTime: "2026-03-18T10:00:00Z",
+      },
+    });
+
+    writeLaunchSummaryFile({
+      environment: "slot.eternum",
+      chain: "slot",
+      gameType: "eternum",
+      gameName: "etrn-season-730",
+      startTime: 1_710_756_000,
+      startTimeIso: "2026-03-18T10:00:00.000Z",
+      rpcUrl: "https://rpc.example",
+      factoryAddress: "0x123",
+      indexerCreated: true,
+      indexerTier: "pro",
+      indexerUrl: "https://api.cartridge.gg/x/etrn-season-730/torii",
+      indexerVersion: "1.7.0",
+      indexerBranch: "next",
+      lastIndexerDescribeAt: "2026-03-18T10:10:00.000Z",
+      configMode: "batched",
+      configSteps: [],
+      dryRun: false,
+    });
+
+    await recordFactoryLaunchStepSucceeded({
+      environmentId: "slot.eternum",
+      gameName: "etrn-season-730",
+      requestedLaunchStep: "full",
+      stepId: "create-indexer",
+      request: {
+        environmentId: "slot.eternum",
+        gameName: "etrn-season-730",
+        startTime: "2026-03-18T10:00:00Z",
+      },
+    });
+
+    const snapshot = branchStore.readJson("indexes/indexers/live.json");
+    const entry = snapshot.entries["etrn-season-730"];
+
+    expect(entry.gameName).toBe("etrn-season-730");
+    expect(entry.liveState).toMatchObject({
+      state: "existing",
+      stateSource: "describe",
+      currentTier: "pro",
+      url: "https://api.cartridge.gg/x/etrn-season-730/torii",
+      version: "1.7.0",
+      branch: "next",
+      describedAt: "2026-03-18T10:10:00.000Z",
+    });
+  });
+
   test("records paymaster completion in launch artifacts", async () => {
     const branchStore = createBranchStoreFetch();
     globalThis.fetch = branchStore.fetch;
@@ -756,6 +818,9 @@ describe("factory run store", () => {
     expect(
       recoveredGame?.steps.find((step: { id: string }) => step.id === "create-indexers")?.errorMessage,
     ).toBeUndefined();
+
+    const snapshot = branchStore.readJson("indexes/indexers/live.json");
+    expect(snapshot.entries["bltz-series-recovery-02"].liveState.state).toBe("existing");
   });
 
   test("rewrites a targeted rotation child indexer status without a refreshed workspace summary", async () => {
@@ -840,6 +905,9 @@ describe("factory run store", () => {
     expect(
       recoveredGame?.steps.find((step: { id: string }) => step.id === "create-indexers")?.errorMessage,
     ).toBeUndefined();
+
+    const snapshot = branchStore.readJson("indexes/indexers/live.json");
+    expect(snapshot.entries["bltz-rotation-recovery-02"].liveState.state).toBe("existing");
   });
 
   test("marks a failed step as needing attention", async () => {


### PR DESCRIPTION
## Summary

This updates launch run-store recording so successful game, series, and rotation indexer steps also publish entries into `indexes/indexers/live.json`. The dashboard was reading that live snapshot, but normal launch CI only updated run artifacts, so newly shipped indexers could be live in Slot while missing from Factory V2 until a separate maintenance refresh ran. The shared snapshot helper derives live state from the indexer artifacts already written by launch CI.

## Verification

Ran `bun test config/deployer/clean/tests/run-store.test.ts`, `pnpm run format`, `pnpm run knip`, and `git diff --check`.
