### PR TITLE
[codex] Fix mainnet game loading

### DIFF
--- a/client/apps/game/dojo-config.ts
+++ b/client/apps/game/dojo-config.ts
@@ -7,9 +7,11 @@ import {
   normalizeRpcUrl,
   patchManifestWithFactory,
   probeSlotDeploymentRpcAlive,
+  probeWorldToriiAlive,
   purgeDeadSlotWorldProfiles,
   purgeUnavailableSlotWorldProfiles,
   resolveChain,
+  type WorldProfile,
 } from "@/runtime/world";
 import { Chain, getGameManifest } from "@contracts";
 import { createDojoConfig } from "@dojoengine/core";
@@ -34,21 +36,31 @@ const cartridgeApiBase = env.VITE_PUBLIC_CARTRIDGE_API_BASE || "https://api.cart
 // on "Reconnect to Continue" forever.
 purgeUnavailableSlotWorldProfiles();
 
-// Probe each saved slot profile's RPC directly — this is the *exact* request
-// `ControllerConnector` is about to make, so it's the only liveness signal
-// that's authoritative for the controller-init path. Realtime-server bulk
-// availability lags GC by 30s + has a 5min stale cache, so we don't trust it
-// here. `null` = indeterminate, treat as alive (no false-positive evictions).
-const slotProfilesToProbe = listSavedWorldProfiles().filter(
-  (profile) => profile.chain === "slot" || profile.chain === "slottest",
-);
-const probedDeadSlotNames = new Set<string>();
-await Promise.all(
-  slotProfilesToProbe.map(async (profile) => {
-    const alive = await probeSlotDeploymentRpcAlive(profile.rpcUrl);
-    if (alive === false) probedDeadSlotNames.add(profile.name);
-  }),
-);
+const isSavedSlotWorldProfile = (profile: WorldProfile): boolean =>
+  profile.chain === "slot" || profile.chain === "slottest";
+
+const probeSavedSlotWorldProfile = async (profile: WorldProfile): Promise<string | null> => {
+  const [rpcAlive, toriiAlive] = await Promise.all([
+    probeSlotDeploymentRpcAlive(profile.rpcUrl),
+    probeWorldToriiAlive(profile.toriiBaseUrl),
+  ]);
+
+  return rpcAlive === false || toriiAlive === false ? profile.name : null;
+};
+
+const resolveDeadSlotWorldNames = async (): Promise<Set<string>> => {
+  const slotProfilesToProbe = listSavedWorldProfiles().filter(isSavedSlotWorldProfile);
+  const probeResults = await Promise.all(slotProfilesToProbe.map(probeSavedSlotWorldProfile));
+
+  return new Set(probeResults.filter((name): name is string => name !== null));
+};
+
+// Probe each saved slot profile before `ControllerConnector` is created.
+// The RPC probe protects controller init, while the Torii probe catches old
+// per-world indexers that can 404 even when the shared slot RPC is still alive.
+// `null` from either probe is indeterminate, so profiles are only evicted on
+// explicit dead signals.
+const probedDeadSlotNames = await resolveDeadSlotWorldNames();
 const evictedDeadSlotWorlds = purgeDeadSlotWorldProfiles(probedDeadSlotNames);
 if (evictedDeadSlotWorlds.length > 0) {
   console.warn(

--- a/client/apps/game/env.ts
+++ b/client/apps/game/env.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_STANDALONE_AMMV2_ROUTER_ADDRESS,
 } from "@bibliothecadao/ammv2-sdk";
 import { getSelectedChain } from "./src/runtime/world/store";
+import { assertPublicEnvConsistency } from "./src/utils/public-env-consistency";
 
 const _rawEnv = import.meta.env as Record<string, string | undefined>;
 
@@ -295,9 +296,12 @@ try {
     ...import.meta.env,
     VITE_PUBLIC_AMM_ROUTER_ADDRESS: resolveLegacyAmmRouterAddress(_rawEnv),
   });
