### PR TITLE
Use ownerless spatial bootstrap snapshot

### DIFF
--- a/client/apps/game/src/dojo/sync.regression.source.test.ts
+++ b/client/apps/game/src/dojo/sync.regression.source.test.ts
@@ -22,11 +22,13 @@ describe("network boot-regression guards", () => {
     expect(source).toMatch(/cancelEntityStreamSubscription[\s\S]*?if \(isInitialSyncInFlight\) return/);
   });
 
-  it("sync.ts resets the spatial handshake clock after global spatial map snapshot is applied", () => {
+  it("sync.ts keeps the global spatial bootstrap snapshot disabled for the overwrite trial", () => {
     const source = readSource("src/dojo/sync.ts");
 
+    expect(source).toContain("const ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT = false");
     expect(source).toContain("syncGlobalSpatialMapSnapshot");
     expect(source).not.toContain("spatialMapStreamSubscription");
+    expect(source).toMatch(/if \(ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT\)[\s\S]*?syncGlobalSpatialMapSnapshot/);
     expect(source).toContain("recordSpatialHandshake()");
   });
 

--- a/client/apps/game/src/dojo/sync.regression.source.test.ts
+++ b/client/apps/game/src/dojo/sync.regression.source.test.ts
@@ -22,13 +22,14 @@ describe("network boot-regression guards", () => {
     expect(source).toMatch(/cancelEntityStreamSubscription[\s\S]*?if \(isInitialSyncInFlight\) return/);
   });
 
-  it("sync.ts keeps the global spatial bootstrap snapshot disabled for the overwrite trial", () => {
+  it("sync.ts keeps Structure owners out of the global spatial bootstrap snapshot", () => {
     const source = readSource("src/dojo/sync.ts");
+    const spatialModelsSource = readSource("src/dojo/torii-spatial-models.ts");
 
-    expect(source).toContain("const ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT = false");
-    expect(source).toContain("syncGlobalSpatialMapSnapshot");
+    expect(spatialModelsSource).toContain('GLOBAL_SPATIAL_OWNER_MODEL_NAME = "s1_eternum-Structure"');
+    expect(spatialModelsSource).toContain("model !== GLOBAL_SPATIAL_OWNER_MODEL_NAME");
+    expect(source).toContain("syncGlobalSpatialBootstrapSnapshot");
     expect(source).not.toContain("spatialMapStreamSubscription");
-    expect(source).toMatch(/if \(ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT\)[\s\S]*?syncGlobalSpatialMapSnapshot/);
     expect(source).toContain("recordSpatialHandshake()");
   });
 

--- a/client/apps/game/src/dojo/sync.test.ts
+++ b/client/apps/game/src/dojo/sync.test.ts
@@ -469,10 +469,10 @@ describe("initialSync global streams", () => {
       }),
       expect.any(Function),
     );
-    expect(getEntitiesMock).not.toHaveBeenCalled();
+    expect(getEntitiesMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips the global spatial snapshot while the bootstrap trial is disabled", async () => {
+  it("hydrates render-critical spatial rows without replaying Structure owners", async () => {
     vi.useFakeTimers();
     getEntitiesMock.mockResolvedValue(undefined);
     const harness = createSyncHarness();
@@ -492,10 +492,18 @@ describe("initialSync global streams", () => {
     await vi.advanceTimersByTimeAsync(200);
     await syncPromise;
 
-    expect(getEntitiesMock).not.toHaveBeenCalled();
+    const snapshotCall = getEntitiesMock.mock.calls[0];
+    expect(snapshotCall[1]).toEqual(
+      expect.objectContaining({
+        models: expect.arrayContaining(["s1_eternum-TileOpt", "s1_eternum-Building"]),
+      }),
+    );
+    expect(snapshotCall[1].models).not.toContain("s1_eternum-Structure");
+    expect(snapshotCall[4]).toEqual(expect.arrayContaining(["s1_eternum-TileOpt", "s1_eternum-Building"]));
+    expect(snapshotCall[4]).not.toContain("s1_eternum-Structure");
   });
 
-  it("does not let a disabled global spatial snapshot timeout block initial sync", async () => {
+  it("fails initial sync when the ownerless global spatial bootstrap snapshot times out", async () => {
     vi.useFakeTimers();
     getEntitiesMock.mockImplementation(() => new Promise(() => undefined));
     const harness = createSyncHarness();
@@ -505,6 +513,7 @@ describe("initialSync global streams", () => {
       reportProgress: false,
       subscriptionSetupTimeoutMs: 25,
     });
+    const expectedRejection = expect(syncPromise).rejects.toThrow(/global spatial map bootstrap snapshot/i);
 
     await flushMicrotasks();
     harness.emitEntityUpdate({
@@ -515,8 +524,7 @@ describe("initialSync global streams", () => {
     });
     await vi.advanceTimersByTimeAsync(225);
 
-    await expect(syncPromise).resolves.toBeUndefined();
-    expect(getEntitiesMock).not.toHaveBeenCalled();
+    await expectedRejection;
   });
 
   it("cancels the single global stream pair after initial sync", async () => {

--- a/client/apps/game/src/dojo/sync.test.ts
+++ b/client/apps/game/src/dojo/sync.test.ts
@@ -469,10 +469,10 @@ describe("initialSync global streams", () => {
       }),
       expect.any(Function),
     );
-    expect(getEntitiesMock).toHaveBeenCalledTimes(1);
+    expect(getEntitiesMock).not.toHaveBeenCalled();
   });
 
-  it("hydrates Building rows in the strict global spatial snapshot", async () => {
+  it("skips the global spatial snapshot while the bootstrap trial is disabled", async () => {
     vi.useFakeTimers();
     getEntitiesMock.mockResolvedValue(undefined);
     const harness = createSyncHarness();
@@ -492,20 +492,10 @@ describe("initialSync global streams", () => {
     await vi.advanceTimersByTimeAsync(200);
     await syncPromise;
 
-    expect(getEntitiesMock).toHaveBeenCalledWith(
-      harness.client,
-      expect.objectContaining({
-        models: expect.arrayContaining(["s1_eternum-Building"]),
-      }),
-      harness.setup.network.contractComponents,
-      [],
-      expect.arrayContaining(["s1_eternum-Building"]),
-      expect.any(Number),
-      false,
-    );
+    expect(getEntitiesMock).not.toHaveBeenCalled();
   });
 
-  it("fails initial sync when the strict global spatial snapshot times out", async () => {
+  it("does not let a disabled global spatial snapshot timeout block initial sync", async () => {
     vi.useFakeTimers();
     getEntitiesMock.mockImplementation(() => new Promise(() => undefined));
     const harness = createSyncHarness();
@@ -515,7 +505,6 @@ describe("initialSync global streams", () => {
       reportProgress: false,
       subscriptionSetupTimeoutMs: 25,
     });
-    const expectedRejection = expect(syncPromise).rejects.toThrow(/global spatial map snapshot/i);
 
     await flushMicrotasks();
     harness.emitEntityUpdate({
@@ -526,7 +515,8 @@ describe("initialSync global streams", () => {
     });
     await vi.advanceTimersByTimeAsync(225);
 
-    await expectedRejection;
+    await expect(syncPromise).resolves.toBeUndefined();
+    expect(getEntitiesMock).not.toHaveBeenCalled();
   });
 
   it("cancels the single global stream pair after initial sync", async () => {

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -26,7 +26,10 @@ import { env } from "../../env";
 import { resolveInitialStructureSelection } from "./sync-initial-selection";
 import { isDeletionPayload } from "./sync-utils";
 import { ToriiSyncWorkerManager } from "./sync-worker-manager";
-import { GLOBAL_SPATIAL_MAP_MODEL_NAMES, GLOBAL_SPATIAL_MAP_SNAPSHOT_MODELS } from "./torii-spatial-models";
+import {
+  GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODEL_NAMES,
+  GLOBAL_SPATIAL_MAP_BOOTSTRAP_SNAPSHOT_MODELS,
+} from "./torii-spatial-models";
 import { buildModelKeysClause, type GlobalModelStreamConfig } from "./torii-stream-manager";
 import {
   setupToriiSubscriptions,
@@ -49,9 +52,6 @@ interface SyncEntitiesSubscriptionOptions {
 
 let entityStreamSubscription: { cancel: () => void; ready: Promise<void> } | null = null;
 let isInitialSyncInFlight = false;
-
-// Trial gate: keep the extra spatial snapshot from overwriting global stream state.
-const ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT = false;
 
 /**
  * Cancel the global entity stream subscription.
@@ -141,7 +141,7 @@ const GLOBAL_EVENT_MODELS: string[] = [
 
 const GLOBAL_EVENT_STREAM_MODELS: GlobalModelStreamConfig[] = GLOBAL_EVENT_MODELS.map((model) => ({ model }));
 const GLOBAL_EVENT_STREAM_CLAUSE = buildModelKeysClause(GLOBAL_EVENT_STREAM_MODELS);
-const GLOBAL_SPATIAL_MAP_SNAPSHOT_CLAUSE = buildModelKeysClause(GLOBAL_SPATIAL_MAP_SNAPSHOT_MODELS);
+const GLOBAL_SPATIAL_MAP_BOOTSTRAP_SNAPSHOT_CLAUSE = buildModelKeysClause(GLOBAL_SPATIAL_MAP_BOOTSTRAP_SNAPSHOT_MODELS);
 
 type BatchPayload = { upserts: ToriiEntity[]; deletions: string[] };
 type SyncEntityReadinessMatcher = (data: ToriiEntity) => boolean;
@@ -643,7 +643,7 @@ async function runRequiredToriiOperationWithTimeout<T>(input: {
   });
 }
 
-async function hydrateGlobalSpatialMapSnapshot(input: {
+async function hydrateGlobalSpatialBootstrapSnapshot(input: {
   setup: SetupResult;
   logging: boolean;
   timeoutMs: number;
@@ -652,16 +652,16 @@ async function hydrateGlobalSpatialMapSnapshot(input: {
   const snapshotStart = performance.now();
   try {
     await runRequiredToriiOperationWithTimeout({
-      label: "global spatial map snapshot",
+      label: "global spatial map bootstrap snapshot",
       timeoutMs: input.timeoutMs,
       onTimeout: input.onTimeout,
       operation: () =>
         getEntitiesSnapshot(
           input.setup.network.toriiClient,
-          GLOBAL_SPATIAL_MAP_SNAPSHOT_CLAUSE,
+          GLOBAL_SPATIAL_MAP_BOOTSTRAP_SNAPSHOT_CLAUSE,
           input.setup.network.contractComponents as unknown as Component<Schema, Metadata, undefined>[],
           [],
-          [...GLOBAL_SPATIAL_MAP_MODEL_NAMES],
+          [...GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODEL_NAMES],
           EVENT_QUERY_LIMIT,
           input.logging,
         ),
@@ -671,7 +671,7 @@ async function hydrateGlobalSpatialMapSnapshot(input: {
   }
 }
 
-async function syncGlobalSpatialMapSnapshot(input: {
+async function syncGlobalSpatialBootstrapSnapshot(input: {
   setup: SetupResult;
   logging: boolean;
   subscriptionSetupTimeoutMs: number;
@@ -679,7 +679,7 @@ async function syncGlobalSpatialMapSnapshot(input: {
 }): Promise<void> {
   const totalStart = performance.now();
   try {
-    await hydrateGlobalSpatialMapSnapshot({
+    await hydrateGlobalSpatialBootstrapSnapshot({
       setup: input.setup,
       logging: input.logging,
       timeoutMs: input.subscriptionSetupTimeoutMs,
@@ -687,17 +687,6 @@ async function syncGlobalSpatialMapSnapshot(input: {
     });
   } finally {
     recordGameEntryDuration("initial-sync-global-spatial-map-sync", performance.now() - totalStart);
-  }
-}
-
-async function syncGlobalSpatialBootstrapSnapshotIfEnabled(input: {
-  setup: SetupResult;
-  logging: boolean;
-  subscriptionSetupTimeoutMs: number;
-  onSubscriptionSetupTimeout?: (info: ToriiSubscriptionSetupTimeoutInfo) => void;
-}): Promise<void> {
-  if (ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT) {
-    await syncGlobalSpatialMapSnapshot(input);
   }
 }
 
@@ -745,7 +734,7 @@ export const initialSync = async (
     );
     useConnectionStore.getState().recordGlobalHandshake();
 
-    await syncGlobalSpatialBootstrapSnapshotIfEnabled({
+    await syncGlobalSpatialBootstrapSnapshot({
       setup,
       logging,
       subscriptionSetupTimeoutMs,

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -50,6 +50,9 @@ interface SyncEntitiesSubscriptionOptions {
 let entityStreamSubscription: { cancel: () => void; ready: Promise<void> } | null = null;
 let isInitialSyncInFlight = false;
 
+// Trial gate: keep the extra spatial snapshot from overwriting global stream state.
+const ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT = false;
+
 /**
  * Cancel the global entity stream subscription.
  * Used during game switching to stop the old Torii client from writing
@@ -687,6 +690,17 @@ async function syncGlobalSpatialMapSnapshot(input: {
   }
 }
 
+async function syncGlobalSpatialBootstrapSnapshotIfEnabled(input: {
+  setup: SetupResult;
+  logging: boolean;
+  subscriptionSetupTimeoutMs: number;
+  onSubscriptionSetupTimeout?: (info: ToriiSubscriptionSetupTimeoutInfo) => void;
+}): Promise<void> {
+  if (ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT) {
+    await syncGlobalSpatialMapSnapshot(input);
+  }
+}
+
 // initial sync runs before the game is playable and should sync minimal data
 type InitialSyncOptions = {
   logging?: boolean;
@@ -731,7 +745,7 @@ export const initialSync = async (
     );
     useConnectionStore.getState().recordGlobalHandshake();
 
-    await syncGlobalSpatialMapSnapshot({
+    await syncGlobalSpatialBootstrapSnapshotIfEnabled({
       setup,
       logging,
       subscriptionSetupTimeoutMs,

--- a/client/apps/game/src/dojo/torii-spatial-models.ts
+++ b/client/apps/game/src/dojo/torii-spatial-models.ts
@@ -16,8 +16,15 @@ export const GLOBAL_SPATIAL_MAP_MODELS = [
   { model: "s1_eternum-BattleEvent", colField: "coord.x", rowField: "coord.y" },
 ] as const satisfies readonly ToriiSpatialMapModelConfig[];
 
-export const GLOBAL_SPATIAL_MAP_MODEL_NAMES = GLOBAL_SPATIAL_MAP_MODELS.map(({ model }) => model);
+const GLOBAL_SPATIAL_OWNER_MODEL_NAME = "s1_eternum-Structure";
 
-export const GLOBAL_SPATIAL_MAP_SNAPSHOT_MODELS: GlobalModelStreamConfig[] = GLOBAL_SPATIAL_MAP_MODEL_NAMES.map(
-  (model) => ({ model }),
+// Structure carries ownership, so the live all-entity stream owns that model.
+// A late bootstrap snapshot must not replay stale owners after a capture.
+const GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODELS = GLOBAL_SPATIAL_MAP_MODELS.filter(
+  ({ model }) => model !== GLOBAL_SPATIAL_OWNER_MODEL_NAME,
 );
+
+export const GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODEL_NAMES = GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODELS.map(({ model }) => model);
+
+export const GLOBAL_SPATIAL_MAP_BOOTSTRAP_SNAPSHOT_MODELS: GlobalModelStreamConfig[] =
+  GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODEL_NAMES.map((model) => ({ model }));

--- a/client/apps/game/src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts
@@ -8,17 +8,11 @@ import { describe, expect, it } from "vitest";
 const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
 
 describe("global spatial setup-timeout wiring", () => {
-  it("routes global spatial snapshot timeout reporting through initial sync", () => {
+  it("keeps the global spatial snapshot timeout path disabled for the overwrite trial", () => {
     const source = readSource("src/dojo/sync.ts");
-    const start = source.indexOf("async function hydrateGlobalSpatialMapSnapshot");
-    const end = source.indexOf("async function syncGlobalSpatialMapSnapshot", start);
-    expect(start).toBeGreaterThan(-1);
-    expect(end).toBeGreaterThan(start);
-    const methodSource = source.slice(start, end);
 
-    expect(methodSource).toContain('label: "global spatial map snapshot"');
-    expect(methodSource).toContain("onTimeout: input.onTimeout");
-    expect(methodSource).toContain("recordGameEntryDuration");
+    expect(source).toContain("const ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT = false");
+    expect(source).toMatch(/if \(ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT\)[\s\S]*?syncGlobalSpatialMapSnapshot/);
   });
 
   it("keeps live global spatial updates owned by the all-entity stream", () => {

--- a/client/apps/game/src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts
@@ -8,22 +8,28 @@ import { describe, expect, it } from "vitest";
 const readSource = (relativePath: string) => readFileSync(resolve(process.cwd(), relativePath), "utf8");
 
 describe("global spatial setup-timeout wiring", () => {
-  it("keeps the global spatial snapshot timeout path disabled for the overwrite trial", () => {
+  it("routes global spatial bootstrap snapshot timeout reporting through initial sync", () => {
     const source = readSource("src/dojo/sync.ts");
+    const start = source.indexOf("async function hydrateGlobalSpatialBootstrapSnapshot");
+    const end = source.indexOf("async function syncGlobalSpatialBootstrapSnapshot", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const methodSource = source.slice(start, end);
 
-    expect(source).toContain("const ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT = false");
-    expect(source).toMatch(/if \(ENABLE_GLOBAL_SPATIAL_BOOTSTRAP_SNAPSHOT\)[\s\S]*?syncGlobalSpatialMapSnapshot/);
+    expect(methodSource).toContain('label: "global spatial map bootstrap snapshot"');
+    expect(methodSource).toContain("onTimeout: input.onTimeout");
+    expect(methodSource).toContain("recordGameEntryDuration");
   });
 
   it("keeps live global spatial updates owned by the all-entity stream", () => {
     const source = readSource("src/dojo/sync.ts");
-    const start = source.indexOf("async function syncGlobalSpatialMapSnapshot");
+    const start = source.indexOf("async function syncGlobalSpatialBootstrapSnapshot");
     const end = source.indexOf("// initial sync runs before the game is playable", start);
     expect(start).toBeGreaterThan(-1);
     const methodSource = source.slice(start, end);
 
     expect(source).not.toContain("async function subscribeGlobalSpatialMapStream");
-    expect(methodSource).toContain("hydrateGlobalSpatialMapSnapshot");
+    expect(methodSource).toContain("hydrateGlobalSpatialBootstrapSnapshot");
     expect(methodSource).not.toContain("syncEntitiesDebounced");
   });
 


### PR DESCRIPTION
Restores the spatial bootstrap needed to seed worldmap TileOpt/render rows, but narrows it to an ownerless model set that excludes `s1_eternum-Structure`.

This keeps `Structure.owner` owned by the global all-entity stream so a late bootstrap snapshot cannot replay stale ownership after hyperstructure capture.

The fully-disabled snapshot proved the stream alone does not replay historical map state, which caused blank map hydration on boot.

Validation: `pnpm --dir client/apps/game test src/dojo/sync.test.ts`; `pnpm --dir client/apps/game test src/dojo/sync.regression.source.test.ts`; `pnpm --dir client/apps/game test src/three/scenes/worldmap-setup-timeout-toast-policy.source.test.ts`; `pnpm run format`; `pnpm run knip`; `git diff --check`.