### PR TITLE
[codex] Default mainnet config launches to sequential

### DIFF
--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -326,10 +326,11 @@ jobs:
             local -n args_ref="${args_name}"
             local resolved_factory_address=""
             local resolved_account_address=""
-            local resolved_execution_mode="${GAME_LAUNCH_EXECUTION_MODE:-batched}"
+            local resolved_execution_mode=""
 
             resolved_factory_address="$(resolve_configured_factory_address)"
             resolved_account_address="$(resolve_configured_account_address)"
+            resolved_execution_mode="$(resolve_config_execution_mode)"
 
             args_ref+=(
               --mode "${resolved_execution_mode}"
@@ -373,6 +374,20 @@ jobs:
             echo "Unable to resolve config sync target from ${GAME_LAUNCH_ENVIRONMENT}" >&2
             exit 1
           fi
+
+          resolve_config_execution_mode() {
+            if [ -n "${GAME_LAUNCH_EXECUTION_MODE:-}" ]; then
+              printf '%s' "${GAME_LAUNCH_EXECUTION_MODE}"
+              return 0
+            fi
+
+            if [ "${GAME_LAUNCH_NETWORK}" = "mainnet" ]; then
+              printf 'sequential'
+              return 0
+            fi
+
+            printf 'batched'
+          }
 
           if [ "${GAME_LAUNCH_KIND}" = "series" ]; then
             if [ -z "${GAME_LAUNCH_SERIES_NAME}" ] || [ -z "${GAME_LAUNCH_SERIES_GAMES_JSON}" ]; then

--- a/config/deployer/clean/README.md
+++ b/config/deployer/clean/README.md
@@ -51,7 +51,7 @@ Optional env or flags:
 - `SINGLE_REALM_MODE=true|false` or `--single-realm-mode true|false`
 - `TWO_PLAYER_MODE=true|false` or `--two-player-mode true|false`
 - `DURATION_SECONDS=<integer>` or `--duration-seconds <integer>`
-- `--mode batched|sequential`
+- `--mode batched|sequential` to override config execution; mainnet defaults to `sequential`, slot defaults to `batched`
 - `--max-actions <integer>` to override the environment default (`slot`: `300`, `mainnet`: `50`)
 - `--skip-indexer`
 - `--skip-lootchest-role-grant`

--- a/config/deployer/clean/cli/launch-request.ts
+++ b/config/deployer/clean/cli/launch-request.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_NAMESPACE,
   DEFAULT_VERSION,
 } from "../constants";
+import { resolveDefaultConfigExecutionMode } from "../config/execution-mode";
 import { resolveDeploymentEnvironment } from "../environment";
 import type { FactoryBlitzRegistrationOverrides, FactoryMapConfigOverrides } from "@bibliothecadao/types";
 import type {
@@ -51,16 +52,22 @@ function resolveOptionalBooleanArg(args: Args, flag: string, envKeys: string[]):
   }
 }
 
