### PR TITLE
[codex] Fix Blitz leaderboard crash

### DIFF
--- a/client/apps/game/src/services/blitz/blitz-settlement-component.ts
+++ b/client/apps/game/src/services/blitz/blitz-settlement-component.ts
@@ -1,6 +1,0 @@
-import { Has } from "@dojoengine/recs";
-
-type BlitzSettlementComponent = Parameters<typeof Has>[0];
-
-export const resolveBlitzSettlementComponent = (components: unknown): BlitzSettlementComponent | null =>
-  (components as { BlitzSettlement?: BlitzSettlementComponent }).BlitzSettlement ?? null;

--- a/client/apps/game/src/services/blitz/blitz-settlement-players.test.ts
+++ b/client/apps/game/src/services/blitz/blitz-settlement-players.test.ts
@@ -1,0 +1,22 @@
+import { defineContractComponents } from "@bibliothecadao/types";
+import { createWorld, setComponent } from "@dojoengine/recs";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { describe, expect, it } from "vitest";
+
+import { readBlitzSettlementPlayerAddresses } from "./blitz-settlement-players";
+
+describe("readBlitzSettlementPlayerAddresses", () => {
+  it("reads players from the typed BlitzSettlement component", () => {
+    const components = defineContractComponents(createWorld());
+    const playerAddress = 0x123n;
+    const settlementEntity = getEntityIdFromKeys([playerAddress]);
+    const missingEntity = getEntityIdFromKeys([0x456n]);
+
+    setComponent(components.BlitzSettlement, settlementEntity, {
+      player: playerAddress,
+      structure_ids: [1, 2, 3],
+    });
+
+    expect(readBlitzSettlementPlayerAddresses(components, [settlementEntity, missingEntity])).toEqual([playerAddress]);
+  });
+});

--- a/client/apps/game/src/services/blitz/blitz-settlement-players.ts
+++ b/client/apps/game/src/services/blitz/blitz-settlement-players.ts
@@ -1,0 +1,24 @@
+import type { ClientComponents } from "@bibliothecadao/types";
+import { useEntityQuery } from "@dojoengine/react";
+import { type Entity, getComponentValue, Has } from "@dojoengine/recs";
+import { useMemo } from "react";
+
+type BlitzSettlementComponents = Pick<ClientComponents, "BlitzSettlement">;
+
+export const readBlitzSettlementPlayerAddresses = (
+  components: BlitzSettlementComponents,
+  blitzSettlementEntities: Entity[],
+): bigint[] =>
+  blitzSettlementEntities
+    .map((entityId) => getComponentValue(components.BlitzSettlement, entityId))
+    .filter((settlement): settlement is NonNullable<typeof settlement> => Boolean(settlement))
+    .map((settlement) => settlement.player as unknown as bigint);
+
+export const useBlitzSettlementPlayerAddresses = (components: BlitzSettlementComponents): bigint[] => {
+  const blitzSettlementEntities = useEntityQuery([Has(components.BlitzSettlement)]);
+
+  return useMemo(
+    () => readBlitzSettlementPlayerAddresses(components, blitzSettlementEntities),
+    [blitzSettlementEntities, components.BlitzSettlement],
+  );
+};

--- a/client/apps/game/src/ui/features/prize/blitz-settlement-query.source.test.ts
+++ b/client/apps/game/src/ui/features/prize/blitz-settlement-query.source.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
+
+describe("Blitz prize settlement queries", () => {
+  it("uses the typed BlitzSettlement component instead of an empty query fallback", () => {
+    const prizeSources = [
+      readSource("src/ui/features/prize/components/blitz-mmr-table.tsx"),
+      readSource("src/ui/features/prize/prize-panel.tsx"),
+    ];
+
+    prizeSources.forEach((source) => {
+      expect(source).toContain("useBlitzSettlementPlayerAddresses(components)");
+      expect(source).not.toContain("resolveBlitzSettlementComponent");
+      expect(source).not.toContain("useEntityQuery(blitzSettlementComponent ? [Has(blitzSettlementComponent)] : [])");
+      expect(source).not.toContain("? [Has(blitzSettlementComponent)] : []");
+    });
+  });
+});

--- a/client/apps/game/src/ui/features/prize/components/blitz-mmr-table.tsx
+++ b/client/apps/game/src/ui/features/prize/components/blitz-mmr-table.tsx
@@ -1,9 +1,9 @@
+import { useBlitzSettlementPlayerAddresses } from "@/services/blitz/blitz-settlement-players";
 import { displayAddress } from "@/ui/utils/utils";
 import { getMMRTierFromRaw, MMR_TOKEN_DECIMALS } from "@/ui/utils/mmr-tiers";
 import { getAddressName, toHexString } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
-import { resolveBlitzSettlementComponent } from "@/services/blitz/blitz-settlement-component";
 import { useEntityQuery } from "@dojoengine/react";
 import { getComponentValue, Has } from "@dojoengine/recs";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -54,18 +54,7 @@ export const BlitzMMRTable = () => {
   }, [worldCfg?.mmr_config?.mmr_token_address]);
 
   // Blitz settlement rows are the source of truth for players who actually entered the world.
