### PR TITLE
[codex] Stabilize building construction transactions

### DIFF
--- a/client/apps/game/src/three/scenes/context-menu/structure-construction-menu.tsx
+++ b/client/apps/game/src/three/scenes/context-menu/structure-construction-menu.tsx
@@ -1,17 +1,11 @@
 import { LeftView } from "@/types";
+import { getGameModeConfig } from "@/config/game-modes";
 import { ContextMenuAction, ContextMenuIcon, ContextMenuRadialOptions } from "@/types/context-menu";
 import { CONTEXT_MENU_CONFIG } from "@/ui/config";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
+import { resolveConstructionBuildability } from "@/ui/features/settlement/construction/construction-buildability";
 import { SetupResult } from "@bibliothecadao/dojo";
-import {
-  configManager,
-  divideByPrecision,
-  getBalance,
-  getBlockTimestamp,
-  getBuildingCosts,
-  getRealmInfo,
-  hasEnoughPopulationForBuilding,
-} from "@bibliothecadao/eternum";
+import { getRealmInfo } from "@bibliothecadao/eternum";
 import {
   BuildingType,
   HexEntityInfo,
@@ -126,7 +120,7 @@ export const createConstructionMenu = ({
   const structureId = BigInt(structure.id);
   const idString = structureId.toString();
   const structureEntityId = Number(structureId);
-  const { currentDefaultTick } = getBlockTimestamp();
+  const mode = getGameModeConfig();
 
   const realmInfo = (() => {
     try {
@@ -135,15 +129,6 @@ export const createConstructionMenu = ({
       return undefined;
     }
   })();
-
-  const checkBalance = (cost: Record<string, { resource: ResourcesIds; amount: number }> | Array<any>) =>
-    Object.values(cost).every((entry: any) => {
-      if (!entry) {
-        return true;
-      }
-      const balance = getBalance(structureEntityId, entry.resource, currentDefaultTick, components);
-      return divideByPrecision(balance.balance) >= entry.amount;
-    });
 
   const makeBuildingAction = ({
     suffix,
@@ -187,9 +172,6 @@ export const createConstructionMenu = ({
     building,
     resource,
     iconResource,
-    requiresCapacity = true,
-    requiresPopulation = true,
-    requiresStandardCost = false,
   }: {
     suffix: string;
     label: string;
@@ -197,40 +179,16 @@ export const createConstructionMenu = ({
     building: BuildingType;
     resource?: ResourcesIds;
     iconResource?: string | ResourcesIds | null;
-    requiresCapacity?: boolean;
-    requiresPopulation?: boolean;
-    requiresStandardCost?: boolean;
   }): ContextMenuAction | null => {
-    const buildingCosts = getBuildingCosts(structureEntityId, components, building, simpleCostEnabled);
-
-    if (!buildingCosts) {
-      return null;
-    }
-
-    const hasBalance = checkBalance(buildingCosts as any);
-    const populationConfig = configManager.getBuildingCategoryConfig(building);
-    const populationCost = populationConfig?.population_cost ?? 0;
-    const hasEnoughPopulation = requiresPopulation
-      ? realmInfo
-        ? hasEnoughPopulationForBuilding(realmInfo, populationCost)
-        : false
-      : true;
-    const realmHasCapacity = requiresCapacity ? (realmInfo?.hasCapacity ?? false) : true;
-    const simpleModeAllowed = requiresStandardCost ? !simpleCostEnabled : true;
-    const canBuild = hasBalance && realmHasCapacity && hasEnoughPopulation && simpleModeAllowed;
-
-    let hint: string | undefined;
-    if (!canBuild) {
-      if (!hasBalance) {
-        hint = "Insufficient resources";
-      } else if (!realmHasCapacity) {
-        hint = "No building capacity";
-      } else if (!hasEnoughPopulation) {
-        hint = "Not enough population";
-      } else if (!simpleModeAllowed) {
-        hint = "Unavailable in labor cost mode";
-      }
-    }
+    const buildability = resolveConstructionBuildability({
+      entityId: structureEntityId,
+      buildingType: building,
+      useSimpleCost: simpleCostEnabled,
+      components,
+      realm: realmInfo,
+      mode,
+    });
+    const canBuild = buildability.canSubmit;
 
     const iconDescriptor = iconResource ?? resource ?? label;
 
@@ -243,7 +201,7 @@ export const createConstructionMenu = ({
       resource,
       iconComponent: createResourceIconComponent(iconDescriptor, !canBuild),
       disabled: !canBuild,
-      hint,
+      hint: buildability.reason,
     });
   };
 
@@ -259,11 +217,6 @@ export const createConstructionMenu = ({
 
       const icon = resource.img ?? undefined;
 
-      const requiresStandardCost =
-        typedResourceId === ResourcesIds.Dragonhide ||
-        typedResourceId === ResourcesIds.Mithral ||
-        typedResourceId === ResourcesIds.Adamantine;
-
       return createActionWithAvailability({
         suffix: `resource-${resourceId}`,
         label: resource.trait,
@@ -271,7 +224,6 @@ export const createConstructionMenu = ({
         building,
         resource: typedResourceId,
         iconResource: typedResourceId,
-        requiresStandardCost,
       });
     })
     .filter((action): action is ContextMenuAction => action !== null);
@@ -289,8 +241,6 @@ export const createConstructionMenu = ({
       label: "Workers Hut",
       building: BuildingType.WorkersHut,
       iconResource: ResourcesIds.Labor,
-      requiresCapacity: false,
-      requiresPopulation: false,
     },
     {
       suffix: "economic-storehouse",
@@ -338,7 +288,6 @@ export const createConstructionMenu = ({
             building,
             resource,
             iconResource,
-            requiresStandardCost: requiresStandardMode,
           });
         })
         .filter((action): action is ContextMenuAction => action !== null),

--- a/client/apps/game/src/three/scenes/hexception.tsx
+++ b/client/apps/game/src/three/scenes/hexception.tsx
@@ -50,6 +50,7 @@ import {
   releaseOccupiedBuildSpot,
   reserveOccupiedBuildSpot,
 } from "@/ui/features/settlement/construction/build-reservation-store";
+import { resolveConstructionBuildability } from "@/ui/features/settlement/construction/construction-buildability";
 import { SetupResult } from "@bibliothecadao/dojo";
 import {
   ActionType,
@@ -57,10 +58,8 @@ import {
   ResourceIdToMiningType,
   ResourceManager,
   TileManager,
-  divideByPrecision,
-  getBalance,
-  getBuildingCosts,
   getEntityIdFromKeys,
+  getRealmInfo,
   getStructureStage,
 } from "@bibliothecadao/eternum";
 import {
@@ -386,23 +385,6 @@ export default class HexceptionScene extends HexagonScene {
     this.state.setPreviewBuilding(null);
   }
 
-  private canAffordPreviewBuilding(
-    structureEntityId: number,
-    buildingCategory: BuildingType,
-    useSimpleCost: boolean,
-  ): boolean {
-    const { currentDefaultTick } = getBlockTimestamp();
-    const buildingCosts = getBuildingCosts(structureEntityId, this.dojo.components, buildingCategory, useSimpleCost);
-    if (!buildingCosts?.length) {
-      return false;
-    }
-
-    return buildingCosts.every((resourceCost) => {
-      const balance = getBalance(structureEntityId, resourceCost.resource, currentDefaultTick, this.dojo.components);
-      return divideByPrecision(balance.balance) >= resourceCost.amount;
-    });
-  }
-
   private loadBuildingModels() {
     for (const category of Object.values(BUILDINGS_GROUPS)) {
       const categoryPaths = this.mode.assets.buildingModelPaths[category];
@@ -655,47 +637,55 @@ export default class HexceptionScene extends HexagonScene {
     // Check if account exists before allowing actions
     const account = useAccountStore.getState().account;
     if (buildingType) {
-      // if building mode
-      if (!this.tileManager.isHexOccupied(normalizedCoords)) {
-        this.clearBuildingMode();
-        const useSimpleCost = this.state.useSimpleCost;
-        const structureEntityId = useUIStore.getState().structureEntityId;
-        if (!this.canAffordPreviewBuilding(structureEntityId, buildingType.type, useSimpleCost)) {
-          toast.error("Insufficient resources to build here.");
-          this.updateHexceptionGrid(this.hexceptionRadius);
-          return;
-        }
-        reserveOccupiedBuildSpot(structureEntityId, normalizedCoords);
-        try {
-          console.log("Placing building at:", {
-            dojo: account!,
-            entityId: structureEntityId,
-            col: normalizedCoords.col,
-            row: normalizedCoords.row,
-            buildingId: buildingType.type,
-          });
+      const useSimpleCost = this.state.useSimpleCost;
+      const structureEntityId = useUIStore.getState().structureEntityId;
+      const realm = getRealmInfo(getEntityIdFromKeys([BigInt(structureEntityId)]), this.dojo.components);
+      const buildability = resolveConstructionBuildability({
+        entityId: structureEntityId,
+        buildingType: buildingType.type,
+        useSimpleCost,
+        components: this.dojo.components,
+        realm,
+        mode: this.mode,
+        targetSpot: normalizedCoords,
+        tileManager: this.tileManager,
+      });
 
-          await this.tileManager.placeBuilding(
-            account!,
-            structureEntityId,
-            buildingType.type,
-            normalizedCoords,
-            useSimpleCost,
-          );
-          AudioManager.getInstance().play("ui.build_place");
-        } catch (error) {
-          console.log("catched error so removing building", error);
-          const message = error instanceof Error ? error.message : String(error);
-          if (!message.toLowerCase().includes("space is occupied")) {
-            releaseOccupiedBuildSpot(structureEntityId, normalizedCoords);
-          }
-          this.removeBuilding(normalizedCoords.col, normalizedCoords.row);
-        }
-        this.updateHexceptionGrid(this.hexceptionRadius);
-      } else {
-        // Hex is occupied — invalid placement
+      if (!buildability.canSubmit) {
+        toast.error(buildability.reason ?? "Building cannot be submitted.");
         AudioManager.getInstance().play("ui.build_invalid");
+        this.updateHexceptionGrid(this.hexceptionRadius);
+        return;
       }
+
+      this.clearBuildingMode();
+      reserveOccupiedBuildSpot(structureEntityId, normalizedCoords);
+      try {
+        console.log("Placing building at:", {
+          dojo: account!,
+          entityId: structureEntityId,
+          col: normalizedCoords.col,
+          row: normalizedCoords.row,
+          buildingId: buildingType.type,
+        });
+
+        await this.tileManager.placeBuilding(
+          account!,
+          structureEntityId,
+          buildingType.type,
+          normalizedCoords,
+          useSimpleCost,
+        );
+        AudioManager.getInstance().play("ui.build_place");
+      } catch (error) {
+        console.log("catched error so removing building", error);
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.toLowerCase().includes("space is occupied")) {
+          releaseOccupiedBuildSpot(structureEntityId, normalizedCoords);
+        }
+        this.removeBuilding(normalizedCoords.col, normalizedCoords.row);
+      }
+      this.updateHexceptionGrid(this.hexceptionRadius);
     } else {
       // if not building mode
       const { col: outerCol, row: outerRow } = this.tileManager.getHexCoords();

--- a/client/apps/game/src/ui/features/settlement/construction/construction-buildability.source.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/construction-buildability.source.test.ts
@@ -1,0 +1,23 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("construction buildability resolver wiring", () => {
+  it("routes every construction entrypoint through the shared resolver", () => {
+    const entrypointPaths = [
+      "src/ui/features/settlement/construction/select-preview-building.tsx",
+      "src/ui/features/settlement/construction/realm-build-actions.ts",
+      "src/ui/modules/entity-details/realm/realm-info-panel.tsx",
+      "src/three/scenes/context-menu/structure-construction-menu.tsx",
+      "src/three/scenes/hexception.tsx",
+    ];
+
+    for (const entrypointPath of entrypointPaths) {
+      expect(readSource(entrypointPath), entrypointPath).toContain("resolveConstructionBuildability");
+    }
+  });
+});

--- a/client/apps/game/src/ui/features/settlement/construction/construction-buildability.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/construction-buildability.test.ts
@@ -1,0 +1,196 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BuildingType, ResourcesIds, StructureType } from "@bibliothecadao/types";
+import { resolveConstructionBuildability } from "./construction-buildability";
+
+const {
+  getBalance,
+  getBuildingCosts,
+  getBlockTimestamp,
+  divideByPrecision,
+  getBuildingCategoryConfig,
+  getBasePopulationCapacity,
+} = vi.hoisted(() => ({
+  getBalance: vi.fn(),
+  getBuildingCosts: vi.fn(),
+  getBlockTimestamp: vi.fn(() => ({ currentDefaultTick: 100 })),
+  divideByPrecision: vi.fn((value: bigint | number) => Number(value)),
+  getBuildingCategoryConfig: vi.fn(),
+  getBasePopulationCapacity: vi.fn(() => 0),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => ({
+  getBalance,
+  getBuildingCosts,
+  getBlockTimestamp,
+  divideByPrecision,
+  configManager: {
+    getBuildingCategoryConfig,
+    getBasePopulationCapacity,
+  },
+}));
+
+const allowAllMode = {
+  rules: {
+    isBuildingTypeAllowed: vi.fn(() => true),
+  },
+};
+
+const buildableRealm = {
+  category: StructureType.Realm,
+  level: 1,
+  resources: [ResourcesIds.Wood],
+  population: 1,
+  capacity: 10,
+  hasCapacity: true,
+};
+
+const buildabilityInput = (overrides: Partial<Parameters<typeof resolveConstructionBuildability>[0]> = {}) => ({
+  entityId: 101,
+  buildingType: BuildingType.ResourceWood,
+  useSimpleCost: true,
+  components: {},
+  realm: buildableRealm,
+  mode: allowAllMode,
+  ...overrides,
+});
+
+describe("resolveConstructionBuildability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBuildingCosts.mockReturnValue([{ resource: ResourcesIds.Wood, amount: 10 }]);
+    getBalance.mockReturnValue({ balance: 20n });
+    getBuildingCategoryConfig.mockReturnValue({ population_cost: 1, capacity_grant: 0 });
+    getBasePopulationCapacity.mockReturnValue(0);
+    allowAllMode.rules.isBuildingTypeAllowed.mockReturnValue(true);
+  });
+
+  it("allows a locally valid construction request", () => {
+    expect(resolveConstructionBuildability(buildabilityInput())).toMatchObject({
+      canSubmit: true,
+      reason: undefined,
+    });
+  });
+
+  it("rejects non-production structures before submission", () => {
+    const result = resolveConstructionBuildability(
+      buildabilityInput({
+        realm: {
+          ...buildableRealm,
+          category: StructureType.Hyperstructure,
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      canSubmit: false,
+      code: "invalid_structure",
+    });
+  });
+
+  it("rejects center-tile construction", () => {
+    const result = resolveConstructionBuildability(buildabilityInput({ targetSpot: { col: 10, row: 10 } }));
+
+    expect(result).toMatchObject({
+      canSubmit: false,
+      code: "center_tile",
+    });
+  });
+
+  it("rejects occupied or reserved tiles", () => {
+    const occupiedResult = resolveConstructionBuildability(
+      buildabilityInput({
+        targetSpot: { col: 11, row: 10 },
+        tileManager: { isHexOccupied: () => true },
+      }),
+    );
+    const reservedResult = resolveConstructionBuildability(
+      buildabilityInput({
+        targetSpot: { col: 11, row: 10 },
+        occupiedSpots: new Set(["11,10"]),
+      }),
+    );
+
+    expect(occupiedResult).toMatchObject({ canSubmit: false, code: "occupied_tile" });
+    expect(reservedResult).toMatchObject({ canSubmit: false, code: "reserved_tile" });
+  });
+
+  it("rejects out-of-radius tiles", () => {
+    const result = resolveConstructionBuildability(
+      buildabilityInput({
+        realm: { ...buildableRealm, level: 0 },
+        targetSpot: { col: 14, row: 10 },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      canSubmit: false,
+      code: "out_of_radius",
+    });
+  });
+
+  it("rejects missing costs and insufficient resources", () => {
+    getBuildingCosts.mockReturnValueOnce(undefined);
+    const noCostResult = resolveConstructionBuildability(buildabilityInput());
+
+    getBuildingCosts.mockReturnValueOnce([{ resource: ResourcesIds.Wood, amount: 10 }]);
+    getBalance.mockReturnValueOnce({ balance: 5n });
+    const insufficientResourceResult = resolveConstructionBuildability(buildabilityInput());
+
+    expect(noCostResult).toMatchObject({ canSubmit: false, code: "missing_cost" });
+    expect(insufficientResourceResult).toMatchObject({ canSubmit: false, code: "insufficient_resources" });
+  });
+
+  it("rejects insufficient capacity and population", () => {
+    const noCapacityResult = resolveConstructionBuildability(
+      buildabilityInput({
+        realm: { ...buildableRealm, hasCapacity: false },
+      }),
+    );
+
+    getBuildingCategoryConfig.mockReturnValueOnce({ population_cost: 2, capacity_grant: 0 });
+    const noPopulationResult = resolveConstructionBuildability(
+      buildabilityInput({
+        realm: { ...buildableRealm, population: 9, capacity: 10, hasCapacity: true },
+      }),
+    );
+
+    expect(noCapacityResult).toMatchObject({ canSubmit: false, code: "insufficient_capacity" });
+    expect(noPopulationResult).toMatchObject({ canSubmit: false, code: "insufficient_population" });
+  });
+
+  it("rejects resource producers not supported by the structure resource set", () => {
+    const result = resolveConstructionBuildability(
+      buildabilityInput({
+        buildingType: BuildingType.ResourceStone,
+        realm: { ...buildableRealm, resources: [ResourcesIds.Wood] },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      canSubmit: false,
+      code: "invalid_resource_for_structure",
+    });
+  });
+
+  it("rejects labor-mode locks and mode exclusions", () => {
+    const laborLockedResult = resolveConstructionBuildability(
+      buildabilityInput({
+        buildingType: BuildingType.ResourceDragonhide,
+        realm: { ...buildableRealm, resources: [ResourcesIds.Dragonhide] },
+      }),
+    );
+
+    allowAllMode.rules.isBuildingTypeAllowed.mockReturnValueOnce(false);
+    const excludedByModeResult = resolveConstructionBuildability(
+      buildabilityInput({
+        buildingType: BuildingType.ResourceFish,
+        realm: { ...buildableRealm, resources: [ResourcesIds.Fish] },
+      }),
+    );
+
+    expect(laborLockedResult).toMatchObject({ canSubmit: false, code: "simple_cost_locked" });
+    expect(excludedByModeResult).toMatchObject({ canSubmit: false, code: "mode_excluded" });
+  });
+});

--- a/client/apps/game/src/ui/features/settlement/construction/construction-buildability.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/construction-buildability.test.ts
@@ -34,6 +34,7 @@ vi.mock("@bibliothecadao/eternum", () => ({
 const allowAllMode = {
   rules: {
     isBuildingTypeAllowed: vi.fn(() => true),
+    autoAllocateHyperstructureShares: false,
   },
 };
 

--- a/client/apps/game/src/ui/features/settlement/construction/construction-buildability.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/construction-buildability.ts
@@ -101,7 +101,7 @@ const RESOURCE_PRODUCER_BUILDINGS_REQUIRING_STRUCTURE_RESOURCE = new Set<Buildin
   BuildingType.ResourceEtherealSilica,
   BuildingType.ResourceDragonhide,
   BuildingType.ResourceLabor,
-  BuildingType.ResourceEarthenShard,
+  BuildingType.ResourceAncientFragment,
 ]);
 
 const SIMPLE_COST_LOCKED_RESOURCE_BUILDINGS = new Set<BuildingType>([

--- a/client/apps/game/src/ui/features/settlement/construction/construction-buildability.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/construction-buildability.ts
@@ -1,0 +1,344 @@
+import type { GameModeConfig } from "@/config/game-modes";
+import {
+  configManager,
+  divideByPrecision,
+  getBalance,
+  getBlockTimestamp,
+  getBuildingCosts,
+} from "@bibliothecadao/eternum";
+import {
+  BUILDINGS_CENTER,
+  BuildingType,
+  getNeighborHexes,
+  getProducedResource,
+  ResourcesIds,
+  StructureType,
+} from "@bibliothecadao/types";
+
+type ConstructionSpot = {
+  col: number;
+  row: number;
+};
+
+type ConstructionRealm = {
+  category?: StructureType | number | null;
+  level?: number | bigint | null;
+  resources?: Array<ResourcesIds | number>;
+  population?: number | bigint | null;
+  capacity?: number | bigint | null;
+  hasCapacity?: boolean | null;
+};
+
+type ConstructionTileManager = {
+  isHexOccupied?: (spot: ConstructionSpot) => boolean;
+  getRealmLevel?: (entityId: number) => number | bigint;
+};
+
+type ConstructionMode = Pick<GameModeConfig, "rules">;
+
+type ConstructionBuildabilityCode =
+  | "missing_realm"
+  | "invalid_structure"
+  | "mode_excluded"
+  | "center_tile"
+  | "out_of_radius"
+  | "reserved_tile"
+  | "occupied_tile"
+  | "missing_cost"
+  | "simple_cost_locked"
+  | "insufficient_resources"
+  | "insufficient_capacity"
+  | "insufficient_population"
+  | "invalid_resource_for_structure"
+  | "realm_full";
+
+type ConstructionBuildabilityResult = {
+  canSubmit: boolean;
+  code?: ConstructionBuildabilityCode;
+  reason?: string;
+};
+
+export type ConstructionBuildabilityInput = {
+  entityId: number;
+  buildingType: BuildingType;
+  useSimpleCost: boolean;
+  components: any;
+  realm?: ConstructionRealm | null;
+  mode?: ConstructionMode | null;
+  targetSpot?: ConstructionSpot | null;
+  tileManager?: ConstructionTileManager | null;
+  occupiedSpots?: ReadonlySet<string>;
+  vacatedSpots?: ReadonlySet<string>;
+  hasAvailableBuildingTile?: boolean;
+};
+
+type ResourceCost = {
+  resource: ResourcesIds | number;
+  amount: number;
+};
+
+const RESOURCE_PRODUCER_BUILDINGS_REQUIRING_STRUCTURE_RESOURCE = new Set<BuildingType>([
+  BuildingType.ResourceStone,
+  BuildingType.ResourceCoal,
+  BuildingType.ResourceWood,
+  BuildingType.ResourceCopper,
+  BuildingType.ResourceIronwood,
+  BuildingType.ResourceObsidian,
+  BuildingType.ResourceGold,
+  BuildingType.ResourceSilver,
+  BuildingType.ResourceMithral,
+  BuildingType.ResourceAlchemicalSilver,
+  BuildingType.ResourceColdIron,
+  BuildingType.ResourceDeepCrystal,
+  BuildingType.ResourceRuby,
+  BuildingType.ResourceDiamonds,
+  BuildingType.ResourceHartwood,
+  BuildingType.ResourceIgnium,
+  BuildingType.ResourceTwilightQuartz,
+  BuildingType.ResourceTrueIce,
+  BuildingType.ResourceAdamantine,
+  BuildingType.ResourceSapphire,
+  BuildingType.ResourceEtherealSilica,
+  BuildingType.ResourceDragonhide,
+  BuildingType.ResourceLabor,
+  BuildingType.ResourceEarthenShard,
+]);
+
+const SIMPLE_COST_LOCKED_RESOURCE_BUILDINGS = new Set<BuildingType>([
+  BuildingType.ResourceDragonhide,
+  BuildingType.ResourceMithral,
+  BuildingType.ResourceAdamantine,
+]);
+
+const fail = (code: ConstructionBuildabilityCode, reason: string): ConstructionBuildabilityResult => ({
+  canSubmit: false,
+  code,
+  reason,
+});
+
+const pass = (): ConstructionBuildabilityResult => ({ canSubmit: true, reason: undefined });
+
+const toConstructionSpotKey = ({ col, row }: ConstructionSpot): string => `${col},${row}`;
+
+const isProductionStructure = (category: StructureType | number | null | undefined) =>
+  category === StructureType.Realm || category === StructureType.Village || category === StructureType.Camp;
+
+const isCenterSpot = (spot: ConstructionSpot) => spot.col === BUILDINGS_CENTER[0] && spot.row === BUILDINGS_CENTER[1];
+
+const toNumber = (value: number | bigint | null | undefined): number => {
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "number") return value;
+  return 0;
+};
+
+const normalizeResourceCosts = (buildingCosts: unknown): ResourceCost[] => {
+  if (!buildingCosts) return [];
+  if (typeof buildingCosts !== "object") return [];
+
+  const values = Array.isArray(buildingCosts) ? buildingCosts : Object.values(buildingCosts);
+  return values.filter((cost): cost is ResourceCost => Boolean(cost && typeof cost === "object"));
+};
+
+const resolveBuildingTypeKey = (buildingType: BuildingType) => BuildingType[buildingType] ?? String(buildingType);
+
+const getMilitaryTier = (buildingType: BuildingType): number => {
+  if (
+    buildingType === BuildingType.ResourceCrossbowmanT1 ||
+    buildingType === BuildingType.ResourcePaladinT1 ||
+    buildingType === BuildingType.ResourceKnightT1
+  ) {
+    return 1;
+  }
+
+  if (
+    buildingType === BuildingType.ResourceCrossbowmanT2 ||
+    buildingType === BuildingType.ResourcePaladinT2 ||
+    buildingType === BuildingType.ResourceKnightT2
+  ) {
+    return 2;
+  }
+
+  if (
+    buildingType === BuildingType.ResourceCrossbowmanT3 ||
+    buildingType === BuildingType.ResourcePaladinT3 ||
+    buildingType === BuildingType.ResourceKnightT3
+  ) {
+    return 3;
+  }
+
+  return 0;
+};
+
+const isSimpleCostLockedBuilding = (buildingType: BuildingType, useSimpleCost: boolean) =>
+  useSimpleCost && (SIMPLE_COST_LOCKED_RESOURCE_BUILDINGS.has(buildingType) || getMilitaryTier(buildingType) > 1);
+
+const resolveConstructionRadius = (input: ConstructionBuildabilityInput): number => {
+  const tileManagerLevel = input.tileManager?.getRealmLevel?.(input.entityId);
+  const level = toNumber(tileManagerLevel ?? input.realm?.level);
+  return Math.max(1, level + 1);
+};
+
+const resolveDistanceFromCenter = (targetSpot: ConstructionSpot, maxDistance: number): number | null => {
+  if (isCenterSpot(targetSpot)) return 0;
+
+  const start: ConstructionSpot = { col: BUILDINGS_CENTER[0], row: BUILDINGS_CENTER[1] };
+  let frontier = [start];
+  const seen = new Set([toConstructionSpotKey(start)]);
+
+  for (let distance = 1; distance <= maxDistance; distance += 1) {
+    const nextFrontier: ConstructionSpot[] = [];
+
+    for (const spot of frontier) {
+      for (const neighbor of getNeighborHexes(spot.col, spot.row)) {
+        const key = toConstructionSpotKey(neighbor);
+        if (seen.has(key)) continue;
+        if (neighbor.col === targetSpot.col && neighbor.row === targetSpot.row) {
+          return distance;
+        }
+
+        seen.add(key);
+        nextFrontier.push(neighbor);
+      }
+    }
+
+    frontier = nextFrontier;
+  }
+
+  return null;
+};
+
+const validateMode = ({ buildingType, mode }: ConstructionBuildabilityInput) => {
+  if (!mode) return pass();
+
+  const buildingTypeKey = resolveBuildingTypeKey(buildingType);
+  if (mode.rules.isBuildingTypeAllowed(buildingTypeKey)) return pass();
+
+  return fail("mode_excluded", "This building is not available in the current game mode.");
+};
+
+const validateTargetSpot = (input: ConstructionBuildabilityInput) => {
+  const { targetSpot } = input;
+  if (!targetSpot) {
+    if (input.hasAvailableBuildingTile === false) {
+      return fail("realm_full", "No empty building tiles available.");
+    }
+    return pass();
+  }
+
+  if (isCenterSpot(targetSpot)) {
+    return fail("center_tile", "Buildings cannot be placed on the center tile.");
+  }
+
+  const radius = resolveConstructionRadius(input);
+  const distance = resolveDistanceFromCenter(targetSpot, radius);
+  if (distance === null || distance > radius) {
+    return fail("out_of_radius", "This tile is outside the current structure level radius.");
+  }
+
+  const targetKey = toConstructionSpotKey(targetSpot);
+  if (input.occupiedSpots?.has(targetKey)) {
+    return fail("reserved_tile", "This tile already has a pending building.");
+  }
+
+  const isOccupied = input.tileManager?.isHexOccupied?.(targetSpot) ?? false;
+  if (input.vacatedSpots?.has(targetKey) && isOccupied) {
+    return fail("occupied_tile", "This tile is still waiting for destroy confirmation.");
+  }
+
+  if (isOccupied) {
+    return fail("occupied_tile", "This tile is already occupied.");
+  }
+
+  return pass();
+};
+
+const validateCosts = (input: ConstructionBuildabilityInput): ConstructionBuildabilityResult => {
+  const buildingCosts = normalizeResourceCosts(
+    getBuildingCosts(input.entityId, input.components, input.buildingType, input.useSimpleCost),
+  );
+  if (buildingCosts.length === 0) {
+    return fail("missing_cost", "No construction cost is configured for this building.");
+  }
+
+  const { currentDefaultTick } = getBlockTimestamp();
+  const hasResources = buildingCosts.every((resourceCost) => {
+    const balance = getBalance(input.entityId, resourceCost.resource, currentDefaultTick, input.components);
+    return divideByPrecision(balance.balance) >= resourceCost.amount;
+  });
+
+  if (!hasResources) {
+    return fail("insufficient_resources", "Insufficient resources to build.");
+  }
+
+  return pass();
+};
+
+const validatePopulation = (input: ConstructionBuildabilityInput): ConstructionBuildabilityResult => {
+  if (input.buildingType === BuildingType.WorkersHut) return pass();
+
+  const buildingConfig = configManager.getBuildingCategoryConfig(input.buildingType);
+  const populationCost = toNumber(buildingConfig?.population_cost);
+  const capacityGrant = toNumber(buildingConfig?.capacity_grant);
+  const currentPopulation = toNumber(input.realm?.population);
+  const currentCapacity = toNumber(input.realm?.capacity);
+  const basePopulationCapacity = toNumber(configManager.getBasePopulationCapacity());
+
+  if (input.realm?.hasCapacity === false && populationCost > 0 && capacityGrant <= 0) {
+    return fail("insufficient_capacity", "Need more capacity.");
+  }
+
+  const projectedPopulation = currentPopulation + populationCost;
+  const projectedCapacity = currentCapacity + capacityGrant + basePopulationCapacity;
+  if (projectedPopulation > projectedCapacity) {
+    return fail("insufficient_population", "Need more population.");
+  }
+
+  return pass();
+};
+
+const validateStructureResource = ({ buildingType, realm }: ConstructionBuildabilityInput) => {
+  if (!RESOURCE_PRODUCER_BUILDINGS_REQUIRING_STRUCTURE_RESOURCE.has(buildingType)) return pass();
+
+  const producedResource = getProducedResource(buildingType);
+  if (producedResource === undefined || producedResource === null) {
+    return fail("invalid_resource_for_structure", "This structure cannot produce that resource.");
+  }
+
+  const realmResources = new Set(realm?.resources ?? []);
+  if (realmResources.has(producedResource)) return pass();
+
+  return fail("invalid_resource_for_structure", "This structure cannot produce that resource.");
+};
+
+export const resolveConstructionBuildability = (
+  input: ConstructionBuildabilityInput,
+): ConstructionBuildabilityResult => {
+  if (!input.realm) {
+    return fail("missing_realm", "Select a realm before building.");
+  }
+
+  if (!isProductionStructure(input.realm.category)) {
+    return fail("invalid_structure", "Only realms, villages, and camps can construct buildings.");
+  }
+
+  const modeResult = validateMode(input);
+  if (!modeResult.canSubmit) return modeResult;
+
+  const targetResult = validateTargetSpot(input);
+  if (!targetResult.canSubmit) return targetResult;
+
+  if (isSimpleCostLockedBuilding(input.buildingType, input.useSimpleCost)) {
+    return fail("simple_cost_locked", "Switch to Resource mode to create this building.");
+  }
+
+  const costResult = validateCosts(input);
+  if (!costResult.canSubmit) return costResult;
+
+  const populationResult = validatePopulation(input);
+  if (!populationResult.canSubmit) return populationResult;
+
+  const resourceResult = validateStructureResource(input);
+  if (!resourceResult.canSubmit) return resourceResult;
+
+  return pass();
+};

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { BuildingType } from "@bibliothecadao/types";
+import { BuildingType, ResourcesIds, StructureType } from "@bibliothecadao/types";
 import {
   clearAllBuildReservationState,
   getBuildReservationState,
@@ -10,16 +10,27 @@ import {
 } from "./build-reservation-store";
 import { buildRealmBuilding } from "./realm-build-actions";
 
-const { placeBuilding, isHexOccupied, getBuildingCosts, getBalance, divideByPrecision, getBlockTimestamp, toastError } =
-  vi.hoisted(() => ({
-    placeBuilding: vi.fn(),
-    isHexOccupied: vi.fn(),
-    getBuildingCosts: vi.fn(),
-    getBalance: vi.fn(),
-    divideByPrecision: vi.fn((value: bigint | number) => Number(value)),
-    getBlockTimestamp: vi.fn(() => ({ currentDefaultTick: 123 })),
-    toastError: vi.fn(),
-  }));
+const {
+  placeBuilding,
+  isHexOccupied,
+  getBuildingCosts,
+  getBalance,
+  divideByPrecision,
+  getBlockTimestamp,
+  getBuildingCategoryConfig,
+  getBasePopulationCapacity,
+  toastError,
+} = vi.hoisted(() => ({
+  placeBuilding: vi.fn(),
+  isHexOccupied: vi.fn(),
+  getBuildingCosts: vi.fn(),
+  getBalance: vi.fn(),
+  divideByPrecision: vi.fn((value: bigint | number) => Number(value)),
+  getBlockTimestamp: vi.fn(() => ({ currentDefaultTick: 123 })),
+  getBuildingCategoryConfig: vi.fn(() => ({ population_cost: 1, capacity_grant: 0 })),
+  getBasePopulationCapacity: vi.fn(() => 0),
+  toastError: vi.fn(),
+}));
 
 vi.mock("sonner", () => ({
   toast: {
@@ -37,7 +48,26 @@ vi.mock("@bibliothecadao/eternum", () => ({
   getBlockTimestamp,
   getBalance,
   getBuildingCosts,
+  configManager: {
+    getBuildingCategoryConfig,
+    getBasePopulationCapacity,
+  },
 }));
+
+const buildableRealm = {
+  category: StructureType.Realm,
+  level: 1,
+  resources: [ResourcesIds.Wheat],
+  population: 1,
+  capacity: 10,
+  hasCapacity: true,
+};
+
+const allowAllMode = {
+  rules: {
+    isBuildingTypeAllowed: vi.fn(() => true),
+  },
+};
 
 describe("buildRealmBuilding", () => {
   beforeEach(() => {
@@ -55,6 +85,8 @@ describe("buildRealmBuilding", () => {
     const result = await buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {
@@ -76,6 +108,8 @@ describe("buildRealmBuilding", () => {
     const result = await buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {
@@ -100,6 +134,8 @@ describe("buildRealmBuilding", () => {
     const result = await buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {
@@ -124,6 +160,8 @@ describe("buildRealmBuilding", () => {
     const result = await buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {
@@ -142,6 +180,8 @@ describe("buildRealmBuilding", () => {
     const result = await buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {
@@ -166,6 +206,8 @@ describe("buildRealmBuilding", () => {
     const resultPromise = buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {
@@ -188,6 +230,8 @@ describe("buildRealmBuilding", () => {
       buildRealmBuilding({
         entityId: 101,
         realmPosition: { x: 20, y: 30 },
+        realm: buildableRealm,
+        mode: allowAllMode,
         target: { type: BuildingType.ResourceWheat },
         useSimpleCost: true,
         world: {
@@ -199,6 +243,8 @@ describe("buildRealmBuilding", () => {
       buildRealmBuilding({
         entityId: 101,
         realmPosition: { x: 20, y: 30 },
+        realm: buildableRealm,
+        mode: allowAllMode,
         target: { type: BuildingType.ResourceWheat },
         useSimpleCost: true,
         world: {
@@ -220,6 +266,8 @@ describe("buildRealmBuilding", () => {
     const result = await buildRealmBuilding({
       entityId: 101,
       realmPosition: { x: 20, y: 30 },
+      realm: buildableRealm,
+      mode: allowAllMode,
       target: { type: BuildingType.ResourceWheat },
       useSimpleCost: true,
       world: {

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
@@ -66,6 +66,7 @@ const buildableRealm = {
 const allowAllMode = {
   rules: {
     isBuildingTypeAllowed: vi.fn(() => true),
+    autoAllocateHyperstructureShares: false,
   },
 };
 

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
@@ -1,17 +1,12 @@
 import { BUILDINGS_CENTER, BuildingType, getNeighborHexes, ResourcesIds } from "@bibliothecadao/types";
-import {
-  TileManager,
-  divideByPrecision,
-  getBalance,
-  getBuildingCosts,
-  getBlockTimestamp,
-} from "@bibliothecadao/eternum";
+import { TileManager } from "@bibliothecadao/eternum";
 import { toast } from "sonner";
 import {
   getBuildReservationState,
   releaseOccupiedBuildSpot,
   reserveOccupiedBuildSpot,
 } from "./build-reservation-store";
+import { resolveConstructionBuildability, type ConstructionBuildabilityInput } from "./construction-buildability";
 
 type RealmPosition = {
   x: bigint | number;
@@ -44,6 +39,8 @@ type BuildSpot = {
 type RealmBuildActionOptions = {
   entityId: number;
   realmPosition?: RealmPosition | null;
+  realm?: ConstructionBuildabilityInput["realm"];
+  mode?: ConstructionBuildabilityInput["mode"];
   target: RealmBuildTarget;
   useSimpleCost: boolean;
   world: BuildWorldContext;
@@ -213,27 +210,11 @@ const hasBuildableCandidate = ({
 export const resolveRealmHasAvailableBuildingTile = (options: RealmAvailableTileOptions) =>
   hasBuildableCandidate(options);
 
-const canAffordRealmBuilding = ({
-  entityId,
-  target,
-  useSimpleCost,
-  world,
-}: Pick<RealmBuildActionOptions, "entityId" | "target" | "useSimpleCost" | "world">): boolean => {
-  const { currentDefaultTick } = getBlockTimestamp();
-  const buildingCosts = getBuildingCosts(entityId, world.components, target.type, useSimpleCost);
-  if (!buildingCosts?.length) {
-    return false;
-  }
-
-  return buildingCosts.every((resourceCost) => {
-    const balance = getBalance(entityId, resourceCost.resource, currentDefaultTick, world.components);
-    return divideByPrecision(balance.balance) >= resourceCost.amount;
-  });
-};
-
 export const buildRealmBuilding = async ({
   entityId,
   realmPosition,
+  realm,
+  mode,
   target,
   useSimpleCost,
   world,
@@ -248,8 +229,17 @@ export const buildRealmBuilding = async ({
     return false;
   }
 
-  if (!canAffordRealmBuilding({ entityId, target, useSimpleCost, world })) {
-    toast.error("Insufficient resources to build.");
+  const baseBuildability = resolveConstructionBuildability({
+    entityId,
+    buildingType: target.type,
+    useSimpleCost,
+    components: world.components,
+    realm,
+    mode,
+  });
+
+  if (!baseBuildability.canSubmit) {
+    toast.error(baseBuildability.reason ?? "Building cannot be submitted.");
     return false;
   }
 
@@ -268,6 +258,23 @@ export const buildRealmBuilding = async ({
 
   try {
     for (const availableSpot of availableSpots) {
+      const spotBuildability = resolveConstructionBuildability({
+        entityId,
+        buildingType: target.type,
+        useSimpleCost,
+        components: world.components,
+        realm,
+        mode,
+        targetSpot: availableSpot,
+        tileManager,
+        occupiedSpots: reservedSpots.occupiedSpots,
+        vacatedSpots: reservedSpots.vacatedSpots,
+      });
+
+      if (!spotBuildability.canSubmit) {
+        continue;
+      }
+
       const spotKey = toBuildSpotKey(availableSpot);
       reserveAutoBuildSpot(entityId, spotKey, onReserveSpot);
 

--- a/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-building-summary.tsx
@@ -34,15 +34,6 @@ type RealmBuildingSummaryBuildAction = {
   title?: string;
 };
 
-type RealmBuildAvailabilityOptions = {
-  buildingId: BuildingType;
-  hasBalance: boolean;
-  hasEnoughPopulation: boolean;
-  hasCapacity: boolean;
-  hasAvailableBuildingTile: boolean;
-  useSimpleCost: boolean;
-};
-
 const prioritizeEconomicBuilding = (buildingType: BuildingType) => {
   if (buildingType === BuildingType.ResourceWheat) return -2;
   if (buildingType === BuildingType.ResourceFish) return -1;
@@ -121,54 +112,6 @@ export const buildRealmBuildingSummary = ({
     },
     [],
   );
-
-export const resolveRealmBuildingSummaryBuildability = ({
-  buildingId,
-  hasBalance,
-  hasEnoughPopulation,
-  hasCapacity,
-  hasAvailableBuildingTile,
-  useSimpleCost,
-}: RealmBuildAvailabilityOptions) => {
-  if (!hasAvailableBuildingTile) {
-    return { canBuild: false, disabledReason: "Realm full" };
-  }
-
-  const militaryInfo = getMilitaryBuildingInfo(buildingId);
-  if (useSimpleCost && (militaryInfo?.tier ?? 0) > 1) {
-    return {
-      canBuild: false,
-      disabledReason: `Switch to Resource mode to build Tier ${militaryInfo?.tier} military buildings.`,
-    };
-  }
-
-  const isLaborLockedResource =
-    useSimpleCost &&
-    (buildingId === BuildingType.ResourceDragonhide ||
-      buildingId === BuildingType.ResourceMithral ||
-      buildingId === BuildingType.ResourceAdamantine);
-  if (isLaborLockedResource) {
-    return { canBuild: false, disabledReason: "Switch to Resource mode to create this building." };
-  }
-
-  if (!hasBalance) {
-    return { canBuild: false, disabledReason: "Need more resources." };
-  }
-
-  if (buildingId === BuildingType.WorkersHut) {
-    return { canBuild: true, disabledReason: undefined };
-  }
-
-  if (!hasCapacity) {
-    return { canBuild: false, disabledReason: "Need more capacity." };
-  }
-
-  if (!hasEnoughPopulation) {
-    return { canBuild: false, disabledReason: "Need more population." };
-  }
-
-  return { canBuild: true, disabledReason: undefined };
-};
 
 export const RealmBuildingSummary = ({
   items,

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -21,14 +21,15 @@ import {
   reconcileBuildReservationState,
   releaseOccupiedBuildSpot,
   reserveOccupiedBuildSpot,
+  reserveVacatedBuildSpot,
 } from "./build-reservation-store";
+import { resolveConstructionBuildability } from "./construction-buildability";
 import { buildRealmBuilding, resolveRealmHasAvailableBuildingTile } from "./realm-build-actions";
 import {
   buildRealmBuildingSummary,
   getMilitaryBuildingInfo,
   MILITARY_BUILDING_GROUP_ORDER,
   RealmBuildingSummary,
-  resolveRealmBuildingSummaryBuildability,
 } from "./realm-building-summary";
 
 import {
@@ -41,7 +42,6 @@ import {
   getBuildingCount,
   getConsumedBy,
   getRealmInfo,
-  hasEnoughPopulationForBuilding,
   ResourceManager,
   ResourceIdToMiningType,
   TileManager,
@@ -99,6 +99,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const useSimpleCost = useUIStore((state) => state.useSimpleCost);
   const setUseSimpleCost = useUIStore((state) => state.setUseSimpleCost);
   const setSelectedBuildingHex = useUIStore((state) => state.setSelectedBuildingHex);
+  const mode = useGameModeConfig();
 
   const realm = getRealmInfo(getEntityIdFromKeys([BigInt(entityId)]), dojo.setup.components);
   const structure = useComponentValue(dojo.setup.components.Structure, getEntityIdFromKeys([BigInt(entityId)]));
@@ -110,9 +111,6 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const currentTime = useMemo(() => Date.now(), [timerTick]);
   const currentTimeRef = useRef(currentTime);
   currentTimeRef.current = currentTime;
-
-  const currentDefaultTickRef = useRef(currentDefaultTick);
-  currentDefaultTickRef.current = currentDefaultTick;
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -178,8 +176,6 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
     pendingDestroys,
     structureBuildings,
   ]);
-  const isRealmFull = !hasAvailableBuildingTile;
-
   const getBuildingCountFor = useCallback(
     (buildingType: BuildingType) => {
       if (!structureBuildings) return 0;
@@ -206,6 +202,8 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
         await buildRealmBuilding({
           entityId,
           realmPosition: realm?.position,
+          realm,
+          mode,
           target,
           useSimpleCost,
           world: {
@@ -236,10 +234,12 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
       dojo.setup.components,
       dojo.setup.systemCalls,
       entityId,
+      realm,
       realm?.position,
       setPreviewBuilding,
       setSelectedBuildingHex,
       useSimpleCost,
+      mode,
     ],
   );
 
@@ -264,6 +264,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
         return;
       }
       setPendingDestroys((prev) => ({ ...prev, [buildingKey]: true }));
+      reserveVacatedBuildSpot(entityId, { col: existing.col, row: existing.row });
 
       try {
         await tileManager.destroyBuilding(dojo.account.account, entityId, existing.col, existing.row);
@@ -430,7 +431,6 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   }, [realmBiome]);
 
   const { playResourceSound } = usePlayResourceSound();
-  const mode = useGameModeConfig();
 
   const buildingTypes = useMemo(
     () => Object.keys(BuildingType).filter((key) => mode.rules.isBuildingTypeAllowed(key)),
@@ -555,38 +555,25 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
     setSelectedArmyType(recommendedArmyType ?? armyGroups[0].armyType);
   }, [armyGroups, entityId, recommendedArmyType, selectedArmyType]);
 
-  const checkBalance = useCallback(
-    (cost: any) =>
-      Object.keys(cost).every((resourceId) => {
-        const resourceCost = cost[Number(resourceId)];
-        const balance = getBalance(
-          entityId,
-          resourceCost.resource,
-          currentDefaultTickRef.current,
-          dojo.setup.components,
-        );
-        return divideByPrecision(balance.balance) >= resourceCost.amount;
-      }),
-    [entityId, dojo.setup.components],
-  );
-
   const activeArmyType = selectedArmyType ?? recommendedArmyType ?? armyGroups[0]?.armyType ?? null;
   const getSummaryBuildState = useCallback(
     (buildingId: BuildingType) => {
-      const buildingCosts = getBuildingCosts(entityId, dojo.setup.components, buildingId, useSimpleCost);
-      const hasBalance = Boolean(buildingCosts && checkBalance(buildingCosts));
-      const hasEnoughPopulation = Boolean(realm && hasEnoughPopulationForBuilding(realm, buildingId));
-
-      return resolveRealmBuildingSummaryBuildability({
-        buildingId,
-        hasBalance,
-        hasEnoughPopulation,
-        hasCapacity: Boolean(realm?.hasCapacity),
-        hasAvailableBuildingTile,
+      const buildability = resolveConstructionBuildability({
+        entityId,
+        buildingType: buildingId,
         useSimpleCost,
+        components: dojo.setup.components,
+        realm,
+        mode,
+        hasAvailableBuildingTile,
       });
+
+      return {
+        canBuild: buildability.canSubmit,
+        disabledReason: buildability.reason,
+      };
     },
-    [checkBalance, dojo.setup.components, entityId, hasAvailableBuildingTile, realm, useSimpleCost],
+    [dojo.setup.components, entityId, hasAvailableBuildingTile, mode, realm, useSimpleCost],
   );
   const allowedBuildingTypes = useMemo(
     () =>
@@ -639,27 +626,20 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
             {realm?.resources.map((resourceId) => {
               const resource = findResourceById(resourceId)!;
               const building = getBuildingFromResource(resourceId);
-
-              const buildingCosts = getBuildingCosts(entityId, dojo.setup.components, building, useSimpleCost);
-
-              if (!buildingCosts) return;
-
-              const hasBalance = checkBalance(buildingCosts);
               const productionStatus = productionStatusByResourceRef.current.get(resourceId as ResourcesIds);
 
-              const hasEnoughPopulation = hasEnoughPopulationForBuilding(realm, building);
-              const isLaborLockedResource =
-                useSimpleCost &&
-                (resourceId === ResourcesIds.Dragonhide ||
-                  resourceId === ResourcesIds.Mithral ||
-                  resourceId === ResourcesIds.Adamantine);
-              const canBuild = !isLaborLockedResource && hasBalance && realm?.hasCapacity && hasEnoughPopulation;
-              const disabledReason = isRealmFull
-                ? "Realm full"
-                : isLaborLockedResource
-                  ? "Switch to Resource mode to create this building."
-                  : undefined;
-              const disabled = isLaborLockedResource || isRealmFull;
+              const buildability = resolveConstructionBuildability({
+                entityId,
+                buildingType: building,
+                useSimpleCost,
+                components: dojo.setup.components,
+                realm,
+                mode,
+                hasAvailableBuildingTile,
+              });
+              const canBuild = buildability.canSubmit;
+              const disabledReason = buildability.reason;
+              const disabled = !canBuild;
               const buildKey = building.toString();
               const isPending = Boolean(pendingBuilds[buildKey]);
               const count = getBuildingCountFor(building);
@@ -675,7 +655,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                   buildingId={building}
                   resourceId={resourceId}
                   onClick={() => {
-                    if (!canBuild || isRealmFull) {
+                    if (!canBuild) {
                       return;
                     }
                     if (previewBuilding?.type === building && previewBuilding?.resource === resourceId) {
@@ -699,13 +679,11 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                       useSimpleCost={useSimpleCost}
                     />
                   }
-                  hasFunds={hasBalance}
-                  hasPopulation={hasEnoughPopulation}
                   disabled={disabled}
                   disabledReason={disabledReason}
                   count={count}
                   onBuild={() => handleAutoBuild({ type: building, resource: resourceId })}
-                  buildDisabled={!canBuild || isPending || isRealmFull}
+                  buildDisabled={!canBuild || isPending}
                   buildLoading={isPending}
                   onDestroy={() => handleDestroyBuilding({ type: building, resource: resourceId })}
                   destroyDisabled={destroyDisabled}
@@ -745,11 +723,6 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                 const building = BuildingType[buildingType as keyof typeof BuildingType];
 
                 const isWorkersHut = building === BuildingType.WorkersHut;
-                const buildingCosts = getBuildingCosts(entityId, dojo.setup.components, building, useSimpleCost);
-
-                if (!buildingCosts) return;
-
-                const hasBalance = checkBalance(buildingCosts);
                 const producedResourceId = configManager.getResourceBuildingProduced(building) as
                   | ResourcesIds
                   | undefined;
@@ -757,13 +730,18 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                   ? productionStatusByResourceRef.current.get(producedResourceId as ResourcesIds)
                   : undefined;
 
-                const hasEnoughPopulation = hasEnoughPopulationForBuilding(realm, building);
-                const canBuild =
-                  building === BuildingType.WorkersHut
-                    ? hasBalance
-                    : hasBalance && realm?.hasCapacity && hasEnoughPopulation;
-                const disabledReason = isRealmFull ? "Realm full" : undefined;
-                const disabled = Boolean(disabledReason);
+                const buildability = resolveConstructionBuildability({
+                  entityId,
+                  buildingType: building,
+                  useSimpleCost,
+                  components: dojo.setup.components,
+                  realm,
+                  mode,
+                  hasAvailableBuildingTile,
+                });
+                const canBuild = buildability.canSubmit;
+                const disabledReason = buildability.reason;
+                const disabled = !canBuild;
                 const buildKey = building.toString();
                 const isPending = Boolean(pendingBuilds[buildKey]);
                 const count = getBuildingCountFor(building);
@@ -789,7 +767,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                     key={index}
                     buildingId={building}
                     onClick={() => {
-                      if (!canBuild || isRealmFull) {
+                      if (!canBuild) {
                         return;
                       }
                       if (previewBuilding?.type === building) {
@@ -818,13 +796,11 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                     productionStatus={productionStatus}
                     currentTime={currentTimeRef.current}
                     toolTip={<BuildingInfo buildingId={building} entityId={entityId} useSimpleCost={useSimpleCost} />}
-                    hasFunds={hasBalance}
-                    hasPopulation={hasEnoughPopulation}
                     disabled={disabled}
                     disabledReason={disabledReason}
                     count={count}
                     onBuild={() => handleAutoBuild({ type: building })}
-                    buildDisabled={!canBuild || isPending || isRealmFull}
+                    buildDisabled={!canBuild || isPending}
                     buildLoading={isPending}
                     onDestroy={() => handleDestroyBuilding({ type: building })}
                     destroyDisabled={destroyDisabled}
@@ -914,9 +890,6 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                           })
                           .map((buildingType, index) => {
                             const building = BuildingType[buildingType as keyof typeof BuildingType];
-                            const buildingCost =
-                              getBuildingCosts(entityId, dojo.setup.components, building, useSimpleCost) ?? [];
-                            const info = getMilitaryBuildingInfo(building);
                             const producedResourceId = configManager.getResourceBuildingProduced(building) as
                               | ResourcesIds
                               | undefined;
@@ -924,16 +897,17 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                               ? productionStatusByResourceRef.current.get(producedResourceId as ResourcesIds)
                               : undefined;
 
-                            const hasBalance = checkBalance(buildingCost);
-                            const hasEnoughPopulation = hasEnoughPopulationForBuilding(realm, building);
-                            const isTierLockedInSimpleMode = useSimpleCost && (info?.tier ?? 0) > 1;
-                            const canBuild =
-                              !isTierLockedInSimpleMode && hasBalance && realm?.hasCapacity && hasEnoughPopulation;
-                            const disabledReason = isRealmFull
-                              ? "Realm full"
-                              : isTierLockedInSimpleMode && info?.tier
-                                ? `Switch to Resource mode to build Tier ${info.tier} military buildings.`
-                                : undefined;
+                            const buildability = resolveConstructionBuildability({
+                              entityId,
+                              buildingType: building,
+                              useSimpleCost,
+                              components: dojo.setup.components,
+                              realm,
+                              mode,
+                              hasAvailableBuildingTile,
+                            });
+                            const canBuild = buildability.canSubmit;
+                            const disabledReason = buildability.reason;
                             const buildKey = building.toString();
                             const isPending = Boolean(pendingBuilds[buildKey]);
                             const count = getBuildingCountFor(building);
@@ -953,7 +927,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                                 key={index}
                                 buildingId={building}
                                 onClick={() => {
-                                  if (!canBuild || isRealmFull) return;
+                                  if (!canBuild) return;
                                   if (previewBuilding?.type === building) {
                                     setPreviewBuilding(null);
                                   } else {
@@ -977,13 +951,11 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
                                     useSimpleCost={useSimpleCost}
                                   />
                                 }
-                                hasFunds={hasBalance}
-                                hasPopulation={hasEnoughPopulation}
-                                disabled={isTierLockedInSimpleMode || isRealmFull}
+                                disabled={!canBuild}
                                 disabledReason={disabledReason}
                                 count={count}
                                 onBuild={() => handleAutoBuild({ type: building })}
-                                buildDisabled={!canBuild || isPending || isRealmFull}
+                                buildDisabled={!canBuild || isPending}
                                 buildLoading={isPending}
                                 onDestroy={() => handleDestroyBuilding({ type: building })}
                                 destroyDisabled={destroyDisabled}
@@ -1017,11 +989,11 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
       pendingDestroys,
       pendingPauseResume,
       pausedByCategory,
+      mode,
       handleAutoBuild,
       handleDestroyBuilding,
       handlePauseResumeAll,
       getBuildingCountFor,
-      checkBalance,
     ],
   );
 
@@ -1098,8 +1070,6 @@ const BuildingCard = ({
   productionStatus,
   currentTime,
   toolTip,
-  hasFunds = true,
-  hasPopulation = true,
   resourceId,
   className,
   disabled = false,
@@ -1126,8 +1096,6 @@ const BuildingCard = ({
   productionStatus?: ResourceProductionStatus;
   currentTime?: number;
   toolTip: React.ReactElement;
-  hasFunds?: boolean;
-  hasPopulation?: boolean;
   resourceId?: ResourcesIds;
   className?: string;
   disabled?: boolean;
@@ -1147,7 +1115,6 @@ const BuildingCard = ({
 }) => {
   const setTooltip = useUIStore((state) => state.setTooltip);
   const isDisabled = disabled;
-  const lacksRequirements = !hasFunds || !hasPopulation;
   const showDisabledMessage = isDisabled && disabledReason;
   const effectiveRemainingSeconds =
     productionStatus && currentTime
@@ -1234,16 +1201,16 @@ const BuildingCard = ({
         <div className="flex flex-col items-start gap-2">
           <button
             type="button"
-            disabled={Boolean(buildDisabled || isDisabled || lacksRequirements)}
+            disabled={Boolean(buildDisabled || isDisabled)}
             onClick={(event) => {
               event.stopPropagation();
-              if (buildDisabled || isDisabled || lacksRequirements) return;
+              if (buildDisabled || isDisabled) return;
               onBuild?.();
             }}
             className={clsx(
               "flex items-center justify-center rounded-md border border-amber-500/80 bg-amber-400/90 px-2.5 py-1 text-[10px] font-semibold text-black shadow transition",
-              !buildDisabled && !isDisabled && !lacksRequirements && "hover:translate-y-[-1px] hover:bg-amber-300",
-              (buildDisabled || isDisabled || lacksRequirements) && "opacity-60 cursor-not-allowed",
+              !buildDisabled && !isDisabled && "hover:translate-y-[-1px] hover:bg-amber-300",
+              (buildDisabled || isDisabled) && "opacity-60 cursor-not-allowed",
             )}
           >
             {buildLoading ? "…" : "Build"}
@@ -1307,16 +1274,9 @@ const BuildingCard = ({
           {badge && <div>{badge}</div>}
         </div>
       </div>
-      {(lacksRequirements || showDisabledMessage) && (
+      {showDisabledMessage && (
         <div className="absolute inset-0 bg-brown/60 p-4 text-xs flex justify-center text-center">
-          {showDisabledMessage ? (
-            <div className="self-center text-gold/90 leading-tight">{disabledReason}</div>
-          ) : (
-            <div className="self-center flex items-center space-x-2">
-              {!hasFunds && <ResourceIcon tooltipText="Need More Resources" resource="Silo" size="lg" />}
-              {!hasPopulation && <ResourceIcon tooltipText="Need More Housing" resource="House" size="lg" />}
-            </div>
-          )}
+          <div className="self-center text-gold/90 leading-tight">{disabledReason}</div>
         </div>
       )}
       <div className="absolute inset-x-0 bottom-0 p-2 space-y-2">

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-15",
+    title: "Safer Construction",
+    description:
+      "Building actions now catch more invalid placements before wallet submission and keep construction transactions isolated, reducing rejected builds and rollback cleanup.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-05-15",
     title: "Smarter Network Recovery",
     description:
       "The game now distinguishes unsupported health checks from real Torii outages, reducing unnecessary reconnect banners while keeping stale streams recoverable.",

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-info-panel.tsx
@@ -12,6 +12,7 @@ import {
   buildRealmBuilding,
   resolveRealmHasAvailableBuildingTile,
 } from "@/ui/features/settlement/construction/realm-build-actions";
+import { resolveConstructionBuildability } from "@/ui/features/settlement/construction/construction-buildability";
 import {
   beginRealmBuildPlacement,
   completeRealmBuildPlacement,
@@ -19,7 +20,6 @@ import {
 import {
   buildRealmBuildingSummary,
   RealmBuildingSummary,
-  resolveRealmBuildingSummaryBuildability,
 } from "@/ui/features/settlement/construction/realm-building-summary";
 import { productionAutomation } from "@/ui/features/world/components/config";
 import { ActiveRelicEffects } from "@/ui/features/world/components/entities/active-relic-effects";
@@ -34,16 +34,12 @@ import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/uti
 import { inferRealmPreset } from "@/utils/automation-presets";
 import { getRealmStatusColor, getFailureSeverity, timeAgo } from "@/utils/automation-status";
 import {
-  divideByPrecision,
   formatTime,
-  getBalance,
-  getBuildingCosts,
   getBuildingCount,
   getGuardsByStructure,
   getRealmInfo,
   getStructureArmyRelicEffects,
   getStructureRelicEffects,
-  hasEnoughPopulationForBuilding,
 } from "@bibliothecadao/eternum";
 import { useDojo, useExplorersByStructure } from "@bibliothecadao/react";
 import {
@@ -258,7 +254,7 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
     structureEntityId ? getEntityIdFromKeys([BigInt(structureEntityId)]) : undefined,
   );
 
-  const { currentArmiesTick, currentBlockTimestamp, currentDefaultTick } = useBlockTimestamp();
+  const { currentArmiesTick, currentBlockTimestamp } = useBlockTimestamp();
   const { data: storyEvents = [] } = useStoryEvents(200);
   const mode = useGameModeConfig();
   const [pendingBuilds, setPendingBuilds] = useState<Record<string, boolean>>({});
@@ -298,6 +294,18 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
   const emptyGuardSlots = canManageGuards && maxGuardArmies !== null ? Math.max(maxGuardArmies - guardArmyCount, 0) : 0;
   const attentionStarvedResources = canShowProductionCard ? starvedResources : new Map<ResourcesIds, string>();
   const canBuildFromAttention = isOwned && structureCapabilities.canOpenConstruction;
+  const hasAvailableBuildingTile = useMemo(
+    () =>
+      resolveRealmHasAvailableBuildingTile({
+        entityId: realmId ?? 0,
+        realmPosition: realm?.position,
+        world: {
+          components,
+          systemCalls: setup.systemCalls,
+        },
+      }),
+    [components, pendingBuilds, realm?.position, realmId, setup.systemCalls],
+  );
 
   const handleManageGuards = useCallback(() => {
     if (!structureEntityId || !canManageGuards) return;
@@ -311,13 +319,41 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
 
   const handleBuildForResource = useCallback(
     (resourceId: ResourcesIds) => {
+      if (!realmId) return;
+
       const building = getBuildingFromResource(resourceId);
       if (building === BuildingType.None) return;
+
+      const buildability = resolveConstructionBuildability({
+        entityId: realmId,
+        buildingType: building,
+        useSimpleCost,
+        components,
+        realm,
+        mode,
+        hasAvailableBuildingTile,
+      });
+
+      if (!buildability.canSubmit) {
+        toast.error(buildability.reason ?? "Building cannot be submitted.");
+        return;
+      }
+
       setSelectedBuilding(building);
       setPreviewBuilding({ type: building, resource: resourceId });
       setLeftNavigationView(LeftView.ConstructionView);
     },
-    [setLeftNavigationView, setPreviewBuilding, setSelectedBuilding],
+    [
+      components,
+      hasAvailableBuildingTile,
+      mode,
+      realm,
+      realmId,
+      setLeftNavigationView,
+      setPreviewBuilding,
+      setSelectedBuilding,
+      useSimpleCost,
+    ],
   );
   const getBuildingCountFor = useCallback(
     (buildingType: BuildingType) => {
@@ -332,15 +368,6 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
     },
     [structureBuildings],
   );
-  const checkBalance = useCallback(
-    (cost: any) =>
-      Object.keys(cost).every((resourceId) => {
-        const resourceCost = cost[Number(resourceId)];
-        const balance = getBalance(realmId ?? 0, resourceCost.resource, currentDefaultTick, components);
-        return divideByPrecision(balance.balance) >= resourceCost.amount;
-      }),
-    [components, currentDefaultTick, realmId],
-  );
   const allowedBuildingTypes = useMemo(
     () =>
       Object.keys(BuildingType)
@@ -348,18 +375,6 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
         .map((buildingType) => BuildingType[buildingType as keyof typeof BuildingType])
         .filter((buildingType): buildingType is BuildingType => typeof buildingType === "number"),
     [mode],
-  );
-  const hasAvailableBuildingTile = useMemo(
-    () =>
-      resolveRealmHasAvailableBuildingTile({
-        entityId: realmId ?? 0,
-        realmPosition: realm?.position,
-        world: {
-          components,
-          systemCalls: setup.systemCalls,
-        },
-      }),
-    [components, realm?.position, realmId, setup.systemCalls],
   );
   const realmBuildingSummary = useMemo(
     () =>
@@ -385,6 +400,8 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
         await buildRealmBuilding({
           entityId: realmId,
           realmPosition: realm?.position,
+          realm,
+          mode,
           target: { type: buildingId },
           useSimpleCost,
           world: {
@@ -403,22 +420,30 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
         completeRealmBuildPlacement(realmId, buildingId);
       }
     },
-    [account.account, components, realm?.position, realmId, setSelectedBuildingHex, setup.systemCalls, useSimpleCost],
+    [
+      account.account,
+      components,
+      mode,
+      realm,
+      realm?.position,
+      realmId,
+      setSelectedBuildingHex,
+      setup.systemCalls,
+      useSimpleCost,
+    ],
   );
   const realmBuildingSummaryActions = useMemo(
     () =>
       new Map(
         realmBuildingSummary.map((item) => {
-          const buildingCosts = getBuildingCosts(realmId ?? 0, components, item.buildingId, useSimpleCost);
-          const hasBalance = Boolean(buildingCosts && checkBalance(buildingCosts));
-          const hasEnoughPopulation = Boolean(realm && hasEnoughPopulationForBuilding(realm, item.buildingId));
-          const buildState = resolveRealmBuildingSummaryBuildability({
-            buildingId: item.buildingId,
-            hasBalance,
-            hasEnoughPopulation,
-            hasCapacity: Boolean(realm?.hasCapacity),
-            hasAvailableBuildingTile,
+          const buildState = resolveConstructionBuildability({
+            entityId: realmId ?? 0,
+            buildingType: item.buildingId,
             useSimpleCost,
+            components,
+            realm,
+            mode,
+            hasAvailableBuildingTile,
           });
           const isPending = Boolean(pendingBuilds[item.buildingId.toString()]);
 
@@ -426,23 +451,23 @@ export const RealmInfoPanel = memo(({ className }: { className?: string }) => {
             item.buildingId,
             {
               onBuild: () => void handleBuildSummaryItem(item.buildingId),
-              disabled: !isOwned || !buildState.canBuild || isPending,
+              disabled: !isOwned || !buildState.canSubmit || isPending,
               loading: isPending,
               title: !isOwned
                 ? "You do not own this realm."
                 : isPending
                   ? `Building ${item.label}...`
-                  : (buildState.disabledReason ?? `Build ${item.label}`),
+                  : (buildState.reason ?? `Build ${item.label}`),
             },
           ] as const;
         }),
       ),
     [
-      checkBalance,
       components,
       handleBuildSummaryItem,
       hasAvailableBuildingTile,
       isOwned,
+      mode,
       pendingBuilds,
       realm,
       realmBuildingSummary,

--- a/packages/core/src/managers/resource-manager.optimistic-update.test.ts
+++ b/packages/core/src/managers/resource-manager.optimistic-update.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+
+import {
+  type ClientComponents,
+  RESOURCE_PRECISION,
+  ResourcesIds,
+  createClientComponents,
+  defineContractComponents,
+} from "@bibliothecadao/types";
+import { Type as RecsType, createWorld, setComponent, type ComponentValue } from "@dojoengine/recs";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { describe, expect, it } from "vitest";
+import { ResourceManager } from "./resource-manager";
+
+type ResourceValue = ComponentValue<ClientComponents["Resource"]["schema"]>;
+
+describe("ResourceManager.optimisticResourceUpdate", () => {
+  it("composes optimistic debits across separate resource balance fields", () => {
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      STONE_BALANCE: precise(100),
+      WOOD_BALANCE: precise(100),
+    });
+    const resourceManager = new ResourceManager(components, 1);
+
+    const removeWoodDebit = resourceManager.optimisticResourceUpdate(ResourcesIds.Wood, -25);
+    const removeStoneDebit = resourceManager.optimisticResourceUpdate(ResourcesIds.Stone, -40);
+
+    expect(resourceManager.balance(ResourcesIds.Wood)).toBe(precise(75));
+    expect(resourceManager.balance(ResourcesIds.Stone)).toBe(precise(60));
+
+    removeStoneDebit();
+    expect(resourceManager.balance(ResourcesIds.Wood)).toBe(precise(75));
+    expect(resourceManager.balance(ResourcesIds.Stone)).toBe(precise(100));
+
+    removeWoodDebit();
+    expect(resourceManager.balance(ResourcesIds.Wood)).toBe(precise(100));
+    expect(resourceManager.balance(ResourcesIds.Stone)).toBe(precise(100));
+  });
+});
+
+function createTestComponents() {
+  const world = createWorld();
+  return createClientComponents({ contractComponents: defineContractComponents(world) });
+}
+
+function seedResource(components: ClientComponents, entityId: number, overrides: Partial<ResourceValue>) {
+  const entity = getEntityIdFromKeys([BigInt(entityId)]);
+  const value = {
+    ...createDefaultResourceValue(components),
+    entity_id: entityId,
+    weight: { capacity: 0n, weight: 0n },
+    ...overrides,
+  };
+
+  setComponent(components.Resource, entity, value);
+}
+
+function createDefaultResourceValue(components: ClientComponents): ResourceValue {
+  return createDefaultValue(components.Resource.schema) as ResourceValue;
+}
+
+function createDefaultValue(schema: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(schema).map(([key, value]) => [key, createDefaultSchemaValue(value)]));
+}
+
+function createDefaultSchemaValue(value: unknown): unknown {
+  if (isNestedSchema(value)) return createDefaultValue(value);
+
+  switch (value) {
+    case RecsType.Boolean:
+      return false;
+    case RecsType.Number:
+    case RecsType.OptionalNumber:
+      return 0;
+    case RecsType.BigInt:
+    case RecsType.OptionalBigInt:
+      return 0n;
+    case RecsType.String:
+    case RecsType.OptionalString:
+      return "";
+    case RecsType.NumberArray:
+    case RecsType.OptionalNumberArray:
+    case RecsType.BigIntArray:
+    case RecsType.OptionalBigIntArray:
+    case RecsType.StringArray:
+    case RecsType.OptionalStringArray:
+    case RecsType.EntityArray:
+    case RecsType.OptionalEntityArray:
+      return [];
+    case RecsType.T:
+    case RecsType.OptionalT:
+      return null;
+    default:
+      return undefined;
+  }
+}
+
+function isNestedSchema(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function precise(amount: number) {
+  return BigInt(amount) * BigInt(RESOURCE_PRECISION);
+}

--- a/packages/core/src/managers/resource-manager.ts
+++ b/packages/core/src/managers/resource-manager.ts
@@ -89,10 +89,11 @@ export class ResourceManager {
     const overrideId = uuid();
 
     const entity = getEntityIdFromKeys([BigInt(this.entityId)]);
+    const currentResource = getComponentValue(this.components.Resource, entity);
     const currentBalance = this.balance(resourceId);
     const weight = configManager.getResourceWeightKg(resourceId) || 0;
     // current weight in nanograms per unit with precision
-    const currentWeight = getComponentValue(this.components.Resource, entity)?.weight || { capacity: 0n, weight: 0n };
+    const currentWeight = currentResource?.weight || { capacity: 0n, weight: 0n };
     const amountWithPrecision = BigInt(Math.floor(multiplyByPrecision(actualResourceChange)));
     const weightChange = BigInt(kgToGram(weight)) * amountWithPrecision;
 
@@ -102,6 +103,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -114,6 +116,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -126,6 +129,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -138,6 +142,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -150,6 +155,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -162,6 +168,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -174,6 +181,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -186,6 +194,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -198,6 +207,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -210,6 +220,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -222,6 +233,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -234,6 +246,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -246,6 +259,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -258,6 +272,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -270,6 +285,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -282,6 +298,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -294,6 +311,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -306,6 +324,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -318,6 +337,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -330,6 +350,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -342,6 +363,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -354,6 +376,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -366,6 +389,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -378,6 +402,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -390,6 +415,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -402,6 +428,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -414,6 +441,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -426,6 +454,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -438,6 +467,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -450,6 +480,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -462,6 +493,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -474,6 +506,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -486,6 +519,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -498,6 +532,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -510,6 +545,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -522,6 +558,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,
@@ -534,6 +571,7 @@ export class ResourceManager {
           this.components.Resource.addOverride(overrideId, {
             entity,
             value: {
+              ...currentResource,
               weight: {
                 ...currentWeight,
                 weight: currentWeight.weight + weightChange,

--- a/packages/core/src/managers/tile-manager.optimistic-cleanup.source.test.ts
+++ b/packages/core/src/managers/tile-manager.optimistic-cleanup.source.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("TileManager optimistic construction cleanup", () => {
+  it("clears build-slot transitions from transaction wait failures, not only reverted receipts", () => {
+    const source = readSource("src/managers/tile-manager.ts");
+
+    expect(source).toContain("waitForTransactionWithCheck");
+    expect(source).toContain("onFailed");
+    expect(source).toMatch(/onFailed:\s*\(failureReason\)/);
+    expect(source).toContain("clearBuildSlotTransition(buildSlotTransitions, buildKey)");
+  });
+});

--- a/packages/core/src/managers/tile-manager.ts
+++ b/packages/core/src/managers/tile-manager.ts
@@ -263,12 +263,42 @@ export class TileManager {
     return typeof transactionHash === "string" ? transactionHash : undefined;
   };
 
+  private _resolveTransactionWaiter = (signer: DojoAccount): ((transactionHash: string) => Promise<unknown>) | null => {
+    const signerWithWaiters = signer as DojoAccount & {
+      waitForTransaction?: (transactionHash: string) => Promise<unknown>;
+      waitForTransactionWithCheck?: (transactionHash: string) => Promise<unknown>;
+      provider?: {
+        waitForTransaction?: (transactionHash: string) => Promise<unknown>;
+        waitForTransactionWithCheck?: (transactionHash: string) => Promise<unknown>;
+      };
+    };
+
+    if (typeof signerWithWaiters.provider?.waitForTransactionWithCheck === "function") {
+      return signerWithWaiters.provider.waitForTransactionWithCheck.bind(signerWithWaiters.provider);
+    }
+
+    if (typeof signerWithWaiters.waitForTransactionWithCheck === "function") {
+      return signerWithWaiters.waitForTransactionWithCheck.bind(signerWithWaiters);
+    }
+
+    if (typeof signerWithWaiters.waitForTransaction === "function") {
+      return signerWithWaiters.waitForTransaction.bind(signerWithWaiters);
+    }
+
+    if (typeof signerWithWaiters.provider?.waitForTransaction === "function") {
+      return signerWithWaiters.provider.waitForTransaction.bind(signerWithWaiters.provider);
+    }
+
+    return null;
+  };
+
   private _scheduleOptimisticCleanupOnTransaction = (
     signer: DojoAccount,
     transactionHash: string | undefined,
     cleanup: () => void,
     options?: {
       onReverted?: (revertReason: string) => void;
+      onFailed?: (failureReason: string) => void;
     },
   ) => {
     let isCleanedUp = false;
@@ -293,13 +323,13 @@ export class TileManager {
       return;
     }
 
-    if (!("waitForTransaction" in signer) || typeof signer.waitForTransaction !== "function") {
+    const waitForTransaction = this._resolveTransactionWaiter(signer);
+    if (!waitForTransaction) {
       finalizeAndClearTimeout();
       return;
     }
 
-    void signer
-      .waitForTransaction(transactionHash)
+    void waitForTransaction(transactionHash)
       .then((receipt) => {
         const receiptAny = receipt as { isReverted?: () => boolean; revert_reason?: string; revertReason?: string };
         if (typeof receiptAny.isReverted === "function" && receiptAny.isReverted()) {
@@ -315,6 +345,7 @@ export class TileManager {
       })
       .catch((error) => {
         console.error(`Error while waiting for transaction ${transactionHash}`, error);
+        options?.onFailed?.(extractErrorMessage(error));
       })
       .finally(() => {
         finalizeAndClearTimeout();
@@ -484,6 +515,15 @@ export class TileManager {
       });
 
       const transactionHash = this._extractTransactionHash(result);
+      const clearFailedBuildTransition = (failureReason: string) => {
+        removeBuildingOverride();
+        if (failureReason.toLowerCase().includes(OCCUPIED_SPACE_REASON)) {
+          markOccupiedUnconfirmed(buildSlotTransitions, buildKey);
+          return;
+        }
+        clearBuildSlotTransition(buildSlotTransitions, buildKey);
+      };
+
       this._scheduleOptimisticCleanupOnTransaction(
         signer,
         transactionHash,
@@ -491,13 +531,9 @@ export class TileManager {
           removeBuildingOverride();
         },
         {
-          onReverted: (revertReason) => {
-            removeBuildingOverride();
-            if (revertReason.toLowerCase().includes(OCCUPIED_SPACE_REASON)) {
-              markOccupiedUnconfirmed(buildSlotTransitions, buildKey);
-              return;
-            }
-            clearBuildSlotTransition(buildSlotTransitions, buildKey);
+          onReverted: clearFailedBuildTransition,
+          onFailed: (failureReason) => {
+            clearFailedBuildTransition(failureReason);
           },
         },
       );
@@ -540,6 +576,10 @@ export class TileManager {
       const transactionHash = this._extractTransactionHash(result);
       this._scheduleOptimisticCleanupOnTransaction(signer, transactionHash, removeBuildingOverride, {
         onReverted: () => {
+          removeBuildingOverride();
+          clearBuildSlotTransition(buildSlotTransitions, buildKey);
+        },
+        onFailed: () => {
           removeBuildingOverride();
           clearBuildSlotTransition(buildSlotTransitions, buildKey);
         },

--- a/packages/provider/src/promise-queue.test.ts
+++ b/packages/provider/src/promise-queue.test.ts
@@ -566,6 +566,64 @@ describe("Parallel Category Processing", () => {
     }
   });
 
+  it("never merges CREATE_BUILDING transactions into one multicall", async () => {
+    const localExecutor = makeExecutor();
+    const queue = new PromiseQueue(localExecutor, { batchDelayMs: 0 });
+    const signer = makeSigner();
+
+    const pA = queue.enqueue({
+      signer,
+      calls: makeCall("create_building"),
+      transactionType: TransactionType.CREATE_BUILDING,
+    });
+    const pB = queue.enqueue({
+      signer,
+      calls: makeCall("create_building"),
+      transactionType: TransactionType.CREATE_BUILDING,
+    });
+
+    await Promise.all([pA, pB]);
+
+    expect(localExecutor.executeAndCheckTransaction).toHaveBeenCalledTimes(2);
+    for (const call of (localExecutor.executeAndCheckTransaction as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(call[1]).toEqual(makeCall("create_building"));
+      expect(call[2]).toBeUndefined();
+      expect(call[3]).toEqual({
+        waitForConfirmation: false,
+        transactionType: TransactionType.CREATE_BUILDING,
+      });
+    }
+  });
+
+  it("never merges DESTROY_BUILDING transactions into one multicall", async () => {
+    const localExecutor = makeExecutor();
+    const queue = new PromiseQueue(localExecutor, { batchDelayMs: 0 });
+    const signer = makeSigner();
+
+    const pA = queue.enqueue({
+      signer,
+      calls: makeCall("destroy_building"),
+      transactionType: TransactionType.DESTROY_BUILDING,
+    });
+    const pB = queue.enqueue({
+      signer,
+      calls: makeCall("destroy_building"),
+      transactionType: TransactionType.DESTROY_BUILDING,
+    });
+
+    await Promise.all([pA, pB]);
+
+    expect(localExecutor.executeAndCheckTransaction).toHaveBeenCalledTimes(2);
+    for (const call of (localExecutor.executeAndCheckTransaction as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(call[1]).toEqual(makeCall("destroy_building"));
+      expect(call[2]).toBeUndefined();
+      expect(call[3]).toEqual({
+        waitForConfirmation: false,
+        transactionType: TransactionType.DESTROY_BUILDING,
+      });
+    }
+  });
+
   it("keeps non-VRF HIGH transactions batched around isolated VRF submissions", async () => {
     const localExecutor = makeExecutor();
     const queue = new PromiseQueue(localExecutor, { batchDelayMs: 0 });

--- a/packages/provider/src/promise-queue.test.ts
+++ b/packages/provider/src/promise-queue.test.ts
@@ -566,33 +566,33 @@ describe("Parallel Category Processing", () => {
     }
   });
 
-  it("never merges CREATE_BUILDING transactions into one multicall", async () => {
+  it("batches CREATE_BUILDING transactions into one multicall", async () => {
     const localExecutor = makeExecutor();
     const queue = new PromiseQueue(localExecutor, { batchDelayMs: 0 });
     const signer = makeSigner();
+    const callA = makeCall("create_building_a");
+    const callB = makeCall("create_building_b");
 
     const pA = queue.enqueue({
       signer,
-      calls: makeCall("create_building"),
+      calls: callA,
       transactionType: TransactionType.CREATE_BUILDING,
     });
     const pB = queue.enqueue({
       signer,
-      calls: makeCall("create_building"),
+      calls: callB,
       transactionType: TransactionType.CREATE_BUILDING,
     });
 
     await Promise.all([pA, pB]);
 
-    expect(localExecutor.executeAndCheckTransaction).toHaveBeenCalledTimes(2);
-    for (const call of (localExecutor.executeAndCheckTransaction as ReturnType<typeof vi.fn>).mock.calls) {
-      expect(call[1]).toEqual(makeCall("create_building"));
-      expect(call[2]).toBeUndefined();
-      expect(call[3]).toEqual({
-        waitForConfirmation: false,
-        transactionType: TransactionType.CREATE_BUILDING,
-      });
-    }
+    expect(localExecutor.executeAndCheckTransaction).toHaveBeenCalledTimes(1);
+    const call = (localExecutor.executeAndCheckTransaction as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[1]).toEqual([callA, callB]);
+    expect(call[2]).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: TransactionType.CREATE_BUILDING, count: 2 })]),
+    );
+    expect(call[3]).toEqual({ waitForConfirmation: false });
   });
 
   it("never merges DESTROY_BUILDING transactions into one multicall", async () => {

--- a/packages/provider/src/promise-queue.ts
+++ b/packages/provider/src/promise-queue.ts
@@ -26,16 +26,13 @@ interface QueueItem {
 
 const asCallArray = (calls: AllowArray<Call>): Call[] => (Array.isArray(calls) ? calls : [calls]);
 
-const CONSTRUCTION_TRANSACTION_TYPES = new Set<TransactionType>([
-  TransactionType.CREATE_BUILDING,
-  TransactionType.DESTROY_BUILDING,
-]);
+const ISOLATED_CONSTRUCTION_TRANSACTION_TYPES = new Set<TransactionType>([TransactionType.DESTROY_BUILDING]);
 
 const hasVrfRequestRandomCall = (transaction: QueueableTransaction): boolean =>
   asCallArray(transaction.calls).some((call) => call.entrypoint === "request_random");
 
 const isConstructionWriteTransaction = (transaction: QueueableTransaction): boolean =>
-  Boolean(transaction.transactionType && CONSTRUCTION_TRANSACTION_TYPES.has(transaction.transactionType));
+  Boolean(transaction.transactionType && ISOLATED_CONSTRUCTION_TRANSACTION_TYPES.has(transaction.transactionType));
 
 const shouldSubmitIndividually = (item: QueueItem): boolean =>
   item.transaction.transactionType === TransactionType.EXPLORE ||
@@ -198,8 +195,8 @@ export class PromiseQueue {
    *
    * Sensitive submissions never merge with others:
    * - VRF request_random calls must stay paired with exactly one consumer.
-   * - Building construction/destruction must not let one rejected slot roll back
-   *   unrelated construction calls in the same multicall.
+   * - Building destruction must not let one rejected slot roll back unrelated
+   *   construction calls in the same multicall.
    */
   private async processBatch(batch: QueueItem[]) {
     if (batch.length === 0) return;

--- a/packages/provider/src/promise-queue.ts
+++ b/packages/provider/src/promise-queue.ts
@@ -26,11 +26,21 @@ interface QueueItem {
 
 const asCallArray = (calls: AllowArray<Call>): Call[] => (Array.isArray(calls) ? calls : [calls]);
 
+const CONSTRUCTION_TRANSACTION_TYPES = new Set<TransactionType>([
+  TransactionType.CREATE_BUILDING,
+  TransactionType.DESTROY_BUILDING,
+]);
+
 const hasVrfRequestRandomCall = (transaction: QueueableTransaction): boolean =>
   asCallArray(transaction.calls).some((call) => call.entrypoint === "request_random");
 
+const isConstructionWriteTransaction = (transaction: QueueableTransaction): boolean =>
+  Boolean(transaction.transactionType && CONSTRUCTION_TRANSACTION_TYPES.has(transaction.transactionType));
+
 const shouldSubmitIndividually = (item: QueueItem): boolean =>
-  item.transaction.transactionType === TransactionType.EXPLORE || hasVrfRequestRandomCall(item.transaction);
+  item.transaction.transactionType === TransactionType.EXPLORE ||
+  hasVrfRequestRandomCall(item.transaction) ||
+  isConstructionWriteTransaction(item.transaction);
 
 const splitBatchForSubmission = (batch: QueueItem[]): QueueItem[][] => {
   const submissionBatches: QueueItem[][] = [];
@@ -186,9 +196,10 @@ export class PromiseQueue {
   /**
    * Process a batch of queue items as a single multicall transaction.
    *
-   * VRF request_random items never merge with others. Each request must stay
-   * paired with exactly one consuming system call, otherwise a later consume can
-   * run without its matching request and fail with "VrfProvider: not consumed".
+   * Sensitive submissions never merge with others:
+   * - VRF request_random calls must stay paired with exactly one consumer.
+   * - Building construction/destruction must not let one rejected slot roll back
+   *   unrelated construction calls in the same multicall.
    */
   private async processBatch(batch: QueueItem[]) {
     if (batch.length === 0) return;


### PR DESCRIPTION
Centralizes construction buildability checks across the construction panel, context menu, realm summary, attention chips, and manual hex placement so locally-known contract rejects are blocked before submission.
CREATE_BUILDING now stays eligible for normal batching, while DESTROY_BUILDING remains isolated to avoid one rejected destroy rolling back unrelated construction work.
Optimistic construction cleanup now responds to provider transaction wait failures, confirmed reverts, success cleanup, and vacated-slot reservations.
The resource-balance trace showed RECS Resource overrides are last-write-wins per entity, so multi-resource construction costs could optimistically drop earlier debits; ResourceManager now carries forward the current Resource snapshot and has a regression for Wood+Stone debits.

Validation: pnpm run format; pnpm run knip; focused construction, provider queue, TileManager, and ResourceManager tests.