+  assertPublicEnvConsistency(env);
 } catch (error) {
   if (error instanceof z.ZodError) {
     console.error("❌ Invalid environment variables:", JSON.stringify(error.errors, null, 2));
+  } else {
+    console.error("❌ Invalid environment variables:", error);
   }
   throw new Error("Invalid environment variables");
 }

--- a/client/apps/game/src/game-entry/play-route-boot.test.tsx
+++ b/client/apps/game/src/game-entry/play-route-boot.test.tsx
@@ -8,17 +8,25 @@ const retryMock = vi.fn();
 const setAccountNameMock = vi.fn();
 const setShowBlankOverlayMock = vi.fn();
 const useGameEntryBootstrapControllerMock = vi.fn();
+const starknetReactState = vi.hoisted(() => ({
+  account: null as unknown,
+  connector: null as unknown,
+  controllerAccount: null as unknown,
+  connectors: [] as unknown[],
+  isConnected: false,
+  isConnecting: false,
+}));
 
 vi.mock("@starknet-react/core", () => ({
   useAccount: () => ({
-    account: null,
-    connector: null,
-    isConnected: false,
-    isConnecting: false,
+    account: starknetReactState.account,
+    connector: starknetReactState.connector,
+    isConnected: starknetReactState.isConnected,
+    isConnecting: starknetReactState.isConnecting,
   }),
   useConnect: () => ({
     connectAsync: connectAsyncMock,
-    connectors: [],
+    connectors: starknetReactState.connectors,
   }),
 }));
 
@@ -27,7 +35,7 @@ vi.mock("@/game-entry/bootstrap-controller", () => ({
 }));
 
 vi.mock("@/hooks/context/use-controller-account", () => ({
-  useControllerAccount: () => null,
+  useControllerAccount: () => starknetReactState.controllerAccount,
 }));
 
 vi.mock("@/hooks/store/use-account-store", () => ({
@@ -52,8 +60,10 @@ vi.mock("@/hooks/use-cartridge-username", () => ({
 const { usePlayRouteBootController } = await import("./play-route-boot");
 const { usePlayRouteReadinessStore } = await import("./play-route-readiness-store");
 
+let latestBootController: ReturnType<typeof usePlayRouteBootController> | null = null;
+
 const BootControllerHarness = () => {
-  usePlayRouteBootController();
+  latestBootController = usePlayRouteBootController();
   return null;
 };
 
@@ -90,6 +100,13 @@ describe("usePlayRouteBootController", () => {
     setShowBlankOverlayMock.mockReset();
     useGameEntryBootstrapControllerMock.mockReset();
     useGameEntryBootstrapControllerMock.mockReturnValue(createIdleBootstrapControllerState());
+    starknetReactState.account = null;
+    starknetReactState.connector = null;
+    starknetReactState.controllerAccount = null;
+    starknetReactState.connectors = [];
+    starknetReactState.isConnected = false;
+    starknetReactState.isConnecting = false;
+    latestBootController = null;
     usePlayRouteReadinessStore.getState().reset(0);
   });
 
@@ -114,5 +131,45 @@ describe("usePlayRouteBootController", () => {
     expect(getRenderPhaseUpdateWarnings(consoleErrorMock)).toEqual([]);
     expect(usePlayRouteReadinessStore.getState().bootToken).toBe(1);
     expect(setShowBlankOverlayMock).toHaveBeenCalledWith(true);
+  });
+
+  it("retries controller connection when Starknet is connected without a resolved controller account", async () => {
+    const connector = { id: "controller" };
+    starknetReactState.connectors = [connector];
+    starknetReactState.isConnected = true;
+    connectAsyncMock.mockResolvedValue(undefined);
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/play/mainnet/iron-age/map"]}>
+          <BootControllerHarness />
+        </MemoryRouter>,
+      );
+    });
+
+    latestBootController?.connectWallet();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(connectAsyncMock).toHaveBeenCalledWith({ connector });
+  });
+
+  it("does not reconnect when Starknet and the controller account are both resolved", async () => {
+    starknetReactState.connectors = [{ id: "controller" }];
+    starknetReactState.controllerAccount = { address: "0x123" };
+    starknetReactState.isConnected = true;
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/play/mainnet/iron-age/map"]}>
+          <BootControllerHarness />
+        </MemoryRouter>,
+      );
+    });
+
+    latestBootController?.connectWallet();
+
+    expect(connectAsyncMock).not.toHaveBeenCalled();
   });
 });

