### PR TITLE
Guard worldmap visual terrain lifecycle

### DIFF
--- a/client/apps/game/src/three/scenes/worldmap-terrain-presentation-wiring.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-terrain-presentation-wiring.source.test.ts
@@ -99,4 +99,58 @@ describe("worldmap terrain presentation wiring", () => {
       exactCommit.indexOf("setVisibleTerrainMembership"),
     );
   });
+
+  it("guards rolling visual terrain behind active worldmap chunk ownership", () => {
+    const refreshMethod = extractMethod(
+      readSource("src/three/scenes/worldmap.tsx"),
+      "  private async refreshVisualTerrainWindowFromCamera",
+      "  private async refreshVisualTerrainWindowForFocus",
+    );
+
+    expect(refreshMethod).toContain("canRefreshWorldmapVisualTerrain");
+    expect(refreshMethod).toContain("currentScene: this.sceneManager.getCurrentScene()");
+    expect(refreshMethod).toContain("hasInitialized: this.hasInitialized");
+    expect(refreshMethod).toContain("currentChunk: this.currentChunk");
+  });
+
+  it("threads transition ownership through rolling visual page builds and commits", () => {
+    const refreshMethod = extractMethod(
+      readSource("src/three/scenes/worldmap.tsx"),
+      "  private async refreshVisualTerrainWindowForFocus",
+      "  private visualTerrainWindowsMatch",
+    );
+    const criticalBuilder = extractMethod(
+      readSource("src/three/scenes/worldmap.tsx"),
+      "  private async buildCriticalVisualTerrainPages",
+      "  private enqueueMissingVisualTerrainPages",
+    );
+    const queueBuilder = extractMethod(
+      readSource("src/three/scenes/worldmap.tsx"),
+      "  private enqueueMissingVisualTerrainPages",
+      "  private processVisualTerrainBuildQueue",
+    );
+    const buildMethod = extractMethod(
+      readSource("src/three/scenes/worldmap.tsx"),
+      "  private async buildAndApplyVisualTerrainPage",
+      "  private shouldApplyVisualTerrainPageBuild",
+    );
+
+    expect(refreshMethod).toContain("const transitionToken = this.chunkTransitionToken");
+    expect(criticalBuilder).toContain("transitionToken: window.transitionToken");
+    expect(queueBuilder).toContain("transitionToken: window.transitionToken");
+    expect(buildMethod).toContain("latestTransitionToken: this.chunkTransitionToken");
+  });
+
+  it("invalidates visual terrain work when clearing presentations", () => {
+    const clearMethod = extractMethod(
+      readSource("src/three/scenes/worldmap.tsx"),
+      "  private clearVisualTerrainPresentations",
+      "  private cachePreparedTerrainChunk",
+    );
+
+    expect(clearMethod).toContain("this.visualTerrainGeneration += 1");
+    expect(clearMethod).toContain("this.refreshVisualTerrainWindowThrottled?.cancel()");
+    expect(clearMethod).toContain("this.visualTerrainBuildQueue = []");
+    expect(clearMethod).toContain("this.activeVisualTerrainBuildPageKeys.clear()");
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-visual-terrain-lifecycle.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-visual-terrain-lifecycle.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canRefreshWorldmapVisualTerrain,
+  shouldApplyWorldmapVisualTerrainPageBuild,
+} from "./worldmap-visual-terrain-lifecycle";
+import { SceneName } from "../types/common";
+
+const activeRefreshInput = {
+  currentChunk: "0,0",
+  currentScene: SceneName.WorldMap,
+  hasInitialized: true,
+  isSwitchedOff: false,
+  rollingWindowEnabled: true,
+};
+
+const activeBuildInput = {
+  ...activeRefreshInput,
+  currentGeneration: 7,
+  currentTransitionToken: 11,
+  pageKey: "0,0",
+  requestGeneration: 7,
+  requestTransitionToken: 11,
+  targetPageKeys: new Set(["0,0"]),
+};
+
+describe("worldmap visual terrain lifecycle", () => {
+  it("rejects rolling terrain before the worldmap has completed initial setup", () => {
+    expect(
+      canRefreshWorldmapVisualTerrain({
+        ...activeRefreshInput,
+        hasInitialized: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects rolling terrain when another scene owns the renderer", () => {
+    expect(
+      canRefreshWorldmapVisualTerrain({
+        ...activeRefreshInput,
+        currentScene: SceneName.Hexception,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects rolling terrain before chunk authority is resolved", () => {
+    expect(
+      canRefreshWorldmapVisualTerrain({
+        ...activeRefreshInput,
+        currentChunk: "null",
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts rolling terrain only for the initialized active worldmap chunk", () => {
+    expect(canRefreshWorldmapVisualTerrain(activeRefreshInput)).toBe(true);
+  });
+
+  it("rejects visual page builds for stale generation, transition, or page window", () => {
+    expect(
+      shouldApplyWorldmapVisualTerrainPageBuild({
+        ...activeBuildInput,
+        requestGeneration: 6,
+      }),
+    ).toBe(false);
+    expect(
+      shouldApplyWorldmapVisualTerrainPageBuild({
+        ...activeBuildInput,
+        requestTransitionToken: 10,
+      }),
+    ).toBe(false);
+    expect(
+      shouldApplyWorldmapVisualTerrainPageBuild({
+        ...activeBuildInput,
+        pageKey: "0,24",
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts only fully current visual page builds", () => {
+    expect(shouldApplyWorldmapVisualTerrainPageBuild(activeBuildInput)).toBe(true);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-visual-terrain-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/worldmap-visual-terrain-lifecycle.ts
@@ -1,0 +1,39 @@
+import { SceneName } from "../types/common";
+
+export interface WorldmapVisualTerrainRefreshLifecycleInput {
+  currentChunk: string;
+  currentScene: SceneName | undefined;
+  hasInitialized: boolean;
+  isSwitchedOff: boolean;
+  rollingWindowEnabled: boolean;
+}
+
+export interface WorldmapVisualTerrainPageBuildLifecycleInput extends WorldmapVisualTerrainRefreshLifecycleInput {
+  currentGeneration: number;
+  currentTransitionToken: number;
+  pageKey: string;
+  requestGeneration: number;
+  requestTransitionToken: number;
+  targetPageKeys: ReadonlySet<string>;
+}
+
+export function canRefreshWorldmapVisualTerrain(input: WorldmapVisualTerrainRefreshLifecycleInput): boolean {
+  return (
+    input.rollingWindowEnabled &&
+    !input.isSwitchedOff &&
+    input.hasInitialized &&
+    input.currentScene === SceneName.WorldMap &&
+    input.currentChunk !== "null"
+  );
+}
+
+export function shouldApplyWorldmapVisualTerrainPageBuild(
+  input: WorldmapVisualTerrainPageBuildLifecycleInput,
+): boolean {
+  return (
+    canRefreshWorldmapVisualTerrain(input) &&
+    input.requestGeneration === input.currentGeneration &&
+    input.requestTransitionToken === input.currentTransitionToken &&
+    input.targetPageKeys.has(input.pageKey)
+  );
+}

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -425,6 +425,10 @@ import {
   type WorldmapTerrainSourceCellRef,
   type WorldmapVisualTerrainWindow,
 } from "./worldmap-terrain-presentation-runtime";
+import {
+  canRefreshWorldmapVisualTerrain,
+  shouldApplyWorldmapVisualTerrainPageBuild as shouldApplyWorldmapVisualTerrainPageBuildLifecycle,
+} from "./worldmap-visual-terrain-lifecycle";
 
 interface CachedMatrixEntry {
   matrices: InstancedBufferAttribute | null;
@@ -475,7 +479,11 @@ interface WorldmapVisualTerrainPageBuildRequest {
   generation: number;
   pageKey: string;
   priority: "critical" | "normal";
-  transitionToken?: number;
+  transitionToken: number;
+}
+
+interface WorldmapVisualTerrainBuildWindow extends WorldmapVisualTerrainWindow {
+  transitionToken: number;
 }
 
 interface StructureHydrationFetchState {
@@ -638,7 +646,7 @@ export default class WorldmapScene extends WarpTravel {
   private visualTerrainPresentationState: WorldmapTerrainPresentationState = createWorldmapTerrainPresentationState();
   private visualTerrainRetentionTimeout: number | null = null;
   private visualTerrainGeneration = 0;
-  private visualTerrainWindow: WorldmapVisualTerrainWindow | null = null;
+  private visualTerrainWindow: WorldmapVisualTerrainBuildWindow | null = null;
   private visualTerrainWindowPageKeys: Set<string> = new Set();
   private visualTerrainBuildQueue: WorldmapVisualTerrainPageBuildRequest[] = [];
   private visualTerrainBuildFrameHandle: number | null = null;
@@ -5456,7 +5464,15 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private async refreshVisualTerrainWindowFromCamera(): Promise<void> {
-    if (!WORLDMAP_CHUNK_POLICY.visualPresentation.rollingWindowEnabled || this.isSwitchedOff) {
+    if (
+      !canRefreshWorldmapVisualTerrain({
+        currentChunk: this.currentChunk,
+        currentScene: this.sceneManager.getCurrentScene(),
+        hasInitialized: this.hasInitialized,
+        isSwitchedOff: this.isSwitchedOff,
+        rollingWindowEnabled: WORLDMAP_CHUNK_POLICY.visualPresentation.rollingWindowEnabled,
+      })
+    ) {
       return;
     }
 
@@ -5466,18 +5482,22 @@ export default class WorldmapScene extends WarpTravel {
 
   private async refreshVisualTerrainWindowForFocus(focusPoint: Vector3): Promise<void> {
     const nextGeneration = this.visualTerrainGeneration + 1;
-    const nextWindow = resolveWorldmapVisualTerrainWindow({
-      focusPoint: {
-        x: focusPoint.x,
-        z: focusPoint.z,
-      },
-      generation: nextGeneration,
-      hexSize: HEX_SIZE,
-      marginPages: WORLDMAP_CHUNK_POLICY.visualPresentation.viewportMarginPages,
-      pageOrigin: this.getVisualTerrainPageOrigin(),
-      pageSize: WORLDMAP_CHUNK_POLICY.visualPresentation.visualPageSize,
-      renderSize: this.renderChunkSize,
-    });
+    const transitionToken = this.chunkTransitionToken;
+    const nextWindow: WorldmapVisualTerrainBuildWindow = {
+      ...resolveWorldmapVisualTerrainWindow({
+        focusPoint: {
+          x: focusPoint.x,
+          z: focusPoint.z,
+        },
+        generation: nextGeneration,
+        hexSize: HEX_SIZE,
+        marginPages: WORLDMAP_CHUNK_POLICY.visualPresentation.viewportMarginPages,
+        pageOrigin: this.getVisualTerrainPageOrigin(),
+        pageSize: WORLDMAP_CHUNK_POLICY.visualPresentation.visualPageSize,
+        renderSize: this.renderChunkSize,
+      }),
+      transitionToken,
+    };
 
     if (this.visualTerrainWindow && this.visualTerrainWindowsMatch(this.visualTerrainWindow, nextWindow)) {
       return;
@@ -5503,11 +5523,12 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private visualTerrainWindowsMatch(
-    currentWindow: WorldmapVisualTerrainWindow,
-    nextWindow: WorldmapVisualTerrainWindow,
+    currentWindow: WorldmapVisualTerrainBuildWindow,
+    nextWindow: WorldmapVisualTerrainBuildWindow,
   ): boolean {
     return (
       currentWindow.centerPageKey === nextWindow.centerPageKey &&
+      currentWindow.transitionToken === nextWindow.transitionToken &&
       currentWindow.pageKeys.length === nextWindow.pageKeys.length &&
       currentWindow.pageKeys.every((pageKey, index) => pageKey === nextWindow.pageKeys[index])
     );
@@ -5545,7 +5566,7 @@ export default class WorldmapScene extends WarpTravel {
     );
   }
 
-  private async buildCriticalVisualTerrainPages(window: WorldmapVisualTerrainWindow): Promise<void> {
+  private async buildCriticalVisualTerrainPages(window: WorldmapVisualTerrainBuildWindow): Promise<void> {
     const criticalBudget = WORLDMAP_CHUNK_POLICY.visualPresentation.criticalPageImmediateBudget;
     const criticalPageKeys = window.criticalPageKeys.slice(0, criticalBudget);
     for (const pageKey of criticalPageKeys) {
@@ -5556,11 +5577,12 @@ export default class WorldmapScene extends WarpTravel {
         generation: window.generation,
         pageKey,
         priority: "critical",
+        transitionToken: window.transitionToken,
       });
     }
   }
 
-  private enqueueMissingVisualTerrainPages(window: WorldmapVisualTerrainWindow): void {
+  private enqueueMissingVisualTerrainPages(window: WorldmapVisualTerrainBuildWindow): void {
     window.pageKeys.forEach((pageKey) => {
       if (
         this.hasVisualTerrainCoverage(pageKey) ||
@@ -5576,6 +5598,7 @@ export default class WorldmapScene extends WarpTravel {
         generation: window.generation,
         pageKey,
         priority: "normal",
+        transitionToken: window.transitionToken,
       });
       this.traceChunk("visual_page_queued", {
         generation: window.generation,
@@ -5646,7 +5669,7 @@ export default class WorldmapScene extends WarpTravel {
         coverageKind: "visual_page",
         generation: request.generation,
         kind: "provisional",
-        transitionToken: request.transitionToken ?? this.chunkTransitionToken,
+        transitionToken: request.transitionToken,
       });
       this.traceChunk("visual_page_built", {
         cellCount: presentation.cells.length,
@@ -5655,7 +5678,9 @@ export default class WorldmapScene extends WarpTravel {
         priority: request.priority,
       });
       incrementWorldmapRenderCounter("visualPageBuilt");
-      this.applyVisualTerrainPagePresentation(presentation);
+      this.applyVisualTerrainPagePresentation(presentation, {
+        latestTransitionToken: this.chunkTransitionToken,
+      });
     } finally {
       if (this.activeVisualTerrainBuildPageKeys.get(request.pageKey) === request.generation) {
         this.activeVisualTerrainBuildPageKeys.delete(request.pageKey);
@@ -5664,12 +5689,19 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private shouldApplyVisualTerrainPageBuild(request: WorldmapVisualTerrainPageBuildRequest): boolean {
-    return (
-      !this.isSwitchedOff &&
-      request.generation === this.visualTerrainGeneration &&
-      this.visualTerrainWindowPageKeys.has(request.pageKey) &&
-      (request.transitionToken === undefined || request.transitionToken === this.chunkTransitionToken)
-    );
+    return shouldApplyWorldmapVisualTerrainPageBuildLifecycle({
+      currentChunk: this.currentChunk,
+      currentGeneration: this.visualTerrainGeneration,
+      currentScene: this.sceneManager.getCurrentScene(),
+      currentTransitionToken: this.chunkTransitionToken,
+      hasInitialized: this.hasInitialized,
+      isSwitchedOff: this.isSwitchedOff,
+      pageKey: request.pageKey,
+      requestGeneration: request.generation,
+      requestTransitionToken: request.transitionToken,
+      rollingWindowEnabled: WORLDMAP_CHUNK_POLICY.visualPresentation.rollingWindowEnabled,
+      targetPageKeys: this.visualTerrainWindowPageKeys,
+    });
   }
 
   private traceVisualTerrainPageStaleDrop(request: WorldmapVisualTerrainPageBuildRequest, reason: string): void {
@@ -7235,6 +7267,8 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private clearVisualTerrainPresentations(): void {
+    this.visualTerrainGeneration += 1;
+    this.refreshVisualTerrainWindowThrottled?.cancel();
     if (this.visualTerrainRetentionTimeout !== null) {
       window.clearTimeout(this.visualTerrainRetentionTimeout);
       this.visualTerrainRetentionTimeout = null;


### PR DESCRIPTION
## Summary
Guards rolling worldmap visual terrain so refreshes and page commits only run for the initialized active worldmap scene and chunk.
Threads chunk transition tokens through the visual terrain window and build queue, then invalidates queued work when presentations are cleared.
Adds lifecycle unit coverage plus source wiring assertions for the terrain ownership path.

## Validation
- pnpm run format
- pnpm run knip
- pnpm --dir client/apps/game exec vitest run src/three/scenes/worldmap-visual-terrain-lifecycle.test.ts src/three/scenes/worldmap-terrain-presentation-wiring.source.test.ts src/three/scenes/worldmap-visual-terrain-runtime.test.ts
- pnpm --dir client/apps/game run test:three:types