-  const blitzSettlementComponent = useMemo(() => resolveBlitzSettlementComponent(components), [components]);
-  const blitzSettlementEntities = useEntityQuery(blitzSettlementComponent ? [Has(blitzSettlementComponent)] : []);
-  const registeredPlayerAddresses = useMemo(() => {
-    if (!blitzSettlementComponent) {
-      return [];
-    }
-
-    return blitzSettlementEntities
-      .map((eid) => getComponentValue(blitzSettlementComponent, eid))
-      .filter((v): v is NonNullable<typeof v> => Boolean(v))
-      .map((v) => v.player as unknown as bigint);
-  }, [blitzSettlementComponent, blitzSettlementEntities]);
+  const registeredPlayerAddresses = useBlitzSettlementPlayerAddresses(components);
 
   // Get player points and filter to only players with non-zero points
   const playerRegisteredPointsEntities = useEntityQuery([Has(components.PlayerRegisteredPoints)]);

--- a/client/apps/game/src/ui/features/prize/prize-panel.tsx
+++ b/client/apps/game/src/ui/features/prize/prize-panel.tsx
@@ -1,5 +1,5 @@
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { resolveBlitzSettlementComponent } from "@/services/blitz/blitz-settlement-component";
+import { useBlitzSettlementPlayerAddresses } from "@/services/blitz/blitz-settlement-players";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { NumberInput } from "@/ui/design-system/atoms";
 import Button from "@/ui/design-system/atoms/button";
@@ -125,18 +125,7 @@ export const PrizePanel = () => {
   }, [mmrGameMetaEntities, components.MMRGameMeta]);
 
   // All settled blitz players, regardless of points
-  const blitzSettlementComponent = useMemo(() => resolveBlitzSettlementComponent(components), [components]);
-  const blitzSettlementEntities = useEntityQuery(blitzSettlementComponent ? [Has(blitzSettlementComponent)] : []);
-  const registeredAddresses = useMemo(() => {
-    if (!blitzSettlementComponent) {
-      return [];
-    }
-
-    return blitzSettlementEntities
-      .map((eid) => getComponentValue(blitzSettlementComponent, eid))
-      .filter((v): v is NonNullable<typeof v> => Boolean(v))
-      .map((v) => v.player as unknown as bigint);
-  }, [blitzSettlementComponent, blitzSettlementEntities]);
+  const registeredAddresses = useBlitzSettlementPlayerAddresses(components);
 
   const [nowTs, setNowTs] = useState(() => Math.floor(Date.now() / 1000));
   useEffect(() => {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-15",
+    title: "Blitz Leaderboard Fix",
+    description:
+      "Fixed the Blitz leaderboard and prize panel so settled-player rankings open reliably after entering a game.",
+    type: "fix",
+    gameSlug: "blitz",
+  },
+  {
+    date: "2026-05-15",
     title: "Smarter Network Recovery",
     description:
       "The game now distinguishes unsupported health checks from real Torii outages, reducing unnecessary reconnect banners while keeping stale streams recoverable.",

--- a/packages/types/src/dojo/contract-components.test.ts
+++ b/packages/types/src/dojo/contract-components.test.ts
@@ -1,0 +1,20 @@
+import { createWorld } from "@dojoengine/recs";
+import { describe, expect, it } from "vitest";
+
+import { defineContractComponents } from "./contract-components";
+
+describe("defineContractComponents", () => {
+  it("exposes the Blitz settlement model used by prize leaderboards", () => {
+    const components = defineContractComponents(createWorld());
+    const blitzSettlement = (components as Record<string, any>).BlitzSettlement;
+
+    expect(blitzSettlement).toBeDefined();
+    expect(blitzSettlement.metadata).toMatchObject({
+      namespace: "s1_eternum",
+      name: "BlitzSettlement",
+      types: ["ContractAddress", "Span<u32>"],
+      customTypes: [],
+    });
+    expect(Object.keys(blitzSettlement.schema)).toEqual(["player", "structure_ids"]);
+  });
+});

--- a/packages/types/src/dojo/contract-components.ts
+++ b/packages/types/src/dojo/contract-components.ts
@@ -2020,6 +2020,23 @@ export function defineContractComponents(world: World) {
         },
       );
     })(),
+    BlitzSettlement: (() => {
+      return defineComponent(
+        world,
+        {
+          player: RecsType.BigInt,
+          structure_ids: RecsType.NumberArray,
+        },
+        {
+          metadata: {
+            namespace: "s1_eternum",
+            name: "BlitzSettlement",
+            types: ["ContractAddress", "Span<u32>"],
+            customTypes: [],
+          },
+        },
+      );
+    })(),
     BlitzRealmSettleFinish: (() => {
       return defineComponent(
         world,


### PR DESCRIPTION
This fixes the Blitz leaderboard and prize panel crash by adding the missing typed `BlitzSettlement` component and routing both views through a shared settlement-player hook.

The root cause was that `s1_eternum-BlitzSettlement` exists in Cairo/Torii manifests but was absent from the generated TypeScript contract components, so the UI used an optional resolver path that could call `useEntityQuery([])`.

The change removes the obsolete resolver, adds focused coverage for the component/query behavior, and records the 2026-05-15 latest-features fix.

Validated with `pnpm --dir packages/types build`, `pnpm --dir client/apps/game typecheck`, targeted Vitest runs, `pnpm run format`, `pnpm run knip`, and `git diff --check`; manual browser smoke was blocked before the leaderboard by missing local RPC at `http://localhost:5050`.