--- a/client/apps/game/src/game-entry/play-route-boot.ts
+++ b/client/apps/game/src/game-entry/play-route-boot.ts
@@ -302,7 +302,11 @@ export const usePlayRouteBootController = (): PlayRouteBootControllerState => {
   }, [shouldTrackReconnectGrace, location.pathname, location.search]);
 
   const connectWallet = useCallback(() => {
-    if (isConnected || isConnecting) {
+    if (isConnecting) {
+      return;
+    }
+
+    if (isConnected && resolvedAccount) {
       return;
     }
 
@@ -315,7 +319,7 @@ export const usePlayRouteBootController = (): PlayRouteBootControllerState => {
     void connectWithControllerRetry(connectAsync, primaryConnector).catch((error) => {
       console.error("Unable to connect wallet:", error);
     });
-  }, [connectAsync, connectors, isConnected, isConnecting]);
+  }, [connectAsync, connectors, isConnected, isConnecting, resolvedAccount]);
 
   const phase = resolveBootPhase({
     bootstrapError: bootstrap.error,

--- a/client/apps/game/src/init/bootstrap.tsx
+++ b/client/apps/game/src/init/bootstrap.tsx
@@ -11,6 +11,7 @@ import {
   buildSharedSlotRpcUrl,
   isSlotWorldChain,
   patchManifestWithFactory,
+  probeWorldToriiAlive,
   type WorldProfile,
 } from "@/runtime/world";
 import { setSqlApiBaseUrl } from "@/services/api";
@@ -121,13 +122,14 @@ const runBootstrap = async ({
   context: ResolvedEntryContext;
   profile: WorldProfile;
 }): Promise<BootstrapResult> => {
-  console.log("[STARTING DOJO SETUP]");
   const stores = resolveBootstrapStores();
   const worldContext = {
     chain: context.chain,
     profile,
     toriiUrl: resolveBootstrapToriiUrl(context.chain, profile),
   };
+  await assertBootstrapToriiIsAvailable(worldContext);
+  console.log("[STARTING DOJO SETUP]");
   configureDojoRuntime(worldContext);
   const setupResult = await runDojoSetup();
   await runInitialWorldSync(setupResult, stores);
@@ -248,6 +250,15 @@ const resolveBootstrapRpcUrl = (chain: Chain, profile: WorldProfile): string => 
   }
 
   return profile.rpcUrl ?? env.VITE_PUBLIC_NODE_URL;
+};
+
+const assertBootstrapToriiIsAvailable = async ({ profile, toriiUrl }: BootstrapWorldContext): Promise<void> => {
+  const toriiAlive = await probeWorldToriiAlive(toriiUrl);
+  if (toriiAlive !== false) {
+    return;
+  }
+
+  throw new Error(`World indexer is not available: ${profile.name}`);
 };
 
 const runDojoSetup = async (): Promise<SetupResult> => {

--- a/client/apps/game/src/runtime/world/factory-resolver.test.ts
+++ b/client/apps/game/src/runtime/world/factory-resolver.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../../env", () => ({
   },
 }));
 
