### PR TITLE
[codex] Restore automation queue isolation

### DIFF
--- a/client/apps/game/src/hooks/use-automation.source.test.ts
+++ b/client/apps/game/src/hooks/use-automation.source.test.ts
@@ -66,6 +66,7 @@ describe("useAutomation source", () => {
     expect(source).toContain("new ResourceManager(components, plan.realmId).optimisticResourceUpdates");
     expect(source).toContain("buildProductionResourceDebits(plan)");
     expect(source).toContain("scheduleAutomationResourceCleanup");
+    expect(source).toContain("skipQueue: true");
     expect(source).not.toContain("applyAutomationReservationsToSnapshot");
     expect(source).not.toContain("reserveAutomationResources");
     expect(source).not.toMatch(/finally\s*{[\s\S]*removeResourceOverrides\(\);[\s\S]*}/);

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -484,6 +484,7 @@ export const useAutomation = () => {
           const productionResult = await execute_realm_production_plan({
             signer: starknetSignerAccount,
             realm_entity_id: plan.realmId,
+            skipQueue: true,
             resource_to_resource: plan.callset.resourceToResource.map((item) => ({
               resource_id: item.resourceId,
               cycles: item.cycles,


### PR DESCRIPTION
Restores `skipQueue: true` on production automation submissions so each realm plan bypasses `PromiseQueue` batching again.

The regression came from the RECS optimistic-spend refactor, which preserved resource debits but accidentally dropped the queue isolation that prevents one reverted realm or queued action from making unrelated automation look like it did not fire.

Adds a source guard so the live hook keeps passing the isolation flag.

Validation: `pnpm install --frozen-lockfile`, `pnpm run format`, `pnpm --dir client/apps/game test src/hooks/use-automation.source.test.ts`, and `pnpm run knip`.