### PR TITLE
[codex] Fix game list refresh after factory deploy

### DIFF
--- a/client/apps/game/src/hooks/use-player-world-registrations.ts
+++ b/client/apps/game/src/hooks/use-player-world-registrations.ts
@@ -12,6 +12,7 @@
  */
 import type { WorldSummary } from "@bibliothecadao/types";
 import { parseMaybeBooleanFlag } from "@/config/game-modes/resolved-mode";
+import { PLAYER_WORLD_REGISTRATION_QUERY_KEY } from "@/hooks/world-list-queries";
 import { useQueries } from "@tanstack/react-query";
 
 interface PlayerWorldRegistration {
@@ -111,7 +112,7 @@ export const usePlayerWorldRegistrations = ({
       const isBlitz = mode === "blitz";
       const isEternum = mode === "eternum";
       return {
-        queryKey: ["playerWorldRegistration", worldKey, playerAddress ?? "anonymous"],
+        queryKey: [...PLAYER_WORLD_REGISTRATION_QUERY_KEY, worldKey, playerAddress ?? "anonymous"],
         queryFn: async (): Promise<PlayerWorldRegistration> => {
           if (!playerAddress) {
             return { isPlayerRegistered: null, hasPlayerSettledRealm: null };

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -4,6 +4,7 @@
  * by caching results and sharing them across components.
  */
 import { getFactorySqlBaseUrl } from "@/runtime/world";
+import { BULK_WORLD_AVAILABILITY_QUERY_KEY, WORLD_AVAILABILITY_QUERY_KEY } from "@/hooks/world-list-queries";
 import { fetchBulkAvailability, isToriiAvailable, resolveWorldContracts } from "@/runtime/world/factory-resolver";
 import { normalizeSelector } from "@/runtime/world/normalize";
 import {
@@ -504,7 +505,7 @@ const checkWorldAvailability = async (
 /** Fetch bulk world availability from the realtime server, cached with React Query. */
 const useBulkAvailability = (enabled: boolean) => {
   return useQuery({
-    queryKey: ["bulkWorldAvailability"],
+    queryKey: BULK_WORLD_AVAILABILITY_QUERY_KEY,
     queryFn: () => fetchBulkAvailability(env.VITE_PUBLIC_REALTIME_URL),
     enabled,
     staleTime: 30_000,
@@ -527,7 +528,7 @@ export const useWorldsAvailability = (worlds: WorldRef[], enabled = true, player
   const queries = useQueries({
     queries: worlds.map((world) => ({
       // Include playerAddress in query key so it refetches when user connects
-      queryKey: ["worldAvailability", getWorldKey(world), playerAddress ?? "anonymous"],
+      queryKey: [...WORLD_AVAILABILITY_QUERY_KEY, getWorldKey(world), playerAddress ?? "anonymous"],
       queryFn: () => checkWorldAvailability(world.name, world.chain, playerAddress, bulkAvailability),
       enabled: enabled && !!world.name && !isBulkAvailabilityPending,
       staleTime: 30 * 1000, // 30 seconds - data is fresh for 30s

--- a/client/apps/game/src/hooks/use-worlds-summary.ts
+++ b/client/apps/game/src/hooks/use-worlds-summary.ts
@@ -1,6 +1,7 @@
 import type { WorldSummary } from "@bibliothecadao/types";
 import { useQuery } from "@tanstack/react-query";
 import { env } from "../../env";
+import { WORLD_SUMMARY_QUERY_KEY } from "./world-list-queries";
 
 export async function fetchWorldsSummary(realtimeBaseUrl: string): Promise<WorldSummary[]> {
   const url = `${realtimeBaseUrl.replace(/\/+$/, "")}/api/worlds/summary`;
@@ -21,7 +22,7 @@ export async function fetchWorldsSummary(realtimeBaseUrl: string): Promise<World
  */
 export const useWorldsSummary = () =>
   useQuery({
-    queryKey: ["worldsSummary"],
+    queryKey: WORLD_SUMMARY_QUERY_KEY,
     queryFn: () => fetchWorldsSummary(env.VITE_PUBLIC_REALTIME_URL),
     staleTime: 25_000,
     refetchInterval: 30_000,

--- a/client/apps/game/src/hooks/world-list-queries.ts
+++ b/client/apps/game/src/hooks/world-list-queries.ts
@@ -1,0 +1,15 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export const WORLD_SUMMARY_QUERY_KEY = ["worldsSummary"] as const;
+export const BULK_WORLD_AVAILABILITY_QUERY_KEY = ["bulkWorldAvailability"] as const;
+export const WORLD_AVAILABILITY_QUERY_KEY = ["worldAvailability"] as const;
+export const PLAYER_WORLD_REGISTRATION_QUERY_KEY = ["playerWorldRegistration"] as const;
+
+export function invalidateWorldListQueries(queryClient: QueryClient) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: WORLD_SUMMARY_QUERY_KEY }),
+    queryClient.invalidateQueries({ queryKey: BULK_WORLD_AVAILABILITY_QUERY_KEY }),
+    queryClient.invalidateQueries({ queryKey: WORLD_AVAILABILITY_QUERY_KEY }),
+    queryClient.invalidateQueries({ queryKey: PLAYER_WORLD_REGISTRATION_QUERY_KEY }),
+  ]);
+}

--- a/client/apps/game/src/ui/features/factory-v2/game-list-refresh-event.ts
+++ b/client/apps/game/src/ui/features/factory-v2/game-list-refresh-event.ts
@@ -1,0 +1,27 @@
+import type { FactoryLaunchTargetKind, FactoryRun } from "./types";
+
+export const FACTORY_GAME_LIST_REFRESH_EVENT = "factory-v2:game-list-refresh-requested";
+
+export interface FactoryGameListRefreshDetail {
+  environment: string;
+  kind: FactoryLaunchTargetKind;
+  name: string;
+}
+
+export function requestGameListRefreshForCompletedRun(
+  run: Pick<FactoryRun, "environment" | "kind" | "name" | "status">,
+) {
+  if (typeof window === "undefined" || run.status !== "complete") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<FactoryGameListRefreshDetail>(FACTORY_GAME_LIST_REFRESH_EVENT, {
+      detail: {
+        environment: run.environment,
+        kind: run.kind,
+        name: run.name,
+      },
+    }),
+  );
+}

--- a/client/apps/game/src/ui/features/factory-v2/hooks/use-factory-v2.ts
+++ b/client/apps/game/src/ui/features/factory-v2/hooks/use-factory-v2.ts
@@ -59,6 +59,7 @@ import { buildFactoryCreateRunRequest } from "../create-run-request";
 import { buildFactoryCreateSeriesRunRequest } from "../create-series-run-request";
 import { buildBlitzDurationOptions, supportsFactoryDuration } from "../duration";
 import { buildFandomizedGameName } from "../funny-names";
+import { requestGameListRefreshForCompletedRun } from "../game-list-refresh-event";
 import { toggleSingleRealmLaunchMode, toggleTwoPlayerLaunchMode } from "../launch-modes";
 import {
   readFactoryPendingLaunches,
@@ -1566,6 +1567,7 @@ export const useFactoryV2 = () => {
     setSelectedRunId(nextRun.id);
     forgetPendingLaunch(environmentId, nextRun.kind, nextRun.name);
     setNotice(null);
+    requestGameListRefreshForCompletedRun(nextRun);
 
     if (nextRun.status === "complete") {
       clearGuidedRecoveryState(nextRun.id);

--- a/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-entry-modal.tsx
@@ -34,6 +34,7 @@ import { useSeasonPassInventory, type SeasonPassInventoryItem } from "@/hooks/us
 import { useUsername } from "@/hooks/use-username";
 import { useVillagePassInventory, type VillagePassInventoryItem } from "@/hooks/use-village-pass-inventory";
 import { getWorldKey, useWorldsAvailability } from "@/hooks/use-world-availability";
+import { WORLD_AVAILABILITY_QUERY_KEY } from "@/hooks/world-list-queries";
 import { executeObservedClientTransaction } from "@/observability/observed-client-transaction";
 import { captureClientEvent } from "@/posthog";
 import { getFactorySqlBaseUrl } from "@/runtime/world/factory-endpoints";
@@ -4609,7 +4610,7 @@ export const GameEntryModal = ({
           }
 
           const worldKey = getWorldKey({ name: worldName, chain });
-          await queryClient.invalidateQueries({ queryKey: ["worldAvailability", worldKey] });
+          await queryClient.invalidateQueries({ queryKey: [...WORLD_AVAILABILITY_QUERY_KEY, worldKey] });
         }
       }
 
@@ -5210,7 +5211,7 @@ export const GameEntryModal = ({
 
       // Invalidate the world availability cache so the count updates on the landing page
       const worldKey = getWorldKey({ name: worldName, chain });
-      queryClient.invalidateQueries({ queryKey: ["worldAvailability", worldKey] });
+      queryClient.invalidateQueries({ queryKey: [...WORLD_AVAILABILITY_QUERY_KEY, worldKey] });
     } catch (error) {
       debugLog(worldName, "Forge hyperstructures failed:", error);
       setForgeErrorMessage(error instanceof Error ? error.message : "Failed to forge hyperstructures.");

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -8,6 +8,11 @@ import { type WorldConfigMeta } from "@/hooks/use-world-availability";
 import { useWorldJackpot } from "@/hooks/use-world-jackpot";
 import { useWorldsSummary } from "@/hooks/use-worlds-summary";
 import { useWorldRegistration, type RegistrationStage } from "@/hooks/use-world-registration";
+import {
+  PLAYER_WORLD_REGISTRATION_QUERY_KEY,
+  WORLD_AVAILABILITY_QUERY_KEY,
+  WORLD_SUMMARY_QUERY_KEY,
+} from "@/hooks/world-list-queries";
 import type { WorldSummary } from "@bibliothecadao/types";
 import { GLOBAL_TORII_BY_CHAIN } from "@/config/global-chain";
 import type { MarketClass, MarketOutcome } from "@/pm/class";
@@ -1441,8 +1446,8 @@ export const UnifiedGameGrid = ({
       // Invalidate both the legacy per-world availability cache (modal path)
       // and the new player registration cache so fresh data is fetched when
       // navigating back. This ensures the registration status persists across tab switches.
-      queryClient.invalidateQueries({ queryKey: ["worldAvailability", worldKey] });
-      queryClient.invalidateQueries({ queryKey: ["playerWorldRegistration", worldKey] });
+      queryClient.invalidateQueries({ queryKey: [...WORLD_AVAILABILITY_QUERY_KEY, worldKey] });
+      queryClient.invalidateQueries({ queryKey: [...PLAYER_WORLD_REGISTRATION_QUERY_KEY, worldKey] });
 
       onRegistrationComplete?.();
     },
@@ -1514,8 +1519,8 @@ export const UnifiedGameGrid = ({
 
       if (runtimeState.shouldRefreshAvailability) {
         // Refresh both the bulk summary and any per-player registration state.
-        void queryClient.invalidateQueries({ queryKey: ["worldsSummary"] });
-        void queryClient.invalidateQueries({ queryKey: ["playerWorldRegistration", game.worldKey] });
+        void queryClient.invalidateQueries({ queryKey: WORLD_SUMMARY_QUERY_KEY });
+        void queryClient.invalidateQueries({ queryKey: [...PLAYER_WORLD_REGISTRATION_QUERY_KEY, game.worldKey] });
       }
 
       if (!runtimeState.shouldOpenEntry) return;

--- a/client/apps/game/src/ui/features/landing/views/play-view.game-list-refresh.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/views/play-view.game-list-refresh.source.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const readPlayViewSource = () =>
+  readFileSync(resolve(process.cwd(), "src/ui/features/landing/views/play-view.tsx"), "utf8");
+const readFactoryHookSource = () =>
+  readFileSync(resolve(process.cwd(), "src/ui/features/factory-v2/hooks/use-factory-v2.ts"), "utf8");
+
+describe("PlayView game list refresh wiring", () => {
+  it("refreshes the shared world list queries from the visible Play refresh button", () => {
+    const source = readPlayViewSource();
+    const refreshStart = source.indexOf("const handleRefresh = useCallback");
+    const reviewStart = source.indexOf("const dismissReviewForWorld");
+    const refreshBlock = source.slice(refreshStart, reviewStart);
+
+    expect(refreshStart).toBeGreaterThan(-1);
+    expect(reviewStart).toBeGreaterThan(refreshStart);
+    expect(refreshBlock).toContain("await invalidateWorldListQueries(queryClient)");
+    expect(refreshBlock).not.toContain('queryKey: ["worldAvailability"]');
+  });
+
+  it("refreshes Play lists when Factory V2 observes a completed run", () => {
+    const playViewSource = readPlayViewSource();
+    const factoryHookSource = readFactoryHookSource();
+
+    expect(playViewSource).toContain("FACTORY_GAME_LIST_REFRESH_EVENT");
+    expect(playViewSource).toContain("window.addEventListener(FACTORY_GAME_LIST_REFRESH_EVENT, refreshGameLists)");
+    expect(factoryHookSource).toContain("requestGameListRefreshForCompletedRun(nextRun)");
+  });
+});

--- a/client/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -34,6 +34,8 @@ import type { LandingModeFilter, LandingEntryRouteState } from "../lib/landing-e
 import { isGameReviewDismissed, setGameReviewDismissed } from "../lib/game-review-storage";
 import { useLandingContext } from "../context/landing-context";
 import { useLandingNetworkState } from "../hooks/use-landing-network-state";
+import { invalidateWorldListQueries } from "@/hooks/world-list-queries";
+import { FACTORY_GAME_LIST_REFRESH_EVENT } from "../../factory-v2/game-list-refresh-event";
 
 interface PlayViewProps {
   className?: string;
@@ -911,6 +913,21 @@ export const PlayView = ({
     primeGameEntry("dashboard");
   }, [activeTab]);
 
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const refreshGameLists = () => {
+      void invalidateWorldListQueries(queryClient);
+    };
+
+    window.addEventListener(FACTORY_GAME_LIST_REFRESH_EVENT, refreshGameLists);
+    return () => {
+      window.removeEventListener(FACTORY_GAME_LIST_REFRESH_EVENT, refreshGameLists);
+    };
+  }, [queryClient]);
+
   const navigateToEntryRoute = useCallback(
     (
       selection: WorldSelection,
@@ -1068,7 +1085,7 @@ export const PlayView = ({
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      await queryClient.invalidateQueries({ queryKey: ["worldAvailability"] });
+      await invalidateWorldListQueries(queryClient);
     } finally {
       // Add a small delay so the spinner is visible
       setTimeout(() => setIsRefreshing(false), 500);


### PR DESCRIPTION
Fixes the Factory V2 deploy-to-Play-list path by centralizing world-list query keys and invalidating every list-related cache from the visible Play refresh button.

The client root cause was that Play now renders from `worldsSummary`, while refresh only invalidated the legacy `worldAvailability` query, so completed deployments could remain hidden behind stale summary data.

While tracing recent deploy CI, I found a separate failure mode where `Game Launch` could die before deployment when concurrent `factory-runs` branch writes exhausted three immediate retries; the run-store writer now retries more deliberately with bounded backoff and regression coverage.

Validated with `bun test config/deployer/clean/tests/run-store.test.ts`, `pnpm --dir client/apps/game test src/hooks/use-worlds-summary.test.ts src/ui/features/landing/views/play-view.game-list-refresh.source.test.ts src/ui/features/landing/views/play-view.live-dev-games.test.ts`, `pnpm --dir client/apps/game typecheck`, `pnpm run format`, `pnpm run knip`, and `git diff --check`.