### PR TITLE
[codex] Harden factory run store write retries

### DIFF
--- a/config/deployer/clean/run-store/github.ts
+++ b/config/deployer/clean/run-store/github.ts
@@ -30,6 +30,10 @@ interface GitHubWriteBranchFileRequest {
   message: string;
 }
 
+const BRANCH_FILE_WRITE_RETRY_ATTEMPTS = 8;
+const BRANCH_FILE_WRITE_RETRY_DELAY_MS = 250;
+const BRANCH_FILE_WRITE_RETRY_MAX_DELAY_MS = 2_000;
+
 export interface ResolveGitHubBranchStoreConfigOptions extends ResolveGitHubRepositoryContextOptions {
   branch?: string;
 }
@@ -139,6 +143,23 @@ async function tryWriteBranchFile(
   throw new Error(`Failed to write run-store file "${request.path}": ${response.status} ${body}`);
 }
 
+function resolveBranchFileWriteRetryDelayMs(attempt: number): number {
+  const configuredDelay = Number(process.env.FACTORY_RUN_STORE_WRITE_RETRY_DELAY_MS);
+  const baseDelay = Number.isFinite(configuredDelay) ? configuredDelay : BRANCH_FILE_WRITE_RETRY_DELAY_MS;
+  return Math.min(BRANCH_FILE_WRITE_RETRY_MAX_DELAY_MS, Math.max(0, baseDelay) * (attempt + 1));
+}
+
+function waitForBranchFileWriteRetry(attempt: number): Promise<void> {
+  const delayMs = resolveBranchFileWriteRetryDelayMs(attempt);
+  if (delayMs <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
 export async function updateGitHubBranchJsonFile<T>(
   config: GitHubBranchStoreConfig,
   path: string,
@@ -147,7 +168,7 @@ export async function updateGitHubBranchJsonFile<T>(
 ): Promise<T> {
   await ensureGitHubBranchExists(config);
 
-  for (let attempt = 0; attempt < 3; attempt += 1) {
+  for (let attempt = 0; attempt < BRANCH_FILE_WRITE_RETRY_ATTEMPTS; attempt += 1) {
     const current = await readGitHubBranchJsonFile<T>(config, path);
     const nextValue = buildValue(current.value);
     const didWrite = await tryWriteBranchFile(
@@ -163,9 +184,13 @@ export async function updateGitHubBranchJsonFile<T>(
     if (didWrite) {
       return nextValue;
     }
+
+    if (attempt < BRANCH_FILE_WRITE_RETRY_ATTEMPTS - 1) {
+      await waitForBranchFileWriteRetry(attempt);
+    }
   }
 
-  throw new Error(`Failed to update run-store file "${path}" after 3 attempts`);
+  throw new Error(`Failed to update run-store file "${path}" after ${BRANCH_FILE_WRITE_RETRY_ATTEMPTS} attempts`);
 }
 
 export function requireGitHubBranchStoreConfig(

--- a/config/deployer/clean/tests/run-store.test.ts
+++ b/config/deployer/clean/tests/run-store.test.ts
@@ -14,7 +14,7 @@ import {
   recordFactoryLaunchStepSucceeded,
   releaseFactoryAccountLeaseRecord,
 } from "../run-store";
-import { requireGitHubBranchStoreConfig } from "../run-store/github";
+import { requireGitHubBranchStoreConfig, updateGitHubBranchJsonFile } from "../run-store/github";
 import { resolveRepoPath } from "../shared/repo";
 import type { LaunchGameSummary, LaunchRotationSummary, LaunchSeriesSummary } from "../types";
 
@@ -31,6 +31,7 @@ const ENV_KEYS = [
   "GITHUB_SERVER_URL",
   "GITHUB_REF_NAME",
   "FACTORY_RUN_STORE_BRANCH",
+  "FACTORY_RUN_STORE_WRITE_RETRY_DELAY_MS",
   "FACTORY_RUN_LEASE_DURATION_SECONDS",
   "FACTORY_ACCOUNT_LEASE_DURATION_SECONDS",
 ] as const;
@@ -80,6 +81,66 @@ afterEach(() => {
 });
 
 describe("factory run store", () => {
+  test("retries transient branch JSON write conflicts before failing the deploy record", async () => {
+    process.env.FACTORY_RUN_STORE_WRITE_RETRY_DELAY_MS = "0";
+
+    let conflictCount = 0;
+    let version = 0;
+    let file = {
+      sha: "sha-0",
+      content: `${JSON.stringify({ count: 0 }, null, 2)}\n`,
+    };
+
+    globalThis.fetch = (async (input, init) => {
+      const url = String(input);
+
+      if (url.endsWith("/git/ref/heads/factory-runs")) {
+        return Response.json({ object: { sha: "branch-sha" } });
+      }
+
+      if (url.includes("/contents/") && init?.method !== "PUT") {
+        return Response.json({
+          sha: file.sha,
+          encoding: "base64",
+          content: Buffer.from(file.content, "utf8").toString("base64"),
+        });
+      }
+
+      if (url.includes("/contents/") && init?.method === "PUT") {
+        if (conflictCount < 4) {
+          conflictCount += 1;
+          version += 1;
+          file = {
+            sha: `external-sha-${version}`,
+            content: `${JSON.stringify({ count: conflictCount }, null, 2)}\n`,
+          };
+          return Response.json({ message: "sha does not match" }, { status: 409 });
+        }
+
+        const body = JSON.parse(String(init.body || "{}")) as { content: string };
+        version += 1;
+        file = {
+          sha: `sha-${version}`,
+          content: Buffer.from(body.content, "base64").toString("utf8"),
+        };
+        return Response.json({ content: { path: "indexes/slot/blitz/games.json" } });
+      }
+
+      throw new Error(`Unexpected fetch request: ${url}`);
+    }) as typeof fetch;
+
+    const result = await updateGitHubBranchJsonFile<{ count: number }>(
+      requireGitHubBranchStoreConfig(),
+      "indexes/slot/blitz/games.json",
+      (current) => ({ count: (current?.count || 0) + 1 }),
+      "factory-runs: retry test",
+    );
+
+    expect(conflictCount).toBe(4);
+    expect(result.count).toBe(5);
+    expect(JSON.parse(file.content).count).toBe(5);
+  });
+
   test("records launch input and initializes a run record on the storage branch", async () => {
     const branchStore = createBranchStoreFetch();
     globalThis.fetch = branchStore.fetch;


### PR DESCRIPTION
Hardens deploy run-store writes after tracing recent Game Launch runs and finding `credence-new-flow-5` failed before deployment because `indexes/slot/blitz/games.json` hit three immediate GitHub content conflicts.

The branch JSON writer now retries 409/422 content conflicts up to eight times with bounded backoff, so transient concurrent writes from launch, maintenance, or run-store automation do not drop deploy requests as quickly.

Adds a regression test that simulates repeated conflicting writes before a successful update.

Validated with `bun test config/deployer/clean/tests/run-store.test.ts`, `pnpm run format`, `pnpm run knip`, and `git diff --check`.