### PR TITLE
[codex] Increase world map Torii subscription area

### DIFF
--- a/client/apps/game/src/three/constants/world-chunk-config.ts
+++ b/client/apps/game/src/three/constants/world-chunk-config.ts
@@ -11,7 +11,7 @@ interface WorldChunkConfig {
   toriiFetch: {
     /**
      * Number of stride chunks per side in a Torii "super-area".
-     * A value of 4 means one fetch covers a 4x4 stride-chunk block.
+     * Larger values reduce subscription churn by keeping bounds stable across more chunk crossings.
      */
     superAreaStrides: number;
   };
@@ -43,7 +43,7 @@ export const WORLD_CHUNK_CONFIG: WorldChunkConfig = {
   switchPadding: 0.05,
   toriiFetch: {
     // Coalesce overlapping render windows into larger stable fetch areas.
-    superAreaStrides: 4,
+    superAreaStrides: 16,
   },
   prefetch: {
     forwardDepthStrides: 2,

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-17",
+    title: "Wider Map Streaming",
+    description:
+      "World map streaming now keeps Torii subscriptions on larger regions, reducing stream swaps and terrain churn while traversing long distances.",
+    type: "improvement",
+    gameSlug: "world",
+  },
+  {
     date: "2026-05-16",
     title: "Building Count Sync",
     description:


### PR DESCRIPTION
## Summary
- Expands the world-map Torii super-area from 4 to 16 stride chunks so bounds stay stable across more traversal.
- Updates the latest-features feed with a player-facing note about wider map streaming.

## Verification
- `pnpm --dir client/apps/game test src/three/scenes/worldmap-chunk-policy.test.ts src/three/scenes/worldmap-chunk-bounds.test.ts`
- `pnpm run format`
- `pnpm run knip`