### PR TITLE
[codex] Reduce world map streaming churn

### DIFF
--- a/client/apps/game/scripts/run-renderer-scene-smoke.mjs
+++ b/client/apps/game/scripts/run-renderer-scene-smoke.mjs
@@ -14,6 +14,11 @@ const DEFAULT_WAIT_MS = 20000;
 const AGENT_BROWSER_RETRY_DELAY_MS = 2000;
 const AGENT_BROWSER_RETRY_ATTEMPTS = 2;
 const DEFAULT_CARTRIDGE_API_BASE = "https://api.cartridge.gg";
+const RETRYABLE_AGENT_BROWSER_FAILURE_PATTERNS = [
+  "CDP command timed out: Runtime.evaluate",
+  "Failed to read: Resource temporarily unavailable",
+  "daemon may be busy or unresponsive",
+];
 const FACTORY_SQL_BASE_URLS = {
   local: [],
   mainnet: [`${DEFAULT_CARTRIDGE_API_BASE}/x/eternum-factory-mainnet/torii/sql`],
@@ -272,8 +277,7 @@ export function isRetryableAgentBrowserFailure({ commandArgs, stderr = "", stdou
     return false;
   }
 
-  const output = `${stderr}\n${stdout}`;
-  return output.includes("CDP command timed out: Runtime.evaluate");
+  return isRetryableAgentBrowserOutput(`${stderr}\n${stdout}`);
 }
 
 function isRetryableAgentBrowserCommand(commandArgs) {
@@ -282,6 +286,10 @@ function isRetryableAgentBrowserCommand(commandArgs) {
   }
 
   return commandArgs[0] === "get" && ["count", "url"].includes(commandArgs[1]);
+}
+
+function isRetryableAgentBrowserOutput(output) {
+  return RETRYABLE_AGENT_BROWSER_FAILURE_PATTERNS.some((pattern) => output.includes(pattern));
 }
 
 async function runAgentBrowserWithRetries(

--- a/client/apps/game/scripts/run-renderer-scene-smoke.test.mjs
+++ b/client/apps/game/scripts/run-renderer-scene-smoke.test.mjs
@@ -149,6 +149,25 @@ describe("isRetryableAgentBrowserFailure", () => {
     ).toBe(true);
   });
 
+  it("retries transient agent-browser daemon read failures for read-only commands", () => {
+    expect(
+      isRetryableAgentBrowserFailure({
+        commandArgs: ["eval", "JSON.stringify(window.__rendererDiagnostics ?? null)"],
+        stderr:
+          "Error: ✗ Failed to read: Resource temporarily unavailable (os error 11) (after 5 retries - daemon may be busy or unresponsive)",
+        stdout: "",
+      }),
+    ).toBe(true);
+    expect(
+      isRetryableAgentBrowserFailure({
+        commandArgs: ["get", "count", "text=Unable to Start"],
+        stderr:
+          "Error: ✗ Failed to read: Resource temporarily unavailable (os error 11) (after 5 retries - daemon may be busy or unresponsive)",
+        stdout: "",
+      }),
+    ).toBe(true);
+  });
+
   it("does not retry commands that can change browser state", () => {
     expect(
       isRetryableAgentBrowserFailure({

--- a/client/apps/game/src/three/constants/world-chunk-config.ts
+++ b/client/apps/game/src/three/constants/world-chunk-config.ts
@@ -7,11 +7,19 @@ interface WorldChunkConfig {
   pinRadius: number;
   /** Boundary padding for delaying chunk switches */
   switchPadding: number;
-  /** Torii tile fetch coalescing */
+  /** Exact Torii SQL fetch coalescing */
   toriiFetch: {
     /**
-     * Number of stride chunks per side in a Torii "super-area".
-     * Larger values reduce subscription churn by keeping bounds stable across more chunk crossings.
+     * Number of stride chunks per side in a hydration "super-area".
+     * Larger values reduce repeated SQL hydration across neighboring render windows.
+     */
+    superAreaStrides: number;
+  };
+  /** Live Torii subscription bounds coalescing */
+  toriiSubscription: {
+    /**
+     * Number of stride chunks per side in a subscription "super-area".
+     * This can be larger than hydration fetch areas to reduce live stream churn.
      */
     superAreaStrides: number;
   };
@@ -21,10 +29,16 @@ interface WorldChunkConfig {
     forwardDepthStrides: number;
     /** How many stride steps to each side to prefetch */
     sideRadiusStrides: number;
+    /** How close to a hydration super-area edge before warming the next area */
+    areaBoundaryLookaheadStrides: number;
     /** Max remembered prefetched chunk keys */
     maxAhead: number;
     /** Max concurrent background prefetches */
     maxConcurrent: number;
+  };
+  /** Recently hydrated areas to keep warm after leaving the pinned neighborhood */
+  recentHydrationCache: {
+    maxAreas: number;
   };
 }
 
@@ -45,10 +59,18 @@ export const WORLD_CHUNK_CONFIG: WorldChunkConfig = {
     // Coalesce overlapping render windows into larger stable fetch areas.
     superAreaStrides: 16,
   },
+  toriiSubscription: {
+    // Keep live spatial stream bounds stable across multiple fetch areas.
+    superAreaStrides: 32,
+  },
   prefetch: {
     forwardDepthStrides: 2,
     sideRadiusStrides: 1,
+    areaBoundaryLookaheadStrides: 3,
     maxAhead: 8,
-    maxConcurrent: 3,
+    maxConcurrent: 1,
+  },
+  recentHydrationCache: {
+    maxAreas: 8,
   },
 };

--- a/client/apps/game/src/three/constants/world-chunk-config.ts
+++ b/client/apps/game/src/three/constants/world-chunk-config.ts
@@ -71,6 +71,6 @@ export const WORLD_CHUNK_CONFIG: WorldChunkConfig = {
     maxConcurrent: 1,
   },
   recentHydrationCache: {
-    maxAreas: 8,
+    maxAreas: 32,
   },
 };

--- a/client/apps/game/src/three/constants/world-chunk-config.ts
+++ b/client/apps/game/src/three/constants/world-chunk-config.ts
@@ -61,7 +61,7 @@ export const WORLD_CHUNK_CONFIG: WorldChunkConfig = {
   },
   toriiSubscription: {
     // Keep live spatial stream bounds stable across multiple fetch areas.
-    superAreaStrides: 32,
+    superAreaStrides: 48,
   },
   prefetch: {
     forwardDepthStrides: 2,
@@ -71,6 +71,6 @@ export const WORLD_CHUNK_CONFIG: WorldChunkConfig = {
     maxConcurrent: 1,
   },
   recentHydrationCache: {
-    maxAreas: 32,
+    maxAreas: 48,
   },
 };

--- a/client/apps/game/src/three/scenes/warp-travel-directional-prefetch.test.ts
+++ b/client/apps/game/src/three/scenes/warp-travel-directional-prefetch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { getRenderAreaKeyForChunk } from "./worldmap-chunk-bounds";
 import { resolveWarpTravelDirectionalPrefetchPlan } from "./warp-travel-directional-prefetch";
 
 describe("resolveWarpTravelDirectionalPrefetchPlan", () => {
@@ -92,5 +93,29 @@ describe("resolveWarpTravelDirectionalPrefetchPlan", () => {
     });
 
     expect(result.presentationChunkKeysToPrewarm).toEqual(["48,24", "72,24", "96,24"]);
+  });
+
+  it("queues the next hydration area before crossing a super-area boundary", () => {
+    const result = resolveWarpTravelDirectionalPrefetchPlan({
+      anchor: {
+        forwardChunkKey: "0,336",
+        movementAxis: "x",
+        movementSign: 1,
+      },
+      chunkSize: 24,
+      forwardDepthStrides: 1,
+      sideRadiusStrides: 0,
+      areaBoundaryLookaheadStrides: 3,
+      fetchSuperAreaStrides: 16,
+      pinnedChunkKeys: new Set(["0,336", "0,360"]),
+      currentChunk: "0,288",
+      prefetchedAhead: [],
+      maxPrefetchedAhead: 4,
+      getRenderAreaKeyForChunk: (chunkKey) => getRenderAreaKeyForChunk(chunkKey, 24, 16),
+    });
+
+    expect(result.desiredAreaKeys).toEqual(["0,384"]);
+    expect(result.chunkKeysToEnqueue).toEqual(["0,384"]);
+    expect(result.nextPrefetchedAhead).toEqual(["0,384"]);
   });
 });

--- a/client/apps/game/src/three/scenes/warp-travel-directional-prefetch.ts
+++ b/client/apps/game/src/three/scenes/warp-travel-directional-prefetch.ts
@@ -11,6 +11,8 @@ interface ResolveWarpTravelDirectionalPrefetchPlanInput {
   chunkSize: number;
   forwardDepthStrides: number;
   sideRadiusStrides: number;
+  areaBoundaryLookaheadStrides?: number;
+  fetchSuperAreaStrides?: number;
   pinnedChunkKeys: Set<string>;
   currentChunk: string;
   prefetchedAhead: string[];
@@ -21,6 +23,58 @@ interface ResolveWarpTravelDirectionalPrefetchPlanInput {
 function parseChunkKey(chunkKey: string): { row: number; col: number } {
   const [row, col] = chunkKey.split(",").map(Number);
   return { row, col };
+}
+
+function resolveBoundaryPrefetchChunkKey(input: ResolveWarpTravelDirectionalPrefetchPlanInput): string | null {
+  const { anchor, areaBoundaryLookaheadStrides, chunkSize, currentChunk, fetchSuperAreaStrides } = input;
+  if (!anchor || !areaBoundaryLookaheadStrides || !fetchSuperAreaStrides) {
+    return null;
+  }
+
+  const { row, col } = parseChunkKey(currentChunk);
+  const strideIndex = anchor.movementAxis === "x" ? col / chunkSize : row / chunkSize;
+  if (!Number.isFinite(strideIndex)) {
+    return null;
+  }
+
+  const areaStartIndex = Math.floor(strideIndex / fetchSuperAreaStrides) * fetchSuperAreaStrides;
+  const distanceToBoundary =
+    anchor.movementSign > 0 ? areaStartIndex + fetchSuperAreaStrides - 1 - strideIndex : strideIndex - areaStartIndex;
+
+  if (distanceToBoundary > areaBoundaryLookaheadStrides) {
+    return null;
+  }
+
+  const boundaryStrideIndex =
+    anchor.movementSign > 0 ? areaStartIndex + fetchSuperAreaStrides : areaStartIndex - fetchSuperAreaStrides;
+  const boundaryRow = anchor.movementAxis === "z" ? boundaryStrideIndex * chunkSize : row;
+  const boundaryCol = anchor.movementAxis === "x" ? boundaryStrideIndex * chunkSize : col;
+  return `${boundaryRow},${boundaryCol}`;
+}
+
+function appendFetchPrefetchTarget(
+  chunkKey: string,
+  input: ResolveWarpTravelDirectionalPrefetchPlanInput,
+  output: {
+    chunkKeysToEnqueue: string[];
+    desiredAreaKeys: string[];
+    nextPrefetchedAhead: string[];
+  },
+): void {
+  if (input.pinnedChunkKeys.has(chunkKey) || chunkKey === input.currentChunk) {
+    return;
+  }
+
+  output.desiredAreaKeys.push(input.getRenderAreaKeyForChunk(chunkKey));
+  if (output.nextPrefetchedAhead.includes(chunkKey)) {
+    return;
+  }
+
+  output.nextPrefetchedAhead.push(chunkKey);
+  while (output.nextPrefetchedAhead.length > input.maxPrefetchedAhead) {
+    output.nextPrefetchedAhead.shift();
+  }
+  output.chunkKeysToEnqueue.push(chunkKey);
 }
 
 export function resolveWarpTravelDirectionalPrefetchPlan(input: ResolveWarpTravelDirectionalPrefetchPlanInput): {
@@ -69,21 +123,21 @@ export function resolveWarpTravelDirectionalPrefetchPlan(input: ResolveWarpTrave
   }
 
   prefetchTargets.forEach((chunkKey) => {
-    if (input.pinnedChunkKeys.has(chunkKey) || chunkKey === input.currentChunk) {
-      return;
-    }
-
-    desiredAreaKeys.push(input.getRenderAreaKeyForChunk(chunkKey));
-    if (nextPrefetchedAhead.includes(chunkKey)) {
-      return;
-    }
-
-    nextPrefetchedAhead.push(chunkKey);
-    while (nextPrefetchedAhead.length > input.maxPrefetchedAhead) {
-      nextPrefetchedAhead.shift();
-    }
-    chunkKeysToEnqueue.push(chunkKey);
+    appendFetchPrefetchTarget(chunkKey, input, {
+      chunkKeysToEnqueue,
+      desiredAreaKeys,
+      nextPrefetchedAhead,
+    });
   });
+
+  const boundaryPrefetchChunkKey = resolveBoundaryPrefetchChunkKey(input);
+  if (boundaryPrefetchChunkKey && !prefetchTargets.includes(boundaryPrefetchChunkKey)) {
+    appendFetchPrefetchTarget(boundaryPrefetchChunkKey, input, {
+      chunkKeysToEnqueue,
+      desiredAreaKeys,
+      nextPrefetchedAhead,
+    });
+  }
 
   return {
     desiredAreaKeys,

--- a/client/apps/game/src/three/scenes/worldmap-chunk-bounds.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-bounds.test.ts
@@ -4,6 +4,7 @@ import {
   getRenderAreaKeyForChunk,
   getRenderFetchBoundsForArea,
   getRenderFetchBoundsForChunk,
+  resolveToriiSubscriptionSwitchDecision,
 } from "./worldmap-chunk-bounds";
 
 describe("getRenderFetchBoundsForChunk", () => {
@@ -88,6 +89,65 @@ describe("getRenderFetchBoundsForArea", () => {
     })();
 
     expect(getRenderFetchBoundsForArea(areaKey, renderSize, chunkSize, superAreaStrides)).toEqual(expected);
+  });
+});
+
+describe("resolveToriiSubscriptionSwitchDecision", () => {
+  type ChunkBounds = { minCol: number; maxCol: number; minRow: number; maxRow: number };
+
+  const subscriptionBounds = new Map<string, ChunkBounds>([
+    ["0,0", { minCol: 0, maxCol: 100, minRow: 0, maxRow: 100 }],
+    ["100,0", { minCol: 100, maxCol: 200, minRow: 0, maxRow: 100 }],
+  ]);
+
+  const renderAreaBounds = new Map<string, ChunkBounds>([
+    ["area-current", { minCol: 20, maxCol: 40, minRow: 20, maxRow: 40 }],
+    ["area-prefetch", { minCol: 70, maxCol: 90, minRow: 20, maxRow: 40 }],
+    ["area-outside", { minCol: 120, maxCol: 140, minRow: 20, maxRow: 40 }],
+  ]);
+
+  const getSubscriptionBoundsForArea = (areaKey: string): ChunkBounds => {
+    const bounds = subscriptionBounds.get(areaKey);
+    if (!bounds) throw new Error(`Missing subscription bounds for ${areaKey}`);
+    return bounds;
+  };
+
+  const getRenderAreaBounds = (areaKey: string): ChunkBounds => {
+    const bounds = renderAreaBounds.get(areaKey);
+    if (!bounds) throw new Error(`Missing render bounds for ${areaKey}`);
+    return bounds;
+  };
+
+  it("keeps the current live subscription while it covers useful render areas", () => {
+    expect(
+      resolveToriiSubscriptionSwitchDecision({
+        currentSubscriptionAreaKey: "0,0",
+        requestedSubscriptionAreaKey: "100,0",
+        requiredRenderAreaKeys: ["area-current", "area-prefetch"],
+        getSubscriptionBoundsForArea,
+        getRenderAreaBounds,
+      }),
+    ).toEqual({
+      action: "keep_current",
+      areaKey: "0,0",
+      reason: "covered_by_current_subscription",
+    });
+  });
+
+  it("switches when any useful render area leaves the current live subscription", () => {
+    expect(
+      resolveToriiSubscriptionSwitchDecision({
+        currentSubscriptionAreaKey: "0,0",
+        requestedSubscriptionAreaKey: "100,0",
+        requiredRenderAreaKeys: ["area-current", "area-outside"],
+        getSubscriptionBoundsForArea,
+        getRenderAreaBounds,
+      }),
+    ).toEqual({
+      action: "switch",
+      areaKey: "100,0",
+      reason: "useful_area_outside_current_subscription",
+    });
   });
 });
 

--- a/client/apps/game/src/three/scenes/worldmap-chunk-bounds.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-bounds.ts
@@ -12,6 +12,26 @@ interface ChunkBounds {
   maxRow: number;
 }
 
+interface ToriiSubscriptionSwitchDecisionInput {
+  currentSubscriptionAreaKey: string | null;
+  requestedSubscriptionAreaKey: string;
+  requiredRenderAreaKeys: readonly string[];
+  getSubscriptionBoundsForArea: (areaKey: string) => ChunkBounds;
+  getRenderAreaBounds: (areaKey: string) => ChunkBounds;
+}
+
+type ToriiSubscriptionSwitchDecision =
+  | {
+      action: "keep_current";
+      areaKey: string;
+      reason: "covered_by_current_subscription" | "same_subscription_area";
+    }
+  | {
+      action: "switch";
+      areaKey: string;
+      reason: "no_current_subscription" | "useful_area_outside_current_subscription";
+    };
+
 function parseChunkKey(chunkKey: string): { startRow: number; startCol: number } {
   const segments = chunkKey.split(",");
   if (segments.length !== 2) {
@@ -69,5 +89,69 @@ export function getRenderFetchBoundsForArea(
     maxCol: lastBounds.maxCol,
     minRow: firstBounds.minRow,
     maxRow: lastBounds.maxRow,
+  };
+}
+
+function containsChunkBounds(outerBounds: ChunkBounds, innerBounds: ChunkBounds): boolean {
+  return (
+    innerBounds.minCol >= outerBounds.minCol &&
+    innerBounds.maxCol <= outerBounds.maxCol &&
+    innerBounds.minRow >= outerBounds.minRow &&
+    innerBounds.maxRow <= outerBounds.maxRow
+  );
+}
+
+function coversEveryRenderArea(
+  subscriptionBounds: ChunkBounds,
+  areaKeys: readonly string[],
+  getRenderAreaBounds: (areaKey: string) => ChunkBounds,
+): boolean {
+  return (
+    areaKeys.length > 0 &&
+    areaKeys.every((areaKey) => containsChunkBounds(subscriptionBounds, getRenderAreaBounds(areaKey)))
+  );
+}
+
+export function resolveToriiSubscriptionSwitchDecision({
+  currentSubscriptionAreaKey,
+  getRenderAreaBounds,
+  getSubscriptionBoundsForArea,
+  requestedSubscriptionAreaKey,
+  requiredRenderAreaKeys,
+}: ToriiSubscriptionSwitchDecisionInput): ToriiSubscriptionSwitchDecision {
+  if (!currentSubscriptionAreaKey) {
+    return {
+      action: "switch",
+      areaKey: requestedSubscriptionAreaKey,
+      reason: "no_current_subscription",
+    };
+  }
+
+  if (currentSubscriptionAreaKey === requestedSubscriptionAreaKey) {
+    return {
+      action: "keep_current",
+      areaKey: currentSubscriptionAreaKey,
+      reason: "same_subscription_area",
+    };
+  }
+
+  if (
+    coversEveryRenderArea(
+      getSubscriptionBoundsForArea(currentSubscriptionAreaKey),
+      requiredRenderAreaKeys,
+      getRenderAreaBounds,
+    )
+  ) {
+    return {
+      action: "keep_current",
+      areaKey: currentSubscriptionAreaKey,
+      reason: "covered_by_current_subscription",
+    };
+  }
+
+  return {
+    action: "switch",
+    areaKey: requestedSubscriptionAreaKey,
+    reason: "useful_area_outside_current_subscription",
   };
 }

--- a/client/apps/game/src/three/scenes/worldmap-chunk-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-policy.test.ts
@@ -19,13 +19,13 @@ describe("createWorldmapChunkPolicy", () => {
     const policy = createWorldmapChunkPolicy(WORLD_CHUNK_CONFIG);
 
     expect(policy).toHaveProperty("toriiFetch.superAreaStrides", WORLD_CHUNK_CONFIG.toriiFetch.superAreaStrides);
-    expect(policy).toHaveProperty("toriiSubscription.superAreaStrides", 32);
+    expect(policy).toHaveProperty("toriiSubscription.superAreaStrides", 48);
     expect(policy.toriiSubscription.superAreaStrides).toBeGreaterThan(policy.toriiFetch.superAreaStrides);
     expect(policy).toHaveProperty("prefetch.forwardDepthStrides", WORLD_CHUNK_CONFIG.prefetch.forwardDepthStrides);
     expect(policy).toHaveProperty("prefetch.sideRadiusStrides", WORLD_CHUNK_CONFIG.prefetch.sideRadiusStrides);
     expect(policy).toHaveProperty("prefetch.areaBoundaryLookaheadStrides", 3);
     expect(policy).toHaveProperty("prefetch.maxConcurrent", WORLD_CHUNK_CONFIG.prefetch.maxConcurrent);
-    expect(policy).toHaveProperty("recentHydrationCache.maxAreas", 32);
+    expect(policy).toHaveProperty("recentHydrationCache.maxAreas", 48);
   });
 
   it("derives pinned neighborhood floor metadata for cache budgeting", () => {

--- a/client/apps/game/src/three/scenes/worldmap-chunk-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-policy.test.ts
@@ -25,7 +25,7 @@ describe("createWorldmapChunkPolicy", () => {
     expect(policy).toHaveProperty("prefetch.sideRadiusStrides", WORLD_CHUNK_CONFIG.prefetch.sideRadiusStrides);
     expect(policy).toHaveProperty("prefetch.areaBoundaryLookaheadStrides", 3);
     expect(policy).toHaveProperty("prefetch.maxConcurrent", WORLD_CHUNK_CONFIG.prefetch.maxConcurrent);
-    expect(policy).toHaveProperty("recentHydrationCache.maxAreas", 8);
+    expect(policy).toHaveProperty("recentHydrationCache.maxAreas", 32);
   });
 
   it("derives pinned neighborhood floor metadata for cache budgeting", () => {

--- a/client/apps/game/src/three/scenes/worldmap-chunk-policy.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-policy.test.ts
@@ -19,9 +19,13 @@ describe("createWorldmapChunkPolicy", () => {
     const policy = createWorldmapChunkPolicy(WORLD_CHUNK_CONFIG);
 
     expect(policy).toHaveProperty("toriiFetch.superAreaStrides", WORLD_CHUNK_CONFIG.toriiFetch.superAreaStrides);
+    expect(policy).toHaveProperty("toriiSubscription.superAreaStrides", 32);
+    expect(policy.toriiSubscription.superAreaStrides).toBeGreaterThan(policy.toriiFetch.superAreaStrides);
     expect(policy).toHaveProperty("prefetch.forwardDepthStrides", WORLD_CHUNK_CONFIG.prefetch.forwardDepthStrides);
     expect(policy).toHaveProperty("prefetch.sideRadiusStrides", WORLD_CHUNK_CONFIG.prefetch.sideRadiusStrides);
+    expect(policy).toHaveProperty("prefetch.areaBoundaryLookaheadStrides", 3);
     expect(policy).toHaveProperty("prefetch.maxConcurrent", WORLD_CHUNK_CONFIG.prefetch.maxConcurrent);
+    expect(policy).toHaveProperty("recentHydrationCache.maxAreas", 8);
   });
 
   it("derives pinned neighborhood floor metadata for cache budgeting", () => {

--- a/client/apps/game/src/three/scenes/worldmap-chunk-policy.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-policy.ts
@@ -7,6 +7,9 @@ interface WorldmapChunkPolicy {
   toriiFetch: {
     superAreaStrides: number;
   };
+  toriiSubscription: {
+    superAreaStrides: number;
+  };
   pin: {
     rowsAhead: number;
     rowsBehind: number;
@@ -15,8 +18,12 @@ interface WorldmapChunkPolicy {
   prefetch: {
     forwardDepthStrides: number;
     sideRadiusStrides: number;
+    areaBoundaryLookaheadStrides: number;
     maxAhead: number;
     maxConcurrent: number;
+  };
+  recentHydrationCache: {
+    maxAreas: number;
   };
   cache: {
     pinnedChunkFloor: number;
@@ -33,11 +40,18 @@ interface WorldChunkPolicyInput {
   toriiFetch: {
     superAreaStrides: number;
   };
+  toriiSubscription: {
+    superAreaStrides: number;
+  };
   prefetch: {
     forwardDepthStrides: number;
     sideRadiusStrides: number;
+    areaBoundaryLookaheadStrides: number;
     maxAhead: number;
     maxConcurrent: number;
+  };
+  recentHydrationCache: {
+    maxAreas: number;
   };
 }
 
@@ -52,6 +66,9 @@ export function createWorldmapChunkPolicy(config: WorldChunkPolicyInput = WORLD_
     toriiFetch: {
       superAreaStrides: config.toriiFetch.superAreaStrides,
     },
+    toriiSubscription: {
+      superAreaStrides: config.toriiSubscription.superAreaStrides,
+    },
     pin: {
       rowsAhead: config.pinRadius,
       rowsBehind: config.pinRadius,
@@ -60,8 +77,12 @@ export function createWorldmapChunkPolicy(config: WorldChunkPolicyInput = WORLD_
     prefetch: {
       forwardDepthStrides: config.prefetch.forwardDepthStrides,
       sideRadiusStrides: config.prefetch.sideRadiusStrides,
+      areaBoundaryLookaheadStrides: config.prefetch.areaBoundaryLookaheadStrides,
       maxAhead: config.prefetch.maxAhead,
       maxConcurrent: config.prefetch.maxConcurrent,
+    },
+    recentHydrationCache: {
+      maxAreas: config.recentHydrationCache.maxAreas,
     },
     cache: {
       pinnedChunkFloor,

--- a/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.test.ts
@@ -10,6 +10,8 @@ import {
   isRenderAreaHydrationComplete,
   markRenderAreaHydrationStagesComplete,
   registerPendingRenderAreaHydration,
+  retainRenderAreaHydrationStages,
+  resolveFetchResultRetainedAreaKeys,
   resolveRecentRenderAreaRetention,
   type WorldmapRenderAreaHydrationStage,
 } from "./worldmap-render-area-hydration-state";
@@ -82,7 +84,51 @@ describe("worldmap render area hydration state", () => {
       }),
     ).toEqual({
       areaKeysToClear: ["area-a"],
+      areaKeysToRetainTerrainOnly: [],
       nextRetainedAreaKeys: ["area-b", "area-c"],
     });
+  });
+
+  it("downgrades retained areas to terrain-only once they leave active subscription coverage", () => {
+    expect(
+      resolveRecentRenderAreaRetention({
+        maxRetainedAreas: 8,
+        protectedAreaKeys: new Set(["area-pinned"]),
+        recentlyUnpinnedAreaKeys: [],
+        retainedAreaKeys: ["area-live", "area-stale", "area-pinned"],
+        isAreaCoveredByActiveSubscription: (areaKey) => areaKey === "area-live",
+      }),
+    ).toEqual({
+      areaKeysToClear: [],
+      areaKeysToRetainTerrainOnly: ["area-stale"],
+      nextRetainedAreaKeys: ["area-live", "area-stale"],
+    });
+  });
+
+  it("can keep terrain hydration while clearing dynamic stage ownership", () => {
+    const state = createWorldmapRenderAreaHydrationState();
+    const dynamicFetch = Promise.resolve(true);
+
+    markRenderAreaHydrationStagesComplete(state, "area-a", ACTIVE_STAGES);
+    registerPendingRenderAreaHydration(state, "area-a", ["explorerTroops", "structures"], dynamicFetch);
+    retainRenderAreaHydrationStages(state, "area-a", ["tileOpt"]);
+
+    expect(isRenderAreaHydrationComplete(state, "area-a", ["tileOpt"])).toBe(true);
+    expect(isRenderAreaHydrationComplete(state, "area-a", PREFETCH_STAGES)).toBe(false);
+    expect(isRenderAreaHydrationComplete(state, "area-a", ACTIVE_STAGES)).toBe(false);
+    expect(getPendingRenderAreaHydrationPromise(state, "area-a", ["explorerTroops", "structures"])).toBe(null);
+  });
+
+  it("excludes terrain-only retained areas from late dynamic fetch result ownership", () => {
+    expect(
+      Array.from(
+        resolveFetchResultRetainedAreaKeys({
+          pinnedAreaKeys: new Set(["area-pinned"]),
+          directionalPrefetchAreaKeys: new Set(["area-prefetch"]),
+          retainedAreaKeys: ["area-live", "area-terrain-only"],
+          isRetainedAreaCoveredByActiveSubscription: (areaKey) => areaKey === "area-live",
+        }),
+      ),
+    ).toEqual(["area-pinned", "area-prefetch", "area-live"]);
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.test.ts
@@ -10,6 +10,7 @@ import {
   isRenderAreaHydrationComplete,
   markRenderAreaHydrationStagesComplete,
   registerPendingRenderAreaHydration,
+  resolveRecentRenderAreaRetention,
   type WorldmapRenderAreaHydrationStage,
 } from "./worldmap-render-area-hydration-state";
 
@@ -69,5 +70,19 @@ describe("worldmap render area hydration state", () => {
 
     expect(isRenderAreaHydrationComplete(state, "area-a", ["tileOpt"])).toBe(false);
     expect(getPendingRenderAreaHydrationPromise(state, "area-a", ["structures"])).toBe(pendingFetch);
+  });
+
+  it("retains recently unpinned completed areas until the retention budget is exceeded", () => {
+    expect(
+      resolveRecentRenderAreaRetention({
+        maxRetainedAreas: 2,
+        protectedAreaKeys: new Set(["area-live"]),
+        recentlyUnpinnedAreaKeys: ["area-c"],
+        retainedAreaKeys: ["area-a", "area-b", "area-live"],
+      }),
+    ).toEqual({
+      areaKeysToClear: ["area-a"],
+      nextRetainedAreaKeys: ["area-b", "area-c"],
+    });
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.ts
+++ b/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.ts
@@ -10,11 +10,20 @@ interface RecentRenderAreaRetentionInput {
   recentlyUnpinnedAreaKeys: readonly string[];
   protectedAreaKeys: ReadonlySet<string>;
   maxRetainedAreas: number;
+  isAreaCoveredByActiveSubscription?: (areaKey: string) => boolean;
 }
 
 interface RecentRenderAreaRetentionResult {
   nextRetainedAreaKeys: string[];
   areaKeysToClear: string[];
+  areaKeysToRetainTerrainOnly: string[];
+}
+
+interface FetchResultRetainedAreaKeysInput {
+  pinnedAreaKeys: ReadonlySet<string>;
+  directionalPrefetchAreaKeys: ReadonlySet<string>;
+  retainedAreaKeys: readonly string[];
+  isRetainedAreaCoveredByActiveSubscription?: (areaKey: string) => boolean;
 }
 
 export const WORLDMAP_PREFETCH_HYDRATION_STAGES: readonly WorldmapRenderAreaHydrationStage[] = [
@@ -173,44 +182,114 @@ export function clearAllRenderAreaHydrationState(state: WorldmapRenderAreaHydrat
   state.pendingStages.clear();
 }
 
+export function retainRenderAreaHydrationStages(
+  state: WorldmapRenderAreaHydrationState,
+  areaKey: string,
+  stagesToRetain: readonly WorldmapRenderAreaHydrationStage[],
+): void {
+  const retainedStages = new Set(stagesToRetain);
+  const completedStages = state.completedStages.get(areaKey);
+  if (completedStages) {
+    completedStages.forEach((stage) => {
+      if (!retainedStages.has(stage)) {
+        completedStages.delete(stage);
+      }
+    });
+    if (completedStages.size === 0) {
+      state.completedStages.delete(areaKey);
+    }
+  }
+
+  const pendingStages = state.pendingStages.get(areaKey);
+  if (pendingStages) {
+    pendingStages.forEach((_, stage) => {
+      if (!retainedStages.has(stage)) {
+        pendingStages.delete(stage);
+      }
+    });
+    if (pendingStages.size === 0) {
+      state.pendingStages.delete(areaKey);
+    }
+  }
+}
+
+function addUniqueAreaKey(areaKeys: string[], areaKey: string): void {
+  if (!areaKeys.includes(areaKey)) {
+    areaKeys.push(areaKey);
+  }
+}
+
+function removeAreaKey(areaKeys: string[], areaKey: string): void {
+  const existingIndex = areaKeys.indexOf(areaKey);
+  if (existingIndex >= 0) {
+    areaKeys.splice(existingIndex, 1);
+  }
+}
+
 export function resolveRecentRenderAreaRetention({
   maxRetainedAreas,
   protectedAreaKeys,
   recentlyUnpinnedAreaKeys,
   retainedAreaKeys,
+  isAreaCoveredByActiveSubscription,
 }: RecentRenderAreaRetentionInput): RecentRenderAreaRetentionResult {
   const areaKeysToClear: string[] = [];
+  const areaKeysToRetainTerrainOnly: string[] = [];
   const nextRetainedAreaKeys: string[] = [];
 
-  retainedAreaKeys.forEach((areaKey) => {
-    if (!protectedAreaKeys.has(areaKey) && !nextRetainedAreaKeys.includes(areaKey)) {
-      nextRetainedAreaKeys.push(areaKey);
-    }
-  });
-
-  recentlyUnpinnedAreaKeys.forEach((areaKey) => {
+  const retainAreaKey = (areaKey: string, shouldRefreshRecency: boolean): void => {
     if (protectedAreaKeys.has(areaKey)) {
       return;
     }
 
-    const existingIndex = nextRetainedAreaKeys.indexOf(areaKey);
-    if (existingIndex >= 0) {
-      nextRetainedAreaKeys.splice(existingIndex, 1);
+    if (shouldRefreshRecency) {
+      removeAreaKey(nextRetainedAreaKeys, areaKey);
     }
-    nextRetainedAreaKeys.push(areaKey);
+
+    if (isAreaCoveredByActiveSubscription && !isAreaCoveredByActiveSubscription(areaKey)) {
+      addUniqueAreaKey(areaKeysToRetainTerrainOnly, areaKey);
+    }
+
+    addUniqueAreaKey(nextRetainedAreaKeys, areaKey);
+  };
+
+  retainedAreaKeys.forEach((areaKey) => {
+    retainAreaKey(areaKey, false);
+  });
+
+  recentlyUnpinnedAreaKeys.forEach((areaKey) => {
+    retainAreaKey(areaKey, true);
   });
 
   while (nextRetainedAreaKeys.length > Math.max(0, maxRetainedAreas)) {
     const evictedAreaKey = nextRetainedAreaKeys.shift();
     if (evictedAreaKey) {
+      removeAreaKey(areaKeysToRetainTerrainOnly, evictedAreaKey);
       areaKeysToClear.push(evictedAreaKey);
     }
   }
 
   return {
     areaKeysToClear,
+    areaKeysToRetainTerrainOnly,
     nextRetainedAreaKeys,
   };
+}
+
+export function resolveFetchResultRetainedAreaKeys({
+  directionalPrefetchAreaKeys,
+  isRetainedAreaCoveredByActiveSubscription,
+  pinnedAreaKeys,
+  retainedAreaKeys,
+}: FetchResultRetainedAreaKeysInput): Set<string> {
+  const retainedAreaKeySet = new Set([...pinnedAreaKeys, ...directionalPrefetchAreaKeys]);
+  retainedAreaKeys.forEach((areaKey) => {
+    if (isRetainedAreaCoveredByActiveSubscription && !isRetainedAreaCoveredByActiveSubscription(areaKey)) {
+      return;
+    }
+    retainedAreaKeySet.add(areaKey);
+  });
+  return retainedAreaKeySet;
 }
 
 export function listCompletedRenderAreaHydrationKeys(state: WorldmapRenderAreaHydrationState): string[] {

--- a/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.ts
+++ b/client/apps/game/src/three/scenes/worldmap-render-area-hydration-state.ts
@@ -5,6 +5,18 @@ export interface WorldmapRenderAreaHydrationState {
   pendingStages: Map<string, Map<WorldmapRenderAreaHydrationStage, Promise<boolean>>>;
 }
 
+interface RecentRenderAreaRetentionInput {
+  retainedAreaKeys: readonly string[];
+  recentlyUnpinnedAreaKeys: readonly string[];
+  protectedAreaKeys: ReadonlySet<string>;
+  maxRetainedAreas: number;
+}
+
+interface RecentRenderAreaRetentionResult {
+  nextRetainedAreaKeys: string[];
+  areaKeysToClear: string[];
+}
+
 export const WORLDMAP_PREFETCH_HYDRATION_STAGES: readonly WorldmapRenderAreaHydrationStage[] = [
   "tileOpt",
   "explorerTroops",
@@ -159,6 +171,46 @@ export function clearCompletedRenderAreaHydrationState(state: WorldmapRenderArea
 export function clearAllRenderAreaHydrationState(state: WorldmapRenderAreaHydrationState): void {
   state.completedStages.clear();
   state.pendingStages.clear();
+}
+
+export function resolveRecentRenderAreaRetention({
+  maxRetainedAreas,
+  protectedAreaKeys,
+  recentlyUnpinnedAreaKeys,
+  retainedAreaKeys,
+}: RecentRenderAreaRetentionInput): RecentRenderAreaRetentionResult {
+  const areaKeysToClear: string[] = [];
+  const nextRetainedAreaKeys: string[] = [];
+
+  retainedAreaKeys.forEach((areaKey) => {
+    if (!protectedAreaKeys.has(areaKey) && !nextRetainedAreaKeys.includes(areaKey)) {
+      nextRetainedAreaKeys.push(areaKey);
+    }
+  });
+
+  recentlyUnpinnedAreaKeys.forEach((areaKey) => {
+    if (protectedAreaKeys.has(areaKey)) {
+      return;
+    }
+
+    const existingIndex = nextRetainedAreaKeys.indexOf(areaKey);
+    if (existingIndex >= 0) {
+      nextRetainedAreaKeys.splice(existingIndex, 1);
+    }
+    nextRetainedAreaKeys.push(areaKey);
+  });
+
+  while (nextRetainedAreaKeys.length > Math.max(0, maxRetainedAreas)) {
+    const evictedAreaKey = nextRetainedAreaKeys.shift();
+    if (evictedAreaKey) {
+      areaKeysToClear.push(evictedAreaKey);
+    }
+  }
+
+  return {
+    areaKeysToClear,
+    nextRetainedAreaKeys,
+  };
 }
 
 export function listCompletedRenderAreaHydrationKeys(state: WorldmapRenderAreaHydrationState): string[] {

--- a/client/apps/game/src/three/scenes/worldmap-torii-bounds-debug-overlay.wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-torii-bounds-debug-overlay.wiring.test.ts
@@ -33,7 +33,9 @@ describe("worldmap Torii bounds debug overlay wiring", () => {
     const body = source.slice(methodStart, methodEnd);
 
     expect(body).toContain("this.refreshToriiBoundsDebugOverlay");
-    expect(body).toContain("requestedAreaKey: areaKey");
+    expect(body).toContain("const requestedAreaKey = this.getToriiSubscriptionAreaKeyForChunk(chunkKey)");
+    expect(body).toContain("requestedAreaKey,");
+    expect(body).toContain("subscribedAreaKey: switchDecision.areaKey");
     expect(body).toContain("subscribedAreaKey: areaKey");
     expect(body).toContain("subscriptionBounds");
   });

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -302,6 +302,7 @@ import {
 import {
   getRenderAreaKeyForChunk as getCanonicalRenderAreaKeyForChunk,
   getRenderFetchBoundsForArea as getCanonicalRenderFetchBoundsForArea,
+  resolveToriiSubscriptionSwitchDecision as resolveCanonicalToriiSubscriptionSwitchDecision,
 } from "./worldmap-chunk-bounds";
 import { resolveTerrainPresentationWorldBounds } from "./worldmap-terrain-bounds-policy";
 import { getRenderOverlapChunkKeys, getRenderOverlapNeighborChunkKeys } from "./worldmap-chunk-neighbors";
@@ -6181,6 +6182,25 @@ export default class WorldmapScene extends WarpTravel {
     return new Set([...nextPinnedAreas, ...this.directionalPrefetchAreaKeys]);
   }
 
+  private getRequiredToriiSubscriptionRenderAreaKeys(targetChunkKey: string): string[] {
+    const areaKeys = this.getProtectedHydrationAreaKeys(this.pinnedRenderAreas);
+    areaKeys.add(this.getRenderAreaKeyForChunk(targetChunkKey));
+    return Array.from(areaKeys);
+  }
+
+  private resolveToriiSubscriptionSwitchDecision(
+    targetChunkKey: string,
+    requestedAreaKey: string,
+  ): ReturnType<typeof resolveCanonicalToriiSubscriptionSwitchDecision> {
+    return resolveCanonicalToriiSubscriptionSwitchDecision({
+      currentSubscriptionAreaKey: this.toriiBoundsAreaKey,
+      requestedSubscriptionAreaKey: requestedAreaKey,
+      requiredRenderAreaKeys: this.getRequiredToriiSubscriptionRenderAreaKeys(targetChunkKey),
+      getSubscriptionBoundsForArea: (areaKey) => this.getToriiSubscriptionBoundsForArea(areaKey),
+      getRenderAreaBounds: (areaKey) => this.getRenderFetchBoundsForArea(areaKey),
+    });
+  }
+
   private getActiveToriiSubscriptionBounds(): ToriiBoundsDebugRange | null {
     if (!this.toriiBoundsAreaKey) {
       return null;
@@ -6626,17 +6646,19 @@ export default class WorldmapScene extends WarpTravel {
 
     recordChunkDiagnosticsEvent(this.chunkDiagnostics, "bounds_switch_requested");
 
-    const areaKey = this.getToriiSubscriptionAreaKeyForChunk(chunkKey);
-    const { localBounds, subscriptionBounds } = this.buildToriiBoundsDebugRanges(areaKey);
+    const requestedAreaKey = this.getToriiSubscriptionAreaKeyForChunk(chunkKey);
+    const switchDecision = this.resolveToriiSubscriptionSwitchDecision(chunkKey, requestedAreaKey);
+    const { localBounds, subscriptionBounds } = this.buildToriiBoundsDebugRanges(requestedAreaKey);
     const debugBounds = {
-      requestedAreaKey: areaKey,
+      requestedAreaKey,
       localBounds,
       subscriptionBounds,
       modelCount: TORII_BOUNDS_MODELS.length,
     };
     this.traceChunk("torii_bounds_switch_requested", {
       chunkKey,
-      areaKey,
+      areaKey: requestedAreaKey,
+      switchDecision,
       transitionToken: transitionToken ?? null,
     });
     this.refreshToriiBoundsDebugOverlay({
@@ -6644,19 +6666,22 @@ export default class WorldmapScene extends WarpTravel {
       lastOutcome: "requested",
     });
 
-    if (areaKey === this.toriiBoundsAreaKey) {
-      recordChunkDiagnosticsEvent(this.chunkDiagnostics, "bounds_switch_skipped_same_signature");
+    if (switchDecision.action === "keep_current") {
+      if (switchDecision.reason === "same_subscription_area") {
+        recordChunkDiagnosticsEvent(this.chunkDiagnostics, "bounds_switch_skipped_same_signature");
+      }
       this.refreshToriiBoundsDebugOverlay({
         ...debugBounds,
-        subscribedAreaKey: areaKey,
-        lastOutcome: "skipped_same_signature",
+        subscribedAreaKey: switchDecision.areaKey,
+        lastOutcome: switchDecision.reason,
       });
       if (TORII_BOUNDS_DEBUG) {
-        console.log("[ToriiBounds] Skip switch (area unchanged)", { chunkKey, areaKey });
+        console.log("[ToriiBounds] Skip switch", { chunkKey, requestedAreaKey, switchDecision });
       }
       return;
     }
 
+    const areaKey = switchDecision.areaKey;
     const descriptor: BoundsDescriptor = {
       ...subscriptionBounds,
       models: TORII_BOUNDS_MODELS,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -385,6 +385,8 @@ import {
   listPendingRenderAreaHydrationKeys,
   markRenderAreaHydrationStagesComplete,
   registerPendingRenderAreaHydration,
+  retainRenderAreaHydrationStages,
+  resolveFetchResultRetainedAreaKeys,
   resolveRecentRenderAreaRetention,
   WORLDMAP_ACTIVE_HYDRATION_STAGES,
   WORLDMAP_PREFETCH_HYDRATION_STAGES,
@@ -6179,21 +6181,71 @@ export default class WorldmapScene extends WarpTravel {
     return new Set([...nextPinnedAreas, ...this.directionalPrefetchAreaKeys]);
   }
 
+  private getActiveToriiSubscriptionBounds(): ToriiBoundsDebugRange | null {
+    if (!this.toriiBoundsAreaKey) {
+      return null;
+    }
+
+    return this.getToriiSubscriptionBoundsForArea(this.toriiBoundsAreaKey);
+  }
+
+  private isRenderAreaCoveredBySubscriptionBounds(areaKey: string, subscriptionBounds: ToriiBoundsDebugRange): boolean {
+    const areaBounds = this.getRenderFetchBoundsForArea(areaKey);
+    return (
+      areaBounds.minCol >= subscriptionBounds.minCol &&
+      areaBounds.maxCol <= subscriptionBounds.maxCol &&
+      areaBounds.minRow >= subscriptionBounds.minRow &&
+      areaBounds.maxRow <= subscriptionBounds.maxRow
+    );
+  }
+
+  private applyRecentHydrationRetention(retention: ReturnType<typeof resolveRecentRenderAreaRetention>): void {
+    this.retainedHydrationAreaKeys = retention.nextRetainedAreaKeys;
+    retention.areaKeysToRetainTerrainOnly.forEach((areaKey) => {
+      retainRenderAreaHydrationStages(this.renderAreaHydrationState, areaKey, ["tileOpt"]);
+    });
+    retention.areaKeysToClear.forEach((areaKey) => {
+      clearCompletedRenderAreaHydrationState(this.renderAreaHydrationState, areaKey);
+    });
+  }
+
   private retainRecentlyUnpinnedHydrationAreas(
     removedPinnedAreas: readonly string[],
     nextPinnedAreas: ReadonlySet<string>,
   ): void {
+    const activeSubscriptionBounds = this.getActiveToriiSubscriptionBounds();
     const retention = resolveRecentRenderAreaRetention({
       retainedAreaKeys: this.retainedHydrationAreaKeys,
       recentlyUnpinnedAreaKeys: removedPinnedAreas,
       protectedAreaKeys: this.getProtectedHydrationAreaKeys(nextPinnedAreas),
       maxRetainedAreas: WORLDMAP_CHUNK_POLICY.recentHydrationCache.maxAreas,
+      ...(activeSubscriptionBounds
+        ? {
+            isAreaCoveredByActiveSubscription: (areaKey: string) =>
+              this.isRenderAreaCoveredBySubscriptionBounds(areaKey, activeSubscriptionBounds),
+          }
+        : {}),
     });
 
-    this.retainedHydrationAreaKeys = retention.nextRetainedAreaKeys;
-    retention.areaKeysToClear.forEach((areaKey) => {
-      clearCompletedRenderAreaHydrationState(this.renderAreaHydrationState, areaKey);
+    this.applyRecentHydrationRetention(retention);
+  }
+
+  private pruneRetainedHydrationAreasOutsideActiveSubscription(): void {
+    const activeSubscriptionBounds = this.getActiveToriiSubscriptionBounds();
+    if (!activeSubscriptionBounds || this.retainedHydrationAreaKeys.length === 0) {
+      return;
+    }
+
+    const retention = resolveRecentRenderAreaRetention({
+      retainedAreaKeys: this.retainedHydrationAreaKeys,
+      recentlyUnpinnedAreaKeys: [],
+      protectedAreaKeys: this.getProtectedHydrationAreaKeys(this.pinnedRenderAreas),
+      maxRetainedAreas: WORLDMAP_CHUNK_POLICY.recentHydrationCache.maxAreas,
+      isAreaCoveredByActiveSubscription: (areaKey) =>
+        this.isRenderAreaCoveredBySubscriptionBounds(areaKey, activeSubscriptionBounds),
     });
+
+    this.applyRecentHydrationRetention(retention);
   }
 
   private updatePinnedChunks(newChunkKeys: string[]): void {
@@ -6643,6 +6695,7 @@ export default class WorldmapScene extends WarpTravel {
       }
       recordChunkDiagnosticsEvent(this.chunkDiagnostics, "bounds_switch_applied");
       this.toriiBoundsAreaKey = areaKey;
+      this.pruneRetainedHydrationAreasOutsideActiveSubscription();
       this.refreshToriiBoundsDebugOverlay({
         ...debugBounds,
         subscribedAreaKey: areaKey,
@@ -7100,7 +7153,18 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private getRetainedRenderAreaKeys(): Set<string> {
-    return new Set([...this.pinnedRenderAreas, ...this.directionalPrefetchAreaKeys, ...this.retainedHydrationAreaKeys]);
+    const activeSubscriptionBounds = this.getActiveToriiSubscriptionBounds();
+    return resolveFetchResultRetainedAreaKeys({
+      pinnedAreaKeys: this.pinnedRenderAreas,
+      directionalPrefetchAreaKeys: this.directionalPrefetchAreaKeys,
+      retainedAreaKeys: this.retainedHydrationAreaKeys,
+      ...(activeSubscriptionBounds
+        ? {
+            isRetainedAreaCoveredByActiveSubscription: (areaKey: string) =>
+              this.isRenderAreaCoveredBySubscriptionBounds(areaKey, activeSubscriptionBounds),
+          }
+        : {}),
+    });
   }
 
   private hydrateExploredTilesFromTileOptRecs(

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -385,6 +385,7 @@ import {
   listPendingRenderAreaHydrationKeys,
   markRenderAreaHydrationStagesComplete,
   registerPendingRenderAreaHydration,
+  resolveRecentRenderAreaRetention,
   WORLDMAP_ACTIVE_HYDRATION_STAGES,
   WORLDMAP_PREFETCH_HYDRATION_STAGES,
   type WorldmapRenderAreaHydrationStage,
@@ -611,6 +612,7 @@ export default class WorldmapScene extends WarpTravel {
   private prefetchQueue: PrefetchQueueItem[] = [];
   private directionalPrefetchAreaKeys: Set<string> = new Set();
   private queuedPrefetchAreaKeys: Set<string> = new Set();
+  private retainedHydrationAreaKeys: string[] = [];
   private activePrefetches = 0;
   private readonly maxConcurrentPrefetches = WORLDMAP_CHUNK_POLICY.prefetch.maxConcurrent;
   private readonly worldmapMinZoomDistance = 10;
@@ -4243,7 +4245,10 @@ export default class WorldmapScene extends WarpTravel {
       pendingArmyMovementAuthoritativeResolutions: this.pendingArmyMovementAuthoritativeResolutions,
       armyStructureOwners: this.armyStructureOwners,
       suppressedArmies: this.armyManager.getSuppressedArmiesRef(),
-      clearRenderAreaHydrationState: () => clearAllRenderAreaHydrationState(this.renderAreaHydrationState),
+      clearRenderAreaHydrationState: () => {
+        clearAllRenderAreaHydrationState(this.renderAreaHydrationState);
+        this.clearRetainedHydrationAreas();
+      },
       pinnedChunkKeys: this.pinnedChunkKeys,
       pinnedRenderAreas: this.pinnedRenderAreas,
       hydratedChunkRefreshes: this.hydratedChunkRefreshes,
@@ -5001,7 +5006,9 @@ export default class WorldmapScene extends WarpTravel {
       }
       this.removeCachedMatricesForChunk(chunkRow, chunkCol);
       if (options?.invalidateFetchAreas) {
-        clearRenderAreaHydrationState(this.renderAreaHydrationState, this.getRenderAreaKeyForChunk(chunkKey));
+        const areaKey = this.getRenderAreaKeyForChunk(chunkKey);
+        clearRenderAreaHydrationState(this.renderAreaHydrationState, areaKey);
+        this.removeRetainedHydrationArea(areaKey);
       }
     });
   }
@@ -5019,6 +5026,18 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   /**
+   * Derive a stable live Torii subscription key for a chunk key.
+   * Subscription areas are intentionally larger than hydration fetch areas.
+   */
+  private getToriiSubscriptionAreaKeyForChunk(chunkKey: string): string {
+    return getCanonicalRenderAreaKeyForChunk(
+      chunkKey,
+      this.chunkSize,
+      WORLDMAP_CHUNK_POLICY.toriiSubscription.superAreaStrides,
+    );
+  }
+
+  /**
    * Compute integer fetch bounds that fully cover all render windows inside a Torii super-area.
    */
   private getRenderFetchBoundsForArea(areaKey: string): {
@@ -5032,6 +5051,23 @@ export default class WorldmapScene extends WarpTravel {
       this.renderChunkSize,
       this.chunkSize,
       WORLDMAP_CHUNK_POLICY.toriiFetch.superAreaStrides,
+    );
+  }
+
+  /**
+   * Compute integer subscription bounds that cover a live Torii subscription super-area.
+   */
+  private getToriiSubscriptionBoundsForArea(areaKey: string): {
+    minCol: number;
+    maxCol: number;
+    minRow: number;
+    maxRow: number;
+  } {
+    return getCanonicalRenderFetchBoundsForArea(
+      areaKey,
+      this.renderChunkSize,
+      this.chunkSize,
+      WORLDMAP_CHUNK_POLICY.toriiSubscription.superAreaStrides,
     );
   }
 
@@ -5129,6 +5165,8 @@ export default class WorldmapScene extends WarpTravel {
       chunkSize: this.chunkSize,
       forwardDepthStrides: WORLDMAP_CHUNK_POLICY.prefetch.forwardDepthStrides,
       sideRadiusStrides: WORLDMAP_CHUNK_POLICY.prefetch.sideRadiusStrides,
+      areaBoundaryLookaheadStrides: WORLDMAP_CHUNK_POLICY.prefetch.areaBoundaryLookaheadStrides,
+      fetchSuperAreaStrides: WORLDMAP_CHUNK_POLICY.toriiFetch.superAreaStrides,
       pinnedChunkKeys: this.pinnedChunkKeys,
       currentChunk: this.currentChunk,
       prefetchedAhead: this.prefetchedAhead,
@@ -6127,6 +6165,37 @@ export default class WorldmapScene extends WarpTravel {
     );
   }
 
+  private removeRetainedHydrationArea(areaKey: string): void {
+    this.retainedHydrationAreaKeys = this.retainedHydrationAreaKeys.filter(
+      (retainedAreaKey) => retainedAreaKey !== areaKey,
+    );
+  }
+
+  private clearRetainedHydrationAreas(): void {
+    this.retainedHydrationAreaKeys = [];
+  }
+
+  private getProtectedHydrationAreaKeys(nextPinnedAreas: ReadonlySet<string>): Set<string> {
+    return new Set([...nextPinnedAreas, ...this.directionalPrefetchAreaKeys]);
+  }
+
+  private retainRecentlyUnpinnedHydrationAreas(
+    removedPinnedAreas: readonly string[],
+    nextPinnedAreas: ReadonlySet<string>,
+  ): void {
+    const retention = resolveRecentRenderAreaRetention({
+      retainedAreaKeys: this.retainedHydrationAreaKeys,
+      recentlyUnpinnedAreaKeys: removedPinnedAreas,
+      protectedAreaKeys: this.getProtectedHydrationAreaKeys(nextPinnedAreas),
+      maxRetainedAreas: WORLDMAP_CHUNK_POLICY.recentHydrationCache.maxAreas,
+    });
+
+    this.retainedHydrationAreaKeys = retention.nextRetainedAreaKeys;
+    retention.areaKeysToClear.forEach((areaKey) => {
+      clearCompletedRenderAreaHydrationState(this.renderAreaHydrationState, areaKey);
+    });
+  }
+
   private updatePinnedChunks(newChunkKeys: string[]): void {
     const nextPinned = new Set(newChunkKeys);
     const prevPinned = this.pinnedChunkKeys;
@@ -6157,11 +6226,7 @@ export default class WorldmapScene extends WarpTravel {
       }
     });
 
-    // Drop completed tile data for render areas that are no longer covered.
-    // Keep in-flight pending promises for dedupe stability while they resolve.
-    removedPinnedAreas.forEach((areaKey) => {
-      clearCompletedRenderAreaHydrationState(this.renderAreaHydrationState, areaKey);
-    });
+    this.retainRecentlyUnpinnedHydrationAreas(removedPinnedAreas, nextPinnedAreas);
 
     this.pinnedChunkKeys = nextPinned;
     this.pinnedRenderAreas = nextPinnedAreas;
@@ -6178,7 +6243,7 @@ export default class WorldmapScene extends WarpTravel {
     localBounds: ToriiBoundsDebugRange;
     subscriptionBounds: ToriiBoundsDebugRange;
   } {
-    const localBounds = this.getRenderFetchBoundsForArea(areaKey);
+    const localBounds = this.getToriiSubscriptionBoundsForArea(areaKey);
     const feltCenter = FELT_CENTER();
 
     return {
@@ -6195,7 +6260,8 @@ export default class WorldmapScene extends WarpTravel {
   private buildToriiBoundsDebugSnapshot(
     extra: Partial<ToriiBoundsDebugOverlaySnapshot> = {},
   ): ToriiBoundsDebugOverlaySnapshot {
-    const currentAreaKey = this.currentChunk !== "null" ? this.getRenderAreaKeyForChunk(this.currentChunk) : null;
+    const currentAreaKey =
+      this.currentChunk !== "null" ? this.getToriiSubscriptionAreaKeyForChunk(this.currentChunk) : null;
 
     this.toriiBoundsDebugSnapshot = {
       ...this.toriiBoundsDebugSnapshot,
@@ -6309,6 +6375,7 @@ export default class WorldmapScene extends WarpTravel {
 
     const areaKey = this.getRenderAreaKeyForChunk(chunkKey);
     clearRenderAreaHydrationState(this.renderAreaHydrationState, areaKey);
+    this.removeRetainedHydrationArea(areaKey);
     this.tileHydrationFetches.delete(areaKey);
     this.structureHydrationFetches.delete(areaKey);
     this.hydratedRefreshSuppressionAreaKeys.delete(areaKey);
@@ -6507,7 +6574,7 @@ export default class WorldmapScene extends WarpTravel {
 
     recordChunkDiagnosticsEvent(this.chunkDiagnostics, "bounds_switch_requested");
 
-    const areaKey = this.getRenderAreaKeyForChunk(chunkKey);
+    const areaKey = this.getToriiSubscriptionAreaKeyForChunk(chunkKey);
     const { localBounds, subscriptionBounds } = this.buildToriiBoundsDebugRanges(areaKey);
     const debugBounds = {
       requestedAreaKey: areaKey,
@@ -7033,7 +7100,7 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private getRetainedRenderAreaKeys(): Set<string> {
-    return new Set([...this.pinnedRenderAreas, ...this.directionalPrefetchAreaKeys]);
+    return new Set([...this.pinnedRenderAreas, ...this.directionalPrefetchAreaKeys, ...this.retainedHydrationAreaKeys]);
   }
 
   private hydrateExploredTilesFromTileOptRecs(
@@ -8910,6 +8977,7 @@ export default class WorldmapScene extends WarpTravel {
   public clearTileEntityCache() {
     this.clearQueuedPrefetchState();
     clearAllRenderAreaHydrationState(this.renderAreaHydrationState);
+    this.clearRetainedHydrationAreas();
     this.pinnedRenderAreas.clear();
     this.clearCache();
     this.armyLastTileSyncAt.clear();

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-17",
+    title: "Map Streaming Stability",
+    description:
+      "World map streaming now keeps live Torii subscriptions steadier while warming nearby terrain data earlier, reducing loading churn during long travel.",
+    type: "improvement",
+    gameSlug: "world",
+  },
+  {
+    date: "2026-05-17",
     title: "Wider Map Streaming",
     description:
       "World map streaming now keeps Torii subscriptions on larger regions, reducing stream swaps and terrain churn while traversing long distances.",

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -25,7 +25,7 @@ const allLatestFeatures: LatestFeature[] = [
     date: "2026-05-17",
     title: "Map Streaming Stability",
     description:
-      "World map streaming now keeps live Torii subscriptions steadier and recently visited terrain warm, reducing loading churn during long travel and backtracking.",
+      "World map streaming now holds wider live Torii regions, avoids unnecessary stream swaps while nearby areas stay covered, and keeps recently visited terrain warm.",
     type: "improvement",
     gameSlug: "world",
   },

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -25,7 +25,7 @@ const allLatestFeatures: LatestFeature[] = [
     date: "2026-05-17",
     title: "Map Streaming Stability",
     description:
-      "World map streaming now keeps live Torii subscriptions steadier while warming nearby terrain data earlier, reducing loading churn during long travel.",
+      "World map streaming now keeps live Torii subscriptions steadier and recently visited terrain warm, reducing loading churn during long travel and backtracking.",
     type: "improvement",
     gameSlug: "world",
   },


### PR DESCRIPTION
## Summary
This PR reduces world-map streaming churn by keeping exact SQL hydration at 16-stride render areas while switching live Torii subscriptions on wider 48-stride areas.
It adds coverage-based hysteresis so the client keeps the current live subscription when the target, pinned, and prefetch render areas are still covered, instead of switching just because the requested area key changed.
It warms boundary-crossing prefetches and keeps recently visited terrain cached across backtracking with a 48-area retention budget.
Retained areas inside the active live subscription stay fully hot, while retained areas outside it keep only TileOpt terrain and refresh dynamic explorer/structure data on return so stale live data is not trusted.

## Verification
- `pnpm --dir client/apps/game test src/three/scenes/worldmap-chunk-policy.test.ts src/three/scenes/worldmap-chunk-bounds.test.ts src/three/scenes/warp-travel-directional-prefetch.test.ts src/three/scenes/worldmap-render-area-hydration-state.test.ts src/three/scenes/worldmap-cache-budget-policy.test.ts src/three/scenes/worldmap-prefetch-queue.test.ts src/three/scenes/worldmap-runtime-lifecycle.test.ts`
- `pnpm run format`
- `pnpm run knip`
- `git diff --check`