### PR TITLE
Registered game entry countdown

### DIFF
--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.blitz-registration.source.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.blitz-registration.source.test.ts
@@ -47,4 +47,17 @@ describe("Game card reservation visibility", () => {
     expect(source).toContain("const canSpectatePreMainBlitz = isBlitzMode && canRegisterPeriod;");
     expect(source).toContain("const canSpectate = isOngoing || isEnded || canSpectatePreMainBlitz;");
   });
+
+  it("shows an enter action for registered blitz games without removing spectate", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/ui/features/landing/components/game-selector/game-card-grid.tsx"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      "const canEnterRegisteredBlitz = isBlitzMode && showRegistered && (isUpcoming || isOngoing);",
+    );
+    expect(source).toContain('canEnterRegisteredBlitz ? "Enter"');
+    expect(source).toContain("{canSpectate && (");
+  });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.mode-isolation.test.ts
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.mode-isolation.test.ts
@@ -12,7 +12,10 @@ describe("Game card mode isolation", () => {
 
     expect(source).toContain('const isBlitzMode = game.config?.mode === "blitz";');
     expect(source).toContain('const isUnknownMode = game.config?.mode === "unknown" || !game.config?.mode;');
-    expect(source).toContain("const canPlay = !isUnknownMode && (canPlayBlitz || canOpenEternumEntry);");
+    expect(source).toContain(
+      "const canEnterRegisteredBlitz = isBlitzMode && showRegistered && (isUpcoming || isOngoing);",
+    );
+    expect(source).toContain("const canPlay = !isUnknownMode && (canEnterRegisteredBlitz || canOpenEternumEntry);");
     expect(source).toContain("Detecting mode...");
   });
 });

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -32,7 +32,7 @@ import { useMarketRedeem } from "@/ui/features/market/landing-markets/use-market
 import { getChainLabel } from "@/ui/utils/network-switch";
 import type { Chain } from "@contracts";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, Eye, Loader2, Play, RefreshCw, Sparkles, Trophy, UserPlus, Users } from "lucide-react";