-import { resolveWorldDeploymentFromFactory } from "./factory-resolver";
+import { probeWorldToriiAlive, resolveWorldDeploymentFromFactory } from "./factory-resolver";
 
 describe("resolveWorldDeploymentFromFactory", () => {
   beforeEach(() => {
@@ -133,5 +133,56 @@ describe("resolveWorldDeploymentFromFactory", () => {
     expect(mockFetch).toHaveBeenCalledWith("https://realtime.example/api/world-deployments/slot/bltz-warzone-31", {
       signal: expect.any(AbortSignal),
     });
+  });
+});
+
+describe("probeWorldToriiAlive", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true when the SQL endpoint is reachable", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("[]", { status: 200 }));
+
+    await expect(probeWorldToriiAlive("https://api.cartridge.gg/x/mainnet-world/torii")).resolves.toBe(true);
+
+    expect(mockFetch).toHaveBeenCalledWith("https://api.cartridge.gg/x/mainnet-world/torii/sql", {
+      method: "GET",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("returns false when the SQL endpoint explicitly reports a missing deployment", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("not found", { status: 404 }));
+
+    await expect(probeWorldToriiAlive("https://api.cartridge.gg/x/dead-slot-world/torii")).resolves.toBe(false);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the health endpoint when SQL reachability is indeterminate", async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response("gateway unavailable", { status: 503 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    await expect(probeWorldToriiAlive("https://api.cartridge.gg/x/recovering-world/torii")).resolves.toBe(true);
+
+    expect(mockFetch).toHaveBeenLastCalledWith("https://api.cartridge.gg/x/recovering-world/torii/health", {
+      method: "GET",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("keeps indeterminate probes from being treated as dead", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }));
+
+    await expect(probeWorldToriiAlive("https://api.cartridge.gg/x/maybe-live-world/torii")).resolves.toBe(null);
   });
 });

--- a/client/apps/game/src/runtime/world/factory-resolver.ts
+++ b/client/apps/game/src/runtime/world/factory-resolver.ts
@@ -49,6 +49,55 @@ export const isToriiAvailable = async (toriiBaseUrl: string): Promise<boolean> =
   }
 };
 
