### PR TITLE
fix(game): harden ghost army movement recovery

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.chunk-eviction-ghost.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.chunk-eviction-ghost.test.ts
@@ -57,5 +57,46 @@ describe("chunk-eviction ghosting prevention", () => {
       // cleanup must happen before freeInstanceSlot (which kills the movement callback)
       expect(cleanupPos).toBeLessThan(freeSlotPos);
     });
+
+    it("only notifies movement visual cancellation for true entity removal, not chunk reconciliation", () => {
+      const src = readSource("army-manager.ts");
+
+      const methodStart = src.indexOf("private removeVisibleArmy(");
+      expect(methodStart).toBeGreaterThan(-1);
+
+      const methodBody = src.slice(methodStart, methodStart + 2800);
+
+      const cancelGuardPos = methodBody.indexOf("if (options?.notifyMovementVisualCancel)");
+      const cancelPos = methodBody.indexOf("this.runMovementVisualCancelListeners(numericId)");
+      const freeSlotPos = methodBody.indexOf("this.armyModel.freeInstanceSlot(");
+      const removeArmyPos = src.indexOf("this.removeVisibleArmy(entityId, { notifyMovementVisualCancel: true })");
+
+      expect(src).toContain("public onMovementVisualCancel(entityId: ID, callback: () => void): () => void");
+      expect(src).toContain("options?: { notifyMovementVisualCancel?: boolean }");
+      expect(cancelGuardPos).toBeGreaterThan(-1);
+      expect(cancelPos).toBeGreaterThan(-1);
+      expect(freeSlotPos).toBeGreaterThan(-1);
+      expect(removeArmyPos).toBeGreaterThan(-1);
+      expect(cancelPos).toBeLessThan(freeSlotPos);
+    });
+
+    it("routes real army removals through movement cancellation instead of movement completion", () => {
+      const src = readSource("army-manager.ts");
+
+      const methodStart = src.indexOf("public removeArmy(");
+      expect(methodStart).toBeGreaterThan(-1);
+
+      const methodBody = src.slice(methodStart, methodStart + 2800);
+      const removeVisibleArmyPos = methodBody.indexOf(
+        "this.removeVisibleArmy(entityId, { notifyMovementVisualCancel: true })",
+      );
+      const completePos = methodBody.indexOf("this.runMovementCompleteListeners(numericEntityId)");
+      const nullSlotCancelPos = methodBody.indexOf("this.runMovementVisualCancelListeners(numericEntityId)");
+
+      expect(removeVisibleArmyPos).toBeGreaterThan(-1);
+      expect(completePos).toBe(-1);
+      expect(nullSlotCancelPos).toBeGreaterThan(-1);
+      expect(nullSlotCancelPos).toBeGreaterThan(removeVisibleArmyPos);
+    });
   });
 });

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -199,6 +199,7 @@ export class ArmyManager {
   private components?: ClientComponents;
   private movementStartListeners: Map<number, Set<() => void>> = new Map();
   private movementCompleteListeners: Map<number, Set<() => void>> = new Map();
+  private movementVisualCancelListeners: Map<number, Set<() => void>> = new Map();
   private pointsRenderers?: {
     player: PointsLabelRenderer;
     enemy: PointsLabelRenderer;
@@ -1164,7 +1165,7 @@ export class ArmyManager {
     this.updateArmyPointIcon(army, position);
   }
 
-  private removeVisibleArmy(entityId: ID): number | null {
+  private removeVisibleArmy(entityId: ID, options?: { notifyMovementVisualCancel?: boolean }): number | null {
     const slot = this.visibleArmyIndices.get(entityId);
     if (slot === undefined) {
       return null;
@@ -1199,6 +1200,9 @@ export class ArmyManager {
     // Clean up movement source bucket before freeing the slot, since
     // freeInstanceSlot kills the movement callback that would normally do this
     this.cleanupMovementSourceBucket(entityId);
+    if (options?.notifyMovementVisualCancel) {
+      this.runMovementVisualCancelListeners(numericId);
+    }
 
     this.armyModel.freeInstanceSlot(numericId, slot);
     return slot;
@@ -2108,6 +2112,7 @@ export class ArmyManager {
     // optimistic tween we just cancelled and should not fire.
     this.movementStartListeners.delete(numericEntityId);
     this.movementCompleteListeners.delete(numericEntityId);
+    this.movementVisualCancelListeners.delete(numericEntityId);
 
     if (armyData && (sourceState || lockedSource)) {
       const sourcePosition = new Position({
@@ -2174,7 +2179,6 @@ export class ArmyManager {
 
     this.armyPaths.delete(entityId);
     this.armyModel.setMovementCompleteCallback(numericEntityId, undefined);
-    this.runMovementCompleteListeners(numericEntityId);
     this.lastKnownVisibleHexes.delete(entityId);
 
     // Remove path visualization
@@ -2215,8 +2219,9 @@ export class ArmyManager {
     // console.debug(`[ArmyManager] Preparing world cleanup for entity ${entityId}`);
     const worldPosition = this.getArmyWorldPosition(entityId, army.hexCoords);
 
-    const removedSlot = this.removeVisibleArmy(entityId);
+    const removedSlot = this.removeVisibleArmy(entityId, { notifyMovementVisualCancel: true });
     if (removedSlot === null) {
+      this.runMovementVisualCancelListeners(numericEntityId);
       this.removeArmyPointIcon(entityId);
       this.removeEntityIdLabel(entityId);
     }
@@ -2405,6 +2410,29 @@ export class ArmyManager {
     };
   }
 
+  public onMovementVisualCancel(entityId: ID, callback: () => void): () => void {
+    const numericEntityId = this.toNumericId(entityId);
+    let listeners = this.movementVisualCancelListeners.get(numericEntityId);
+    if (!listeners) {
+      listeners = new Set();
+      this.movementVisualCancelListeners.set(numericEntityId, listeners);
+    }
+
+    listeners.add(callback);
+
+    return () => {
+      const active = this.movementVisualCancelListeners.get(numericEntityId);
+      if (!active) {
+        return;
+      }
+
+      active.delete(callback);
+      if (active.size === 0) {
+        this.movementVisualCancelListeners.delete(numericEntityId);
+      }
+    };
+  }
+
   public hasMovingArmies(): boolean {
     return this.armyModel.hasMovingInstances();
   }
@@ -2436,11 +2464,31 @@ export class ArmyManager {
     }
 
     this.movementCompleteListeners.delete(entityId);
+    this.movementVisualCancelListeners.delete(entityId);
     listeners.forEach((listener) => {
       try {
         listener();
       } catch (error) {
         console.error("[ArmyManager] Movement complete listener failed", error);
+      }
+    });
+  }
+
+  private runMovementVisualCancelListeners(entityId: number): void {
+    const listeners = this.movementVisualCancelListeners.get(entityId);
+    this.movementVisualCancelListeners.delete(entityId);
+    this.movementStartListeners.delete(entityId);
+    this.movementCompleteListeners.delete(entityId);
+
+    if (!listeners || listeners.size === 0) {
+      return;
+    }
+
+    listeners.forEach((listener) => {
+      try {
+        listener();
+      } catch (error) {
+        console.error("[ArmyManager] Movement visual cancel listener failed", error);
       }
     });
   }
@@ -3368,6 +3416,7 @@ ${
     this.chunkToArmies.clear();
     this.movementStartListeners.clear();
     this.movementCompleteListeners.clear();
+    this.movementVisualCancelListeners.clear();
 
     destroyArmyManagerOwnedResources({
       pathRenderer: this.pathRenderer,

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.test.ts
@@ -141,6 +141,26 @@ describe("ArrivalGhostManager", () => {
     expect(manager.hasArrivalGhost(1)).toBe(false);
   });
 
+  it("clears stranded unresolved ghosts after the defensive max lifetime", () => {
+    const manager = new ArrivalGhostManager(new Scene(), {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: hex(0, 0),
+      sourceScene: createTemplateScene(),
+      visualStyle: createVisualStyle(),
+    });
+
+    manager.update(120);
+
+    expect(manager.hasArrivalGhost(1)).toBe(false);
+    expect(manager.snapshotDiagnostics().cleared.max_lifetime).toBe(1);
+  });
+
   it("clears ghosts by reason and destroys all tracked ghosts", () => {
     const manager = new ArrivalGhostManager(new Scene(), {
       chunkStride: 5,
@@ -166,5 +186,37 @@ describe("ArrivalGhostManager", () => {
     });
     manager.destroy();
     expect(manager.getTrackedEntityIds()).toEqual([]);
+  });
+
+  it("tracks created and cleared ghost diagnostics by clear reason", () => {
+    const manager = new ArrivalGhostManager(new Scene(), {
+      chunkStride: 5,
+      renderChunkSize: { width: 10, height: 10 },
+    });
+
+    manager.setCurrentChunk("0,0");
+    manager.upsertLocalArrivalGhost({
+      entityId: 1,
+      hexCoords: hex(0, 0),
+      sourceScene: createTemplateScene(),
+      visualStyle: createVisualStyle(),
+    });
+    manager.clearArrivalGhost(1, "movement_evicted");
+    manager.upsertLocalArrivalGhost({
+      entityId: 2,
+      hexCoords: hex(0, 0),
+      sourceScene: createTemplateScene(),
+      visualStyle: createVisualStyle(),
+    });
+    manager.clearArrivalGhost(2, "optimistic_aborted");
+
+    expect(manager.snapshotDiagnostics()).toMatchObject({
+      active: 0,
+      created: 2,
+      cleared: {
+        movement_evicted: 1,
+        optimistic_aborted: 1,
+      },
+    });
   });
 });

--- a/client/apps/game/src/three/managers/arrival-ghost-manager.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-manager.ts
@@ -33,6 +33,18 @@ const ARRIVAL_GHOST_RING_PULSE_AMPLITUDE = 0.22;
 const ARRIVAL_GHOST_RING_PULSE_SPEED = 2.4;
 const ARRIVAL_GHOST_BURST_RING_OPACITY = 0.52;
 const ARRIVAL_GHOST_BURST_RING_EXPANSION = 0.95;
+const ARRIVAL_GHOST_MAX_LIFETIME_S = 90;
+const ARRIVAL_GHOST_CLEAR_REASONS: ArrivalGhostClearReason[] = [
+  "arrived",
+  "tx_failed",
+  "stale_timeout",
+  "army_removed",
+  "scene_destroyed",
+  "superseded",
+  "movement_evicted",
+  "max_lifetime",
+  "optimistic_aborted",
+];
 
 export interface ArrivalGhostSpec {
   entityId: ID;
@@ -42,6 +54,7 @@ export interface ArrivalGhostSpec {
 }
 
 interface ArrivalGhostState extends ArrivalGhostSpec {
+  ageElapsedS: number;
   baseScale: Vector3;
   burstRing: Mesh<RingGeometry, MeshBasicMaterial>;
   container: Group;
@@ -57,8 +70,32 @@ interface ArrivalGhostManagerOptions {
   renderChunkSize: { width: number; height: number };
 }
 
+export interface ArrivalGhostDiagnosticsSnapshot {
+  active: number;
+  cleared: Record<ArrivalGhostClearReason, number>;
+  created: number;
+  updatedAtMs: number;
+}
+
+function createArrivalGhostClearCounts(): Record<ArrivalGhostClearReason, number> {
+  return Object.fromEntries(ARRIVAL_GHOST_CLEAR_REASONS.map((reason) => [reason, 0])) as Record<
+    ArrivalGhostClearReason,
+    number
+  >;
+}
+
+function createArrivalGhostDiagnostics(): ArrivalGhostDiagnosticsSnapshot {
+  return {
+    active: 0,
+    cleared: createArrivalGhostClearCounts(),
+    created: 0,
+    updatedAtMs: Date.now(),
+  };
+}
+
 export class ArrivalGhostManager {
   private readonly ghosts = new Map<ID, ArrivalGhostState>();
+  private readonly diagnostics = createArrivalGhostDiagnostics();
   private currentChunkKey: string | null = MANAGER_UNCOMMITTED_CHUNK;
 
   constructor(
@@ -72,6 +109,7 @@ export class ArrivalGhostManager {
     const container = this.buildGhostContainer(input);
     const state: ArrivalGhostState = {
       ...input,
+      ageElapsedS: 0,
       burstRing: container.getObjectByName("arrival-ghost-burst-ring") as Mesh<RingGeometry, MeshBasicMaterial>,
       baseScale: container.scale.clone(),
       container,
@@ -83,6 +121,7 @@ export class ArrivalGhostManager {
     };
 
     this.ghosts.set(input.entityId, state);
+    this.recordGhostCreated();
     this.syncGhostVisibility(state);
   }
 
@@ -95,7 +134,7 @@ export class ArrivalGhostManager {
     ghost.resolveRequested = true;
   }
 
-  public clearArrivalGhost(entityId: ID, _reason: ArrivalGhostClearReason): void {
+  public clearArrivalGhost(entityId: ID, reason: ArrivalGhostClearReason): void {
     const ghost = this.ghosts.get(entityId);
     if (!ghost) {
       return;
@@ -104,6 +143,7 @@ export class ArrivalGhostManager {
     this.scene.remove(ghost.container);
     this.disposeGhostContainer(ghost.container);
     this.ghosts.delete(entityId);
+    this.recordGhostCleared(reason);
   }
 
   public hasArrivalGhost(entityId: ID): boolean {
@@ -114,8 +154,23 @@ export class ArrivalGhostManager {
     return Array.from(this.ghosts.keys());
   }
 
+  public snapshotDiagnostics(): ArrivalGhostDiagnosticsSnapshot {
+    return {
+      active: this.ghosts.size,
+      cleared: { ...this.diagnostics.cleared },
+      created: this.diagnostics.created,
+      updatedAtMs: this.diagnostics.updatedAtMs,
+    };
+  }
+
   public update(deltaTime: number): void {
-    for (const ghost of this.ghosts.values()) {
+    for (const ghost of Array.from(this.ghosts.values())) {
+      ghost.ageElapsedS += deltaTime;
+      if (this.hasExceededMaxLifetime(ghost)) {
+        this.clearArrivalGhost(ghost.entityId, "max_lifetime");
+        continue;
+      }
+
       this.syncGhostVisibility(ghost);
       if (!ghost.container.visible) {
         continue;
@@ -277,6 +332,10 @@ export class ArrivalGhostManager {
     ghost.burstRing.scale.setScalar(1);
   }
 
+  private hasExceededMaxLifetime(ghost: ArrivalGhostState): boolean {
+    return ghost.ageElapsedS >= ARRIVAL_GHOST_MAX_LIFETIME_S;
+  }
+
   private syncGhostVisibility(ghost: ArrivalGhostState): void {
     ghost.container.visible = this.isGhostVisibleInCurrentChunk(ghost.hexCoords);
   }
@@ -334,5 +393,15 @@ export class ArrivalGhostManager {
         }
       });
     });
+  }
+
+  private recordGhostCreated(): void {
+    this.diagnostics.created += 1;
+    this.diagnostics.updatedAtMs = Date.now();
+  }
+
+  private recordGhostCleared(reason: ArrivalGhostClearReason): void {
+    this.diagnostics.cleared[reason] += 1;
+    this.diagnostics.updatedAtMs = Date.now();
   }
 }

--- a/client/apps/game/src/three/managers/arrival-ghost-policy.ts
+++ b/client/apps/game/src/three/managers/arrival-ghost-policy.ts
@@ -6,7 +6,10 @@ export type ArrivalGhostClearReason =
   | "stale_timeout"
   | "army_removed"
   | "scene_destroyed"
-  | "superseded";
+  | "superseded"
+  | "movement_evicted"
+  | "max_lifetime"
+  | "optimistic_aborted";
 
 export interface ArrivalGhostVisualStyle {
   color: string;

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.test.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.test.ts
@@ -203,4 +203,16 @@ describe("worldmap-render-diagnostics", () => {
 
     expect(snapshot.counters).toHaveProperty("duplicateTileAuthoritativeUpdates", 1);
   });
+
+  it("tracks ghost-army recovery counters for pending removal cancellation sources", () => {
+    incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByTileRecovery" as any);
+    incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByExplorerTroopsZero" as any);
+    incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery" as any);
+
+    const snapshot = snapshotWorldmapRenderDiagnostics();
+
+    expect(snapshot.counters).toHaveProperty("pendingArmyRemovalCancelledByTileRecovery", 1);
+    expect(snapshot.counters).toHaveProperty("pendingArmyRemovalCancelledByExplorerTroopsZero", 1);
+    expect(snapshot.counters).toHaveProperty("pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery", 1);
+  });
 });

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
@@ -47,7 +47,12 @@ export type WorldmapRenderCounter =
   | "spatialTileOptReadyTimeouts"
   | "spatialTileOptStreamReceived"
   | "postCommitManagerCatchUpImmediate"
-  | "postCommitManagerCatchUpDeferred";
+  | "postCommitManagerCatchUpDeferred"
+  | "pendingArmyRemovalCancelledByTileRecovery"
+  | "pendingArmyRemovalCancelledByDelete"
+  | "pendingArmyRemovalCancelledBySuperseded"
+  | "pendingArmyRemovalCancelledByExplorerTroopsZero"
+  | "pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery";
 
 export interface WorldmapZoomTelemetrySummary {
   controlsChangeEvents: number;
@@ -151,6 +156,11 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     spatialTileOptStreamReceived: 0,
     postCommitManagerCatchUpImmediate: 0,
     postCommitManagerCatchUpDeferred: 0,
+    pendingArmyRemovalCancelledByTileRecovery: 0,
+    pendingArmyRemovalCancelledByDelete: 0,
+    pendingArmyRemovalCancelledBySuperseded: 0,
+    pendingArmyRemovalCancelledByExplorerTroopsZero: 0,
+    pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery: 0,
   },
   forceRefreshReasons: {
     default: 0,

--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.stale-position.test.ts
@@ -9,30 +9,39 @@ const baseUpdate = {
 } as any;
 
 describe("processExplorerTroopsUpdate stale-position skip", () => {
-  it("skips updateArmyHexes but still applies updateArmyFromExplorerTroopsUpdate when stale", () => {
+  it("skips updateArmyHexes and does not treat stale replays as live recovery", () => {
     const updateArmyHexes = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
+    const cancelPendingArmyRemoval = vi.fn();
+    const recordLiveArmyPresenceUpdate = vi.fn();
+    const recoverPendingArmyRemovalFromExplorerTroops = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => true);
     const onAuthoritativePositionApplied = vi.fn();
 
     processExplorerTroopsUpdate(baseUpdate, {
-      cancelPendingArmyRemoval: vi.fn(),
+      cancelPendingArmyRemoval,
       scheduleArmyRemoval: vi.fn(),
       updateArmyHexes,
       updateArmyFromExplorerTroopsUpdate,
+      recordLiveArmyPresenceUpdate,
       onAuthoritativePositionApplied,
+      recoverPendingArmyRemovalFromExplorerTroops,
       shouldSkipStalePositionUpdate,
     });
 
     expect(shouldSkipStalePositionUpdate).toHaveBeenCalledWith(7, expect.objectContaining({ x: expect.any(Number) }));
+    expect(cancelPendingArmyRemoval).not.toHaveBeenCalled();
     expect(updateArmyHexes).not.toHaveBeenCalled();
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(baseUpdate);
+    expect(recordLiveArmyPresenceUpdate).not.toHaveBeenCalled();
     expect(onAuthoritativePositionApplied).not.toHaveBeenCalled();
+    expect(recoverPendingArmyRemovalFromExplorerTroops).not.toHaveBeenCalled();
   });
 
   it("applies both handlers when the predicate returns false", () => {
     const updateArmyHexes = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
+    const recordLiveArmyPresenceUpdate = vi.fn();
     const shouldSkipStalePositionUpdate = vi.fn(() => false);
     const onAuthoritativePositionApplied = vi.fn();
 
@@ -41,12 +50,14 @@ describe("processExplorerTroopsUpdate stale-position skip", () => {
       scheduleArmyRemoval: vi.fn(),
       updateArmyHexes,
       updateArmyFromExplorerTroopsUpdate,
+      recordLiveArmyPresenceUpdate,
       onAuthoritativePositionApplied,
       shouldSkipStalePositionUpdate,
     });
 
     expect(updateArmyHexes).toHaveBeenCalledWith(baseUpdate);
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(baseUpdate);
+    expect(recordLiveArmyPresenceUpdate).toHaveBeenCalledWith(baseUpdate);
     expect(onAuthoritativePositionApplied).toHaveBeenCalledWith(baseUpdate);
   });
 

--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
@@ -21,18 +21,20 @@ describe("processExplorerTroopsUpdate", () => {
       updateArmyFromExplorerTroopsUpdate,
     });
 
-    expect(cancelPendingArmyRemoval).toHaveBeenCalledWith(42);
+    expect(cancelPendingArmyRemoval).toHaveBeenCalledWith(42, "explorer_troops_zero");
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(update);
     expect(updateArmyHexes).not.toHaveBeenCalled();
     expect(scheduleArmyRemoval).toHaveBeenCalledWith(42, "zero");
   });
 
-  it("updates hexes and army state for living armies", () => {
+  it("updates hexes and army state before explicitly recovering pending removals for living armies", () => {
     const cancelPendingArmyRemoval = vi.fn();
     const scheduleArmyRemoval = vi.fn();
     const updateArmyHexes = vi.fn();
     const updateArmyFromExplorerTroopsUpdate = vi.fn();
+    const recordLiveArmyPresenceUpdate = vi.fn();
     const onAuthoritativePositionApplied = vi.fn();
+    const recoverPendingArmyRemovalFromExplorerTroops = vi.fn();
 
     const update = {
       entityId: 7,
@@ -45,13 +47,17 @@ describe("processExplorerTroopsUpdate", () => {
       scheduleArmyRemoval,
       updateArmyHexes,
       updateArmyFromExplorerTroopsUpdate,
+      recordLiveArmyPresenceUpdate,
       onAuthoritativePositionApplied,
+      recoverPendingArmyRemovalFromExplorerTroops,
     });
 
-    expect(cancelPendingArmyRemoval).toHaveBeenCalledWith(7);
+    expect(cancelPendingArmyRemoval).not.toHaveBeenCalled();
     expect(updateArmyHexes).toHaveBeenCalledWith(update);
     expect(updateArmyFromExplorerTroopsUpdate).toHaveBeenCalledWith(update);
+    expect(recordLiveArmyPresenceUpdate).toHaveBeenCalledWith(update);
     expect(onAuthoritativePositionApplied).toHaveBeenCalledWith(update);
+    expect(recoverPendingArmyRemovalFromExplorerTroops).toHaveBeenCalledWith(update);
     expect(scheduleArmyRemoval).not.toHaveBeenCalled();
   });
 
@@ -68,9 +74,11 @@ describe("processExplorerTroopsUpdate", () => {
       scheduleArmyRemoval: vi.fn(),
       updateArmyHexes: vi.fn(() => callOrder.push("hexes")),
       updateArmyFromExplorerTroopsUpdate: vi.fn(() => callOrder.push("army")),
+      recordLiveArmyPresenceUpdate: vi.fn(() => callOrder.push("live-signal")),
       onAuthoritativePositionApplied: vi.fn(() => callOrder.push("pending-clear")),
+      recoverPendingArmyRemovalFromExplorerTroops: vi.fn(() => callOrder.push("recovery")),
     });
 
-    expect(callOrder).toEqual(["hexes", "army", "pending-clear"]);
+    expect(callOrder).toEqual(["hexes", "army", "live-signal", "pending-clear", "recovery"]);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
@@ -56,7 +56,7 @@ describe("worldmap army suppression integration", () => {
     expect(restorePos).toBeGreaterThan(movePos);
   });
 
-  it("troop updates do not recover visuals before tile state catches up", () => {
+  it("troop updates delegate pending-removal recovery through the ordered helper", () => {
     const src = readSource("worldmap.tsx");
 
     const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {");
@@ -66,5 +66,6 @@ describe("worldmap army suppression integration", () => {
     expect(listenerBody).not.toContain("this.cancelPendingArmyRemoval(update.entityId)");
     expect(listenerBody).not.toContain("restoreArmyVisualIfVisible(update.entityId)");
     expect(listenerBody).toContain("this.armyManager.updateArmyFromExplorerTroopsUpdate(update)");
+    expect(listenerBody).toContain("recoverPendingArmyRemovalFromExplorerTroops");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
@@ -41,18 +41,23 @@ describe("worldmap army tile-sync recovery", () => {
     expect(listenerBody).not.toContain("this.armyLastTileSyncAt.set(update.entityId");
   });
 
-  it("uses tile-sync timestamps for scheduled removal cancellation and deferred retry", () => {
+  it("uses the aggregated live-update helper for scheduled removal cancellation and deferred retry", () => {
     const src = readSource("worldmap.tsx");
 
     const scheduleStart = src.indexOf("private scheduleArmyRemoval(");
     const retryStart = src.indexOf("private retryDeferredChunkRemovals()");
+    const helperStart = src.indexOf("private resolveLastArmyLiveUpdateAt(");
     expect(scheduleStart).toBeGreaterThan(-1);
     expect(retryStart).toBeGreaterThan(-1);
+    expect(helperStart).toBeGreaterThan(-1);
 
     const scheduleBody = src.slice(scheduleStart, scheduleStart + 3200);
     const retryBody = src.slice(retryStart, retryStart + 900);
+    const helperBody = src.slice(helperStart, helperStart + 300);
 
-    expect(scheduleBody).toContain("this.armyLastTileSyncAt.get(entityId)");
-    expect(retryBody).toContain("this.armyLastTileSyncAt.get(entityId)");
+    expect(scheduleBody).toContain("this.resolveLastArmyLiveUpdateAt(entityId)");
+    expect(retryBody).toContain("this.resolveLastArmyLiveUpdateAt(entityId)");
+    expect(helperBody).toContain("this.armyLastTileSyncAt.get(entityId)");
+    expect(helperBody).toContain("this.armyLastLiveUpdateAt.get(entityId)");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-arrival-ghost.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-arrival-ghost.source.test.ts
@@ -21,4 +21,24 @@ describe("Worldmap arrival ghost wiring", () => {
     expect(source).toContain("this.arrivalGhostManager.resolveArrivalGhost");
     expect(source).not.toContain("shouldResolveArrivalGhost");
   });
+
+  it("clears tracked arrival ghosts when movement visuals are cancelled before completion", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    expect(source).toContain("this.armyManager.onMovementVisualCancel");
+    expect(source).toContain('this.arrivalGhostManager.clearArrivalGhost(entityId, "movement_evicted")');
+  });
+
+  it("clears tracked arrival ghosts when optimistic movement aborts before animation starts", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+
+    const handlerStart = source.indexOf("private async applySubmittedArmyMovementOptimisticPlan(");
+    expect(handlerStart).toBeGreaterThan(-1);
+    const handlerEnd = source.indexOf("\n  private ", handlerStart + 20);
+    const handler = source.slice(handlerStart, handlerEnd);
+    const abortCleanupCalls = handler.match(/this\.clearArrivalGhostAfterOptimisticMovementAbort\(entityId, txHash\)/g);
+
+    expect(abortCleanupCalls).toHaveLength(2);
+    expect(source).toContain('this.arrivalGhostManager.clearArrivalGhost(entityId, "optimistic_aborted")');
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-optimistic-mirror-gated.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-optimistic-mirror-gated.source.test.ts
@@ -78,14 +78,16 @@ describe("Worldmap optimistic mirror gated on applyMovementPlan result", () => {
   it("emits optimistic_animation_skipped latency phase when the plan no-ops", () => {
     const source = readSource("worldmap.tsx");
 
-    const handlerStart = source.indexOf("private async applySubmittedArmyMovementOptimisticPlan(");
-    const handlerEnd = source.indexOf("\n  private ", handlerStart + 20);
-    const handler = source.slice(handlerStart, handlerEnd);
+    const helperStart = source.indexOf("private clearArrivalGhostAfterOptimisticMovementAbort(");
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperEnd = source.indexOf("\n  private ", helperStart + 20);
+    expect(helperEnd).toBeGreaterThan(helperStart);
+    const helper = source.slice(helperStart, helperEnd);
 
     // Observability: without this phase marker, the no-op path is invisible
     // in the latency trace and we can't confirm from logs which early-return
     // fired in production.
-    expect(handler).toContain('"optimistic_animation_skipped"');
+    expect(helper).toContain('"optimistic_animation_skipped"');
   });
 
   it("registers optimistic_animation_skipped in the latency phase union", () => {

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
@@ -84,4 +84,17 @@ describe("Worldmap pending movement visual handoff wiring", () => {
       body.indexOf("this.armyManager.applyMovementPlan"),
     );
   });
+
+  it("keeps the authoritative movement lifecycle installed when optimistic animation is skipped", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const helperStart = source.indexOf("private clearArrivalGhostAfterOptimisticMovementAbort(");
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperEnd = source.indexOf("private mirrorOptimisticArmyDestinationIntoWorldmapCache", helperStart);
+    const helperBody = source.slice(helperStart, helperEnd);
+
+    expect(helperBody).toContain('"optimistic_animation_skipped"');
+    expect(helperBody).toContain('this.arrivalGhostManager.clearArrivalGhost(entityId, "optimistic_aborted")');
+    expect(helperBody).not.toContain("this.disposePendingMovementVisualLifecycle(entityId)");
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.ts
@@ -5,6 +5,7 @@ interface WorldmapSwitchOffRuntimeStateInput<TEntityId, TTimeout, TPendingChunk>
   pendingArmyRemovalMeta: Map<TEntityId, unknown>;
   deferredChunkRemovals: Map<TEntityId, unknown>;
   armyLastTileSyncAt: Map<TEntityId, number>;
+  armyLastLiveUpdateAt?: Map<TEntityId, number>;
   pendingArmyMovements: Set<TEntityId>;
   pendingArmyMovementStartedAt: Map<TEntityId, number>;
   pendingArmyMovementFallbackTimeouts: Map<TEntityId, TTimeout>;
@@ -62,6 +63,7 @@ export const applyWorldmapSwitchOffRuntimeState = <TEntityId, TTimeout, TPending
   pendingArmyRemovalMeta,
   deferredChunkRemovals,
   armyLastTileSyncAt,
+  armyLastLiveUpdateAt,
   pendingArmyMovements,
   pendingArmyMovementStartedAt,
   pendingArmyMovementFallbackTimeouts,
@@ -86,6 +88,7 @@ export const applyWorldmapSwitchOffRuntimeState = <TEntityId, TTimeout, TPending
   pendingArmyRemovalMeta.clear();
   deferredChunkRemovals.clear();
   armyLastTileSyncAt.clear();
+  armyLastLiveUpdateAt?.clear();
   pendingArmyMovements.forEach((entityId) => clearPendingArmyMovement(entityId));
   pendingArmyMovements.clear();
   pendingArmyMovementStartedAt.clear();

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
@@ -108,4 +108,13 @@ describe("resolveExploreCompletionPendingClearPlan", () => {
       }),
     ).toBe(true);
   });
+
+  it("cleans up travel effects when movement visuals are evicted before completion", () => {
+    expect(
+      shouldCleanupTrackedTravelEffectOnPendingClear({
+        trackedEffect: { key: "7,8", effectType: "travel" },
+        reason: "movement_evicted",
+      }),
+    ).toBe(true);
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
@@ -4,7 +4,8 @@ export type TravelEffectType = "travel" | "compass";
 export type PendingArmyMovementEffectClearReason =
   | "movement_started"
   | "cleanup_requested"
-  | "authoritative_reconciled";
+  | "authoritative_reconciled"
+  | "movement_evicted";
 
 export interface TrackedTravelEffect {
   key: string;

--- a/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
+++ b/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
@@ -1,12 +1,21 @@
 import { ExplorerTroopsSystemUpdate, Position } from "@bibliothecadao/eternum";
 import { ID } from "@bibliothecadao/types";
 
+export type PendingArmyRemovalCancelSource =
+  | "tile_recovery"
+  | "delete"
+  | "superseded"
+  | "explorer_troops_zero"
+  | "explorer_troops_live_recovery";
+
 type ExplorerTroopsUpdateHandlers = {
-  cancelPendingArmyRemoval: (entityId: ID) => void;
+  cancelPendingArmyRemoval: (entityId: ID, source: PendingArmyRemovalCancelSource) => void;
   scheduleArmyRemoval: (entityId: ID, reason: "tile" | "zero") => void;
   updateArmyHexes: (update: ExplorerTroopsSystemUpdate) => void;
   updateArmyFromExplorerTroopsUpdate: (update: ExplorerTroopsSystemUpdate) => void;
+  recordLiveArmyPresenceUpdate?: (update: ExplorerTroopsSystemUpdate) => void;
   onAuthoritativePositionApplied?: (update: ExplorerTroopsSystemUpdate) => void;
+  recoverPendingArmyRemovalFromExplorerTroops?: (update: ExplorerTroopsSystemUpdate) => void;
   shouldSkipStalePositionUpdate?: (entityId: ID, normalized: { x: number; y: number }) => boolean;
 };
 
@@ -14,9 +23,8 @@ export function processExplorerTroopsUpdate(
   update: ExplorerTroopsSystemUpdate,
   handlers: ExplorerTroopsUpdateHandlers,
 ): void {
-  handlers.cancelPendingArmyRemoval(update.entityId);
-
   if (update.troopCount <= 0) {
+    handlers.cancelPendingArmyRemoval(update.entityId, "explorer_troops_zero");
     // Keep army manager state in sync so zero-count transitions can trigger death handling
     // before worldmap removal.
     handlers.updateArmyFromExplorerTroopsUpdate(update);
@@ -30,11 +38,14 @@ export function processExplorerTroopsUpdate(
   if (!shouldSkipPosition) {
     handlers.updateArmyHexes(update);
   }
+
   // Always apply non-positional fields (stamina/troop-count/owner). Tick-based
   // staleness resolution downstream handles any regression in those fields.
   handlers.updateArmyFromExplorerTroopsUpdate(update);
 
   if (!shouldSkipPosition) {
+    handlers.recordLiveArmyPresenceUpdate?.(update);
     handlers.onAuthoritativePositionApplied?.(update);
+    handlers.recoverPendingArmyRemovalFromExplorerTroops?.(update);
   }
 }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -44,7 +44,10 @@ import { SceneManager } from "@/three/scene-manager";
 import { CameraView } from "@/three/scenes/camera-view";
 import { CAMERA_CONFIG } from "@/three/constants";
 import { HexagonScene } from "@/three/scenes/hexagon-scene";
-import { processExplorerTroopsUpdate } from "@/three/scenes/worldmap-update-helpers";
+import {
+  processExplorerTroopsUpdate,
+  type PendingArmyRemovalCancelSource,
+} from "@/three/scenes/worldmap-update-helpers";
 import { WorldmapPerfSimulation } from "@/three/scenes/worldmap-perf-simulation";
 import { playResourceSound } from "@/three/sound/utils";
 import { LeftView } from "@/types";
@@ -764,6 +767,7 @@ export default class WorldmapScene extends WarpTravel {
   // normalized coordinates
   private armiesPositions: Map<ID, HexPosition> = new Map();
   private armyLastTileSyncAt: Map<ID, number> = new Map();
+  private armyLastLiveUpdateAt: Map<ID, number> = new Map();
   // normalized coordinates
   private structuresPositions: Map<ID, HexPosition> = new Map();
 
@@ -1167,16 +1171,14 @@ export default class WorldmapScene extends WarpTravel {
     plan: ArmyMovementPlan | null,
   ): Promise<void> {
     if (!this.pendingArmyMovements.has(entityId)) return;
-    if (!plan) return;
+    if (!plan) {
+      this.clearArrivalGhostAfterOptimisticMovementAbort(entityId, txHash);
+      return;
+    }
 
     const planApplied = await this.armyManager.applyMovementPlan(plan, { optimistic: true });
     if (!planApplied) {
-      recordArmyMovementLatencyPhase({
-        phase: "optimistic_animation_skipped",
-        source: "worldmap",
-        entityId,
-        txHash,
-      });
+      this.clearArrivalGhostAfterOptimisticMovementAbort(entityId, txHash);
       return;
     }
 
@@ -1188,6 +1190,18 @@ export default class WorldmapScene extends WarpTravel {
     });
     this.mirrorOptimisticArmyDestinationIntoWorldmapCache(entityId, plan);
     this.paintOptimisticDestinationBiome(plan);
+  }
+
+  private clearArrivalGhostAfterOptimisticMovementAbort(entityId: ID, txHash: string): void {
+    recordArmyMovementLatencyPhase({
+      phase: "optimistic_animation_skipped",
+      source: "worldmap",
+      entityId,
+      txHash,
+    });
+    // Keep the pending movement lifecycle installed so the later authoritative
+    // movement handoff can still clear pending state and resolve travel FX.
+    this.arrivalGhostManager.clearArrivalGhost(entityId, "optimistic_aborted");
   }
 
   private mirrorOptimisticArmyDestinationIntoWorldmapCache(entityId: ID, plan: ArmyMovementPlan): void {
@@ -1382,7 +1396,7 @@ export default class WorldmapScene extends WarpTravel {
             row: update.hexCoords.row,
           },
         });
-        const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId);
+        const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId, "tile_recovery");
         const normalizedPos = new Position({ x: update.hexCoords.col, y: update.hexCoords.row }).getNormalized();
 
         if (update.removed) {
@@ -1442,6 +1456,7 @@ export default class WorldmapScene extends WarpTravel {
             row: update.hexCoords.row,
           },
         });
+        this.recordAuthoritativeArmyLiveUpdate(update.entityId);
         this.armyLastTileSyncAt.set(update.entityId, Date.now());
         if (recoveredPendingRemoval) {
           void this.armyManager.restoreArmyVisualIfVisible(update.entityId);
@@ -1462,11 +1477,14 @@ export default class WorldmapScene extends WarpTravel {
     this.addWorldUpdateSubscription(
       this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {
         processExplorerTroopsUpdate(update, {
-          cancelPendingArmyRemoval: (entityId) => this.cancelPendingArmyRemoval(entityId),
+          cancelPendingArmyRemoval: (entityId, source) => this.cancelPendingArmyRemoval(entityId, source),
           scheduleArmyRemoval: (entityId, reason) => this.scheduleArmyRemoval(entityId, reason),
           updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
           updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
+          recordLiveArmyPresenceUpdate: (update) => this.recordAuthoritativeArmyLiveUpdate(update.entityId),
           onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
+          recoverPendingArmyRemovalFromExplorerTroops: (update) =>
+            this.recoverPendingArmyRemovalFromExplorerTroops(update),
           shouldSkipStalePositionUpdate: (entityId, normalized) =>
             this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
         });
@@ -2978,10 +2996,16 @@ export default class WorldmapScene extends WarpTravel {
       }
       this.disposePendingMovementVisualLifecycle(entityId);
     });
+    const disposeMovementVisualCancel = this.armyManager.onMovementVisualCancel(entityId, () => {
+      this.clearPendingArmyMovement(entityId, "movement_evicted");
+      this.arrivalGhostManager.clearArrivalGhost(entityId, "movement_evicted");
+      this.disposePendingMovementVisualLifecycle(entityId);
+    });
 
     this.pendingArmyMovementVisualLifecycleDisposers.set(entityId, () => {
       disposeMovementStart();
       disposeMovementComplete();
+      disposeMovementVisualCancel();
       this.pendingArmyMovementVisualLifecycleDisposers.delete(entityId);
     });
   }
@@ -3998,6 +4022,7 @@ export default class WorldmapScene extends WarpTravel {
       pendingArmyRemovalMeta: this.pendingArmyRemovalMeta,
       deferredChunkRemovals: this.deferredChunkRemovals,
       armyLastTileSyncAt: this.armyLastTileSyncAt,
+      armyLastLiveUpdateAt: this.armyLastLiveUpdateAt,
       pendingArmyMovements: this.pendingArmyMovements,
       pendingArmyMovementStartedAt: this.pendingArmyMovementStartedAt,
       pendingArmyMovementFallbackTimeouts: this.pendingArmyMovementFallbackTimeouts,
@@ -4042,7 +4067,7 @@ export default class WorldmapScene extends WarpTravel {
 
   public deleteArmy(entityId: ID, options: { playDefeatFx?: boolean } = {}) {
     const { playDefeatFx = true } = options;
-    this.cancelPendingArmyRemoval(entityId);
+    this.cancelPendingArmyRemoval(entityId, "delete");
     this.disposePendingMovementVisualLifecycle(entityId);
     this.arrivalGhostManager.clearArrivalGhost(entityId, "army_removed");
     this.armyManager.removeArmy(entityId, { playDefeatFx });
@@ -4061,6 +4086,7 @@ export default class WorldmapScene extends WarpTravel {
     }
     this.armiesPositions.delete(entityId);
     this.armyLastTileSyncAt.delete(entityId);
+    this.armyLastLiveUpdateAt.delete(entityId);
     this.pendingArmyRemovalMeta.delete(entityId);
     this.armyStructureOwners.delete(entityId);
     this.clearArmyMovementTxEntriesForEntity(entityId);
@@ -4095,7 +4121,7 @@ export default class WorldmapScene extends WarpTravel {
       return;
     }
 
-    this.cancelPendingArmyRemoval(supersededEntityId);
+    this.cancelPendingArmyRemoval(supersededEntityId, "superseded");
     this.deleteArmy(supersededEntityId, { playDefeatFx: false });
   }
 
@@ -4170,7 +4196,7 @@ export default class WorldmapScene extends WarpTravel {
         }
 
         if (reason === "tile") {
-          const lastUpdate = this.armyLastTileSyncAt.get(entityId) ?? 0;
+          const lastUpdate = this.resolveLastArmyLiveUpdateAt(entityId);
           if (lastUpdate > meta.scheduledAt) {
             this.pendingArmyRemovalMeta.delete(entityId);
             this.pendingArmyRemovals.delete(entityId);
@@ -4230,11 +4256,11 @@ export default class WorldmapScene extends WarpTravel {
       onRetryRemoval: (entityId, reason) => {
         this.scheduleArmyRemoval(entityId, reason);
       },
-      resolveLastTileSyncAt: (entityId) => this.armyLastTileSyncAt.get(entityId) ?? 0,
+      resolveLastTileSyncAt: (entityId) => this.resolveLastArmyLiveUpdateAt(entityId),
     });
   }
 
-  private cancelPendingArmyRemoval(entityId: ID): boolean {
+  private cancelPendingArmyRemoval(entityId: ID, source: PendingArmyRemovalCancelSource): boolean {
     const timeout = this.pendingArmyRemovals.get(entityId);
     const hasDeferredRemoval = this.deferredChunkRemovals.has(entityId);
     const hasRemovalMeta = this.pendingArmyRemovalMeta.has(entityId);
@@ -4247,7 +4273,43 @@ export default class WorldmapScene extends WarpTravel {
     this.pendingArmyRemovalMeta.delete(entityId);
     this.deferredChunkRemovals.delete(entityId);
     this.armyManager.unsuppressArmy(entityId);
+    this.recordPendingArmyRemovalCancelled(source);
     return true;
+  }
+
+  private recoverPendingArmyRemovalFromExplorerTroops(update: { entityId: ID }): void {
+    const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId, "explorer_troops_live_recovery");
+    if (recoveredPendingRemoval) {
+      void this.armyManager.restoreArmyVisualIfVisible(update.entityId);
+    }
+  }
+
+  private recordAuthoritativeArmyLiveUpdate(entityId: ID): void {
+    this.armyLastLiveUpdateAt.set(entityId, Date.now());
+  }
+
+  private resolveLastArmyLiveUpdateAt(entityId: ID): number {
+    return Math.max(this.armyLastTileSyncAt.get(entityId) ?? 0, this.armyLastLiveUpdateAt.get(entityId) ?? 0);
+  }
+
+  private recordPendingArmyRemovalCancelled(source: PendingArmyRemovalCancelSource): void {
+    switch (source) {
+      case "tile_recovery":
+        incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByTileRecovery");
+        return;
+      case "delete":
+        incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByDelete");
+        return;
+      case "superseded":
+        incrementWorldmapRenderCounter("pendingArmyRemovalCancelledBySuperseded");
+        return;
+      case "explorer_troops_zero":
+        incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByExplorerTroopsZero");
+        return;
+      case "explorer_troops_live_recovery":
+        incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery");
+        return;
+    }
   }
 
   public deleteChest(entityId: ID) {
@@ -8524,6 +8586,7 @@ export default class WorldmapScene extends WarpTravel {
     this.pinnedRenderAreas.clear();
     this.clearCache();
     this.armyLastTileSyncAt.clear();
+    this.armyLastLiveUpdateAt.clear();
     // Also clear the interactive hexes when clearing the entire cache
     this.interactiveHexManager.clearHexes();
   }


### PR DESCRIPTION
This PR hardens worldmap ghost-army reconciliation by separating movement-visual cancellation from movement completion, preserving pending movement handoff when optimistic animation is skipped, and cleaning up arrival ghosts when visuals are evicted or aborted. It also adds arrival-ghost diagnostics and a defensive max lifetime, tracks authoritative live updates so deferred removals can recover from ExplorerTroops signals, and records pending-removal cancellation sources in worldmap render diagnostics. The supporting tests cover chunk-eviction ghosting, optimistic abort cleanup, stale-position handling, travel-effect cleanup, suppression recovery ordering, and the new diagnostics counters. Verification: `pnpm run format`, `pnpm run knip`, and a focused `vitest` run for the touched worldmap and manager tests.