+import { CheckCircle2, Eye, Loader2, LogIn, Play, RefreshCw, Sparkles, Trophy, UserPlus, Users } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { toast } from "sonner";
@@ -328,9 +328,7 @@ const GameCard = ({
   const isUnknownMode = game.config?.mode === "unknown" || !game.config?.mode;
   const hasSettledEternumRealm = isEternumMode && game.config?.hasPlayerSettledRealm === true;
   const devModeOn = game.config?.devModeOn ?? false;
-  const canPlayBlitz = isBlitzMode && isOngoing && game.isRegistered;
   const canOpenEternumEntry = isEternumMode && !isEnded;
-  const canPlay = !isUnknownMode && (canPlayBlitz || canOpenEternumEntry);
   const canPlayEternumDirect = canOpenEternumEntry && hasSettledEternumRealm;
   const showEternumSettleShortcut = canOpenEternumEntry && hasSettledEternumRealm;
   const eternumPrimaryActionLabel = canPlayEternumDirect ? "Play" : "Settle";
@@ -410,6 +408,8 @@ const GameCard = ({
     enabled: isBlitzMode && game.status === "ok" && canRegisterPeriod,
   });
   const showRegistered = game.isRegistered || entryStage === "done";
+  const canEnterRegisteredBlitz = isBlitzMode && showRegistered && (isUpcoming || isOngoing);
+  const canPlay = !isUnknownMode && (canEnterRegisteredBlitz || canOpenEternumEntry);
 
   // Handle settle entry with toast notification.
   const handleSettle = useCallback(() => {
@@ -689,8 +689,8 @@ const GameCard = ({
                   : "bg-emerald-500 text-white hover:bg-emerald-400 transition-colors",
               )}
             >
-              <Play className="w-3 h-3" />
-              {canOpenEternumEntry ? eternumPrimaryActionLabel : "Play"}
+              {canEnterRegisteredBlitz ? <LogIn className="w-3 h-3" /> : <Play className="w-3 h-3" />}
+              {canEnterRegisteredBlitz ? "Enter" : canOpenEternumEntry ? eternumPrimaryActionLabel : "Play"}
             </button>
           ) : isUnknownMode ? (
             <div className="flex-1 flex items-center justify-center gap-1 px-2 py-1.5 rounded text-xs font-medium bg-white/5 text-white/40 border border-white/10">

--- a/client/apps/game/src/ui/features/world/containers/top-header/game-start-countdown.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/top-header/game-start-countdown.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { formatGameStartCountdown, shouldShowGameStartCountdown } from "./game-start-countdown";
+
+describe("game start countdown", () => {
+  it("stays hidden when no game start timestamp is available", () => {
+    expect(shouldShowGameStartCountdown({ gameStartMainAt: null, currentBlockTimestamp: 100 })).toBe(false);
+  });
+
+  it("shows before the main phase starts", () => {
+    expect(shouldShowGameStartCountdown({ gameStartMainAt: 220, currentBlockTimestamp: 100 })).toBe(true);
+  });
+
+  it("hides once the main phase has started", () => {
+    expect(shouldShowGameStartCountdown({ gameStartMainAt: 220, currentBlockTimestamp: 220 })).toBe(false);
+  });
+
+  it("formats the remaining time for the top nav", () => {
+    expect(formatGameStartCountdown(4_328)).toBe("1h 12m 08s");
+    expect(formatGameStartCountdown(68)).toBe("1m 08s");
+  });
+});

--- a/client/apps/game/src/ui/features/world/containers/top-header/game-start-countdown.tsx
+++ b/client/apps/game/src/ui/features/world/containers/top-header/game-start-countdown.tsx
@@ -1,0 +1,85 @@
+import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
+import { useUIStore } from "@/hooks/store/use-ui-store";
+import Clock from "lucide-react/dist/esm/icons/clock";
+import { memo, useEffect, useMemo, useState } from "react";
+
+interface GameStartCountdownVisibilityInput {
+  gameStartMainAt: number | null;
+  currentBlockTimestamp: number;
+}
+
+export const shouldShowGameStartCountdown = ({
+  gameStartMainAt,
+  currentBlockTimestamp,
+}: GameStartCountdownVisibilityInput): boolean => {
+  return (
+    typeof gameStartMainAt === "number" &&
+    Number.isFinite(gameStartMainAt) &&
+    gameStartMainAt > 0 &&
+    Number.isFinite(currentBlockTimestamp) &&
+    currentBlockTimestamp > 0 &&
+    currentBlockTimestamp < gameStartMainAt
+  );
+};
+
+export const formatGameStartCountdown = (secondsUntilStart: number): string => {
+  const total = Math.max(0, Math.floor(secondsUntilStart));
+  const days = Math.floor(total / 86_400);
+  const hours = Math.floor((total % 86_400) / 3_600);
+  const minutes = Math.floor((total % 3_600) / 60);
+  const seconds = total % 60;
+  const minuteSecondLabel = `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+
+  if (days > 0) {
+    return `${days}d ${hours.toString().padStart(2, "0")}h ${minuteSecondLabel}`;
+  }
+
+  if (hours > 0) {
+    return `${hours}h ${minuteSecondLabel}`;
+  }
+
+  return minuteSecondLabel;
+};
+
+export const GameStartCountdown = memo(() => {
+  const gameStartMainAt = useUIStore((state) => state.gameStartMainAt);
+  const currentBlockTimestamp = useCurrentBlockTimestamp();
+  const [localElapsedSeconds, setLocalElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    setLocalElapsedSeconds(0);
+    const intervalId = window.setInterval(() => {
+      setLocalElapsedSeconds((current) => current + 1);
+    }, 1000);
+
+    return () => window.clearInterval(intervalId);
+  }, [currentBlockTimestamp]);
+
+  const effectiveTimestamp = currentBlockTimestamp + localElapsedSeconds;
+  const shouldShow = shouldShowGameStartCountdown({ gameStartMainAt, currentBlockTimestamp: effectiveTimestamp });
+  const countdownLabel = useMemo(() => {
+    if (!shouldShow || gameStartMainAt == null) {
+      return null;
+    }
+
+    return formatGameStartCountdown(gameStartMainAt - effectiveTimestamp);
+  }, [effectiveTimestamp, gameStartMainAt, shouldShow]);
+
+  if (!shouldShow || !countdownLabel) {
+    return null;
+  }
+
+  return (
+    <div className="self-center border-l border-gold/20 px-2 py-1 text-center">
+      <div className="flex items-center gap-2 rounded border border-cyan-300/35 bg-cyan-400/10 px-2 py-1 text-cyan-100 shadow-[0_0_12px_rgba(34,211,238,0.18)]">
+        <Clock className="h-3.5 w-3.5" />
+        <span className="whitespace-nowrap text-xs font-semibold uppercase tracking-[0.12em] text-cyan-100/75">
+          Game starts in
+        </span>
+        <span className="font-mono text-sm font-semibold tracking-wide text-cyan-50">{countdownLabel}</span>
+      </div>
+    </div>
+  );
+});
+
+GameStartCountdown.displayName = "GameStartCountdown";

--- a/client/apps/game/src/ui/features/world/containers/top-header/top-header.tsx
+++ b/client/apps/game/src/ui/features/world/containers/top-header/top-header.tsx
@@ -7,6 +7,7 @@ import { useUISound } from "@/audio/hooks/useUISound";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { SecondaryMenuItems } from "@/ui/features/world";
 import { GameEndTimer } from "./game-end-timer";
+import { GameStartCountdown } from "./game-start-countdown";
 import { TickProgress } from "./tick-progress";
 import {
   MIN_REFRESH_INTERVAL_MS,
@@ -197,6 +198,7 @@ export const TopHeader = memo(() => {
             <div className="flex flex-shrink-0 flex-nowrap items-center gap-3 text-xs md:text-base">
               <div className="cycle-selector flex justify-center md:justify-start gap-2 whitespace-nowrap">
                 <TickProgress />
+                <GameStartCountdown />
                 <GameEndTimer />
               </div>
               <div className="map-button-selector flex items-center justify-center md:justify-start gap-2 px-3 whitespace-nowrap">

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-14",
+    title: "Registered Game Entry",
+    description:
+      "Registered Blitz games now show an Enter action on the dashboard and display an in-game top-nav countdown until the main phase begins.",
+    type: "improvement",
+    gameSlug: "landing",
+  },
+  {
     date: "2026-05-13",
     title: "Settle Or Spectate",
     description:


### PR DESCRIPTION
Adds an Enter action for registered Blitz games on the dashboard while keeping Spectate available.
Adds an in-game top-nav countdown that reads the existing start_main_at store value and hides once the main phase begins.
Also records the UX change in latest features and adds focused coverage for the dashboard action and countdown helpers.

Validation: pnpm --dir client/apps/game test src/ui/features/world/containers/top-header/game-start-countdown.test.ts src/ui/features/landing/components/game-selector/game-card-grid.blitz-registration.source.test.ts; pnpm run format; pnpm run knip.