### PR TITLE
Stabilize structure visibility at chunk boundaries

### DIFF
--- a/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
+++ b/client/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/hooks/store/use-account-store", () => ({
   useAccountStore: {
@@ -166,6 +166,17 @@ vi.mock("./points-label-renderer", () => ({
 }));
 
 const { StructureManager } = await import("./structure-manager");
+const { getRenderBounds } = await import("../utils/chunk-geometry");
+const actualChunkGeometry = await vi.importActual<typeof import("../utils/chunk-geometry")>("../utils/chunk-geometry");
+
+function mockCanonicalRenderBounds() {
+  vi.mocked(getRenderBounds).mockImplementation(actualChunkGeometry.getRenderBounds);
+}
+
+afterEach(() => {
+  vi.mocked(getRenderBounds).mockReset();
+  vi.mocked(getRenderBounds).mockReturnValue({ minCol: 0, minRow: 0, maxCol: 0, maxRow: 0 });
+});
 
 function createVisibleStructurePassFence() {
   let fenceVersion = 0;
@@ -394,6 +405,64 @@ function createVisibleStructurePassSubject() {
 
   return { subject, visibleStructurePassFence };
 }
+
+function createStructureVisibilitySubject() {
+  const subject = Object.create(StructureManager.prototype) as any;
+
+  subject.currentChunk = "0,0";
+  subject.renderChunkSize = { width: 48, height: 48 };
+  subject.chunkStride = 24;
+  subject.needsSpatialReindex = false;
+
+  return subject;
+}
+
+describe("StructureManager structure visibility", () => {
+  it("retains structures in the presentation overlap while crossing a chunk boundary", () => {
+    mockCanonicalRenderBounds();
+    const subject = createStructureVisibilitySubject();
+    const structuresById = new Map([
+      [
+        196,
+        {
+          entityId: 196,
+          hexCoords: { col: -13, row: -9 },
+          structureType: "Realm",
+        },
+      ],
+      [
+        197,
+        {
+          entityId: 197,
+          hexCoords: { col: -37, row: -9 },
+          structureType: "Realm",
+        },
+      ],
+      [
+        198,
+        {
+          entityId: 198,
+          hexCoords: { col: -36, row: -9 },
+          structureType: "Realm",
+        },
+      ],
+    ]);
+
+    subject.chunkToStructures = new Map([
+      ["-1,-1", new Set([196])],
+      ["-2,-1", new Set([197, 198])],
+    ]);
+    subject.structures = {
+      getStructureByEntityId: vi.fn((entityId: number) => structuresById.get(entityId)),
+    };
+
+    const visibleStructures = subject.getVisibleStructuresForChunk(0, 0);
+
+    expect(visibleStructures.map((structure: { entityId: number }) => structure.entityId).toSorted()).toEqual([
+      196, 198,
+    ]);
+  });
+});
 
 describe("StructureManager destroy lifecycle", () => {
   it("runs a single visible-structure rebuild during chunk switches", async () => {

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -96,6 +96,26 @@ import {
 const INITIAL_STRUCTURE_CAPACITY = 64;
 const WONDER_MODEL_INDEX = 4;
 
+interface ChunkBounds {
+  minCol: number;
+  maxCol: number;
+  minRow: number;
+  maxRow: number;
+}
+
+// Chunk authority can move by one stride while the camera moves by one hex at a boundary.
+// Structures are sparse, so keep the neighboring presentation window live to avoid edge flicker.
+function expandBoundsForStructurePresentation(bounds: ChunkBounds, chunkStride: number): ChunkBounds {
+  const overlap = Math.max(0, Math.floor(chunkStride));
+
+  return {
+    minCol: bounds.minCol - overlap,
+    maxCol: bounds.maxCol + overlap,
+    minRow: bounds.minRow - overlap,
+    maxRow: bounds.maxRow + overlap,
+  };
+}
+
 interface VisibleStructurePassSnapshot {
   chunkKey: string;
   passFenceSnapshot: {
@@ -1006,8 +1026,9 @@ export class StructureManager {
     }
   }
 
-  private getChunkBounds(startRow: number, startCol: number) {
-    return getRenderBounds(startRow, startCol, this.renderChunkSize, this.chunkStride);
+  private getStructurePresentationBounds(startRow: number, startCol: number) {
+    const renderBounds = getRenderBounds(startRow, startCol, this.renderChunkSize, this.chunkStride);
+    return expandBoundsForStructurePresentation(renderBounds, this.chunkStride);
   }
 
   async updateChunk(chunkKey: string, options?: ManagerChunkUpdateOptions) {
@@ -1509,7 +1530,7 @@ export class StructureManager {
       this.rebuildSpatialIndex();
     }
     const visibleStructures: StructureInfo[] = [];
-    const bounds = this.getChunkBounds(startRow, startCol);
+    const bounds = this.getStructurePresentationBounds(startRow, startCol);
 
     const minCol = bounds.minCol;
     const maxCol = bounds.maxCol;
@@ -1572,7 +1593,7 @@ export class StructureManager {
     }
 
     const [chunkRow, chunkCol] = this.currentChunk?.split(",").map(Number) || [];
-    const bounds = this.getChunkBounds(chunkRow || 0, chunkCol || 0);
+    const bounds = this.getStructurePresentationBounds(chunkRow || 0, chunkCol || 0);
     // Use inclusive bounds (<=) to match isStructureVisible behavior
     return (
       hexCoords.col >= bounds.minCol &&


### PR DESCRIPTION
## Summary
Stabilizes Realm and structure presentation at chunk boundaries by expanding `StructureManager` visibility bounds one chunk stride while leaving canonical terrain/fetch bounds unchanged.
Adds a regression for the 48x48 render window with 24-hex stride so structures in the neighboring presentation window stay visible and structures outside the overlap remain excluded.

## Validation
- `pnpm --dir client/apps/game test src/three/managers/structure-manager.lifecycle.test.ts src/three/managers/structure-manager.deferred-bounds.test.ts src/three/utils/chunk-geometry.test.ts src/three/scenes/worldmap-chunk-transition.test.ts -- --runInBand`
- Playwright spectate on `bltz-ping-626`, route `-1,18 <-> 0,18`: `visibleStructures` stayed `34`; manager/tile failure counters stayed `0`.
- `pnpm run format`
- `pnpm run knip`