### PR TITLE
[codex] Fix landing settlement sync hang

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts
@@ -82,6 +82,36 @@ describe("runBlitzSettlementFlow", () => {
     expect(result.recoveryStatus?.canPlay).toBe(false);
   });
 
+  it("does not submit extra mainnet settlement calls before initial progress is indexed", async () => {
+    const readSettlementSnapshot = vi
+      .fn<() => Promise<SettlementSnapshot | null>>()
+      .mockResolvedValueOnce(snapshot({ registered: true }))
+      .mockResolvedValueOnce(snapshot({ onceRegistered: true, settledCount: 0 }));
+    const runAssignAndSettle = vi.fn<(_: number) => Promise<void>>().mockResolvedValue(undefined);
+    const runSingleSettle = vi.fn<(_: number, __: number) => Promise<void>>().mockResolvedValue(undefined);
+    const waitForSettlementTarget = vi
+      .fn<(_: number) => Promise<SettlementSnapshot | null>>()
+      .mockResolvedValue(snapshot({ onceRegistered: true, settledCount: 0 }));
+
+    const result = await runBlitzSettlementFlow({
+      isMainnet: true,
+      singleRealmMode: false,
+      readSettlementSnapshot,
+      syncSettlementStateFromSnapshot: deriveSettlementStatus,
+      waitForSettlementTarget,
+      onStageChange: vi.fn(),
+      runAssignAndSettle,
+      runSingleSettle,
+    });
+
+    expect(result).toMatchObject({
+      status: "syncing",
+      pendingTargetSettleCount: 3,
+    });
+    expect(runAssignAndSettle).toHaveBeenCalledWith(1);
+    expect(runSingleSettle).not.toHaveBeenCalled();
+  });
+
   it("fails when verification breaks before any settlement submission is confirmed", async () => {
     const readSettlementSnapshot = vi
       .fn<() => Promise<SettlementSnapshot | null>>()

--- a/client/apps/game/src/ui/features/landing/components/game-entry-blitz-settlement-flow.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-blitz-settlement-flow.ts
@@ -117,6 +117,26 @@ const buildSyncingResult = ({
   recoveryStatus,
 });
 
+const waitForSubmittedSettlementProgress = async ({
+  targetSettleCount,
+  waitForSettlementTarget,
+  syncSettlementStateFromSnapshot,
+}: {
+  targetSettleCount: number;
+  waitForSettlementTarget: RunBlitzSettlementFlowParams["waitForSettlementTarget"];
+  syncSettlementStateFromSnapshot: RunBlitzSettlementFlowParams["syncSettlementStateFromSnapshot"];
+}) => {
+  const snapshot = await waitForSettlementTarget(targetSettleCount);
+  if (!snapshot) {
+    throw new Error("Timed out waiting for submitted settlement progress.");
+  }
+
+  const status = syncSettlementStateFromSnapshot(snapshot);
+  if (!hasReachedSettlementTarget(status, targetSettleCount)) {
+    throw new Error(`Settlement is still syncing: ${status.settledCount}/${targetSettleCount} realms settled.`);
+  }
+};
+
 export const runBlitzSettlementFlow = async ({
   isMainnet,
   singleRealmMode,
@@ -154,7 +174,11 @@ export const runBlitzSettlementFlow = async ({
       await runAssignAndSettle(plan.initialSettleCount);
       hasConfirmedSettlementSubmission = true;
       targetProgress = Math.min(plan.targetSettleCount, targetProgress + plan.initialSettleCount);
-      await waitForSettlementTarget(targetProgress);
+      await waitForSubmittedSettlementProgress({
+        targetSettleCount: targetProgress,
+        waitForSettlementTarget,
+        syncSettlementStateFromSnapshot,
+      });
     }
 
     if (plan.extraSettleCalls > 0) {
@@ -163,7 +187,11 @@ export const runBlitzSettlementFlow = async ({
         await runSingleSettle(stepIndex, plan.extraSettleCalls);
         hasConfirmedSettlementSubmission = true;
         targetProgress = Math.min(plan.targetSettleCount, targetProgress + 1);
-        await waitForSettlementTarget(targetProgress);
+        await waitForSubmittedSettlementProgress({
+          targetSettleCount: targetProgress,
+          waitForSettlementTarget,
+          syncSettlementStateFromSnapshot,
+        });
       }
     }
 

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.settlement-sync.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.settlement-sync.source.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("GameEntryModal settlement sync recovery", () => {
+  it("submits landing settlement transactions without blocking on confirmation", () => {
+    const source = readSource("src/ui/features/landing/components/game-entry-modal.tsx");
+
+    expect(source).toMatch(/operation: "assign_and_settle_realms"[\s\S]*waitForConfirmation: false/);
+    expect(source).toMatch(/operation: "settle_realms"[\s\S]*waitForConfirmation: false/);
+    expect(source).toMatch(/operation: "season_realm_create"[\s\S]*waitForConfirmation: false/);
+    expect(source).toMatch(/operation: "village_systems.create"[\s\S]*waitForConfirmation: false/);
+    expect(source).toContain("confirm: async (txHash) => {");
+  });
+
+  it("polls indexed settlement state after submitted realm and village transactions", () => {
+    const source = readSource("src/ui/features/landing/components/game-entry-modal.tsx");
+
+    expect(source).toContain("const waitForRealmSettlementIndex = useCallback");
+    expect(source).toContain("findIndexedRealmSettlement");
+    expect(source).toContain("findNewIndexedVillageSettlement");
+    expect(source).toContain("Submitted but still syncing. Checking indexed world state.");
+    expect(source).toContain('buildSettlementStillSyncingMessage("realm")');
+    expect(source).toContain('buildSettlementStillSyncingMessage("village")');
+  });
+
+  it("refreshes settlement queries when the modal opens", () => {
+    const source = readSource("src/ui/features/landing/components/game-entry-modal.tsx");
+
+    expect(source).toContain("const invalidateEternumSettlementQueries = useCallback");
+    expect(source).toContain('queryKey: ["eternumOwnedStructures", chain, worldName, account?.address]');
+    expect(source).toContain('queryKey: ["settlementPlannerSnapshot", chain, worldName]');
+    expect(source).toContain("const refreshEternumSettlementQueries = useCallback");
+    expect(source).toContain("refetchOwnedStructures()");
+    expect(source).toContain("refetchRealmVillageSlots()");
+    expect(source).toContain("refetchSettlementPlannerData()");
+    expect(source).toContain("void refreshEternumSettlementQueries();");
+  });
+
+  it("keeps settlement buttons disabled while submitted transactions are being verified", () => {
+    const source = readSource("src/ui/features/landing/components/game-entry-modal.tsx");
+
+    expect(source).toContain(
+      "disabled={!seasonTimingValid || selectedSeasonPassTokenId == null || isSubmittingRealmSettlement}",
+    );
+    expect(source).toContain(
+      "disabled={!seasonTimingValid || selectedVillagePassTokenId == null || isSubmittingVillageSettlement}",
+    );
+    expect(source).toContain("selectedSeasonPassTokenId != null && canSettle");
+    expect(source).toContain("!isSubmittingSettlement");
+  });
+});

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -57,8 +57,12 @@ import {
   applyDashboardRegistrationHint,
   deriveSettlementPhaseViewModel,
   deriveSettlementStatus,
+  findIndexedRealmSettlement,
+  findNewIndexedVillageSettlement,
   hasReachedSettlementTarget,
   parseSnapshotRegistrationRow,
+  type IndexedRealmSettlementTarget,
+  type SettlementSubmissionStatus,
   type SettleStage,
   type SettlementSnapshot,
 } from "./game-entry-settlement.utils";
@@ -363,7 +367,40 @@ const computeSeasonPlacementPreview = ({
   };
 };
 
+const buildSettlementStillSyncingMessage = (settlementType: "realm" | "village"): string =>
+  `${settlementType === "realm" ? "Realm" : "Village"} settlement submitted, but world sync is still catching up. Close and reopen this game card in a moment if it does not appear.`;
+
+const getSubmittedSettlementSyncMessage = (error: unknown): string | null => {
+  const raw = error instanceof Error ? error.message : String(error ?? "");
+  const message = raw.toLowerCase();
+  return message.includes("world sync is still catching up") ? raw : null;
+};
+
+const resolveSettlementSubmissionButtonLabel = ({
+  status,
+  idleLabel,
+  submittingLabel,
+}: {
+  status: SettlementSubmissionStatus;
+  idleLabel: string;
+  submittingLabel: string;
+}): string => {
+  if (status === "submitting") return submittingLabel;
+  if (status === "syncing") return "Checking settlement...";
+  return idleLabel;
+};
+
+const resolveSettlementSubmissionDetail = (status: SettlementSubmissionStatus): string | null => {
+  if (status === "submitting") return "Submitting transaction to your wallet.";
+  if (status === "syncing") return "Submitted but still syncing. Checking indexed world state.";
+  if (status === "failed") return "Settlement failed. You can retry once the wallet is ready.";
+  return null;
+};
+
 const mapSeasonSettleError = (error: unknown): string => {
+  const submittedSyncMessage = getSubmittedSettlementSyncMessage(error);
+  if (submittedSyncMessage) return submittedSyncMessage;
+
   const raw = error instanceof Error ? error.message : String(error ?? "");
   const message = raw.toLowerCase();
   const failingAddressMatch = raw.match(/address\s*(?:\n|:)?\s*(0x[0-9a-f]+)/i);
@@ -441,6 +478,9 @@ const mapSeasonSettleError = (error: unknown): string => {
 };
 
 const mapVillageSettleError = (error: unknown): string => {
+  const submittedSyncMessage = getSubmittedSettlementSyncMessage(error);
+  if (submittedSyncMessage) return submittedSyncMessage;
+
   const raw = error instanceof Error ? error.message : String(error ?? "");
   const message = raw.toLowerCase();
 
@@ -1220,6 +1260,7 @@ const SeasonPlacementPhase = ({
   onSelectSeasonPass,
   onConfirmSettlement,
   isSubmittingSettlement,
+  submissionStatus,
   placementValidationErrors,
   targetCoordPreview,
   settlementError,
@@ -1246,6 +1287,7 @@ const SeasonPlacementPhase = ({
   onSelectSeasonPass: (tokenId: bigint | null) => void;
   onConfirmSettlement: () => void;
   isSubmittingSettlement: boolean;
+  submissionStatus: SettlementSubmissionStatus;
   placementValidationErrors: string[];
   targetCoordPreview: SeasonPlacementPreview | null;
   settlementError: string | null;
@@ -1265,13 +1307,12 @@ const SeasonPlacementPhase = ({
   const maxPointForLayer = Math.max(0, placement.layer - 1);
   const canSubmit =
     selectedSeasonPassTokenId != null && canSettle && placementValidationErrors.length === 0 && !isSubmittingSettlement;
-  const submitLabel = isSubmittingSettlement
-    ? spiresSettled
-      ? "Settling..."
-      : "Creating Spires + Settling..."
-    : spiresSettled
-      ? "Settle Realm"
-      : "Create Spires + Settle Realm";
+  const submitLabel = resolveSettlementSubmissionButtonLabel({
+    status: submissionStatus,
+    idleLabel: spiresSettled ? "Settle Realm" : "Create Spires + Settle Realm",
+    submittingLabel: spiresSettled ? "Submitting..." : "Creating Spires + Settling...",
+  });
+  const submissionDetail = resolveSettlementSubmissionDetail(submissionStatus);
   const spiresProgressLabel =
     spiresSettledCount != null && spiresMaxCount != null
       ? `${Math.min(spiresSettledCount, spiresMaxCount)} / ${spiresMaxCount}`
@@ -1562,6 +1603,7 @@ const SeasonPlacementPhase = ({
       )}
 
       {settlementError && <p className="text-[11px] text-red-200">{settlementError}</p>}
+      {submissionDetail && !settlementError && <p className="text-[11px] text-gold/70">{submissionDetail}</p>}
 
       <div className="sticky bottom-0 z-10 rounded-xl border border-gold/30 bg-gradient-to-r from-[#1a1309]/95 via-[#20170c]/95 to-[#120d07]/95 px-3 py-3 shadow-[0_-10px_25px_rgba(0,0,0,0.35)] backdrop-blur-sm">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -1751,6 +1793,7 @@ const VillagePlacementPhase = ({
   onSelectDirection,
   onConfirmSettlement,
   isSubmittingSettlement,
+  submissionStatus,
   settlementError,
   villagePassInventoryError,
   villageSlotsError,
@@ -1776,6 +1819,7 @@ const VillagePlacementPhase = ({
   onSelectDirection: (direction: Direction | null) => void;
   onConfirmSettlement: () => void;
   isSubmittingSettlement: boolean;
+  submissionStatus: SettlementSubmissionStatus;
   settlementError: string | null;
   villagePassInventoryError: string | null;
   villageSlotsError: string | null;
@@ -1792,6 +1836,12 @@ const VillagePlacementPhase = ({
     selectedDirection != null &&
     selectedDirectionSlot?.isAvailable === true &&
     !isSubmittingSettlement;
+  const submitLabel = resolveSettlementSubmissionButtonLabel({
+    status: submissionStatus,
+    idleLabel: "Settle Village",
+    submittingLabel: "Submitting Village...",
+  });
+  const submissionDetail = resolveSettlementSubmissionDetail(submissionStatus);
 
   return (
     <div className="flex flex-col gap-4">
@@ -1945,6 +1995,7 @@ const VillagePlacementPhase = ({
       />
 
       {settlementError && <p className="text-[11px] text-red-200">{settlementError}</p>}
+      {submissionDetail && !settlementError && <p className="text-[11px] text-gold/70">{submissionDetail}</p>}
 
       <div className="sticky bottom-0 z-10 rounded-xl border border-gold/30 bg-gradient-to-r from-[#1a1309]/95 via-[#20170c]/95 to-[#120d07]/95 px-3 py-3 shadow-[0_-10px_25px_rgba(0,0,0,0.35)] backdrop-blur-sm">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -1967,7 +2018,7 @@ const VillagePlacementPhase = ({
           >
             <div className="flex items-center justify-center gap-2">
               {isSubmittingSettlement ? <Loader2 className="h-4 w-4 animate-spin" /> : <Castle className="h-4 w-4" />}
-              <span>{isSubmittingSettlement ? "Settling Village..." : "Settle Village"}</span>
+              <span>{submitLabel}</span>
             </div>
           </Button>
         </div>
@@ -2027,6 +2078,8 @@ const SettlementPlannerPhase = ({
   onConfirmVillageSettlement,
   isSubmittingRealmSettlement,
   isSubmittingVillageSettlement,
+  realmSettlementSubmissionStatus,
+  villageSettlementSubmissionStatus,
   seasonSettlementError,
   villageSettlementError,
   onEnterGame,
@@ -2082,6 +2135,8 @@ const SettlementPlannerPhase = ({
   onConfirmVillageSettlement: () => void;
   isSubmittingRealmSettlement: boolean;
   isSubmittingVillageSettlement: boolean;
+  realmSettlementSubmissionStatus: SettlementSubmissionStatus;
+  villageSettlementSubmissionStatus: SettlementSubmissionStatus;
   seasonSettlementError: string | null;
   villageSettlementError: string | null;
   onEnterGame: () => void;
@@ -2099,6 +2154,18 @@ const SettlementPlannerPhase = ({
   const selectedSeasonPass = seasonPasses.find((pass) => pass.tokenId === selectedSeasonPassTokenId) ?? null;
   const selectedVillagePass = villagePasses.find((pass) => pass.tokenId === selectedVillagePassTokenId) ?? null;
   const plannerAction = selectedRealmSlot != null ? "realm" : selectedVillageSlot != null ? "village" : "info";
+  const realmSettlementSubmitLabel = resolveSettlementSubmissionButtonLabel({
+    status: realmSettlementSubmissionStatus,
+    idleLabel: "Settle Realm",
+    submittingLabel: "Submitting Realm...",
+  });
+  const realmSettlementSubmissionDetail = resolveSettlementSubmissionDetail(realmSettlementSubmissionStatus);
+  const villageSettlementSubmitLabel = resolveSettlementSubmissionButtonLabel({
+    status: villageSettlementSubmissionStatus,
+    idleLabel: "Settle Village",
+    submittingLabel: "Submitting Village...",
+  });
+  const villageSettlementSubmissionDetail = resolveSettlementSubmissionDetail(villageSettlementSubmissionStatus);
   const spiresProgressLabel =
     spiresSettledCount != null && spiresMaxCount != null
       ? `${Math.min(spiresSettledCount, spiresMaxCount)} / ${spiresMaxCount}`
@@ -2362,6 +2429,9 @@ const SettlementPlannerPhase = ({
             )}
 
             {seasonSettlementError && <p className="text-[11px] text-red-200">{seasonSettlementError}</p>}
+            {realmSettlementSubmissionDetail && !seasonSettlementError && (
+              <p className="text-[11px] text-gold/70">{realmSettlementSubmissionDetail}</p>
+            )}
 
             <Button
               onClick={onConfirmRealmSettlement}
@@ -2375,7 +2445,7 @@ const SettlementPlannerPhase = ({
                 ) : (
                   <Castle className="h-4 w-4" />
                 )}
-                <span>{isSubmittingRealmSettlement ? "Settling Realm..." : "Settle Realm"}</span>
+                <span>{realmSettlementSubmitLabel}</span>
               </div>
             </Button>
           </div>
@@ -2487,6 +2557,9 @@ const SettlementPlannerPhase = ({
             )}
 
             {villageSettlementError && <p className="text-[11px] text-red-200">{villageSettlementError}</p>}
+            {villageSettlementSubmissionDetail && !villageSettlementError && (
+              <p className="text-[11px] text-gold/70">{villageSettlementSubmissionDetail}</p>
+            )}
 
             <Button
               onClick={onConfirmVillageSettlement}
@@ -2500,7 +2573,7 @@ const SettlementPlannerPhase = ({
                 ) : (
                   <Castle className="h-4 w-4" />
                 )}
-                <span>{isSubmittingVillageSettlement ? "Settling Village..." : "Settle Village"}</span>
+                <span>{villageSettlementSubmitLabel}</span>
               </div>
             </Button>
           </div>
@@ -3026,6 +3099,10 @@ export const GameEntryModal = ({
   const [villagePassDistributorTransferError, setVillagePassDistributorTransferError] = useState<string | null>(null);
   const [isSubmittingVillageSettlement, setIsSubmittingVillageSettlement] = useState(false);
   const [villageSettlementError, setVillageSettlementError] = useState<string | null>(null);
+  const [seasonSettlementSubmissionStatus, setSeasonSettlementSubmissionStatus] =
+    useState<SettlementSubmissionStatus>("idle");
+  const [villageSettlementSubmissionStatus, setVillageSettlementSubmissionStatus] =
+    useState<SettlementSubmissionStatus>("idle");
   const [villageRevealResult, setVillageRevealResult] = useState<VillageRevealResult | null>(null);
   const [settlementPlannerTarget, setSettlementPlannerTarget] = useState<SettlementPlannerTarget | null>(null);
   const [settlementPlannerConflict, setSettlementPlannerConflict] = useState<string | null>(null);
@@ -3240,6 +3317,31 @@ export const GameEntryModal = ({
     }
     return distributorVillagePassInventoryError;
   }, [distributorVillagePassInventoryError]);
+  const invalidateEternumSettlementQueries = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ["eternumOwnedStructures", chain, worldName, account?.address] });
+    void queryClient.invalidateQueries({ queryKey: ["eternumRealmVillageSlots", chain, worldName] });
+    void queryClient.invalidateQueries({ queryKey: ["seasonPlacementOccupiedSlots", chain, worldName] });
+    void queryClient.invalidateQueries({ queryKey: ["settlementPlannerSnapshot", chain, worldName] });
+    void queryClient.invalidateQueries({ queryKey: ["settlementPlannerExploredTiles", chain, worldName] });
+  }, [account?.address, chain, queryClient, worldName]);
+  const refetchSettlementPlannerData = settlementPlannerData.refetch;
+  const refreshEternumSettlementQueries = useCallback(async () => {
+    invalidateEternumSettlementQueries();
+    await Promise.allSettled([
+      refetchOwnedStructures(),
+      refetchRealmVillageSlots(),
+      refetchSeasonPassInventory(),
+      refetchVillagePassInventory(),
+      refetchSettlementPlannerData(),
+    ]);
+  }, [
+    invalidateEternumSettlementQueries,
+    refetchOwnedStructures,
+    refetchRealmVillageSlots,
+    refetchSeasonPassInventory,
+    refetchVillagePassInventory,
+    refetchSettlementPlannerData,
+  ]);
   const ownedRealms = useMemo<OwnedRealmOption[]>(() => {
     return (ownedStructures as PlayerStructure[])
       .filter((structure) => structure.category === StructureType.Realm)
@@ -3318,6 +3420,8 @@ export const GameEntryModal = ({
       setSeasonSettlementComplete(false);
       setIsSubmittingVillageSettlement(false);
       setVillageSettlementError(null);
+      setSeasonSettlementSubmissionStatus("idle");
+      setVillageSettlementSubmissionStatus("idle");
       setVillageRevealResult(null);
       setSettlementPlannerTarget(null);
       setSettlementPlannerConflict(null);
@@ -3416,10 +3520,12 @@ export const GameEntryModal = ({
 
   useEffect(() => {
     setSeasonSettlementError(null);
+    setSeasonSettlementSubmissionStatus("idle");
   }, [selectedSeasonPassTokenId, seasonPlacement.side, seasonPlacement.layer, seasonPlacement.point]);
 
   useEffect(() => {
     setVillageSettlementError(null);
+    setVillageSettlementSubmissionStatus("idle");
   }, [selectedVillagePassTokenId, selectedVillageRealmEntityId, selectedVillageDirection]);
 
   useEffect(() => {
@@ -3486,6 +3592,8 @@ export const GameEntryModal = ({
     setVillagePassDistributorTransferError(null);
     setIsSubmittingVillageSettlement(false);
     setVillageSettlementError(null);
+    setSeasonSettlementSubmissionStatus("idle");
+    setVillageSettlementSubmissionStatus("idle");
     setVillageRevealResult(null);
     setSettlementPlannerTarget(null);
     setSettlementPlannerConflict(null);
@@ -3506,6 +3614,14 @@ export const GameEntryModal = ({
 
     return () => window.clearInterval(id);
   }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !isEternumMode) {
+      return;
+    }
+
+    void refreshEternumSettlementQueries();
+  }, [isEternumMode, isOpen, refreshEternumSettlementQueries]);
 
   const blitzSettlementAvailability = resolveBlitzSettlementAvailability({
     startMainAt: worldMeta?.startMainAt ?? null,
@@ -3937,13 +4053,9 @@ export const GameEntryModal = ({
         chain,
         worldName,
         waitForConfirmation,
-        ...(waitForConfirmation
-          ? {
-              confirm: async (txHash) => {
-                await confirmSubmittedTransaction(txHash, label, fallbackWaitAccount);
-              },
-            }
-          : {}),
+        confirm: async (txHash) => {
+          await confirmSubmittedTransaction(txHash, label, fallbackWaitAccount);
+        },
       });
     },
     [chain, confirmSubmittedTransaction, worldName],
@@ -4062,11 +4174,39 @@ export const GameEntryModal = ({
     [buildSetAddressNameCall, resolveWorldSystemAddress],
   );
 
+  const waitForRealmSettlementIndex = useCallback(
+    async ({
+      ownerAddress,
+      target,
+      timeoutMs = SETTLEMENT_SYNC_TIMEOUT_MS,
+    }: {
+      ownerAddress: string;
+      target: IndexedRealmSettlementTarget;
+      timeoutMs?: number;
+    }): Promise<PlayerStructure> => {
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < timeoutMs) {
+        const structures = await selectedWorldSqlApi.fetchPlayerStructures(ownerAddress);
+        const indexedRealm = findIndexedRealmSettlement(structures as PlayerStructure[], target);
+        if (indexedRealm) {
+          await refreshEternumSettlementQueries();
+          return indexedRealm;
+        }
+
+        invalidateEternumSettlementQueries();
+        await new Promise((resolve) => window.setTimeout(resolve, SETTLEMENT_PROGRESS_POLL_MS));
+      }
+
+      throw new Error(buildSettlementStillSyncingMessage("realm"));
+    },
+    [invalidateEternumSettlementQueries, refreshEternumSettlementQueries, selectedWorldSqlApi],
+  );
+
   const waitForVillageResourceReveal = useCallback(
     async ({
       ownerAddress,
       existingVillageIds,
-      timeoutMs = 45_000,
+      timeoutMs = SETTLEMENT_SYNC_TIMEOUT_MS,
     }: {
       ownerAddress: string;
       existingVillageIds: Set<number>;
@@ -4075,16 +4215,13 @@ export const GameEntryModal = ({
       const startedAt = Date.now();
       while (Date.now() - startedAt < timeoutMs) {
         const structures = await selectedWorldSqlApi.fetchPlayerStructures(ownerAddress);
-        const newVillage = structures
-          .filter(
-            (structure) => structure.category === StructureType.Village && !existingVillageIds.has(structure.entity_id),
-          )
-          .toSorted((left, right) => right.entity_id - left.entity_id)[0];
+        const newVillage = findNewIndexedVillageSettlement(structures as PlayerStructure[], existingVillageIds);
 
         if (newVillage) {
           const resourceId = resolvePrimaryVillageResource(newVillage.resources_packed);
           const resourceLabel = resourceId != null ? resolveResourceLabel(resourceId) : null;
           if (resourceId != null && resourceLabel) {
+            await refreshEternumSettlementQueries();
             return {
               villageEntityId: newVillage.entity_id,
               resourceId,
@@ -4093,12 +4230,13 @@ export const GameEntryModal = ({
           }
         }
 
-        await new Promise((resolve) => window.setTimeout(resolve, 1500));
+        invalidateEternumSettlementQueries();
+        await new Promise((resolve) => window.setTimeout(resolve, SETTLEMENT_PROGRESS_POLL_MS));
       }
 
-      throw new Error("Village created but resource assignment is not indexed in Torii yet.");
+      throw new Error(buildSettlementStillSyncingMessage("village"));
     },
-    [selectedWorldSqlApi],
+    [invalidateEternumSettlementQueries, refreshEternumSettlementQueries, selectedWorldSqlApi],
   );
 
   // Check settlement status after bootstrap completes
@@ -4224,6 +4362,7 @@ export const GameEntryModal = ({
       setSettlementPlannerSuccess(null);
 
       if (target.type === "realm_slot") {
+        setSeasonSettlementSubmissionStatus("idle");
         setSeasonPlacement({
           side: target.slot.side,
           layer: target.slot.layer,
@@ -4232,6 +4371,7 @@ export const GameEntryModal = ({
       }
 
       if (target.type === "village_slot") {
+        setVillageSettlementSubmissionStatus("idle");
         setSelectedVillageRealmEntityId(target.slot.realmEntityId);
         setSelectedVillageDirection(target.slot.direction);
       }
@@ -4540,8 +4680,10 @@ export const GameEntryModal = ({
     }
 
     setIsSubmittingSeasonSettlement(true);
+    setSeasonSettlementSubmissionStatus("submitting");
     setSeasonSettlementError(null);
     setSettlementPlannerConflict(null);
+    setSettlementPlannerSuccess(null);
 
     if (unifiedSettlementPlannerEnabled && settlementPlannerRealmTarget) {
       captureClientEvent("planner_submit_clicked", {
@@ -4621,6 +4763,17 @@ export const GameEntryModal = ({
       const realmId = Number(realmIdBigInt);
       const owner = account.address;
       const frontend = account.address;
+      const settlementTarget: IndexedRealmSettlementTarget = {
+        realmId,
+        coordX:
+          unifiedSettlementPlannerEnabled && settlementPlannerRealmTarget
+            ? settlementPlannerRealmTarget.coordX
+            : (targetCoordPreview?.x ?? null),
+        coordY:
+          unifiedSettlementPlannerEnabled && settlementPlannerRealmTarget
+            ? settlementPlannerRealmTarget.coordY
+            : (targetCoordPreview?.y ?? null),
+      };
 
       const seasonPassTokenId = uint256.bnToUint256(realmIdBigInt);
       const optionalPlayerName = await resolveOptionalPlayerNameForSettlement();
@@ -4655,13 +4808,20 @@ export const GameEntryModal = ({
         label: optionalPlayerName
           ? "set address name + approve season pass + season realm create"
           : "approve season pass + season realm create",
+        waitForConfirmation: false,
+      });
+
+      setSeasonSettlementSubmissionStatus("syncing");
+      setSettlementPlannerSuccess("Settlement submitted. Checking indexed world state.");
+      await waitForRealmSettlementIndex({
+        ownerAddress: account.address,
+        target: settlementTarget,
       });
 
       setSeasonSettlementError(null);
-      void refetchSeasonPassInventory();
       void refetchDistributorVillagePassInventory();
-      void refetchOwnedStructures();
       setSeasonSettlementComplete(true);
+      setSeasonSettlementSubmissionStatus("completed");
       setSettlementPlannerSuccess("Realm settled. New village slots will unlock on the planner as sync catches up.");
 
       if (unifiedSettlementPlannerEnabled && settlementPlannerRealmTarget) {
@@ -4683,6 +4843,7 @@ export const GameEntryModal = ({
       }
     } catch (error) {
       debugLog(worldName, "Season settlement failed:", error);
+      setSeasonSettlementSubmissionStatus("failed");
       setSeasonSettlementError(mapSeasonSettleError(error));
       if (unifiedSettlementPlannerEnabled) {
         captureClientEvent("planner_submit_failed", {
@@ -4699,6 +4860,7 @@ export const GameEntryModal = ({
     unifiedSettlementPlannerEnabled,
     settlementPlannerRealmTarget,
     selectedSeasonPassTokenId,
+    targetCoordPreview,
     seasonPlacementErrors,
     seasonTimingValid,
     spiresSettled,
@@ -4717,9 +4879,8 @@ export const GameEntryModal = ({
     executeEntryObservedTransaction,
     resolveOptionalPlayerNameForSettlement,
     buildSetAddressNameCall,
-    refetchSeasonPassInventory,
     refetchDistributorVillagePassInventory,
-    refetchOwnedStructures,
+    waitForRealmSettlementIndex,
     settlementPlannerData,
     queryClient,
   ]);
@@ -4772,8 +4933,10 @@ export const GameEntryModal = ({
     }
 
     setIsSubmittingVillageSettlement(true);
+    setVillageSettlementSubmissionStatus("submitting");
     setVillageSettlementError(null);
     setSettlementPlannerConflict(null);
+    setSettlementPlannerSuccess(null);
 
     if (unifiedSettlementPlannerEnabled && settlementPlannerVillageTarget) {
       captureClientEvent("planner_submit_clicked", {
@@ -4801,8 +4964,11 @@ export const GameEntryModal = ({
         calls: villageSettlementCalls,
         operation: "village_systems.create",
         label: optionalPlayerName ? "set address name + village_systems.create" : "village_systems.create",
+        waitForConfirmation: false,
       });
 
+      setVillageSettlementSubmissionStatus("syncing");
+      setSettlementPlannerSuccess("Village submitted. Checking indexed world state.");
       const revealResult = await waitForVillageResourceReveal({
         ownerAddress: account.address,
         existingVillageIds,
@@ -4811,12 +4977,9 @@ export const GameEntryModal = ({
       setVillageRevealResult(revealResult);
       setVillageSettlementError(null);
       setEternumSettlementMode("village");
+      setVillageSettlementSubmissionStatus("completed");
       setSettlementPlannerSuccess("Village settled. Reveal complete; you can keep planning from the map.");
 
-      refetchVillagePassInventory();
-      void refetchOwnedStructures();
-      void refetchRealmVillageSlots();
-      void settlementPlannerData.refetch();
       if (unifiedSettlementPlannerEnabled) {
         captureClientEvent("planner_submit_succeeded", {
           worldName,
@@ -4826,6 +4989,7 @@ export const GameEntryModal = ({
       }
     } catch (error) {
       debugLog(worldName, "Village settlement failed:", error);
+      setVillageSettlementSubmissionStatus("failed");
       setVillageSettlementError(mapVillageSettleError(error));
       if (unifiedSettlementPlannerEnabled) {
         captureClientEvent("planner_submit_failed", {
@@ -4852,10 +5016,6 @@ export const GameEntryModal = ({
     buildVillageSettlementCalls,
     executeEntryObservedTransaction,
     waitForVillageResourceReveal,
-    refetchVillagePassInventory,
-    refetchOwnedStructures,
-    refetchRealmVillageSlots,
-    settlementPlannerData,
     worldName,
     chain,
   ]);
@@ -4863,6 +5023,7 @@ export const GameEntryModal = ({
   const handleSettleAnotherVillage = useCallback(() => {
     setVillageRevealResult(null);
     setVillageSettlementError(null);
+    setVillageSettlementSubmissionStatus("idle");
     setEternumSettlementMode("village");
     setSettlementPlannerSuccess("Village settled. Choose another free slot or enter the game.");
     void refetchOwnedStructures();
@@ -4959,6 +5120,7 @@ export const GameEntryModal = ({
         calls: assignCalls,
         operation: "assign_and_settle_realms",
         label: "assign_and_settle_realms",
+        waitForConfirmation: false,
       });
     },
     [executeEntryObservedTransaction],
@@ -4985,6 +5147,7 @@ export const GameEntryModal = ({
         },
         operation: "settle_realms",
         label: `settle_realms ${stepIndex + 1}/${totalSteps}`,
+        waitForConfirmation: false,
       });
     },
     [executeEntryObservedTransaction],
@@ -5555,6 +5718,8 @@ export const GameEntryModal = ({
                   onConfirmVillageSettlement={handleVillageSettle}
                   isSubmittingRealmSettlement={isSubmittingSeasonSettlement}
                   isSubmittingVillageSettlement={isSubmittingVillageSettlement}
+                  realmSettlementSubmissionStatus={seasonSettlementSubmissionStatus}
+                  villageSettlementSubmissionStatus={villageSettlementSubmissionStatus}
                   seasonSettlementError={seasonSettlementError}
                   villageSettlementError={villageSettlementError ?? ownedStructuresError}
                   onEnterGame={handleEnterGame}
@@ -5610,6 +5775,7 @@ export const GameEntryModal = ({
                   onSelectSeasonPass={setSelectedSeasonPassTokenId}
                   onConfirmSettlement={handleSeasonSettle}
                   isSubmittingSettlement={isSubmittingSeasonSettlement}
+                  submissionStatus={seasonSettlementSubmissionStatus}
                   placementValidationErrors={seasonPlacementErrors}
                   targetCoordPreview={targetCoordPreview}
                   settlementError={seasonSettlementError}
@@ -5676,6 +5842,7 @@ export const GameEntryModal = ({
                   onSelectDirection={setSelectedVillageDirection}
                   onConfirmSettlement={handleVillageSettle}
                   isSubmittingSettlement={isSubmittingVillageSettlement}
+                  submissionStatus={villageSettlementSubmissionStatus}
                   settlementError={villageSettlementError ?? ownedStructuresError}
                   villagePassInventoryError={villagePassInventoryWarning}
                   villageSlotsError={villageSlotsError}

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.test.ts
@@ -1,12 +1,15 @@
 // @vitest-environment node
 
 import { describe, expect, it } from "vitest";
+import { StructureType } from "@bibliothecadao/types";
 
 import {
   applyDashboardRegistrationHint,
   buildSettlementExecutionPlan,
   deriveSettlementPhaseViewModel,
   deriveSettlementStatus,
+  findIndexedRealmSettlement,
+  findNewIndexedVillageSettlement,
   getExpectedSettlementCount,
   hasReachedSettlementTarget,
   parseSnapshotRegistrationRow,
@@ -96,6 +99,49 @@ describe("hasReachedSettlementTarget", () => {
   it("keeps incomplete settlement targets pending", () => {
     expect(hasReachedSettlementTarget({ settledCount: 2 }, 3)).toBe(false);
     expect(hasReachedSettlementTarget({ settledCount: 0 }, 1)).toBe(false);
+  });
+});
+
+describe("findIndexedRealmSettlement", () => {
+  it("matches the newly indexed realm by realm id", () => {
+    const realm = { category: StructureType.Realm, entity_id: 101, realm_id: 77, coord_x: 12, coord_y: 13 };
+
+    expect(
+      findIndexedRealmSettlement(
+        [{ category: StructureType.Village, entity_id: 202, realm_id: null, coord_x: 12, coord_y: 13 }, realm],
+        { realmId: 77, coordX: null, coordY: null },
+      ),
+    ).toBe(realm);
+  });
+
+  it("falls back to selected settlement coordinates when the realm id is not indexed yet", () => {
+    const realm = { category: StructureType.Realm, entity_id: 101, realm_id: null, coord_x: 22, coord_y: 23 };
+
+    expect(
+      findIndexedRealmSettlement([realm], {
+        realmId: 77,
+        coordX: 22,
+        coordY: 23,
+      }),
+    ).toBe(realm);
+  });
+});
+
+describe("findNewIndexedVillageSettlement", () => {
+  it("returns the newest village that was not present before submission", () => {
+    const oldestVillage = { category: StructureType.Village, entity_id: 10, realm_id: null, coord_x: 1, coord_y: 1 };
+    const newVillage = { category: StructureType.Village, entity_id: 12, realm_id: null, coord_x: 3, coord_y: 3 };
+
+    expect(
+      findNewIndexedVillageSettlement(
+        [
+          oldestVillage,
+          { category: StructureType.Realm, entity_id: 11, realm_id: 5, coord_x: 2, coord_y: 2 },
+          newVillage,
+        ],
+        new Set([10]),
+      ),
+    ).toBe(newVillage);
   });
 });
 

--- a/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-settlement.utils.ts
@@ -1,4 +1,5 @@
 import { parseMaybeBooleanFlag } from "@/config/game-modes/resolved-mode";
+import { StructureType } from "@bibliothecadao/types";
 
 export type SettlementSnapshot = {
   registered: boolean;
@@ -29,6 +30,22 @@ export type SettlementStatus = {
 };
 
 export type SettleStage = "idle" | "assigning" | "settling" | "syncing" | "done" | "error";
+
+export type SettlementSubmissionStatus = "idle" | "submitting" | "syncing" | "failed" | "completed";
+
+type IndexedSettlementStructure = {
+  category?: number | null;
+  entity_id?: number | null;
+  realm_id?: number | null;
+  coord_x?: number | null;
+  coord_y?: number | null;
+};
+
+export type IndexedRealmSettlementTarget = {
+  realmId: number | null;
+  coordX: number | null;
+  coordY: number | null;
+};
 
 type SettlementStepStatus = "pending" | "active" | "complete";
 
@@ -66,6 +83,38 @@ export const hasReachedSettlementTarget = (
   progress: Pick<SettlementSnapshot, "settledCount"> | Pick<SettlementStatus, "settledCount">,
   targetSettleCount: number,
 ): boolean => Math.max(0, progress.settledCount) >= Math.max(0, targetSettleCount);
+
+const hasMatchingRealmId = (structure: IndexedSettlementStructure, target: IndexedRealmSettlementTarget): boolean =>
+  target.realmId != null && structure.realm_id === target.realmId;
+
+const hasMatchingCoordinates = (structure: IndexedSettlementStructure, target: IndexedRealmSettlementTarget): boolean =>
+  target.coordX != null &&
+  target.coordY != null &&
+  structure.coord_x === target.coordX &&
+  structure.coord_y === target.coordY;
+
+export const findIndexedRealmSettlement = <T extends IndexedSettlementStructure>(
+  structures: T[],
+  target: IndexedRealmSettlementTarget,
+): T | null =>
+  structures.find(
+    (structure) =>
+      Number(structure.category) === StructureType.Realm &&
+      (hasMatchingRealmId(structure, target) || hasMatchingCoordinates(structure, target)),
+  ) ?? null;
+
+export const findNewIndexedVillageSettlement = <T extends IndexedSettlementStructure>(
+  structures: T[],
+  existingVillageIds: Set<number>,
+): T | null =>
+  structures
+    .filter(
+      (structure) =>
+        Number(structure.category) === StructureType.Village &&
+        structure.entity_id != null &&
+        !existingVillageIds.has(structure.entity_id),
+    )
+    .toSorted((left, right) => Number(right.entity_id ?? 0) - Number(left.entity_id ?? 0))[0] ?? null;
 
 const buildCompletedStepStatuses = (): SettlementPhaseViewModel["stepStatuses"] => ({
   1: "complete",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-12",
+    title: "Reliable Realm Settlement",
+    description:
+      "Fixed landing settlement flows so submitted realm and village transactions keep checking synced world state instead of spinning until a hard refresh.",
+    type: "fix",
+  },
+  {
     date: "2026-05-07",
     title: "Scrollable Tile HUD",
     description:


### PR DESCRIPTION
## Summary

- Landing realm, village, and Blitz settlement transactions now submit without blocking on RPC confirmation, then poll indexed world state with finite submitted, syncing, completed, and failed UI states.
- The modal refreshes settlement-related React Query data on open and after indexed state appears, so closing and reopening can recover without a hard refresh.
- The hang was caused by the landing flow waiting indefinitely on wallet/RPC confirmation before checking Torii-indexed settlement state.
- Added focused settlement utility, Blitz flow, and source guard tests, plus a 2026-05-12 latest-features fix entry.

## Checks

- `pnpm --dir client/apps/game test -- src/ui/features/landing/components/game-entry-settlement.utils.test.ts src/ui/features/landing/components/game-entry-blitz-settlement-flow.test.ts src/ui/features/landing/components/game-entry-modal.settlement-sync.source.test.ts`
- `pnpm --dir client/apps/game typecheck`
- `pnpm run format`
- `pnpm run knip`
