### PR TITLE
Fix movement visual cleanup on chunk eviction

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.chunk-eviction-ghost.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.chunk-eviction-ghost.test.ts
@@ -58,7 +58,7 @@ describe("chunk-eviction ghosting prevention", () => {
       expect(cleanupPos).toBeLessThan(freeSlotPos);
     });
 
-    it("only notifies movement visual cancellation for true entity removal, not chunk reconciliation", () => {
+    it("notifies movement visual cancellation when chunk reconciliation evicts a moving army", () => {
       const src = readSource("army-manager.ts");
 
       const methodStart = src.indexOf("private removeVisibleArmy(");
@@ -66,14 +66,14 @@ describe("chunk-eviction ghosting prevention", () => {
 
       const methodBody = src.slice(methodStart, methodStart + 2800);
 
-      const cancelGuardPos = methodBody.indexOf("if (options?.notifyMovementVisualCancel)");
+      const movingCheckPos = methodBody.indexOf("this.armyModel.isEntityMoving(numericId)");
       const cancelPos = methodBody.indexOf("this.runMovementVisualCancelListeners(numericId)");
       const freeSlotPos = methodBody.indexOf("this.armyModel.freeInstanceSlot(");
       const removeArmyPos = src.indexOf("this.removeVisibleArmy(entityId, { notifyMovementVisualCancel: true })");
 
       expect(src).toContain("public onMovementVisualCancel(entityId: ID, callback: () => void): () => void");
       expect(src).toContain("options?: { notifyMovementVisualCancel?: boolean }");
-      expect(cancelGuardPos).toBeGreaterThan(-1);
+      expect(movingCheckPos).toBeGreaterThan(-1);
       expect(cancelPos).toBeGreaterThan(-1);
       expect(freeSlotPos).toBeGreaterThan(-1);
       expect(removeArmyPos).toBeGreaterThan(-1);

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1195,12 +1195,17 @@ export class ArmyManager {
     this.indicatorMetadataCache.delete(entityId); // Clear cached metadata
 
     const numericId = this.toNumericId(entityId);
+    const shouldNotifyMovementVisualCancel =
+      options?.notifyMovementVisualCancel === true || this.armyModel.isEntityMoving(numericId);
     this.removeTrackedArmyAttachments(entityId);
 
     // Clean up movement source bucket before freeing the slot, since
     // freeInstanceSlot kills the movement callback that would normally do this
     this.cleanupMovementSourceBucket(entityId);
-    if (options?.notifyMovementVisualCancel) {
+    // Chunk reconciliation can evict a moving army before the tween completes.
+    // Surface that as a visual cancellation so arrival ghosts and travel effects
+    // do not survive the lost movement-complete callback.
+    if (shouldNotifyMovementVisualCancel) {
       this.runMovementVisualCancelListeners(numericId);
     }
 

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
@@ -97,4 +97,30 @@ describe("Worldmap pending movement visual handoff wiring", () => {
     expect(helperBody).toContain('this.arrivalGhostManager.clearArrivalGhost(entityId, "optimistic_aborted")');
     expect(helperBody).not.toContain("this.disposePendingMovementVisualLifecycle(entityId)");
   });
+
+  it("keeps pending movement fallback alive when movement visuals are evicted", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const lifecycleStart = source.indexOf("private installPendingMovementVisualLifecycle(");
+    expect(lifecycleStart).toBeGreaterThan(-1);
+
+    const lifecycleEnd = source.indexOf("private disposePendingMovementVisualLifecycle(", lifecycleStart);
+    const lifecycleBody = source.slice(lifecycleStart, lifecycleEnd);
+    const cancelStart = lifecycleBody.indexOf("const disposeMovementVisualCancel");
+    const cancelEnd = lifecycleBody.indexOf("this.pendingArmyMovementVisualLifecycleDisposers.set", cancelStart);
+    const cancelHandler = lifecycleBody.slice(cancelStart, cancelEnd);
+
+    expect(cancelHandler).toContain("this.clearEvictedArmyMovementVisuals(entityId)");
+    expect(cancelHandler).not.toContain("this.clearPendingArmyMovement");
+
+    const helperStart = source.indexOf("private clearEvictedArmyMovementVisuals(");
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperEnd = source.indexOf("private clearPendingArmyMovement(", helperStart);
+    const helperBody = source.slice(helperStart, helperEnd);
+
+    expect(helperBody).toContain("trackedEffect.cleanup()");
+    expect(helperBody).toContain('this.arrivalGhostManager.clearArrivalGhost(entityId, "movement_evicted")');
+    expect(helperBody).not.toContain("pendingArmyMovements.delete");
+    expect(helperBody).not.toContain("pendingArmyMovementFallbackTimeouts");
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
@@ -108,13 +108,4 @@ describe("resolveExploreCompletionPendingClearPlan", () => {
       }),
     ).toBe(true);
   });
-
-  it("cleans up travel effects when movement visuals are evicted before completion", () => {
-    expect(
-      shouldCleanupTrackedTravelEffectOnPendingClear({
-        trackedEffect: { key: "7,8", effectType: "travel" },
-        reason: "movement_evicted",
-      }),
-    ).toBe(true);
-  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
@@ -4,8 +4,7 @@ export type TravelEffectType = "travel" | "compass";
 export type PendingArmyMovementEffectClearReason =
   | "movement_started"
   | "cleanup_requested"
-  | "authoritative_reconciled"
-  | "movement_evicted";
+  | "authoritative_reconciled";
 
 export interface TrackedTravelEffect {
   key: string;

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -3080,6 +3080,15 @@ export default class WorldmapScene extends WarpTravel {
     this.updateStructureOwnershipPulses(selectedEntityId, extraHexes);
   }
 
+  private clearEvictedArmyMovementVisuals(entityId: ID): void {
+    const trackedEffect = this.travelEffectsByEntity.get(entityId);
+    if (trackedEffect) {
+      trackedEffect.cleanup();
+    }
+
+    this.arrivalGhostManager.clearArrivalGhost(entityId, "movement_evicted");
+  }
+
   private clearPendingArmyMovement(
     entityId: ID,
     reason: PendingArmyMovementEffectClearReason = "cleanup_requested",
@@ -3165,8 +3174,7 @@ export default class WorldmapScene extends WarpTravel {
       }
     });
     const disposeMovementVisualCancel = this.armyManager.onMovementVisualCancel(entityId, () => {
-      this.clearPendingArmyMovement(entityId, "movement_evicted");
-      this.arrivalGhostManager.clearArrivalGhost(entityId, "movement_evicted");
+      this.clearEvictedArmyMovementVisuals(entityId);
       this.disposePendingMovementVisualLifecycle(entityId);
     });
 


### PR DESCRIPTION
Fixes a worldmap ghost-unit case when a unit is moving, the user leaves the chunk, and then returns.

Chunk reconciliation now treats eviction of an actively moving army as a movement visual cancellation before the instance slot is freed, so arrival ghosts and travel effects clean up through the `movement_evicted` visual path. The eviction handler now clears only the evicted visual artifacts; it no longer routes through pending-movement cleanup, which keeps pending fallback state available for unresolved movement.

Updated regression coverage for both sides of the path: moving chunk evictions dispatch the visual-cancel lifecycle, and worldmap visual eviction does not delete pending movement or its fallback timeout.

Validation:
- `pnpm --dir client/apps/game run test -- src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts src/three/scenes/worldmap-travel-effect-policy.test.ts src/three/managers/army-manager.chunk-eviction-ghost.test.ts src/three/scenes/worldmap-arrival-ghost.source.test.ts`
- `pnpm run format`
- `pnpm run knip`