-function resolveExecutionMode(value?: string): ExecutionMode {
+function resolveExplicitExecutionMode(value?: string): ExecutionMode | undefined {
   if (!value) {
-    return "batched";
+    return undefined;
   }
-
   if (value === "batched" || value === "sequential") {
     return value;
   }
 
   throw new Error(`Unsupported execution mode "${value}". Expected "batched" or "sequential"`);
+}
+
+function resolveExecutionMode(
+  value: string | undefined,
+  environmentId: LaunchGameRequest["environmentId"],
+): ExecutionMode {
+  return resolveExplicitExecutionMode(value) ?? resolveDefaultConfigExecutionMode(environmentId);
 }
 
 function resolveOptionalNumber(value: string | undefined, label: string): number | undefined {
@@ -445,7 +452,7 @@ function requireRotationLaunchArgs(args: Args): {
   };
 }
 
-function resolveSharedLaunchRequestOptions(args: Args) {
+function resolveSharedLaunchRequestOptions(args: Args, environmentId: LaunchGameRequest["environmentId"]) {
   return {
     rpcUrl: args["rpc-url"] || process.env.RPC_URL || process.env.VITE_PUBLIC_NODE_URL,
     factoryAddress: args["factory-address"] || process.env.FACTORY_ADDRESS,
@@ -477,7 +484,7 @@ function resolveSharedLaunchRequestOptions(args: Args) {
       process.env.VRF_PROVIDER_ADDRESS ||
       process.env.VITE_PUBLIC_VRF_PROVIDER_ADDRESS ||
       "0x0",
-    executionMode: resolveExecutionMode(args.mode),
+    executionMode: resolveExecutionMode(args.mode, environmentId),
     verboseConfigLogs: args["verbose-config-logs"] === "true" || process.env.VERBOSE_CONFIG_LOGS === "true",
     version: args.version || DEFAULT_VERSION,
     waitForFactoryIndexTimeoutMs:
@@ -503,7 +510,7 @@ export function buildLaunchGameRequest(args: Args): LaunchGameRequest {
     environmentId: requiredArgs.environmentId,
     gameName: requiredArgs.gameName,
     startTime: requiredArgs.startTime,
-    ...resolveSharedLaunchRequestOptions(resolvedArgs),
+    ...resolveSharedLaunchRequestOptions(resolvedArgs, requiredArgs.environmentId),
     maxActions: resolveOptionalNumber(resolvedArgs["max-actions"], "max actions") ?? environment.createGame.maxActions,
     seriesName: resolvedArgs["series-name"],
     seriesGameNumber: resolveOptionalNumber(resolvedArgs["series-game-number"], "series game number"),
@@ -521,7 +528,7 @@ export function buildLaunchSeriesRequest(args: Args): LaunchSeriesRequest {
     seriesName: requiredArgs.seriesName,
     games: requiredArgs.games,
     targetGameNames: resolveTargetGameNamesJson(resolvedArgs),
-    ...resolveSharedLaunchRequestOptions(resolvedArgs),
+    ...resolveSharedLaunchRequestOptions(resolvedArgs, requiredArgs.environmentId),
     maxActions: resolveOptionalNumber(resolvedArgs["max-actions"], "max actions") ?? environment.createGame.maxActions,
     autoRetryEnabled:
       resolveOptionalBooleanArg(resolvedArgs, "auto-retry-enabled", ["GAME_LAUNCH_AUTO_RETRY_ENABLED"]) ?? true,
@@ -549,7 +556,7 @@ export function buildLaunchRotationRequest(args: Args): LaunchRotationRequest {
     weeklyCadence: requiredArgs.weeklyCadence,
     targetGameNames: resolveTargetGameNamesJson(resolvedArgs),
     evaluationIntervalMinutes: requiredArgs.evaluationIntervalMinutes,
-    ...resolveSharedLaunchRequestOptions(resolvedArgs),
+    ...resolveSharedLaunchRequestOptions(resolvedArgs, requiredArgs.environmentId),
     maxActions: resolveOptionalNumber(resolvedArgs["max-actions"], "max actions") ?? environment.createGame.maxActions,
     autoRetryEnabled:
       resolveOptionalBooleanArg(resolvedArgs, "auto-retry-enabled", ["GAME_LAUNCH_AUTO_RETRY_ENABLED"]) ?? true,

--- a/config/deployer/clean/config/execution-mode.ts
+++ b/config/deployer/clean/config/execution-mode.ts
@@ -1,0 +1,5 @@
+import type { DeploymentEnvironmentId, ExecutionMode } from "../types";
+
+export function resolveDefaultConfigExecutionMode(environmentId: DeploymentEnvironmentId): ExecutionMode {
+  return environmentId.startsWith("mainnet.") ? "sequential" : "batched";
+}

--- a/config/deployer/clean/launch/runner.ts
+++ b/config/deployer/clean/launch/runner.ts
@@ -3,6 +3,7 @@ import { getGameManifest, getSeasonAddresses, type Chain } from "@contracts";
 import { setTimeout as sleep } from "node:timers/promises";
 import { Account, shortString } from "starknet";
 import { applyDeploymentConfigOverrides, loadEnvironmentConfiguration } from "../config/config-loader";
+import { resolveDefaultConfigExecutionMode } from "../config/execution-mode";
 import { executeConfigSteps } from "../config/executor";
 import { resolveFactoryWorldConfigSteps } from "../config/steps";
 import {
@@ -168,7 +169,7 @@ function createLaunchRuntime(request: LaunchGameRequest, progress: LaunchProgres
     cartridgeApiBase: request.cartridgeApiBase || DEFAULT_CARTRIDGE_API_BASE,
     toriiNamespaces: request.toriiNamespaces || DEFAULT_NAMESPACE,
     vrfProviderAddress: request.vrfProviderAddress || DEFAULT_VRF_PROVIDER_ADDRESS,
-    executionMode: request.executionMode || "batched",
+    executionMode: request.executionMode || resolveDefaultConfigExecutionMode(environment.id),
     version: request.version || DEFAULT_VERSION,
     createGame: resolveCreateGameSettings(request, environment),
   };

--- a/config/deployer/clean/tests/launch-request.test.ts
+++ b/config/deployer/clean/tests/launch-request.test.ts
@@ -83,6 +83,35 @@ describe("launch request helpers", () => {
     ).toBe(300);
   });
 
+  test("defaults mainnet config execution to sequential and keeps slot batched", () => {
+    expect(
+      buildLaunchGameRequest({
+        environment: "mainnet.blitz",
+        game: "bltz-test-1",
+        "start-time": "2026-03-18T10:00:00Z",
+      }).executionMode,
+    ).toBe("sequential");
+
+    expect(
+      buildLaunchGameRequest({
+        environment: "slot.blitz",
+        game: "bltz-test-2",
+        "start-time": "2026-03-18T10:00:00Z",
+      }).executionMode,
+    ).toBe("batched");
+  });
+
+  test("honors an explicit config execution mode on mainnet", () => {
+    expect(
+      buildLaunchGameRequest({
+        environment: "mainnet.blitz",
+        game: "bltz-test-1",
+        "start-time": "2026-03-18T10:00:00Z",
+        mode: "batched",
+      }).executionMode,
+    ).toBe("batched");
+  });
+
   test("resolves supported launch step ids", () => {
     expect(resolveLaunchGameStepId("create-world")).toBe("create-world");
     expect(resolveLaunchGameStepId("configure-world")).toBe("configure-world");
@@ -177,6 +206,7 @@ games:
       launchKind: "rotation",
       environmentId: "mainnet.blitz",
       rotationName: "blitz-rotation",
+      executionMode: "sequential",
       firstGameStartTime: "2026-04-20T01:00:00Z",
       gameIntervalMinutes: 0,
       maxGames: 5200,

--- a/config/deployer/clean/tests/launch-runner.test.ts
+++ b/config/deployer/clean/tests/launch-runner.test.ts
@@ -523,6 +523,7 @@ describe("runLaunchStep mainnet launch steps", () => {
       factoryAddress,
       accountAddress,
       privateKey,
+      executionMode: "batched",
     });
 
     expect(summary.configureTxHash).toBe("0xconfigure");
@@ -561,6 +562,7 @@ describe("runLaunchStep mainnet launch steps", () => {
       factoryAddress,
       accountAddress,
       privateKey,
+      executionMode: "batched",
     });
 
     expect(summary.entryTokenAddress).toBe("0x55587061e1f470c749e9f7e568a3eb8b8d2335ac2c9b5adf8d9669fb378b38");
@@ -680,6 +682,40 @@ describe("runLaunchStep mainnet launch steps", () => {
     ]);
   });
 
+  test("defaults mainnet configure-world to sequential mode", async () => {
+    executeConfigStepsMock.mockImplementationOnce(async ({ mode }: { mode?: string }) => ({
+      mode: mode || "batched",
+      steps: [
+        {
+          id: "world-admin",
+          description: "Set world admin config",
+          transactionHash: "0xworld-admin",
+        },
+      ],
+      transactionHash: undefined,
+      artifacts: {
+        worldConfigTxHash: "0xworld-admin",
+      },
+    }));
+
+    await runLaunchStep({
+      environmentId: "mainnet.blitz",
+      stepId: "configure-world",
+      gameName: "alpha",
+      startTime,
+      rpcUrl: "https://rpc.example",
+      factoryAddress,
+      accountAddress,
+      privateKey,
+    });
+
+    expect(executeConfigStepsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        mode: "sequential",
+      }),
+    );
+  });
+
   test("creates the indexer directly via Slot and stores live torii state", async () => {
     const summary = await runLaunchStep({
       environmentId: "slot.blitz",
@@ -752,6 +788,7 @@ describe("runLaunchStep mainnet launch steps", () => {
         factoryAddress,
         accountAddress,
         privateKey,
+        executionMode: "batched",
       }),
     ).rejects.toThrow("RPC: starknet_addInvokeTransaction failed");
 


### PR DESCRIPTION
## Summary
Mainnet game launches now default configure-world execution to sequential mode while slot launches keep batched config execution.
The workflow, CLI request builder, and direct launch runner share the same default so mainnet avoids oversized multicall fee estimates that can make the RPC return 500s.
Explicit `--mode batched` / `GAME_LAUNCH_EXECUTION_MODE=batched` still overrides the default.

## Validation
Ran `pnpm exec bun test config/deployer/clean/tests/launch-request.test.ts`, `pnpm exec bun test config/deployer/clean/tests/config-executor.test.ts`, `pnpm run format`, and `pnpm run knip`.
