### PR TITLE
[codex] Persist landing network choice

### DIFF
--- a/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.source.test.ts
@@ -16,17 +16,18 @@ describe("useLandingNetworkState source", () => {
     expect(source).not.toContain("useMemo(\n    () => resolveConnectedTxChainFromRuntime({ chainId, controller })");
   });
 
-  it("defaults every landing page open to mainnet before applying stored preferences", () => {
+  it("seeds mainnet only when no landing chain preference has been saved", () => {
     const source = readFileSync(
       resolve(process.cwd(), "src/ui/features/landing/hooks/use-landing-network-state.ts"),
       "utf8",
     );
 
     expect(source).toContain('const DEFAULT_LANDING_CHAIN: Chain = "mainnet";');
-    expect(source).toContain("let hasDefaultedLandingChainOnPageOpen = false;");
-    expect(source).toContain(
-      "const selectedChain = shouldStartOnDefaultLandingChain ? DEFAULT_LANDING_CHAIN : storedSelectedChain;",
-    );
+    expect(source).toContain("const selectDefaultLandingChainIfMissing = () => {");
+    expect(source).toContain("if (getSelectedChain()) return;");
+    expect(source).toContain("const selectedChain = useSelectedRuntimeChain(DEFAULT_LANDING_CHAIN);");
     expect(source).toContain("setSelectedChain(DEFAULT_LANDING_CHAIN);");
+    expect(source).not.toContain("hasDefaultedLandingChainOnPageOpen");
+    expect(source).not.toContain("shouldStartOnDefaultLandingChain");
   });
 });

--- a/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.test.tsx
+++ b/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useLandingNetworkState } from "./use-landing-network-state";
+
+const mocks = vi.hoisted(() => ({
+  useAccount: vi.fn(),
+}));
+
+vi.mock("@starknet-react/core", () => ({
+  useAccount: mocks.useAccount,
+}));
+
+const CHAIN_KEY = "ACTIVE_WORLD_CHAIN";
+
+const waitForAsyncWork = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const LandingNetworkStateProbe = () => {
+  const state = useLandingNetworkState();
+
+  return <div data-preferred-chain={state.preferredChain} data-status={state.status} />;
+};
+
+const getPreferredChain = (container: HTMLElement) => {
+  return container.querySelector("[data-preferred-chain]")?.getAttribute("data-preferred-chain");
+};
+
+const renderProbe = async (root: Root) => {
+  await act(async () => {
+    root.render(<LandingNetworkStateProbe />);
+    await waitForAsyncWork();
+  });
+};
+
+describe("useLandingNetworkState", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+    mocks.useAccount.mockReset();
+    mocks.useAccount.mockReturnValue({
+      address: undefined,
+      chainId: null,
+      connector: null,
+    });
+
+    window.localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+      await waitForAsyncWork();
+    });
+
+    container.remove();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("defaults first-time users to mainnet and persists that preference once", async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+    await renderProbe(root);
+
+    const selectedChainWrites = setItemSpy.mock.calls.filter(([key]) => key === CHAIN_KEY);
+    expect(getPreferredChain(container)).toBe("mainnet");
+    expect(window.localStorage.getItem(CHAIN_KEY)).toBe("mainnet");
+    expect(selectedChainWrites).toEqual([[CHAIN_KEY, "mainnet"]]);
+  });
+
+  it("keeps a saved slot preference after refresh", async () => {
+    window.localStorage.setItem(CHAIN_KEY, "slot");
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+    await renderProbe(root);
+
+    expect(getPreferredChain(container)).toBe("slot");
+    expect(window.localStorage.getItem(CHAIN_KEY)).toBe("slot");
+    expect(setItemSpy.mock.calls.filter(([key]) => key === CHAIN_KEY)).toEqual([]);
+  });
+
+  it("keeps a saved mainnet preference after refresh", async () => {
+    window.localStorage.setItem(CHAIN_KEY, "mainnet");
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+    await renderProbe(root);
+
+    expect(getPreferredChain(container)).toBe("mainnet");
+    expect(window.localStorage.getItem(CHAIN_KEY)).toBe("mainnet");
+    expect(setItemSpy.mock.calls.filter(([key]) => key === CHAIN_KEY)).toEqual([]);
+  });
+});

