### PR TITLE
[codex] Fix realm provision sync recovery

### DIFF
--- a/client/apps/game/src/dojo/debounced-queries.test.ts
+++ b/client/apps/game/src/dojo/debounced-queries.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const queryMocks = vi.hoisted(() => ({
+  getBuildingsFromTorii: vi.fn(),
+  getEntitiesFromTorii: vi.fn(),
+  getOwnedArmiesFromTorii: vi.fn(),
+  getTilesForPositionsFromTorii: vi.fn(),
+}));
+
+vi.mock("./queries", () => queryMocks);
+
+import { clearSubscriptionQueue, debouncedGetBuildingsFromTorii } from "./debounced-queries";
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+};
+
+const flushMicrotasks = async (count = 4) => {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+};
+
+describe("debounced Torii query queue", () => {
+  afterEach(() => {
+    clearSubscriptionQueue();
+    vi.clearAllMocks();
+  });
+
+  it("resolves a debounced building query only after the queued Torii request completes", async () => {
+    const request = createDeferred();
+    queryMocks.getBuildingsFromTorii.mockReturnValueOnce(request.promise);
+
+    let settled = false;
+    const promise = debouncedGetBuildingsFromTorii({} as any, [] as any, [{ col: 12, row: 34 }]).then(() => {
+      settled = true;
+    });
+
+    await flushMicrotasks();
+    expect(settled).toBe(false);
+
+    request.resolve();
+    await promise;
+
+    expect(settled).toBe(true);
+    expect(queryMocks.getBuildingsFromTorii).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles queued building queries when the queue is cleared", async () => {
+    const blockingRequest = createDeferred();
+    queryMocks.getBuildingsFromTorii.mockReturnValueOnce(blockingRequest.promise).mockResolvedValueOnce(undefined);
+
+    const inFlightPromise = debouncedGetBuildingsFromTorii({} as any, [] as any, [{ col: 1, row: 1 }]);
+    let queuedSettled = false;
+    const queuedPromise = debouncedGetBuildingsFromTorii({} as any, [] as any, [{ col: 99, row: 99 }]).then(() => {
+      queuedSettled = true;
+    });
+
+    await flushMicrotasks();
+    expect(queryMocks.getBuildingsFromTorii).toHaveBeenCalledTimes(1);
+
+    clearSubscriptionQueue();
+    await queuedPromise;
+
+    expect(queuedSettled).toBe(true);
+    expect(queryMocks.getBuildingsFromTorii).toHaveBeenCalledTimes(1);
+
+    blockingRequest.resolve();
+    await inFlightPromise;
+  });
+});

--- a/client/apps/game/src/dojo/debounced-queries.ts
+++ b/client/apps/game/src/dojo/debounced-queries.ts
@@ -9,32 +9,40 @@ import {
 } from "./queries";
 
 // Queue class to manage requests