+type WorldToriiProbePath = "/sql" | "/health";
+
+const buildWorldToriiProbeUrl = (toriiBaseUrl: string, path: WorldToriiProbePath): string =>
+  `${toriiBaseUrl.replace(/\/+$/, "")}${path}`;
+
+const classifyWorldToriiProbeResponse = (response: Response): boolean | null => {
+  if (response.ok) return true;
+  if (response.status === 404) return false;
+  return null;
+};
+
+const probeWorldToriiPath = async (
+  toriiBaseUrl: string,
+  path: WorldToriiProbePath,
+  timeoutMs: number,
+): Promise<boolean | null> => {
+  try {
+    const response = await fetch(buildWorldToriiProbeUrl(toriiBaseUrl, path), {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return classifyWorldToriiProbeResponse(response);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Probes a world's Torii endpoint without requiring any world-specific tables.
+ * Returns:
+ *   - `true`  : Torii responded on `/sql` or `/health`
+ *   - `false` : `/sql` explicitly 404'd, which means the indexed world route is gone
+ *   - `null`  : indeterminate; callers must not evict saved state on this value
+ */
+export const probeWorldToriiAlive = async (
+  toriiBaseUrl: string | null | undefined,
+  timeoutMs = 2_000,
+): Promise<boolean | null> => {
+  if (!toriiBaseUrl) return null;
+
+  const sqlProbeResult = await probeWorldToriiPath(toriiBaseUrl, "/sql", timeoutMs);
+  if (sqlProbeResult !== null) return sqlProbeResult;
+
+  const healthProbeResult = await probeWorldToriiPath(toriiBaseUrl, "/health", timeoutMs);
+  if (healthProbeResult === true) return true;
+
+  return null;
+};
+
 /**
  * Fetch bulk world availability from the realtime server.
  * Returns a map of world names to alive/dead status.

--- a/client/apps/game/src/utils/config.ts
+++ b/client/apps/game/src/utils/config.ts
@@ -1,10 +1,17 @@
-import { ToriiSetting } from "@/types";
 import { resolveGameModeFromBlitzFlag } from "@/config/game-modes/resolved-mode";
 import { ContractComponents, WORLD_CONFIG_ID } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { Chain, GameType, getConfigFromNetwork } from "@config";
 import { env } from "./../../env";
+import {
+  DEFAULT_TORII_SETTING,
+  isToriiSetting,
+  resolveToriiUrlForSetting,
+  resolveUnavailableToriiFallbackSetting,
+} from "./torii-setting";
+
+export { DEFAULT_TORII_SETTING } from "./torii-setting";
 
 type ConfigResolutionOptions = {
   chain?: Chain;
@@ -36,33 +43,24 @@ export const ETERNUM_CONFIG = (options: ConfigResolutionOptions = {}) => {
 };
 
 export const TORII_SETTING = async (): Promise<string> => {
-  let toriiSetting = localStorage.getItem("TORII_SETTING") as ToriiSetting;
-  if (!toriiSetting) {
-    localStorage.setItem("TORII_SETTING", DEFAULT_TORII_SETTING);
-    toriiSetting = DEFAULT_TORII_SETTING;
+  const toriiSetting = readToriiSetting();
+  const toriiUrl = resolveToriiUrlForSetting(toriiSetting, env.VITE_PUBLIC_TORII);
+
+  if (await doAliveCheck(toriiUrl)) {
+    return toriiUrl;
   }
 
-  let toriiUrl = settingToUrl(toriiSetting);
+  const fallbackSetting = resolveUnavailableToriiFallbackSetting(toriiSetting, {
+    chain: env.VITE_PUBLIC_CHAIN as Chain,
+    isDev: import.meta.env.DEV,
+  });
 
-  const isAlive = await doAliveCheck(toriiUrl);
-
-  if (!isAlive) {
-    const newSetting = getOppositeSetting(toriiSetting);
-    localStorage.setItem("TORII_SETTING", newSetting);
-    toriiUrl = settingToUrl(newSetting);
+  if (!fallbackSetting) {
+    return toriiUrl;
   }
 
-  return toriiUrl;
-};
-
-export const DEFAULT_TORII_SETTING = ToriiSetting.Remote;
-
-const settingToUrl = (setting: ToriiSetting) => {
-  return setting === ToriiSetting.Local ? "http://localhost:8080" : env.VITE_PUBLIC_TORII;
-};
-
-const getOppositeSetting = (setting: ToriiSetting) => {
-  return setting === ToriiSetting.Local ? ToriiSetting.Remote : ToriiSetting.Local;
+  localStorage.setItem("TORII_SETTING", fallbackSetting);
+  return resolveToriiUrlForSetting(fallbackSetting, env.VITE_PUBLIC_TORII);
 };
 
 const doAliveCheck = async (url: string) => {
@@ -72,4 +70,14 @@ const doAliveCheck = async (url: string) => {
   } catch {
     return false;
   }
+};
+
+const readToriiSetting = () => {
+  const storedSetting = localStorage.getItem("TORII_SETTING");
+  if (isToriiSetting(storedSetting)) {
+    return storedSetting;
+  }
+
+  localStorage.setItem("TORII_SETTING", DEFAULT_TORII_SETTING);
+  return DEFAULT_TORII_SETTING;
 };

--- a/client/apps/game/src/utils/public-env-consistency.test.ts
+++ b/client/apps/game/src/utils/public-env-consistency.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { assertPublicEnvConsistency, resolvePublicEnvConsistencyErrors } from "./public-env-consistency";
+
+const mainnetEnv = {
+  VITE_PUBLIC_CHAIN: "mainnet" as const,
+  VITE_PUBLIC_SLOT: "eternum-resources-mainnet-5",
+  VITE_PUBLIC_TORII: "https://api.cartridge.gg/x/eternum-game-mainnet-38-pro/torii",
+};
+
+describe("resolvePublicEnvConsistencyErrors", () => {
+  it("accepts the mainnet deployment values used by the checked-in mainnet env", () => {
+    expect(resolvePublicEnvConsistencyErrors(mainnetEnv)).toEqual([]);
+  });
+
+  it("rejects a mainnet build with a slot Torii endpoint", () => {
+    expect(
+      resolvePublicEnvConsistencyErrors({
+        ...mainnetEnv,
+        VITE_PUBLIC_TORII: "https://api.cartridge.gg/x/eternum-blitz-slot-test/torii",
+      }),
+    ).toEqual([
+      "VITE_PUBLIC_TORII points to a slot deployment: https://api.cartridge.gg/x/eternum-blitz-slot-test/torii",
+    ]);
+  });
+
+  it("rejects a mainnet build with a slot deployment name", () => {
+    expect(
+      resolvePublicEnvConsistencyErrors({
+        ...mainnetEnv,
+        VITE_PUBLIC_SLOT: "eternum-blitz-slot-4",
+      }),
+    ).toEqual(["VITE_PUBLIC_SLOT points to a slot deployment: eternum-blitz-slot-4"]);
+  });
+
+  it("allows slot deployments for slot-chain builds", () => {
+    expect(
+      resolvePublicEnvConsistencyErrors({
+        VITE_PUBLIC_CHAIN: "slot",
+        VITE_PUBLIC_SLOT: "eternum-blitz-slot-4",
+        VITE_PUBLIC_TORII: "https://api.cartridge.gg/x/eternum-blitz-slot-4/torii",
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("assertPublicEnvConsistency", () => {
+  it("throws a clear error for contradictory mainnet env values", () => {
+    expect(() =>
+      assertPublicEnvConsistency({
+        ...mainnetEnv,
+        VITE_PUBLIC_SLOT: "eternum-blitz-slot-4",
+        VITE_PUBLIC_TORII: "https://api.cartridge.gg/x/eternum-blitz-slot-test/torii",
+      }),
+    ).toThrow(
+      [
+        "Invalid public environment configuration:",
+        "- VITE_PUBLIC_TORII points to a slot deployment: https://api.cartridge.gg/x/eternum-blitz-slot-test/torii",
+        "- VITE_PUBLIC_SLOT points to a slot deployment: eternum-blitz-slot-4",
+      ].join("\n"),
+    );
+  });
+});

--- a/client/apps/game/src/utils/public-env-consistency.ts
+++ b/client/apps/game/src/utils/public-env-consistency.ts
@@ -1,0 +1,52 @@
+type PublicEnvChain = "sepolia" | "mainnet" | "slot" | "slottest" | "local";
+
+type PublicEnvConsistencyInput = {
+  VITE_PUBLIC_CHAIN: PublicEnvChain;
+  VITE_PUBLIC_SLOT: string;
+  VITE_PUBLIC_TORII: string;
+};
+
+export const assertPublicEnvConsistency = (env: PublicEnvConsistencyInput): void => {
+  const errors = resolvePublicEnvConsistencyErrors(env);
+  if (errors.length === 0) {
+    return;
+  }
+
+  throw new Error(`Invalid public environment configuration:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+};
+
+export const resolvePublicEnvConsistencyErrors = (env: PublicEnvConsistencyInput): string[] => {
+  if (env.VITE_PUBLIC_CHAIN !== "mainnet") {
+    return [];
+  }
+
+  return resolveMainnetEnvConsistencyErrors(env);
+};
+
+const resolveMainnetEnvConsistencyErrors = (env: PublicEnvConsistencyInput): string[] => {
+  const errors: string[] = [];
+
+  if (pointsToSlotDeployment(resolveToriiDeploymentName(env.VITE_PUBLIC_TORII))) {
+    errors.push(`VITE_PUBLIC_TORII points to a slot deployment: ${env.VITE_PUBLIC_TORII}`);
+  }
+
+  if (pointsToSlotDeployment(env.VITE_PUBLIC_SLOT)) {
+    errors.push(`VITE_PUBLIC_SLOT points to a slot deployment: ${env.VITE_PUBLIC_SLOT}`);
+  }
+
+  return errors;
+};
+
+const resolveToriiDeploymentName = (toriiUrl: string): string => {
+  try {
+    const pathnameParts = new URL(toriiUrl).pathname.split("/").filter(Boolean);
+    const deploymentPrefixIndex = pathnameParts.indexOf("x");
+    return deploymentPrefixIndex >= 0 ? (pathnameParts[deploymentPrefixIndex + 1] ?? toriiUrl) : toriiUrl;
+  } catch {
+    return toriiUrl;
+  }
+};
+
+const pointsToSlotDeployment = (deploymentName: string): boolean => {
+  return /(^|[-_/])slot(test)?($|[-_/])/.test(deploymentName.toLowerCase());
+};

--- a/client/apps/game/src/utils/torii-setting.test.ts
+++ b/client/apps/game/src/utils/torii-setting.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { ToriiSetting } from "@/types";
+import { LOCAL_TORII_URL, resolveToriiUrlForSetting, resolveUnavailableToriiFallbackSetting } from "./torii-setting";
+
+describe("resolveToriiUrlForSetting", () => {
+  it("uses localhost for the local loader setting", () => {
+    expect(resolveToriiUrlForSetting(ToriiSetting.Local, "https://api.example.test/x/world/torii")).toBe(
+      LOCAL_TORII_URL,
+    );
+  });
+
+  it("uses the configured remote Torii for the remote setting", () => {
+    expect(resolveToriiUrlForSetting(ToriiSetting.Remote, "https://api.example.test/x/world/torii")).toBe(
+      "https://api.example.test/x/world/torii",
+    );
+  });
+});
+
+describe("resolveUnavailableToriiFallbackSetting", () => {
+  it("keeps a production mainnet remote failure on the configured remote URL", () => {
+    expect(
+      resolveUnavailableToriiFallbackSetting(ToriiSetting.Remote, {
+        chain: "mainnet",
+        isDev: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("allows remote Torii to fall back to local while developing", () => {
+    expect(
+      resolveUnavailableToriiFallbackSetting(ToriiSetting.Remote, {
+        chain: "mainnet",
+        isDev: true,
+      }),
+    ).toBe(ToriiSetting.Local);
+  });
+
+  it("allows remote Torii to fall back to local for local-chain builds", () => {
+    expect(
+      resolveUnavailableToriiFallbackSetting(ToriiSetting.Remote, {
+        chain: "local",
+        isDev: false,
+      }),
+    ).toBe(ToriiSetting.Local);
+  });
+
+  it("falls back to remote when an explicit local loader is unavailable", () => {
+    expect(
+      resolveUnavailableToriiFallbackSetting(ToriiSetting.Local, {
+        chain: "mainnet",
+        isDev: false,
+      }),
+    ).toBe(ToriiSetting.Remote);
+  });
+});

--- a/client/apps/game/src/utils/torii-setting.ts
+++ b/client/apps/game/src/utils/torii-setting.ts
@@ -1,0 +1,37 @@
+import { ToriiSetting } from "@/types";
+import type { Chain } from "@config";
+
+export const DEFAULT_TORII_SETTING = ToriiSetting.Remote;
+export const LOCAL_TORII_URL = "http://localhost:8080";
+
+type ToriiFallbackContext = {
+  chain: Chain;
+  isDev: boolean;
+};
+
+export const isToriiSetting = (value: string | null): value is ToriiSetting => {
+  return value === ToriiSetting.Local || value === ToriiSetting.Remote;
+};
+
+export const resolveToriiUrlForSetting = (setting: ToriiSetting, remoteToriiUrl: string): string => {
+  return setting === ToriiSetting.Local ? LOCAL_TORII_URL : remoteToriiUrl;
+};
+
+export const resolveUnavailableToriiFallbackSetting = (
+  setting: ToriiSetting,
+  context: ToriiFallbackContext,
+): ToriiSetting | null => {
+  if (setting === ToriiSetting.Local) {
+    return ToriiSetting.Remote;
+  }
+
+  if (canAutomaticallyUseLocalTorii(context)) {
+    return ToriiSetting.Local;
+  }
+
+  return null;
+};
+
+const canAutomaticallyUseLocalTorii = ({ chain, isDev }: ToriiFallbackContext): boolean => {
+  return isDev || chain === "local";
+};


### PR DESCRIPTION
Fixes mainnet boot paths that could get stuck when stale slot Torii/RPC state leaked into startup.

The game now rejects contradictory mainnet public env values, avoids production fallback from remote Torii to localhost, and probes saved slot world Torii endpoints before reusing them.

It also retries controller connection when Starknet reports connected but no controller account has resolved, so reconnect can recover from the stuck session state.

Validated with `pnpm run format`, `pnpm run knip`, `pnpm --dir client/apps/game typecheck`, and focused Vitest coverage for Torii/config utilities; the React boot test remains blocked locally by jsdom startup under Node 21 and workspace duplicate-package resolution under Node 20.