--- a/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.ts
+++ b/client/apps/game/src/ui/features/landing/hooks/use-landing-network-state.ts
@@ -1,4 +1,4 @@
-import { setSelectedChain, useSelectedRuntimeChain } from "@/runtime/world";
+import { getSelectedChain, setSelectedChain, useSelectedRuntimeChain } from "@/runtime/world";
 import {
   resolveConnectedTxChainFromRuntime,
   switchWalletToChain,
@@ -27,28 +27,19 @@ interface LandingNetworkControllerState {
 
 const DEFAULT_LANDING_CHAIN: Chain = "mainnet";
 
-// Landing should start on Mainnet for each full page open, while still allowing
-// normal Slot/Mainnet switching during the current page session.
-let hasDefaultedLandingChainOnPageOpen = false;
-
-const defaultLandingChainOnPageOpen = () => {
-  if (hasDefaultedLandingChainOnPageOpen) return;
-
-  hasDefaultedLandingChainOnPageOpen = true;
+const selectDefaultLandingChainIfMissing = () => {
+  if (getSelectedChain()) return;
   setSelectedChain(DEFAULT_LANDING_CHAIN);
 };
 
 export const useLandingNetworkState = (): LandingNetworkControllerState => {
-  const storedSelectedChain = useSelectedRuntimeChain(DEFAULT_LANDING_CHAIN);
-  const shouldStartOnDefaultLandingChain = !hasDefaultedLandingChainOnPageOpen;
-  const selectedChain = shouldStartOnDefaultLandingChain ? DEFAULT_LANDING_CHAIN : storedSelectedChain;
+  const selectedChain = useSelectedRuntimeChain(DEFAULT_LANDING_CHAIN);
   const { address, chainId, connector } = useAccount();
   const controller = (connector as { controller?: WalletChainControllerLike } | undefined)?.controller ?? null;
 
   useEffect(() => {
-    if (!shouldStartOnDefaultLandingChain) return;
-    defaultLandingChainOnPageOpen();
-  }, [shouldStartOnDefaultLandingChain]);
+    selectDefaultLandingChainIfMissing();
+  }, []);
 
   const connectedChain = resolveConnectedTxChainFromRuntime({ chainId, controller });
 

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-12",
+    title: "Saved Network Choice",
+    description:
+      "The landing network switch now remembers your last Mainnet or Slot choice after refresh, while first-time visits still start on Mainnet.",
+    type: "fix",
+  },
+  {
     date: "2026-05-07",
     title: "Scrollable Tile HUD",
     description:
@@ -33,7 +40,7 @@ const allLatestFeatures: LatestFeature[] = [
     date: "2026-05-06",
     title: "Focused Chain Views",
     description:
-      "Landing games, profile ranks, MMR, prediction markets, and cosmetics now follow the selected landing chain, with each page open starting on Mainnet.",
+      "Landing games, profile ranks, MMR, prediction markets, and cosmetics now follow the selected landing chain through one shared network state.",
     type: "fix",
   },
   {


### PR DESCRIPTION
Fixes the landing network switch so a saved Slot or Mainnet choice survives refresh instead of being reset to Mainnet on every page open. First-time users still get Mainnet seeded as the default when no valid saved chain exists, preserving the existing mismatch indicator behavior when the connected wallet is on a different chain. Adds hook coverage for first-time defaulting and persisted Slot/Mainnet refresh behavior, and updates the latest-features feed for the user-visible fix.

Validation: `pnpm --dir client/apps/game test src/ui/features/landing/hooks/use-landing-network-state.test.tsx src/ui/features/landing/hooks/use-landing-network-state.source.test.ts src/ui/features/landing/components/dashboard-network-switch.test.tsx src/ui/features/landing/lib/landing-network-state.test.ts`; `pnpm run format`; `pnpm run knip`.