+type QueuedRequest = {
+  request: () => Promise<void>;
+  onComplete?: () => void;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
 class RequestQueue {
-  private queue: Array<() => Promise<void>> = [];
+  private queue: QueuedRequest[] = [];
   private processing = false;
   private batchSize = 3; // Number of concurrent requests
   private batchDelayMs = 100; // Delay between batches
 
   async add(request: () => Promise<void>, onComplete?: () => void) {
-    this.queue.push(async () => {
-      await request();
-      onComplete?.(); // Call onComplete after the request is processed
+    return new Promise<void>((resolve, reject) => {
+      this.queue.push({
+        request,
+        onComplete,
+        resolve,
+        reject,
+      });
+
+      if (!this.processing) {
+        this.processing = true;
+        void this.processQueue();
+      }
     });
-    if (!this.processing) {
-      this.processing = true;
-      this.processQueue();
-    }
   }
 
   private async processQueue() {
     while (this.queue.length > 0) {
       const batch = this.queue.splice(0, this.batchSize);
 
-      try {
-        await Promise.all(batch.map((request) => request()));
-      } catch (error) {
-        console.error("Error processing request batch:", error);
-      }
+      await Promise.all(batch.map((request) => this.processRequest(request)));
 
       if (this.queue.length > 0) {
         // Add delay between batches to prevent overwhelming the server
@@ -44,8 +52,23 @@ class RequestQueue {
     this.processing = false;
   }
 
+  private async processRequest(queuedRequest: QueuedRequest) {
+    try {
+      await queuedRequest.request();
+      queuedRequest.onComplete?.();
+      queuedRequest.resolve();
+    } catch (error) {
+      console.error("Error processing queued request:", error);
+      queuedRequest.reject(error);
+    }
+  }
+
   clear() {
-    this.queue = [];
+    const queuedRequests = this.queue.splice(0);
+    queuedRequests.forEach((queuedRequest) => {
+      queuedRequest.onComplete?.();
+      queuedRequest.resolve();
+    });
   }
 }
 

--- a/client/apps/game/src/dojo/sync.regression.source.test.ts
+++ b/client/apps/game/src/dojo/sync.regression.source.test.ts
@@ -22,11 +22,11 @@ describe("network boot-regression guards", () => {
     expect(source).toMatch(/cancelEntityStreamSubscription[\s\S]*?if \(isInitialSyncInFlight\) return/);
   });
 
-  it("sync.ts resets the spatial handshake clock after global spatial map sync is applied", () => {
+  it("sync.ts resets the spatial handshake clock after global spatial map snapshot is applied", () => {
     const source = readSource("src/dojo/sync.ts");
 
-    expect(source).toContain("syncGlobalSpatialMapStream");
-    expect(source).toContain("spatialMapStreamSubscription");
+    expect(source).toContain("syncGlobalSpatialMapSnapshot");
+    expect(source).not.toContain("spatialMapStreamSubscription");
     expect(source).toContain("recordSpatialHandshake()");
   });
 

--- a/client/apps/game/src/dojo/sync.test.ts
+++ b/client/apps/game/src/dojo/sync.test.ts
@@ -72,7 +72,10 @@ vi.mock("./sync-utils", () => ({
 }));
 
 vi.mock("./torii-stream-manager", () => ({
-  buildModelKeysClause: vi.fn(() => ({ mocked: "global-stream-clause" })),
+  buildModelKeysClause: vi.fn((models: Array<{ model: string }>) => ({
+    mocked: "model-stream-clause",
+    models: models.map(({ model }) => model),
+  })),
 }));
 
 import { cancelEntityStreamSubscription, initialSync, syncEntitiesDebounced } from "./sync";
@@ -273,6 +276,51 @@ describe("syncEntitiesDebounced", () => {
     );
   });
 
+  it("can keep entity and event subscription clauses separate", async () => {
+    const harness = createSyncHarness();
+    const entityClause = { entity: true };
+    const eventClause = { event: true };
+    const updatedEntityClause = { entity: "updated" };
+    const updatedEventClause = { event: "updated" };
+
+    const subscription = await syncEntitiesDebounced(
+      harness.client as any,
+      harness.setup as any,
+      { entityClause, eventClause } as any,
+      false,
+    );
+
+    expect(harness.client.onEntityUpdated).toHaveBeenCalledWith(entityClause, expect.any(Function));
+    expect(harness.client.onEventMessageUpdated).toHaveBeenCalledWith(eventClause, expect.any(Function));
+
+    await subscription.updateClause?.({ entityClause: updatedEntityClause, eventClause: updatedEventClause } as any);
+
+    expect(harness.client.updateEntitySubscription).toHaveBeenCalledWith(
+      expect.objectContaining({ cancel: harness.cancelEntitySubscription }),
+      updatedEntityClause,
+    );
+    expect(harness.client.updateEventMessageSubscription).toHaveBeenCalledWith(
+      expect.objectContaining({ cancel: harness.cancelEventSubscription }),
+      updatedEventClause,
+    );
+  });
+
+  it("keeps a partial clause pair scoped to the provided side", async () => {
+    const harness = createSyncHarness();
+    const entityClause = { entity: true };
+    const eventClause = { event: true };
+
+    await syncEntitiesDebounced(harness.client as any, harness.setup as any, { entityClause } as any, false);
+
+    expect(harness.client.onEntityUpdated).toHaveBeenCalledWith(entityClause, expect.any(Function));
+    expect(harness.client.onEventMessageUpdated).toHaveBeenCalledWith(entityClause, expect.any(Function));
+
+    await syncEntitiesDebounced(harness.client as any, harness.setup as any, { eventClause } as any, false);
+
+    expect(harness.client.onEntityUpdated).toHaveBeenLastCalledWith(eventClause, expect.any(Function));
+    expect(harness.client.onEventMessageUpdated).toHaveBeenLastCalledWith(eventClause, expect.any(Function));
+  });
+
   it("waits for a fresh ready entity after updating the subscription clause", async () => {
     vi.useFakeTimers();
     const harness = createSyncHarness();
@@ -388,7 +436,7 @@ describe("initialSync global streams", () => {
     cancelEntityStreamSubscription();
   });
 
-  it("opens non-spatial and spatial global streams before reporting sync complete", async () => {
+  it("opens one all-entity global stream with explicitly scoped events before reporting sync complete", async () => {
     vi.useFakeTimers();
     getEntitiesMock.mockResolvedValue(undefined);
     const harness = createSyncHarness();
@@ -408,9 +456,53 @@ describe("initialSync global streams", () => {
     await vi.advanceTimersByTimeAsync(200);
     await syncPromise;
 
-    expect(harness.client.onEntityUpdated).toHaveBeenCalledTimes(2);
-    expect(harness.client.onEventMessageUpdated).toHaveBeenCalledTimes(2);
+    expect(harness.client.onEntityUpdated).toHaveBeenCalledTimes(1);
+    expect(harness.client.onEntityUpdated).toHaveBeenCalledWith(undefined, expect.any(Function));
+    expect(harness.client.onEventMessageUpdated).toHaveBeenCalledTimes(1);
+    expect(harness.client.onEventMessageUpdated).toHaveBeenCalledWith(
+      expect.objectContaining({
+        models: expect.arrayContaining([
+          "s1_eternum-OpenRelicChestEvent",
+          "s1_eternum-ExplorerRewardEvent",
+          "s1_eternum-BattleEvent",
+        ]),
+      }),
+      expect.any(Function),
+    );
     expect(getEntitiesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates Building rows in the strict global spatial snapshot", async () => {
+    vi.useFakeTimers();
+    getEntitiesMock.mockResolvedValue(undefined);
+    const harness = createSyncHarness();
+
+    const syncPromise = initialSync(harness.setup as any, createInitialSyncState() as any, vi.fn(), {
+      logging: false,
+      reportProgress: false,
+    });
+
+    await flushMicrotasks();
+    harness.emitEntityUpdate({
+      hashed_keys: "global-entity-1",
+      models: {
+        "s1_eternum-Guild": { entity_id: 1 },
+      },
+    });
+    await vi.advanceTimersByTimeAsync(200);
+    await syncPromise;
+
+    expect(getEntitiesMock).toHaveBeenCalledWith(
+      harness.client,
+      expect.objectContaining({
+        models: expect.arrayContaining(["s1_eternum-Building"]),
+      }),
+      harness.setup.network.contractComponents,
+      [],
+      expect.arrayContaining(["s1_eternum-Building"]),
+      expect.any(Number),
+      false,
+    );
   });
 
   it("fails initial sync when the strict global spatial snapshot times out", async () => {
@@ -437,7 +529,7 @@ describe("initialSync global streams", () => {
     await expectedRejection;
   });
 
-  it("cancels both global stream pairs after initial sync", async () => {
+  it("cancels the single global stream pair after initial sync", async () => {
     vi.useFakeTimers();
     getEntitiesMock.mockResolvedValue(undefined);
     const harness = createSyncHarness();
@@ -459,7 +551,7 @@ describe("initialSync global streams", () => {
 
     cancelEntityStreamSubscription();
 
-    expect(harness.cancelEntitySubscription).toHaveBeenCalledTimes(2);
-    expect(harness.cancelEventSubscription).toHaveBeenCalledTimes(2);
+    expect(harness.cancelEntitySubscription).toHaveBeenCalledTimes(1);
+    expect(harness.cancelEventSubscription).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -26,7 +26,7 @@ import { env } from "../../env";
 import { resolveInitialStructureSelection } from "./sync-initial-selection";
 import { isDeletionPayload } from "./sync-utils";
 import { ToriiSyncWorkerManager } from "./sync-worker-manager";
-import { GLOBAL_SPATIAL_MAP_MODEL_NAMES, GLOBAL_SPATIAL_MAP_STREAM_MODELS } from "./torii-spatial-models";
+import { GLOBAL_SPATIAL_MAP_MODEL_NAMES, GLOBAL_SPATIAL_MAP_SNAPSHOT_MODELS } from "./torii-spatial-models";
 import { buildModelKeysClause, type GlobalModelStreamConfig } from "./torii-stream-manager";
 import {
   setupToriiSubscriptions,
@@ -48,7 +48,6 @@ interface SyncEntitiesSubscriptionOptions {
 }
 
 let entityStreamSubscription: { cancel: () => void; ready: Promise<void> } | null = null;
-let spatialMapStreamSubscription: { cancel: () => void; ready: Promise<void> } | null = null;
 let isInitialSyncInFlight = false;
 
 /**
@@ -68,10 +67,6 @@ function cancelGlobalEntityStreamSubscriptions(): void {
   if (entityStreamSubscription) {
     entityStreamSubscription.cancel();
     entityStreamSubscription = null;
-  }
-  if (spatialMapStreamSubscription) {
-    spatialMapStreamSubscription.cancel();
-    spatialMapStreamSubscription = null;
   }
 }
 
@@ -135,48 +130,15 @@ function recordTileOptStreamTrace(data: ToriiEntity): void {
   }
 }
 
-const GLOBAL_NON_SPATIAL_MODELS: string[] = [
-  // Events
+const GLOBAL_EVENT_MODELS: string[] = [
   "s1_eternum-OpenRelicChestEvent",
-  // Guilds
-  "s1_eternum-Guild",
-  "s1_eternum-GuildMember",
-  "s1_eternum-GuildWhitelist",
-  // Market
-  "s1_eternum-Market",
-  "s1_eternum-Liquidity",
-  "s1_eternum-Trade",
-  // Config + global metadata
-  "s1_eternum-WorldConfig",
-  "s1_eternum-HyperstrtConstructConfig",
-  "s1_eternum-HyperstructureGlobals",
-  "s1_eternum-WeightConfig",
-  "s1_eternum-ResourceFactoryConfig",
-  "s1_eternum-BuildingCategoryConfig",
-  "s1_eternum-StructureLevelConfig",
-  "s1_eternum-SeasonEnded",
-  "s1_eternum-QuestLevels",
-  "s1_eternum-AddressName",
-  "s1_eternum-PlayerRegisteredPoints",
-  "s1_eternum-BlitzSettlement",
-  "s1_eternum-BlitzEntryTokenRegister",
-  "s1_eternum-PlayersRankTrial",
-  "s1_eternum-PlayersRankFinal",
-  "s1_eternum-ResourceList",
-  "s1_eternum-PlayerRank",
-  "s1_eternum-RankPrize",
+  "s1_eternum-ExplorerRewardEvent",
+  "s1_eternum-BattleEvent",
 ];
 
-// Models synced per-player via a scoped subscription (see usePlayerStructureSync)
-const PLAYER_STRUCTURE_MODELS: string[] = [
-  "s1_eternum-ProductionBoostBonus",
-  "s1_eternum-Resource",
-  "s1_eternum-ResourceArrival",
-];
-
-const GLOBAL_STREAM_MODELS: GlobalModelStreamConfig[] = GLOBAL_NON_SPATIAL_MODELS.map((model) => ({ model }));
-const GLOBAL_STREAM_CLAUSE = buildModelKeysClause(GLOBAL_STREAM_MODELS);
-const GLOBAL_SPATIAL_MAP_STREAM_CLAUSE = buildModelKeysClause(GLOBAL_SPATIAL_MAP_STREAM_MODELS);
+const GLOBAL_EVENT_STREAM_MODELS: GlobalModelStreamConfig[] = GLOBAL_EVENT_MODELS.map((model) => ({ model }));
+const GLOBAL_EVENT_STREAM_CLAUSE = buildModelKeysClause(GLOBAL_EVENT_STREAM_MODELS);
+const GLOBAL_SPATIAL_MAP_SNAPSHOT_CLAUSE = buildModelKeysClause(GLOBAL_SPATIAL_MAP_SNAPSHOT_MODELS);
 
 type BatchPayload = { upserts: ToriiEntity[]; deletions: string[] };
 type SyncEntityReadinessMatcher = (data: ToriiEntity) => boolean;
@@ -193,8 +155,20 @@ interface QueueProcessor {
 interface SyncEntitiesSubscription {
   cancel: () => void;
   ready: Promise<void>;
-  updateClause?: (clause: Clause | undefined | null) => Promise<void>;
+  updateClause?: (clause: SyncSubscriptionClauseInput) => Promise<void>;
 }
+
+type SyncSubscriptionClausePair = {
+  entityClause?: Clause | null;
+  eventClause?: Clause | null;
+};
+
+type SyncSubscriptionClauseInput = Clause | undefined | null | SyncSubscriptionClausePair;
+
+type ResolvedSyncSubscriptionClauses = {
+  entityClause: Clause | undefined | null;
+  eventClause: Clause | undefined | null;
+};
 
 interface SyncReadinessController {
   ready: Promise<void>;
@@ -291,6 +265,23 @@ const createSyncEntityReadinessInfo = (data: ToriiEntity): SyncEntityReadinessIn
   entityId: data.hashed_keys,
   models: Object.keys((data.models as Record<string, unknown>) ?? {}),
 });
+
+const isSyncSubscriptionClausePair = (input: SyncSubscriptionClauseInput): input is SyncSubscriptionClausePair =>
+  typeof input === "object" && input !== null && ("entityClause" in input || "eventClause" in input);
+
+const resolveSyncSubscriptionClauses = (input: SyncSubscriptionClauseInput): ResolvedSyncSubscriptionClauses => {
+  if (isSyncSubscriptionClausePair(input)) {
+    return {
+      entityClause: "entityClause" in input ? input.entityClause : input.eventClause,
+      eventClause: "eventClause" in input ? input.eventClause : input.entityClause,
+    };
+  }
+
+  return {
+    entityClause: input,
+    eventClause: input,
+  };
+};
 
 const createWriteCompletionTracker = (): WriteCompletionTracker => {
   const pendingWriteResolvers = new Map<string, Array<() => void>>();
@@ -484,7 +475,7 @@ const createWorkerQueueProcessor = (
 export const syncEntitiesDebounced = async (
   client: ToriiClient,
   setupResult: SetupResult,
-  entityKeyClause: Clause | undefined | null,
+  subscriptionClause: SyncSubscriptionClauseInput,
   logging = true,
   onUpdate?: () => void,
   options?: SyncEntitiesSubscriptionOptions,
@@ -525,6 +516,7 @@ export const syncEntitiesDebounced = async (
     readyOnSubscriptionsReady: options?.readyOnSubscriptionsReady,
   });
   const isReadyEntity = options?.isReadyEntity ?? (() => true);
+  const initialClauses = resolveSyncSubscriptionClauses(subscriptionClause);
 
   const queueUpdate = (data: ToriiEntity, origin: "entity" | "event") => {
     try {
@@ -540,7 +532,7 @@ export const syncEntitiesDebounced = async (
   try {
     const subscriptions = await setupToriiSubscriptions({
       createEntitySubscription: () =>
-        client.onEntityUpdated(entityKeyClause, (data: ToriiEntity) => {
+        client.onEntityUpdated(initialClauses.entityClause, (data: ToriiEntity) => {
           if (logging) console.log("Entity updated", data);
           recordTileOptStreamTrace(data);
           const writeComplete = queueUpdate(data, "entity");
@@ -554,7 +546,7 @@ export const syncEntitiesDebounced = async (
           }
         }),
       createEventSubscription: () =>
-        client.onEventMessageUpdated(entityKeyClause, (data: ToriiEntity) => {
+        client.onEventMessageUpdated(initialClauses.eventClause, (data: ToriiEntity) => {
           if (logging) console.log("Event message updated", data.hashed_keys);
           queueUpdate(data, "event");
         }),
@@ -580,13 +572,14 @@ export const syncEntitiesDebounced = async (
     };
 
     if (canUpdateSubscriptionClause) {
-      subscription.updateClause = async (clause: Clause | undefined | null) => {
+      subscription.updateClause = async (clause: SyncSubscriptionClauseInput) => {
+        const nextClauses = resolveSyncSubscriptionClauses(clause);
         readiness.reset();
         await updateToriiSubscriptions({
           updateEntitySubscription: () =>
-            client.updateEntitySubscription(subscriptions.entitySubscription as any, clause),
+            client.updateEntitySubscription(subscriptions.entitySubscription as any, nextClauses.entityClause),
           updateEventSubscription: () =>
-            client.updateEventMessageSubscription(subscriptions.eventSubscription as any, clause),
+            client.updateEventMessageSubscription(subscriptions.eventSubscription as any, nextClauses.eventClause),
           subscriptionSetupTimeoutMs: options?.subscriptionSetupTimeoutMs,
           onSubscriptionSetupTimeout: options?.onSubscriptionSetupTimeout,
         });
@@ -662,7 +655,7 @@ async function hydrateGlobalSpatialMapSnapshot(input: {
       operation: () =>
         getEntitiesSnapshot(
           input.setup.network.toriiClient,
-          GLOBAL_SPATIAL_MAP_STREAM_CLAUSE,
+          GLOBAL_SPATIAL_MAP_SNAPSHOT_CLAUSE,
           input.setup.network.contractComponents as unknown as Component<Schema, Metadata, undefined>[],
           [],
           [...GLOBAL_SPATIAL_MAP_MODEL_NAMES],
@@ -675,38 +668,12 @@ async function hydrateGlobalSpatialMapSnapshot(input: {
   }
 }
 
-async function subscribeGlobalSpatialMapStream(input: {
+async function syncGlobalSpatialMapSnapshot(input: {
   setup: SetupResult;
   logging: boolean;
   subscriptionSetupTimeoutMs: number;
   onSubscriptionSetupTimeout?: (info: ToriiSubscriptionSetupTimeoutInfo) => void;
-}): Promise<SyncEntitiesSubscription> {
-  const subscribeStart = performance.now();
-  try {
-    return await syncEntitiesDebounced(
-      input.setup.network.toriiClient,
-      input.setup,
-      GLOBAL_SPATIAL_MAP_STREAM_CLAUSE,
-      input.logging,
-      () => useConnectionStore.getState().recordSpatialUpdate(),
-      {
-        streamType: "spatial",
-        subscriptionSetupTimeoutMs: input.subscriptionSetupTimeoutMs,
-        onSubscriptionSetupTimeout: input.onSubscriptionSetupTimeout,
-        readyOnSubscriptionsReady: true,
-      },
-    );
-  } finally {
-    recordGameEntryDuration("initial-sync-global-spatial-map-subscribe", performance.now() - subscribeStart);
-  }
-}
-
-async function syncGlobalSpatialMapStream(input: {
-  setup: SetupResult;
-  logging: boolean;
-  subscriptionSetupTimeoutMs: number;
-  onSubscriptionSetupTimeout?: (info: ToriiSubscriptionSetupTimeoutInfo) => void;
-}): Promise<SyncEntitiesSubscription> {
+}): Promise<void> {
   const totalStart = performance.now();
   try {
     await hydrateGlobalSpatialMapSnapshot({
@@ -715,19 +682,6 @@ async function syncGlobalSpatialMapStream(input: {
       timeoutMs: input.subscriptionSetupTimeoutMs,
       onTimeout: input.onSubscriptionSetupTimeout,
     });
-    return await subscribeGlobalSpatialMapStream(input);
-  } catch (error) {
-    if (error instanceof Error && error.message.includes("Timed out waiting for entity subscription")) {
-      throw new Error(
-        `Timed out waiting for global spatial map subscription after ${input.subscriptionSetupTimeoutMs}ms.`,
-      );
-    }
-    if (error instanceof Error && error.message.includes("Timed out waiting for event subscription")) {
-      throw new Error(
-        `Timed out waiting for global spatial map event subscription after ${input.subscriptionSetupTimeoutMs}ms.`,
-      );
-    }
-    throw error;
   } finally {
     recordGameEntryDuration("initial-sync-global-spatial-map-sync", performance.now() - totalStart);
   }
@@ -763,7 +717,10 @@ export const initialSync = async (
     entityStreamSubscription = await syncEntitiesDebounced(
       setup.network.toriiClient,
       setup,
-      GLOBAL_STREAM_CLAUSE,
+      {
+        entityClause: undefined,
+        eventClause: GLOBAL_EVENT_STREAM_CLAUSE,
+      },
       logging,
       () => useConnectionStore.getState().recordGlobalUpdate(),
       {
@@ -774,7 +731,7 @@ export const initialSync = async (
     );
     useConnectionStore.getState().recordGlobalHandshake();
 
-    spatialMapStreamSubscription = await syncGlobalSpatialMapStream({
+    await syncGlobalSpatialMapSnapshot({
       setup,
       logging,
       subscriptionSetupTimeoutMs,

--- a/client/apps/game/src/dojo/torii-spatial-models.ts
+++ b/client/apps/game/src/dojo/torii-spatial-models.ts
@@ -10,6 +10,7 @@ export const GLOBAL_SPATIAL_MAP_MODELS = [
   { model: "s1_eternum-TileOpt", colField: "col", rowField: "row" },
   { model: "s1_eternum-Structure", colField: "base.coord_x", rowField: "base.coord_y" },
   { model: "s1_eternum-StructureBuildings", colField: "coord.x", rowField: "coord.y" },
+  { model: "s1_eternum-Building", colField: "outer_col", rowField: "outer_row" },
   { model: "s1_eternum-ExplorerTroops", colField: "coord.x", rowField: "coord.y" },
   { model: "s1_eternum-ExplorerRewardEvent", colField: "coord.x", rowField: "coord.y" },
   { model: "s1_eternum-BattleEvent", colField: "coord.x", rowField: "coord.y" },
@@ -17,6 +18,6 @@ export const GLOBAL_SPATIAL_MAP_MODELS = [
 
 export const GLOBAL_SPATIAL_MAP_MODEL_NAMES = GLOBAL_SPATIAL_MAP_MODELS.map(({ model }) => model);
 
-export const GLOBAL_SPATIAL_MAP_STREAM_MODELS: GlobalModelStreamConfig[] = GLOBAL_SPATIAL_MAP_MODEL_NAMES.map(
+export const GLOBAL_SPATIAL_MAP_SNAPSHOT_MODELS: GlobalModelStreamConfig[] = GLOBAL_SPATIAL_MAP_MODEL_NAMES.map(
   (model) => ({ model }),
 );

--- a/client/apps/game/src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts
@@ -11,8 +11,9 @@ describe("global spatial setup-timeout wiring", () => {
   it("routes global spatial snapshot timeout reporting through initial sync", () => {
     const source = readSource("src/dojo/sync.ts");
     const start = source.indexOf("async function hydrateGlobalSpatialMapSnapshot");
-    const end = source.indexOf("async function subscribeGlobalSpatialMapStream", start);
+    const end = source.indexOf("async function syncGlobalSpatialMapSnapshot", start);
     expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
     const methodSource = source.slice(start, end);
 
     expect(methodSource).toContain('label: "global spatial map snapshot"');
@@ -20,16 +21,16 @@ describe("global spatial setup-timeout wiring", () => {
     expect(methodSource).toContain("recordGameEntryDuration");
   });
 
-  it("routes global spatial subscription setup timeout reporting through initial sync", () => {
+  it("keeps live global spatial updates owned by the all-entity stream", () => {
     const source = readSource("src/dojo/sync.ts");
-    const start = source.indexOf("async function subscribeGlobalSpatialMapStream");
-    const end = source.indexOf("async function syncGlobalSpatialMapStream", start);
+    const start = source.indexOf("async function syncGlobalSpatialMapSnapshot");
+    const end = source.indexOf("// initial sync runs before the game is playable", start);
     expect(start).toBeGreaterThan(-1);
     const methodSource = source.slice(start, end);
 
-    expect(methodSource).toContain('streamType: "spatial"');
-    expect(methodSource).toContain("onSubscriptionSetupTimeout: input.onSubscriptionSetupTimeout");
-    expect(methodSource).toContain("readyOnSubscriptionsReady: true");
+    expect(source).not.toContain("async function subscribeGlobalSpatialMapStream");
+    expect(methodSource).toContain("hydrateGlobalSpatialMapSnapshot");
+    expect(methodSource).not.toContain("syncEntitiesDebounced");
   });
 
   it("keeps worldmap free of the removed per-bounds timeout toast path", () => {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -23,6 +23,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-05-19",
+    title: "Provision Sync Recovery",
+    description:
+      "Fixed realm provisioning so completed realms stay synced after refreshes and duplicate provision attempts recover back into the correct state.",
+    type: "fix",
+    gameSlug: "world",
+  },
+  {
+    date: "2026-05-19",
     title: "Selected Scout Destination",
     description:
       "Fixed scout movement so the destination hex stays selected after an explore or travel command, keeping the tile panel populated through chunk changes.",

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.test.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.test.tsx
@@ -9,10 +9,12 @@ const mocks = vi.hoisted(() => ({
   currentBlockTimestamp: 200,
   worldMode: "blitz" as "blitz" | "eternum" | "unknown",
   buildings: [] as Array<{ category: number }>,
+  structureBuildings: null as Record<string, unknown> | null,
   executeObservedClientTransaction: vi.fn(),
   getStructuresDataFromTorii: vi.fn(),
   toastError: vi.fn(),
   getContractByName: vi.fn(() => ({ address: "0xblitz" })),
+  getBuildingCount: vi.fn(() => 0),
 }));
 
 vi.mock("@/hooks/helpers/use-block-timestamp", () => ({
@@ -70,9 +72,13 @@ vi.mock("@bibliothecadao/react", () => ({
 }));
 
 vi.mock("@dojoengine/react", () => ({
-  useComponentValue: (_component: unknown, realmEntity: unknown) => {
+  useComponentValue: (component: { key?: string } | undefined, realmEntity: unknown) => {
     if (!realmEntity) {
       return null;
+    }
+
+    if (component?.key === "StructureBuildings") {
+      return mocks.structureBuildings;
     }
 
     return { version: String(realmEntity) };
@@ -80,8 +86,9 @@ vi.mock("@dojoengine/react", () => ({
 }));
 
 vi.mock("@bibliothecadao/eternum", () => ({
-  getRealmInfo: (realmEntity: bigint) => ({
-    entityId: Number(realmEntity),
+  getBuildingCount: mocks.getBuildingCount,
+  getRealmInfo: () => ({
+    entityId: 101,
     level: 1,
     category: 1,
     owner: "0xowner",
@@ -174,6 +181,7 @@ describe("useBlitzRealmProvision", () => {
     mocks.currentBlockTimestamp = 200;
     mocks.worldMode = "blitz";
     mocks.buildings = [];
+    mocks.structureBuildings = null;
     mocks.executeObservedClientTransaction.mockReset();
     mocks.executeObservedClientTransaction.mockResolvedValue({ transaction_hash: "0xtx" });
     mocks.getStructuresDataFromTorii.mockReset();
@@ -181,6 +189,8 @@ describe("useBlitzRealmProvision", () => {
     mocks.toastError.mockReset();
     mocks.getContractByName.mockReset();
     mocks.getContractByName.mockReturnValue({ address: "0xblitz" });
+    mocks.getBuildingCount.mockReset();
+    mocks.getBuildingCount.mockReturnValue(0);
 
     useUIStore.setState({
       gameStartMainAt: 100,
@@ -224,6 +234,30 @@ describe("useBlitzRealmProvision", () => {
     expect(readProbeValue("canProvision")).toBe("false");
   });
 
+  it("uses StructureBuildings as the primary provisioned signal", async () => {
+    mocks.structureBuildings = {
+      packed_counts_1: "1",
+      packed_counts_2: "0",
+      packed_counts_3: "0",
+    };
+    mocks.getBuildingCount.mockReturnValue(1);
+
+    await renderProbe();
+
+    expect(readProbeValue("isProvisioned")).toBe("true");
+    expect(readProbeValue("canProvision")).toBe("false");
+    expect(mocks.getBuildingCount).toHaveBeenCalledWith(28, [1n, 0n, 0n]);
+  });
+
+  it("falls back to Building rows when StructureBuildings is not available", async () => {
+    mocks.buildings = [{ category: 28 }];
+
+    await renderProbe();
+
+    expect(readProbeValue("isProvisioned")).toBe("true");
+    expect(readProbeValue("canProvision")).toBe("false");
+  });
+
   it("submits the provision call and clears once the labor building appears", async () => {
     await renderProbe();
     await clickProvision();
@@ -245,5 +279,20 @@ describe("useBlitzRealmProvision", () => {
 
     expect(readProbeValue("isProvisioned")).toBe("true");
     expect(readProbeValue("status")).toBe("idle");
+  });
+
+  it("recovers duplicate already-provisioned errors by refreshing synced realm data", async () => {
+    mocks.executeObservedClientTransaction.mockRejectedValueOnce(new Error("realm is already provisioned"));
+
+    await renderProbe();
+    await clickProvision();
+
+    expect(mocks.getStructuresDataFromTorii).toHaveBeenCalledWith(
+      { id: "torii" },
+      [],
+      [{ entityId: 101, position: { col: 12, row: 34 } }],
+    );
+    expect(readProbeValue("status")).toBe("syncing");
+    expect(readProbeValue("loading")).toBe("true");
   });
 });

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.ts
@@ -9,7 +9,7 @@ import { useComponentValue } from "@dojoengine/react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { CallData } from "starknet";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { getRealmInfo } from "@bibliothecadao/eternum";
+import { getBuildingCount, getRealmInfo } from "@bibliothecadao/eternum";
 import { useBuildings, useDojo } from "@bibliothecadao/react";
 import { BuildingType, ContractAddress, StructureType } from "@bibliothecadao/types";
 import { dojoConfig } from "../../../../../dojo-config";
@@ -22,6 +22,11 @@ type LiveRealmInfo = NonNullable<ReturnType<typeof getRealmInfo>>;
 type RealmProvisionSyncTarget = Parameters<typeof getStructuresDataFromTorii>[2][number];
 type RealmProvisionToriiComponents = Parameters<typeof getStructuresDataFromTorii>[1];
 type RealmProvisionActionStatus = "idle" | "submitting" | "syncing" | "syncTimeout";
+type StructureBuildingsCounts = {
+  packed_counts_1?: bigint | number | string;
+  packed_counts_2?: bigint | number | string;
+  packed_counts_3?: bigint | number | string;
+};
 
 interface StructureProvisionResult {
   canProvision: boolean;
@@ -59,6 +64,41 @@ const resolveRealmProvisionToriiComponents = (contractComponents: unknown): Real
 
 const hasProvisionBuilding = (buildings: Array<{ category: number }> | null | undefined) =>
   Boolean(buildings?.some((building) => building?.category === BuildingType.ResourceLabor));
+
+const readPackedCount = (value: bigint | number | string | undefined): bigint => {
+  if (value === undefined) {
+    return 0n;
+  }
+
+  return BigInt(value);
+};
+
+const resolvePackedBuildingCounts = (structureBuildings: unknown): bigint[] | null => {
+  if (!structureBuildings || typeof structureBuildings !== "object") {
+    return null;
+  }
+
+  const counts = structureBuildings as StructureBuildingsCounts;
+  return [
+    readPackedCount(counts.packed_counts_1),
+    readPackedCount(counts.packed_counts_2),
+    readPackedCount(counts.packed_counts_3),
+  ];
+};
+
+const hasProvisionBuildingCount = (structureBuildings: unknown): boolean => {
+  const packedCounts = resolvePackedBuildingCounts(structureBuildings);
+  if (!packedCounts) {
+    return false;
+  }
+
+  return getBuildingCount(BuildingType.ResourceLabor, packedCounts) > 0;
+};
+
+const isAlreadyProvisionedError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("realm is already provisioned");
+};
 
 const syncRealmStructureIfPossible = async ({
   toriiClient,
@@ -135,7 +175,7 @@ export const useBlitzRealmProvision = (structureEntityId: number | null): Struct
   const isBlitzWorld = resolvedWorldGameMode === "blitz";
   const ownerAddress = account.account?.address ? ContractAddress(account.account.address) : null;
   const isOwner = Boolean(structureInfo && ownerAddress && structureInfo.owner === ownerAddress);
-  const isProvisioned = hasProvisionBuilding(realmBuildings);
+  const isProvisioned = hasProvisionBuildingCount(liveStructureBuildings) || hasProvisionBuilding(realmBuildings);
   const isMainPhase = hasMainStarted(currentBlockTimestamp, gameStartMainAt);
   const isSeasonOver = hasSeasonEnded(currentBlockTimestamp, gameEndAt);
   const canProvision = Boolean(isBlitzWorld && isRealm && isOwner && isMainPhase && !isSeasonOver && !isProvisioned);
@@ -222,10 +262,20 @@ export const useBlitzRealmProvision = (structureEntityId: number | null): Struct
 
       setProvisionActionState("syncing");
     } catch (error) {
+      if (isAlreadyProvisionedError(error) && syncTarget) {
+        setProvisionActionState("syncing");
+        await syncRealmStructureIfPossible({
+          toriiClient: network.toriiClient,
+          contractComponents: toriiComponents,
+          syncTarget,
+        });
+        return;
+      }
+
       setProvisionActionState("idle");
       throw error;
     }
-  }, [account.account, canProvision, structureInfo]);
+  }, [account.account, canProvision, network.toriiClient, structureInfo, syncTarget, toriiComponents]);
 
   if (!structureInfo) {
     return null;


### PR DESCRIPTION
This fixes blitz realm provision recovery by treating StructureBuildings counts as authoritative, polling Torii after successful or duplicate provision attempts, and documenting the fix in latest features.

It also simplifies global sync to one all-entity stream with scoped event subscriptions while hydrating the spatial map from a strict snapshot that includes Building rows.

The debounced Torii query queue now resolves callers after their request completes and settles pending queued work during queue clears, which prevents stale refresh waits from hanging.

Validated with `pnpm run format`, `pnpm run knip`, `git diff --check HEAD`, `pnpm --dir client/apps/game test src/dojo/debounced-queries.test.ts src/dojo/sync.test.ts src/ui/modules/entity-details/hooks/use-blitz-realm-provision.test.tsx`, and `pnpm --dir client/apps/game exec tsc --noEmit --pretty false --incremental false`.