### PR TITLE
Fix movement visual handoff cleanup

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap-army-tab-selection.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tab-selection.test.ts
@@ -273,6 +273,7 @@ describe("resolvePendingArmyMovementFallbackPlan", () => {
     expect(
       resolvePendingArmyMovementFallbackPlan({
         hasPendingMovement: false,
+        hasPendingMovementResolution: false,
         pendingMovementStartedAtMs: 1000,
         nowMs: 9000,
         staleAfterMs: 8000,
@@ -281,6 +282,38 @@ describe("resolvePendingArmyMovementFallbackPlan", () => {
       shouldDeleteFallbackTimeout: true,
       shouldClearPendingMovement: false,
       shouldRequestChunkRefresh: false,
+    });
+  });
+
+  it("keeps fallback armed after movement handoff while resolution is still pending", () => {
+    expect(
+      resolvePendingArmyMovementFallbackPlan({
+        hasPendingMovement: false,
+        hasPendingMovementResolution: true,
+        pendingMovementStartedAtMs: 1000,
+        nowMs: 8500,
+        staleAfterMs: 8000,
+      }),
+    ).toEqual({
+      shouldDeleteFallbackTimeout: false,
+      shouldClearPendingMovement: false,
+      shouldRequestChunkRefresh: false,
+    });
+  });
+
+  it("clears stale movement after visual handoff when resolution never arrives", () => {
+    expect(
+      resolvePendingArmyMovementFallbackPlan({
+        hasPendingMovement: false,
+        hasPendingMovementResolution: true,
+        pendingMovementStartedAtMs: 1000,
+        nowMs: 9000,
+        staleAfterMs: 8000,
+      }),
+    ).toEqual({
+      shouldDeleteFallbackTimeout: false,
+      shouldClearPendingMovement: true,
+      shouldRequestChunkRefresh: true,
     });
   });
 

--- a/client/apps/game/src/three/scenes/worldmap-army-tab-selection.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tab-selection.ts
@@ -29,6 +29,7 @@ interface ResolvePendingArmyMovementSelectionPlanInput extends ShouldClearPendin
 
 interface ResolvePendingArmyMovementFallbackPlanInput extends ShouldClearPendingArmyMovementInput {
   hasPendingMovement: boolean;
+  hasPendingMovementResolution?: boolean;
 }
 
 interface PendingArmyMovementSelectionPlan {
@@ -145,7 +146,9 @@ export function resolvePendingArmyMovementSelectionPlan(
 export function resolvePendingArmyMovementFallbackPlan(
   input: ResolvePendingArmyMovementFallbackPlanInput,
 ): PendingArmyMovementFallbackPlan {
-  if (!input.hasPendingMovement) {
+  const hasMovementToResolve = input.hasPendingMovement || input.hasPendingMovementResolution === true;
+
+  if (!hasMovementToResolve) {
     return {
       shouldDeleteFallbackTimeout: true,
       shouldClearPendingMovement: false,

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-input-lock.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-input-lock.source.test.ts
@@ -37,6 +37,16 @@ describe("Worldmap pending movement input lock", () => {
     expect(helperBody).toContain("this.armyManager.hasUnresolvedOptimisticMovement(entityId)");
   });
 
+  it("keeps movement input locked while authoritative resolution waits for visual completion", () => {
+    const source = readSource("worldmap.tsx");
+
+    const helperStart = source.indexOf("private isArmyMovementInputLocked(entityId: ID)");
+    expect(helperStart).toBeGreaterThan(0);
+    const helperBody = source.slice(helperStart, helperStart + 700);
+
+    expect(helperBody).toContain("this.pendingArmyMovementAuthoritativeResolutions.has(entityId)");
+  });
+
   it("passes unresolved optimistic movement into the selection plan", () => {
     const source = readSource("worldmap.tsx");
 

--- a/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts
@@ -19,11 +19,28 @@ describe("Worldmap pending movement visual handoff wiring", () => {
     expect(methodBody).not.toContain("this.clearPendingArmyMovement(entityId)");
   });
 
-  it("wires local pending clear to ArmyManager movement-start notifications", () => {
+  it("hands movement-start off without clearing authoritative resolution handles", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
 
     expect(source).toContain("this.armyManager.onMovementStart");
-    expect(source).toContain('this.clearPendingArmyMovement(entityId, "movement_started")');
+    expect(source).toContain("this.handoffPendingArmyMovementToVisualLifecycle(entityId)");
+    expect(source).not.toContain('this.clearPendingArmyMovement(entityId, "movement_started")');
+  });
+
+  it("keeps target and fallback handles alive after movement-start handoff", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const helperStart = source.indexOf("private handoffPendingArmyMovementToVisualLifecycle(");
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperEnd = source.indexOf("private clearPendingArmyMovement(", helperStart);
+    const helperBody = source.slice(helperStart, helperEnd);
+
+    expect(helperBody).toContain("this.pendingArmyMovements.delete(entityId)");
+    expect(helperBody).toContain('reason: "movement_started"');
+    expect(helperBody).toContain("trackedEffect.cleanup()");
+    expect(helperBody).not.toContain("this.pendingArmyMovementTargetKeys.delete(entityId)");
+    expect(helperBody).not.toContain("this.pendingArmyMovementFallbackTimeouts");
+    expect(helperBody).not.toContain("clearTimeout");
   });
 
   it("clears pending movement from authoritative tile updates after manager reconciliation", () => {
@@ -52,6 +69,52 @@ describe("Worldmap pending movement visual handoff wiring", () => {
     expect(source).toContain("private clearPendingArmyMovementFromAuthoritativePosition(");
     expect(body).toContain("onAuthoritativePositionApplied:");
     expect(body).toContain("this.clearPendingArmyMovementFromAuthoritativePosition(update)");
+  });
+
+  it("clears retained pending movement handles when visual completion follows authoritative target match", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const lifecycleStart = source.indexOf("private installPendingMovementVisualLifecycle(");
+    expect(lifecycleStart).toBeGreaterThan(-1);
+
+    const lifecycleEnd = source.indexOf("private disposePendingMovementVisualLifecycle(", lifecycleStart);
+    const lifecycleBody = source.slice(lifecycleStart, lifecycleEnd);
+    const completeStart = lifecycleBody.indexOf("const disposeMovementComplete");
+    const completeEnd = lifecycleBody.indexOf("const disposeAuthoritativeReconcile", completeStart);
+    const completeHandler = lifecycleBody.slice(completeStart, completeEnd);
+
+    expect(completeHandler).toContain("this.completePendingArmyMovementAuthoritativeResolution(entityId)");
+    expect(completeHandler.indexOf("this.completePendingArmyMovementAuthoritativeResolution(entityId)")).toBeLessThan(
+      completeHandler.indexOf("this.disposePendingMovementVisualLifecycle(entityId)"),
+    );
+  });
+
+  it("clears retained pending movement handles when visual cancellation replaces completion", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const lifecycleStart = source.indexOf("private installPendingMovementVisualLifecycle(");
+    expect(lifecycleStart).toBeGreaterThan(-1);
+
+    const lifecycleEnd = source.indexOf("private disposePendingMovementVisualLifecycle(", lifecycleStart);
+    const lifecycleBody = source.slice(lifecycleStart, lifecycleEnd);
+    const cancelStart = lifecycleBody.indexOf("const disposeMovementVisualCancel");
+    const cancelEnd = lifecycleBody.indexOf("this.pendingArmyMovementVisualLifecycleDisposers.set", cancelStart);
+    const cancelHandler = lifecycleBody.slice(cancelStart, cancelEnd);
+
+    expect(cancelHandler).toContain("this.completePendingArmyMovementAuthoritativeResolution(entityId)");
+    expect(cancelHandler.indexOf("this.completePendingArmyMovementAuthoritativeResolution(entityId)")).toBeLessThan(
+      cancelHandler.indexOf("this.disposePendingMovementVisualLifecycle(entityId)"),
+    );
+  });
+
+  it("keeps travel effects pending after movement-start handoff retains target handles", () => {
+    const source = readSource("src/three/scenes/worldmap.tsx");
+    const helperStart = source.indexOf("private hasPendingTravelEffectForHex(");
+    expect(helperStart).toBeGreaterThan(-1);
+
+    const helperEnd = source.indexOf("private startPendingActionFx(", helperStart);
+    const helperBody = source.slice(helperStart, helperEnd);
+
+    expect(helperBody).toContain("trackedEffect.key === key");
+    expect(helperBody).toContain("this.pendingArmyMovementTargetKeys.has(entityId)");
   });
 
   it("does not register tx hashes after authoritative updates already cleared pending movement", () => {
@@ -115,7 +178,7 @@ describe("Worldmap pending movement visual handoff wiring", () => {
     const helperStart = source.indexOf("private clearEvictedArmyMovementVisuals(");
     expect(helperStart).toBeGreaterThan(-1);
 
-    const helperEnd = source.indexOf("private clearPendingArmyMovement(", helperStart);
+    const helperEnd = source.indexOf("private handoffPendingArmyMovementToVisualLifecycle(", helperStart);
     const helperBody = source.slice(helperStart, helperEnd);
 
     expect(helperBody).toContain("trackedEffect.cleanup()");

--- a/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.test.ts
@@ -19,6 +19,8 @@ describe("worldmap runtime lifecycle", () => {
     const pendingArmyMovements = new Set<number>([101, 202]);
     const pendingArmyMovementStartedAt = new Map<number, number>([[101, Date.now()]]);
     const pendingArmyMovementFallbackTimeouts = new Map<number, string>([[101, "fallback-timeout"]]);
+    const pendingArmyMovementTargetKeys = new Map<number, string>([[202, "10,11"]]);
+    const pendingArmyMovementAuthoritativeResolutions = new Set<number>([202]);
     const armyStructureOwners = new Map<number, number>([[101, 88]]);
     const pinnedChunkKeys = new Set<string>(["8,8"]);
     const pinnedRenderAreas = new Set<string>(["8,8:render"]);
@@ -39,6 +41,8 @@ describe("worldmap runtime lifecycle", () => {
       pendingArmyMovements,
       pendingArmyMovementStartedAt,
       pendingArmyMovementFallbackTimeouts,
+      pendingArmyMovementTargetKeys,
+      pendingArmyMovementAuthoritativeResolutions,
       armyStructureOwners,
       clearRenderAreaHydrationState: clearRenderAreaHydrationStateSpy,
       pinnedChunkKeys,
@@ -71,6 +75,8 @@ describe("worldmap runtime lifecycle", () => {
     expect(pendingArmyMovements.size).toBe(0);
     expect(pendingArmyMovementStartedAt.size).toBe(0);
     expect(pendingArmyMovementFallbackTimeouts.size).toBe(0);
+    expect(pendingArmyMovementTargetKeys.size).toBe(0);
+    expect(pendingArmyMovementAuthoritativeResolutions.size).toBe(0);
     expect(armyStructureOwners.size).toBe(0);
     expect(pinnedChunkKeys.size).toBe(0);
     expect(pinnedRenderAreas.size).toBe(0);
@@ -100,6 +106,8 @@ describe("worldmap runtime lifecycle", () => {
       pendingArmyMovements: new Set(),
       pendingArmyMovementStartedAt: new Map(),
       pendingArmyMovementFallbackTimeouts: new Map(),
+      pendingArmyMovementTargetKeys: new Map(),
+      pendingArmyMovementAuthoritativeResolutions: new Set(),
       armyStructureOwners: new Map(),
       clearRenderAreaHydrationState: clearRenderAreaHydrationStateSpy,
       pinnedChunkKeys: new Set(),
@@ -154,6 +162,8 @@ describe("worldmap runtime lifecycle", () => {
       pendingArmyMovements: new Set(),
       pendingArmyMovementStartedAt: new Map(),
       pendingArmyMovementFallbackTimeouts: new Map(),
+      pendingArmyMovementTargetKeys: new Map(),
+      pendingArmyMovementAuthoritativeResolutions: new Set(),
       armyStructureOwners: new Map(),
       clearRenderAreaHydrationState: vi.fn(),
       pinnedChunkKeys: new Set(),
@@ -186,6 +196,8 @@ describe("worldmap runtime lifecycle", () => {
       pendingArmyMovements: new Set(),
       pendingArmyMovementStartedAt: new Map(),
       pendingArmyMovementFallbackTimeouts: new Map(),
+      pendingArmyMovementTargetKeys: new Map(),
+      pendingArmyMovementAuthoritativeResolutions: new Set(),
       armyStructureOwners: new Map(),
       suppressedArmies,
       clearRenderAreaHydrationState: vi.fn(),

--- a/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.ts
@@ -9,6 +9,8 @@ interface WorldmapSwitchOffRuntimeStateInput<TEntityId, TTimeout> {
   pendingArmyMovements: Set<TEntityId>;
   pendingArmyMovementStartedAt: Map<TEntityId, number>;
   pendingArmyMovementFallbackTimeouts: Map<TEntityId, TTimeout>;
+  pendingArmyMovementTargetKeys: Map<TEntityId, string>;
+  pendingArmyMovementAuthoritativeResolutions: Set<TEntityId>;
   armyStructureOwners: Map<TEntityId, unknown>;
   suppressedArmies?: Set<TEntityId>;
   clearRenderAreaHydrationState: () => void;
@@ -60,6 +62,8 @@ export const applyWorldmapSwitchOffRuntimeState = <TEntityId, TTimeout>({
   pendingArmyMovements,
   pendingArmyMovementStartedAt,
   pendingArmyMovementFallbackTimeouts,
+  pendingArmyMovementTargetKeys,
+  pendingArmyMovementAuthoritativeResolutions,
   armyStructureOwners,
   suppressedArmies,
   clearRenderAreaHydrationState,
@@ -86,6 +90,8 @@ export const applyWorldmapSwitchOffRuntimeState = <TEntityId, TTimeout>({
   pendingArmyMovementStartedAt.clear();
   pendingArmyMovementFallbackTimeouts.forEach((timeoutId) => clearTimeout(timeoutId));
   pendingArmyMovementFallbackTimeouts.clear();
+  pendingArmyMovementTargetKeys.clear();
+  pendingArmyMovementAuthoritativeResolutions.clear();
   armyStructureOwners.clear();
   suppressedArmies?.clear();
 

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   resolveExploreCompletionPendingClearPlan,
+  resolvePendingMovementAuthoritativeResolutionPlan,
   shouldClearPendingMovementOnAuthoritativePosition,
   shouldCleanupTrackedTravelEffectOnPendingClear,
 } from "./worldmap-travel-effect-policy";
@@ -98,6 +99,32 @@ describe("resolveExploreCompletionPendingClearPlan", () => {
         pendingTargetKey: "2103,2104",
       }),
     ).toBe(false);
+  });
+
+  it("defers pending movement cleanup when the authoritative target arrives during the local tween", () => {
+    expect(
+      resolvePendingMovementAuthoritativeResolutionPlan({
+        authoritativePositionKey: "2103,2104",
+        isMovementInFlight: true,
+        pendingTargetKey: "2103,2104",
+      }),
+    ).toEqual({
+      shouldClearPendingMovement: false,
+      shouldClearAfterVisualCompletion: true,
+    });
+  });
+
+  it("does not defer pending movement cleanup for unrelated authoritative updates", () => {
+    expect(
+      resolvePendingMovementAuthoritativeResolutionPlan({
+        authoritativePositionKey: "2100,2100",
+        isMovementInFlight: true,
+        pendingTargetKey: "2103,2104",
+      }),
+    ).toEqual({
+      shouldClearPendingMovement: false,
+      shouldClearAfterVisualCompletion: false,
+    });
   });
 
   it("cleans up travel effects when authoritative reconciliation clears pending movement", () => {

--- a/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
+++ b/client/apps/game/src/three/scenes/worldmap-travel-effect-policy.ts
@@ -17,6 +17,17 @@ interface ResolveExploreCompletionPendingClearPlanInput {
   pendingArmyMovements: ReadonlySet<ID>;
 }
 
+interface ResolvePendingMovementAuthoritativeResolutionPlanInput {
+  pendingTargetKey?: string;
+  authoritativePositionKey: string;
+  isMovementInFlight: boolean;
+}
+
+interface PendingMovementAuthoritativeResolutionPlan {
+  shouldClearPendingMovement: boolean;
+  shouldClearAfterVisualCompletion: boolean;
+}
+
 /**
  * Exploring can complete without an onchain position change when the revealed tile has a structure.
  * In that case, clear only pending compass effects for the explored tile.
@@ -58,18 +69,38 @@ export function shouldCleanupTrackedTravelEffectOnPendingClear(input: {
   return true;
 }
 
-export function shouldClearPendingMovementOnAuthoritativePosition(input: {
-  pendingTargetKey?: string;
-  authoritativePositionKey: string;
-  isMovementInFlight: boolean;
-}): boolean {
+export function resolvePendingMovementAuthoritativeResolutionPlan(
+  input: ResolvePendingMovementAuthoritativeResolutionPlanInput,
+): PendingMovementAuthoritativeResolutionPlan {
   if (!input.pendingTargetKey) {
-    return false;
+    return {
+      shouldClearPendingMovement: false,
+      shouldClearAfterVisualCompletion: false,
+    };
+  }
+
+  if (input.pendingTargetKey !== input.authoritativePositionKey) {
+    return {
+      shouldClearPendingMovement: false,
+      shouldClearAfterVisualCompletion: false,
+    };
   }
 
   if (input.isMovementInFlight) {
-    return false;
+    return {
+      shouldClearPendingMovement: false,
+      shouldClearAfterVisualCompletion: true,
+    };
   }
 
-  return input.pendingTargetKey === input.authoritativePositionKey;
+  return {
+    shouldClearPendingMovement: true,
+    shouldClearAfterVisualCompletion: false,
+  };
+}
+
+export function shouldClearPendingMovementOnAuthoritativePosition(
+  input: ResolvePendingMovementAuthoritativeResolutionPlanInput,
+): boolean {
+  return resolvePendingMovementAuthoritativeResolutionPlan(input).shouldClearPendingMovement;
 }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -228,7 +228,7 @@ import {
 } from "../managers/arrival-ghost-policy";
 import {
   resolveExploreCompletionPendingClearPlan,
-  shouldClearPendingMovementOnAuthoritativePosition,
+  resolvePendingMovementAuthoritativeResolutionPlan,
   shouldCleanupTrackedTravelEffectOnPendingClear,
   type PendingArmyMovementEffectClearReason,
   type TravelEffectType,
@@ -676,6 +676,7 @@ export default class WorldmapScene extends WarpTravel {
   private pendingArmyMovementFallbackTimeouts: Map<ID, ReturnType<typeof setTimeout>> = new Map();
   private pendingArmyMovementTxMap: Map<string, ID> = new Map();
   private pendingArmyMovementTargetKeys: Map<ID, string> = new Map();
+  private pendingArmyMovementAuthoritativeResolutions: Set<ID> = new Set();
   private pendingArmyMovementVisualLifecycleDisposers: Map<ID, () => void> = new Map();
   // Pre-computed optimistic movement plans keyed by entityId. Planned at submit
   // time in parallel with the tx, applied as soon as the tx hash is submitted
@@ -3089,6 +3090,19 @@ export default class WorldmapScene extends WarpTravel {
     this.arrivalGhostManager.clearArrivalGhost(entityId, "movement_evicted");
   }
 
+  private handoffPendingArmyMovementToVisualLifecycle(entityId: ID): void {
+    this.pendingArmyMovements.delete(entityId);
+
+    const trackedEffect = this.travelEffectsByEntity.get(entityId);
+    if (!trackedEffect) {
+      return;
+    }
+
+    if (shouldCleanupTrackedTravelEffectOnPendingClear({ trackedEffect, reason: "movement_started" })) {
+      trackedEffect.cleanup();
+    }
+  }
+
   private clearPendingArmyMovement(
     entityId: ID,
     reason: PendingArmyMovementEffectClearReason = "cleanup_requested",
@@ -3096,6 +3110,7 @@ export default class WorldmapScene extends WarpTravel {
     this.pendingArmyMovements.delete(entityId);
     this.pendingArmyMovementStartedAt.delete(entityId);
     this.pendingArmyMovementTargetKeys.delete(entityId);
+    this.pendingArmyMovementAuthoritativeResolutions.delete(entityId);
 
     const fallbackTimeout = this.pendingArmyMovementFallbackTimeouts.get(entityId);
     if (fallbackTimeout) {
@@ -3113,14 +3128,18 @@ export default class WorldmapScene extends WarpTravel {
     const entityId = update.entityId;
     const pendingTargetKey = this.pendingArmyMovementTargetKeys.get(entityId);
     const authoritativePositionKey = this.resolveContractHexKey(update.hexCoords);
-    const shouldClearPendingMovement = shouldClearPendingMovementOnAuthoritativePosition({
+    const authoritativeResolutionPlan = resolvePendingMovementAuthoritativeResolutionPlan({
       pendingTargetKey,
       authoritativePositionKey,
       isMovementInFlight:
         this.armyManager.isArmyMoving(entityId) || this.armyManager.isArmyMovingOptimistically(entityId),
     });
 
-    if (!shouldClearPendingMovement) {
+    if (authoritativeResolutionPlan.shouldClearAfterVisualCompletion) {
+      this.pendingArmyMovementAuthoritativeResolutions.add(entityId);
+    }
+
+    if (!authoritativeResolutionPlan.shouldClearPendingMovement) {
       return;
     }
 
@@ -3129,6 +3148,16 @@ export default class WorldmapScene extends WarpTravel {
     useArmyStaminaSourceStore.getState().clearPendingStaminaSource(entityId);
     this.disposePendingMovementVisualLifecycle(entityId);
     this.arrivalGhostManager.clearArrivalGhost(entityId, "arrived");
+  }
+
+  private completePendingArmyMovementAuthoritativeResolution(entityId: ID): void {
+    if (!this.pendingArmyMovementAuthoritativeResolutions.has(entityId)) {
+      return;
+    }
+
+    this.pendingMovementPlans.delete(entityId);
+    this.clearPendingArmyMovement(entityId, "authoritative_reconciled");
+    useArmyStaminaSourceStore.getState().clearPendingStaminaSource(entityId);
   }
 
   private installPendingMovementVisualLifecycle(input: {
@@ -3146,7 +3175,7 @@ export default class WorldmapScene extends WarpTravel {
         source: "worldmap",
         entityId,
       });
-      this.clearPendingArmyMovement(entityId, "movement_started");
+      this.handoffPendingArmyMovementToVisualLifecycle(entityId);
     });
     const disposeMovementComplete = this.armyManager.onMovementComplete(entityId, () => {
       recordArmyMovementLatencyPhase({
@@ -3157,6 +3186,7 @@ export default class WorldmapScene extends WarpTravel {
       if (shouldAnimateArrivalGhostOnCompletion) {
         this.arrivalGhostManager.resolveArrivalGhost(entityId);
       }
+      this.completePendingArmyMovementAuthoritativeResolution(entityId);
       this.disposePendingMovementVisualLifecycle(entityId);
     });
     const disposeAuthoritativeReconcile = this.armyManager.onAuthoritativeReconciliation(entityId, () => {
@@ -3174,6 +3204,7 @@ export default class WorldmapScene extends WarpTravel {
       }
     });
     const disposeMovementVisualCancel = this.armyManager.onMovementVisualCancel(entityId, () => {
+      this.completePendingArmyMovementAuthoritativeResolution(entityId);
       this.clearEvictedArmyMovementVisuals(entityId);
       this.disposePendingMovementVisualLifecycle(entityId);
     });
@@ -3224,7 +3255,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private hasPendingTravelEffectForHex(key: string): boolean {
     for (const [entityId, trackedEffect] of this.travelEffectsByEntity.entries()) {
-      if (trackedEffect.key === key && this.pendingArmyMovements.has(entityId)) {
+      if (trackedEffect.key === key && this.pendingArmyMovementTargetKeys.has(entityId)) {
         return true;
       }
     }
@@ -3489,7 +3520,11 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private isArmyMovementInputLocked(entityId: ID): boolean {
-    return this.pendingArmyMovements.has(entityId) || this.armyManager.hasUnresolvedOptimisticMovement(entityId);
+    return (
+      this.pendingArmyMovements.has(entityId) ||
+      this.pendingArmyMovementAuthoritativeResolutions.has(entityId) ||
+      this.armyManager.hasUnresolvedOptimisticMovement(entityId)
+    );
   }
 
   private hasEligibleArmyForTabCycle(): boolean {
@@ -3507,6 +3542,7 @@ export default class WorldmapScene extends WarpTravel {
     const fallbackTimeout = setTimeout(() => {
       const fallbackPlan = resolvePendingArmyMovementFallbackPlan({
         hasPendingMovement: this.pendingArmyMovements.has(entityId),
+        hasPendingMovementResolution: this.pendingArmyMovementTargetKeys.has(entityId),
         pendingMovementStartedAtMs: this.pendingArmyMovementStartedAt.get(entityId),
         nowMs: Date.now(),
         staleAfterMs: this.authoritativePendingArmyMovementMs,
@@ -4203,6 +4239,8 @@ export default class WorldmapScene extends WarpTravel {
       pendingArmyMovements: this.pendingArmyMovements,
       pendingArmyMovementStartedAt: this.pendingArmyMovementStartedAt,
       pendingArmyMovementFallbackTimeouts: this.pendingArmyMovementFallbackTimeouts,
+      pendingArmyMovementTargetKeys: this.pendingArmyMovementTargetKeys,
+      pendingArmyMovementAuthoritativeResolutions: this.pendingArmyMovementAuthoritativeResolutions,
       armyStructureOwners: this.armyStructureOwners,
       suppressedArmies: this.armyManager.getSuppressedArmiesRef(),
       clearRenderAreaHydrationState: () => clearAllRenderAreaHydrationState(this.renderAreaHydrationState),

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-15",
+    title: "Movement Visual Cleanup",
+    description:
+      "Fixed fast map movement so traveling labels and destination ghosts clear after the unit resolves, even when chunks update quickly.",
+    type: "fix",
+    gameSlug: "eternum",
+  },
+  {
+    date: "2026-05-15",
     title: "Safer Construction",
     description:
       "Building actions now catch more invalid placements before wallet submission and clear pending construction state after failures, reducing rejected builds and rollback cleanup.",


### PR DESCRIPTION
This fixes fast worldmap movement cleanup by keeping pending target and fallback handles alive after local visual handoff, then clearing them when authoritative resolution and visual completion agree. It also keeps movement input locked while that deferred resolution is pending, clears retained state on switch-off, and documents the fix in the latest features feed. Validation: `pnpm run format`, `pnpm run knip`, `pnpm --dir client/apps/game test src/three/scenes/worldmap-army-tab-selection.test.ts src/three/scenes/worldmap-travel-effect-policy.test.ts src/three/scenes/worldmap-runtime-lifecycle.test.ts src/three/scenes/worldmap-pending-movement-input-lock.source.test.ts src/three/scenes/worldmap-pending-movement-visual-handoff.source.test.ts`, and `pnpm --dir client/apps/game test:three:types`.