### PR TITLE
[codex] Fix realtime world summary build

### DIFF
--- a/client/apps/realtime-server/src/services/world-summary.ts
+++ b/client/apps/realtime-server/src/services/world-summary.ts
@@ -124,7 +124,6 @@ function resolveMode(blitzModeOn: unknown): WorldSummaryMode | null {
 
 function parseSummaryRow(row: Record<string, unknown>): SummaryFields {
   const mode = resolveMode(row.blitz_mode_on);
-  const twoPlayerMode = parseMaybeBoolean(row.two_player_mode) ?? false;
   const registrationEndAt =
     mode === "blitz"
       ? (parseMaybeHexToNumber(row.registration_end_at) ?? parseMaybeHexToNumber(row.start_main_at))


### PR DESCRIPTION
Removes a redundant parsed `twoPlayerMode` local in the realtime server world summary parser.

The unused declaration tripped `noUnusedLocals` during the Docker build after packages built successfully, while the returned `twoPlayerMode` field still parses the same Torii column as before.

Validated with `bun run build:packages`, `bun run build` in `client/apps/realtime-server`, the focused world-summary Vitest test, `pnpm run format`, and `pnpm run knip`.