### PR TITLE
[codex] Fix slot env validation

### DIFF
--- a/client/apps/game/env.ts
+++ b/client/apps/game/env.ts
@@ -5,7 +5,10 @@ import {
   DEFAULT_STANDALONE_AMMV2_ROUTER_ADDRESS,
 } from "@bibliothecadao/ammv2-sdk";
 import { getSelectedChain } from "./src/runtime/world/store";
-import { assertPublicEnvConsistency } from "./src/utils/public-env-consistency";
+import {
+  assertPublicEnvConsistency,
+  resolveRuntimePublicEnvConsistencyInput,
+} from "./src/utils/public-env-consistency";
 
 const _rawEnv = import.meta.env as Record<string, string | undefined>;
 
@@ -290,13 +293,29 @@ const envSchema = z.object({
   VITE_NEW_RELIC_LICENSE_KEY: z.string().optional(),
 });
 
-let env: z.infer<typeof envSchema>;
-try {
-  env = envSchema.parse({
+type PublicEnv = z.infer<typeof envSchema>;
+
+const parsePublicEnv = (): PublicEnv => {
+  return envSchema.parse({
     ...import.meta.env,
     VITE_PUBLIC_AMM_ROUTER_ADDRESS: resolveLegacyAmmRouterAddress(_rawEnv),
   });
-  assertPublicEnvConsistency(env);
+};
+
+const resolveRuntimePublicEnv = (parsedEnv: PublicEnv): PublicEnv => {
+  return resolveRuntimePublicEnvConsistencyInput(parsedEnv, getSelectedChain());
+};
+
+const resolveValidatedPublicEnv = (): PublicEnv => {
+  const parsedEnv = parsePublicEnv();
+  const runtimeEnv = resolveRuntimePublicEnv(parsedEnv);
+  assertPublicEnvConsistency(runtimeEnv);
+  return runtimeEnv;
+};
+
+let env: PublicEnv;
+try {
+  env = resolveValidatedPublicEnv();
 } catch (error) {
   if (error instanceof z.ZodError) {
     console.error("❌ Invalid environment variables:", JSON.stringify(error.errors, null, 2));
@@ -304,11 +323,6 @@ try {
     console.error("❌ Invalid environment variables:", error);
   }
   throw new Error("Invalid environment variables");
-}
-
-const storedChain = getSelectedChain();
-if (storedChain) {
-  env = { ...env, VITE_PUBLIC_CHAIN: storedChain };
 }
 
 export { env };

--- a/client/apps/game/src/utils/public-env-consistency.test.ts
+++ b/client/apps/game/src/utils/public-env-consistency.test.ts
@@ -2,7 +2,11 @@
 
 import { describe, expect, it } from "vitest";
 
-import { assertPublicEnvConsistency, resolvePublicEnvConsistencyErrors } from "./public-env-consistency";
+import {
+  assertPublicEnvConsistency,
+  resolvePublicEnvConsistencyErrors,
+  resolveRuntimePublicEnvConsistencyInput,
+} from "./public-env-consistency";
 
 const mainnetEnv = {
   VITE_PUBLIC_CHAIN: "mainnet" as const,
@@ -43,6 +47,19 @@ describe("resolvePublicEnvConsistencyErrors", () => {
         VITE_PUBLIC_TORII: "https://api.cartridge.gg/x/eternum-blitz-slot-4/torii",
       }),
     ).toEqual([]);
+  });
+
+  it("allows slot deployments when the runtime chain has been switched to slot", () => {
+    const runtimeEnv = resolveRuntimePublicEnvConsistencyInput(
+      {
+        ...mainnetEnv,
+        VITE_PUBLIC_SLOT: "eternum-blitz-slot-4",
+        VITE_PUBLIC_TORII: "https://api.cartridge.gg/x/eternum-blitz-slot-test/torii",
+      },
+      "slot",
+    );
+
+    expect(resolvePublicEnvConsistencyErrors(runtimeEnv)).toEqual([]);
   });
 });
 

--- a/client/apps/game/src/utils/public-env-consistency.ts
+++ b/client/apps/game/src/utils/public-env-consistency.ts
@@ -6,6 +6,20 @@ type PublicEnvConsistencyInput = {
   VITE_PUBLIC_TORII: string;
 };
 
+type RuntimePublicEnvConsistencyInput<T extends PublicEnvConsistencyInput> = Omit<T, "VITE_PUBLIC_CHAIN"> &
+  PublicEnvConsistencyInput;
+
+export const resolveRuntimePublicEnvConsistencyInput = <T extends PublicEnvConsistencyInput>(
+  env: T,
+  runtimeChain: PublicEnvChain | null,
+): RuntimePublicEnvConsistencyInput<T> => {
+  if (!runtimeChain) {
+    return env;
+  }
+
+  return { ...env, VITE_PUBLIC_CHAIN: runtimeChain };
+};
+
 export const assertPublicEnvConsistency = (env: PublicEnvConsistencyInput): void => {
   const errors = resolvePublicEnvConsistencyErrors(env);
   if (errors.length === 0) {


### PR DESCRIPTION
## Summary
Fixes the game client env bootstrap so public env consistency checks run after applying the stored runtime chain override.

## Details
The previous ordering validated the base build chain first, so a user/session switched to a slot runtime could still fail as a contradictory mainnet build when slot Torii values were present.
This keeps the mainnet guard intact while allowing runtime slot selection to produce a slot-consistent env.

## Verification
Ran `pnpm --dir client/apps/game test src/utils/public-env-consistency.test.ts`, `pnpm run format`, `pnpm run knip`, `pnpm run build:packages`, and `pnpm --dir client/apps/game typecheck`.
