### PR TITLE
Auto-garrison captured hyperstructures

### DIFF
--- a/contracts/game/src/systems/combat/tests/test_troop_battle.cairo
+++ b/contracts/game/src/systems/combat/tests/test_troop_battle.cairo
@@ -14,7 +14,7 @@ mod tests {
     use crate::models::map::{Tile, TileOccupier};
     use crate::models::map2::TileOpt;
     use crate::models::position::{Coord, CoordTrait, Direction};
-    use crate::models::resource::resource::ResourceImpl;
+    use crate::models::resource::resource::{ResourceImpl, ResourceWeightImpl};
     use crate::models::structure::{
         Structure, StructureBase, StructureBaseStoreImpl, StructureCategory, StructureMetadata, StructureOwnerStoreImpl,
         StructureTroopExplorerStoreImpl, StructureTroopGuardStoreImpl,
@@ -544,6 +544,37 @@ mod tests {
 
         let hyperstructure_wheat = ResourceImpl::read_balance(ref world, hyperstructure_id, ResourceTypes::WHEAT);
         assert!(hyperstructure_wheat == cargo_amount, "Explorer cargo should move into captured hyperstructure");
+    }
+
+    #[test]
+    #[should_panic(expected: "captured hyperstructure cannot store explorer cargo")]
+    fn test_hyperstructure_capture_fails_when_explorer_cargo_exceeds_structure_capacity() {
+        let (mut world, systems) = setup_battle_world();
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        let owner = starknet::contract_address_const::<'overweight_cargo_hyper_owner'>();
+        let realm_id = spawn_test_realm(ref world, 1, owner, Coord { alt: false, x: 80, y: 80 });
+        let hyperstructure_id = spawn_test_structure(
+            ref world, Zero::zero(), StructureCategory::Hyperstructure, Coord { alt: false, x: 82, y: 80 },
+        );
+        let troop_amount = 1_000 * RESOURCE_PRECISION;
+        let cargo_amount = 25 * RESOURCE_PRECISION;
+        tgrant_resources(ref world, realm_id, array![(ResourceTypes::PALADIN_T3, troop_amount)].span());
+        let explorer = create_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: realm_id, owner, coord: Coord { alt: false, x: 80, y: 80 } },
+            TroopType::Paladin,
+            TroopTier::T3,
+            troop_amount,
+            Direction::East,
+        );
+        tgrant_resources(ref world, explorer.explorer_id, array![(ResourceTypes::WHEAT, cargo_amount)].span());
+
+        let wheat_weight_grams = ResourceWeightImpl::grams(ref world, ResourceTypes::WHEAT);
+        let insufficient_capacity = cargo_amount * wheat_weight_grams - 1;
+        ResourceImpl::write_weight(ref world, hyperstructure_id, Weight { capacity: insufficient_capacity, weight: 0 });
+
+        attack_explorer_vs_guard(ref world, systems, explorer, hyperstructure_id, Direction::East);
     }
 
     #[test]

--- a/contracts/game/src/systems/combat/tests/test_troop_battle.cairo
+++ b/contracts/game/src/systems/combat/tests/test_troop_battle.cairo
@@ -6,20 +6,127 @@
 mod tests {
     use core::num::traits::zero::Zero;
     use dojo::model::{ModelStorage, ModelStorageTest};
-    use dojo::world::WorldStorageTrait;
-    use snforge_std::{start_cheat_caller_address, stop_cheat_caller_address};
-    use crate::constants::RESOURCE_PRECISION;
+    use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
+    use snforge_std::{start_cheat_block_timestamp_global, start_cheat_caller_address, stop_cheat_caller_address};
+    use crate::constants::{RESOURCE_PRECISION, ResourceTypes};
+    use crate::models::config::{VictoryPointsGrantConfig, WorldConfigUtilImpl};
+    use crate::models::hyperstructure::PlayerRegisteredPoints;
+    use crate::models::map::{Tile, TileOccupier};
+    use crate::models::map2::TileOpt;
     use crate::models::position::{Coord, CoordTrait, Direction};
-    use crate::models::structure::{StructureBase, StructureBaseStoreImpl, StructureTroopExplorerStoreImpl};
-    use crate::models::troop::{ExplorerTroops, GuardSlot, TroopLimitTrait, TroopTier, TroopType, Troops};
+    use crate::models::resource::resource::ResourceImpl;
+    use crate::models::structure::{
+        Structure, StructureBase, StructureBaseStoreImpl, StructureCategory, StructureMetadata, StructureOwnerStoreImpl,
+        StructureTroopExplorerStoreImpl, StructureTroopGuardStoreImpl,
+    };
+    use crate::models::troop::{
+        ExplorerTroops, GuardSlot, GuardTrait, GuardTroops, TroopLimitTrait, TroopTier, TroopType, Troops,
+    };
+    use crate::models::weight::Weight;
     use crate::systems::combat::contracts::troop_battle::{
         ITroopBattleSystemsDispatcher, ITroopBattleSystemsDispatcherTrait,
     };
     use crate::utils::testing::helpers::{
-        MOCK_TROOP_LIMIT_CONFIG, attack_explorer_vs_explorer, attack_explorer_vs_guard, attack_guard_vs_explorer,
-        get_combat_systems, get_explorer, setup_explorer_battle, setup_guard_battle, spawn_combat_world,
-        spawn_world_minimal,
+        MOCK_TICK_CONFIG, MOCK_TROOP_LIMIT_CONFIG, RealmTestContext, attack_explorer_vs_explorer,
+        attack_explorer_vs_guard, attack_guard_vs_explorer, create_explorer, get_combat_systems, get_explorer,
+        setup_battle_world, setup_explorer_battle, setup_guard_battle, spawn_combat_world, spawn_test_realm,
+        spawn_world_minimal, tgrant_resources,
     };
+
+    fn empty_troops() -> Troops {
+        Troops {
+            category: TroopType::Knight,
+            tier: TroopTier::T1,
+            count: 0,
+            stamina: Default::default(),
+            boosts: Default::default(),
+            battle_cooldown_end: 0,
+        }
+    }
+
+    fn empty_guards() -> GuardTroops {
+        let troops = empty_troops();
+        GuardTroops {
+            delta: troops,
+            charlie: troops,
+            bravo: troops,
+            alpha: troops,
+            delta_destroyed_tick: 0,
+            charlie_destroyed_tick: 0,
+            bravo_destroyed_tick: 0,
+            alpha_destroyed_tick: 0,
+        }
+    }
+
+    fn spawn_test_structure(
+        ref world: WorldStorage, owner: starknet::ContractAddress, category: StructureCategory, coord: Coord,
+    ) -> u32 {
+        let structure_id = world.dispatcher.uuid();
+        let guard_count = if category == StructureCategory::Hyperstructure {
+            4
+        } else {
+            1
+        };
+        let structure = Structure {
+            entity_id: structure_id,
+            owner,
+            base: StructureBase {
+                troop_guard_count: 0,
+                troop_explorer_count: 0,
+                troop_max_guard_count: guard_count,
+                troop_max_explorer_count: 0,
+                created_at: starknet::get_block_timestamp().try_into().unwrap(),
+                category: category.into(),
+                coord_x: coord.x,
+                coord_y: coord.y,
+                level: 3,
+                starting_troops_granted: false,
+            },
+            troop_guards: empty_guards(),
+            troop_explorers: array![].span(),
+            resources_packed: 0,
+            metadata: StructureMetadata {
+                realm_id: 0, order: 0, has_wonder: false, villages_count: 0, village_realm: 0,
+            },
+            category: category.into(),
+        };
+        world.write_model_test(@structure);
+
+        ResourceImpl::initialize(ref world, structure_id);
+        let structure_capacity: u128 = 1000000000000000 * RESOURCE_PRECISION;
+        ResourceImpl::write_weight(ref world, structure_id, Weight { capacity: structure_capacity, weight: 0 });
+
+        let tile = Tile {
+            alt: coord.alt,
+            col: coord.x,
+            row: coord.y,
+            biome: 1,
+            occupier_id: structure_id,
+            occupier_type: match category {
+                StructureCategory::Hyperstructure => TileOccupier::HyperstructureLevel1.into(),
+                _ => TileOccupier::FragmentMine.into(),
+            },
+            occupier_is_structure: true,
+            reward_extracted: false,
+        };
+        let tile_opt: TileOpt = tile.into();
+        world.write_model_test(@tile_opt);
+
+        structure_id
+    }
+
+    fn seed_delta_guard(ref world: WorldStorage, structure_id: u32, category: TroopType, tier: TroopTier, count: u128) {
+        let mut guards = StructureTroopGuardStoreImpl::retrieve(ref world, structure_id);
+        let mut base = StructureBaseStoreImpl::retrieve(ref world, structure_id);
+        let mut troops = empty_troops();
+        troops.category = category;
+        troops.tier = tier;
+        troops.count = count;
+        guards.to_slot(GuardSlot::Delta, troops, 0);
+        base.troop_guard_count = 1;
+        StructureTroopGuardStoreImpl::store(ref guards, ref world, structure_id);
+        StructureBaseStoreImpl::store(ref base, ref world, structure_id);
+    }
 
     // ========================================================================
     // Basic World Tests
@@ -282,6 +389,191 @@ mod tests {
         world.write_model_test(@explorer_troops);
 
         attack_explorer_vs_guard(ref world, systems, explorer, realm.entity_id, Direction::West);
+    }
+
+    #[test]
+    fn test_hyperstructure_capture_garrisons_all_surviving_explorer_troops() {
+        let (mut world, systems) = setup_battle_world();
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        let owner = starknet::contract_address_const::<'hyper_capture_owner'>();
+        let realm_id = spawn_test_realm(ref world, 1, owner, Coord { alt: false, x: 80, y: 80 });
+        let hyperstructure_id = spawn_test_structure(
+            ref world, Zero::zero(), StructureCategory::Hyperstructure, Coord { alt: false, x: 82, y: 80 },
+        );
+        let troop_amount = 1_000 * RESOURCE_PRECISION;
+        tgrant_resources(ref world, realm_id, array![(ResourceTypes::PALADIN_T3, troop_amount)].span());
+        let explorer = create_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: realm_id, owner, coord: Coord { alt: false, x: 80, y: 80 } },
+            TroopType::Paladin,
+            TroopTier::T3,
+            troop_amount,
+            Direction::East,
+        );
+
+        attack_explorer_vs_guard(ref world, systems, explorer, hyperstructure_id, Direction::East);
+
+        let guards = StructureTroopGuardStoreImpl::retrieve(ref world, hyperstructure_id);
+        let (delta, _) = guards.from_slot(GuardSlot::Delta);
+        assert!(delta.count == troop_amount, "Delta guard should receive every surviving troop");
+        assert!(delta.category == TroopType::Paladin, "Delta guard category mismatch");
+        assert!(delta.tier == TroopTier::T3, "Delta guard tier mismatch");
+
+        let hyperstructure_base = StructureBaseStoreImpl::retrieve(ref world, hyperstructure_id);
+        assert!(hyperstructure_base.troop_guard_count == 1, "Hyperstructure should have one guard slot filled");
+
+        let source_explorers = StructureTroopExplorerStoreImpl::retrieve(ref world, realm_id);
+        assert!(source_explorers.is_empty(), "Explorer should be removed from source structure");
+
+        let explorer_tile_opt: TileOpt = world.read_model((false, 81, 80));
+        let explorer_tile: Tile = explorer_tile_opt.into();
+        assert!(explorer_tile.occupier_id == 0, "Explorer tile should be empty after garrison transfer");
+    }
+
+    #[test]
+    fn test_hyperstructure_recapture_auto_garrisons_new_owner() {
+        let (mut world, systems) = setup_battle_world();
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        let previous_owner = starknet::contract_address_const::<'previous_hyper_owner'>();
+        let new_owner = starknet::contract_address_const::<'new_hyper_owner'>();
+        WorldConfigUtilImpl::set_member(
+            ref world,
+            selector!("victory_points_grant_config"),
+            VictoryPointsGrantConfig {
+                hyp_points_per_second: 0,
+                claim_hyperstructure_points: 500,
+                claim_otherstructure_points: 0,
+                explore_tiles_points: 0,
+                relic_open_points: 0,
+            },
+        );
+        let realm_id = spawn_test_realm(ref world, 1, new_owner, Coord { alt: false, x: 80, y: 80 });
+        let hyperstructure_id = spawn_test_structure(
+            ref world, previous_owner, StructureCategory::Hyperstructure, Coord { alt: false, x: 82, y: 80 },
+        );
+        let troop_amount = 1_000 * RESOURCE_PRECISION;
+        tgrant_resources(ref world, realm_id, array![(ResourceTypes::PALADIN_T3, troop_amount)].span());
+        let explorer = create_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: realm_id, owner: new_owner, coord: Coord { alt: false, x: 80, y: 80 } },
+            TroopType::Paladin,
+            TroopTier::T3,
+            troop_amount,
+            Direction::East,
+        );
+
+        attack_explorer_vs_guard(ref world, systems, explorer, hyperstructure_id, Direction::East);
+
+        let player_points: PlayerRegisteredPoints = world.read_model(new_owner);
+        assert!(player_points.registered_points == 0, "Recapture should not grant bandit capture points");
+        let hyperstructure_owner = StructureOwnerStoreImpl::retrieve(ref world, hyperstructure_id);
+        assert!(hyperstructure_owner == new_owner, "Hyperstructure owner should change on recapture");
+        let guards = StructureTroopGuardStoreImpl::retrieve(ref world, hyperstructure_id);
+        let (delta, _) = guards.from_slot(GuardSlot::Delta);
+        assert!(delta.count == troop_amount, "Recaptured hyperstructure should receive surviving troops");
+    }
+
+    #[test]
+    fn test_hyperstructure_guard_loss_auto_garrisons_surviving_defender() {
+        let (mut world, systems) = setup_battle_world();
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        let previous_owner = starknet::contract_address_const::<'guard_loss_hyper_owner'>();
+        let new_owner = starknet::contract_address_const::<'guard_loss_explorer_owner'>();
+        let realm_id = spawn_test_realm(ref world, 1, new_owner, Coord { alt: false, x: 80, y: 80 });
+        let hyperstructure_coord = Coord { alt: false, x: 82, y: 80 };
+        let hyperstructure_id = spawn_test_structure(
+            ref world, previous_owner, StructureCategory::Hyperstructure, hyperstructure_coord,
+        );
+        seed_delta_guard(ref world, hyperstructure_id, TroopType::Knight, TroopTier::T1, 100 * RESOURCE_PRECISION);
+        let troop_amount = 1_000 * RESOURCE_PRECISION;
+        tgrant_resources(ref world, realm_id, array![(ResourceTypes::PALADIN_T3, troop_amount)].span());
+        let explorer = create_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: realm_id, owner: new_owner, coord: Coord { alt: false, x: 80, y: 80 } },
+            TroopType::Paladin,
+            TroopTier::T3,
+            troop_amount,
+            Direction::East,
+        );
+
+        attack_guard_vs_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: hyperstructure_id, owner: previous_owner, coord: hyperstructure_coord },
+            GuardSlot::Delta,
+            explorer.explorer_id,
+            Direction::West,
+        );
+
+        let hyperstructure_owner = StructureOwnerStoreImpl::retrieve(ref world, hyperstructure_id);
+        assert!(hyperstructure_owner == new_owner, "Hyperstructure owner should change when guard loses");
+        let guards = StructureTroopGuardStoreImpl::retrieve(ref world, hyperstructure_id);
+        let (delta, _) = guards.from_slot(GuardSlot::Delta);
+        assert!(delta.count.is_non_zero(), "Surviving defender should become the Delta guard");
+        assert!(delta.category == TroopType::Paladin, "Delta guard category should come from surviving defender");
+        assert!(delta.tier == TroopTier::T3, "Delta guard tier should come from surviving defender");
+    }
+
+    #[test]
+    fn test_hyperstructure_capture_moves_explorer_cargo_to_structure() {
+        let (mut world, systems) = setup_battle_world();
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        let owner = starknet::contract_address_const::<'cargo_hyper_owner'>();
+        let realm_id = spawn_test_realm(ref world, 1, owner, Coord { alt: false, x: 80, y: 80 });
+        let hyperstructure_id = spawn_test_structure(
+            ref world, Zero::zero(), StructureCategory::Hyperstructure, Coord { alt: false, x: 82, y: 80 },
+        );
+        let troop_amount = 1_000 * RESOURCE_PRECISION;
+        let cargo_amount = 25 * RESOURCE_PRECISION;
+        tgrant_resources(ref world, realm_id, array![(ResourceTypes::PALADIN_T3, troop_amount)].span());
+        let explorer = create_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: realm_id, owner, coord: Coord { alt: false, x: 80, y: 80 } },
+            TroopType::Paladin,
+            TroopTier::T3,
+            troop_amount,
+            Direction::East,
+        );
+        tgrant_resources(ref world, explorer.explorer_id, array![(ResourceTypes::WHEAT, cargo_amount)].span());
+
+        attack_explorer_vs_guard(ref world, systems, explorer, hyperstructure_id, Direction::East);
+
+        let hyperstructure_wheat = ResourceImpl::read_balance(ref world, hyperstructure_id, ResourceTypes::WHEAT);
+        assert!(hyperstructure_wheat == cargo_amount, "Explorer cargo should move into captured hyperstructure");
+    }
+
+    #[test]
+    fn test_non_hyperstructure_capture_does_not_auto_garrison() {
+        let (mut world, systems) = setup_battle_world();
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        let owner = starknet::contract_address_const::<'mine_capture_owner'>();
+        let realm_id = spawn_test_realm(ref world, 1, owner, Coord { alt: false, x: 80, y: 80 });
+        let mine_id = spawn_test_structure(
+            ref world, Zero::zero(), StructureCategory::FragmentMine, Coord { alt: false, x: 82, y: 80 },
+        );
+        let troop_amount = 1_000 * RESOURCE_PRECISION;
+        tgrant_resources(ref world, realm_id, array![(ResourceTypes::PALADIN_T3, troop_amount)].span());
+        let explorer = create_explorer(
+            ref world,
+            systems,
+            RealmTestContext { entity_id: realm_id, owner, coord: Coord { alt: false, x: 80, y: 80 } },
+            TroopType::Paladin,
+            TroopTier::T3,
+            troop_amount,
+            Direction::East,
+        );
+
+        attack_explorer_vs_guard(ref world, systems, explorer, mine_id, Direction::East);
+
+        let guards = StructureTroopGuardStoreImpl::retrieve(ref world, mine_id);
+        let (delta, _) = guards.from_slot(GuardSlot::Delta);
+        assert!(delta.count == 0, "Non-hyperstructure captures should not auto-garrison");
+        let source_explorers = StructureTroopExplorerStoreImpl::retrieve(ref world, realm_id);
+        assert!(source_explorers.len() == 1, "Explorer should remain after non-hyperstructure capture");
     }
 
     // ========================================================================

--- a/contracts/game/src/systems/utils/structure.cairo
+++ b/contracts/game/src/systems/utils/structure.cairo
@@ -23,7 +23,7 @@ use crate::models::structure::{
     StructureTroopGuardStoreImpl, StructureVillageSlots,
 };
 use crate::models::troop::{ExplorerTroops, GuardSlot, GuardTrait, GuardTroops, TroopLimitTrait, TroopsImpl};
-use crate::models::weight::Weight;
+use crate::models::weight::{Weight, WeightImpl};
 use crate::system_libraries::biome_library::{IBiomeLibraryDispatcherTrait, biome_library};
 use crate::systems::combat::contracts::troop_management::{
     ITroopManagementSystemsDispatcher, ITroopManagementSystemsDispatcherTrait,
@@ -320,11 +320,32 @@ pub impl iStructureImpl of IStructureTrait {
             return;
         }
 
-        let mut explorer_weight: Weight = WeightStoreImpl::retrieve(ref world, explorer_id);
         let mut structure_weight: Weight = WeightStoreImpl::retrieve(ref world, structure_id);
+        Self::assert_structure_can_store_explorer_cargo(ref world, structure_weight, carried_resources.span());
+        let mut explorer_weight: Weight = WeightStoreImpl::retrieve(ref world, explorer_id);
         iResourceTransferImpl::troop_to_structure_instant(
             ref world, explorer_id, ref explorer_weight, structure_id, ref structure_weight, carried_resources.span(),
         );
+    }
+
+    fn assert_structure_can_store_explorer_cargo(
+        ref world: WorldStorage, mut structure_weight: Weight, carried_resources: Span<(u8, u128)>,
+    ) {
+        let carried_weight = Self::resource_span_weight(ref world, carried_resources);
+        assert!(carried_weight <= structure_weight.unused(), "captured hyperstructure cannot store explorer cargo");
+    }
+
+    fn resource_span_weight(ref world: WorldStorage, mut resources: Span<(u8, u128)>) -> u128 {
+        let mut total_weight: u128 = 0;
+        loop {
+            match resources.pop_front() {
+                Option::Some((
+                    resource_type, amount,
+                )) => { total_weight += *amount * ResourceWeightImpl::grams(ref world, *resource_type); },
+                Option::None => { break; },
+            }
+        }
+        total_weight
     }
 
     fn read_nonzero_resource_balances(ref world: WorldStorage, entity_id: ID) -> Array<(u8, u128)> {

--- a/contracts/game/src/systems/utils/structure.cairo
+++ b/contracts/game/src/systems/utils/structure.cairo
@@ -3,9 +3,10 @@ use dojo::event::EventStorage;
 use dojo::model::ModelStorage;
 use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
 use crate::alias::ID;
-use crate::constants::{DAYDREAMS_AGENT_ID, RESOURCE_PRECISION, ResourceTypes};
+use crate::constants::{DAYDREAMS_AGENT_ID, RESOURCE_PRECISION, ResourceTypes, all_resource_ids};
 use crate::models::config::{
-    StartingResourcesConfig, StructureCapacityConfig, VictoryPointsGrantConfig, VillageTokenConfig, WorldConfigUtilImpl,
+    CombatConfigImpl, StartingResourcesConfig, StructureCapacityConfig, VictoryPointsGrantConfig, VillageTokenConfig,
+    WorldConfigUtilImpl,
 };
 use crate::models::events::{PointsActivity, PointsRegisteredStory, Story, StoryEvent};
 use crate::models::hyperstructure::PlayerRegisteredPointsImpl;
@@ -21,13 +22,14 @@ use crate::models::structure::{
     StructureMetadataStoreImpl, StructureOwnerStoreImpl, StructureResourcesImpl, StructureTroopExplorerStoreImpl,
     StructureTroopGuardStoreImpl, StructureVillageSlots,
 };
-use crate::models::troop::{ExplorerTroops, GuardSlot, GuardTrait, GuardTroops, TroopsImpl};
+use crate::models::troop::{ExplorerTroops, GuardSlot, GuardTrait, GuardTroops, TroopLimitTrait, TroopsImpl};
 use crate::models::weight::Weight;
 use crate::system_libraries::biome_library::{IBiomeLibraryDispatcherTrait, biome_library};
 use crate::systems::combat::contracts::troop_management::{
     ITroopManagementSystemsDispatcher, ITroopManagementSystemsDispatcherTrait,
 };
 use crate::systems::utils::map::IMapImpl;
+use crate::systems::utils::resource::iResourceTransferImpl;
 use crate::systems::utils::troop::iExplorerImpl;
 use crate::systems::utils::village::iVillageImpl;
 use crate::utils::map::biomes::Biome;
@@ -231,6 +233,9 @@ pub impl iStructureImpl of IStructureTrait {
             );
             // store new owner
             StructureOwnerStoreImpl::store(explorer_owner_address, ref world, structure_id);
+            Self::auto_garrison_captured_hyperstructure(
+                ref world, ref structure_guards, ref structure_base, explorer, structure_id,
+            );
 
             // grant victory points to player for conquering hyperstructure
             let structure_was_owned_by_bandits: bool = previous_owner_address.is_zero();
@@ -288,6 +293,90 @@ pub impl iStructureImpl of IStructureTrait {
         }
     }
 
+    fn auto_garrison_captured_hyperstructure(
+        ref world: WorldStorage,
+        ref structure_guards: GuardTroops,
+        ref structure_base: StructureBase,
+        explorer: ExplorerTroops,
+        structure_id: ID,
+    ) {
+        if structure_base.category != StructureCategory::Hyperstructure.into() {
+            return;
+        }
+        if explorer.troops.count.is_zero() {
+            return;
+        }
+
+        Self::move_explorer_cargo_to_structure(ref world, explorer.explorer_id, structure_id);
+        Self::move_explorer_troops_to_delta_guard(
+            ref world, ref structure_guards, ref structure_base, explorer, structure_id,
+        );
+        Self::delete_garrisoned_explorer(ref world, explorer);
+    }
+
+    fn move_explorer_cargo_to_structure(ref world: WorldStorage, explorer_id: ID, structure_id: ID) {
+        let carried_resources = Self::read_nonzero_resource_balances(ref world, explorer_id);
+        if carried_resources.len().is_zero() {
+            return;
+        }
+
+        let mut explorer_weight: Weight = WeightStoreImpl::retrieve(ref world, explorer_id);
+        let mut structure_weight: Weight = WeightStoreImpl::retrieve(ref world, structure_id);
+        iResourceTransferImpl::troop_to_structure_instant(
+            ref world, explorer_id, ref explorer_weight, structure_id, ref structure_weight, carried_resources.span(),
+        );
+    }
+
+    fn read_nonzero_resource_balances(ref world: WorldStorage, entity_id: ID) -> Array<(u8, u128)> {
+        let mut resources: Array<(u8, u128)> = array![];
+        for resource_type in all_resource_ids() {
+            let balance = ResourceImpl::read_balance(ref world, entity_id, resource_type);
+            if balance.is_non_zero() {
+                resources.append((resource_type, balance));
+            }
+        }
+        resources
+    }
+
+    fn move_explorer_troops_to_delta_guard(
+        ref world: WorldStorage,
+        ref structure_guards: GuardTroops,
+        ref structure_base: StructureBase,
+        explorer: ExplorerTroops,
+        structure_id: ID,
+    ) {
+        let troop_limit_config = CombatConfigImpl::troop_limit_config(ref world);
+        let max_army_size: u128 = troop_limit_config.max_army_size(structure_base.level, explorer.troops.tier).into();
+        assert!(
+            explorer.troops.count <= max_army_size * RESOURCE_PRECISION,
+            "reached limit of structure guard troop count. max: {}",
+            max_army_size,
+        );
+
+        structure_guards.to_slot(GuardSlot::Delta, explorer.troops, 0);
+        structure_base.troop_guard_count = 1;
+        StructureTroopGuardStoreImpl::store(ref structure_guards, ref world, structure_id);
+        StructureBaseStoreImpl::store(ref structure_base, ref world, structure_id);
+    }
+
+    fn delete_garrisoned_explorer(ref world: WorldStorage, explorer: ExplorerTroops) {
+        let mut deleted_explorer = explorer;
+        let mut explorer_owner_structure = StructureBaseStoreImpl::retrieve(ref world, deleted_explorer.owner);
+        let explorer_owner_structure_explorers = StructureTroopExplorerStoreImpl::retrieve(
+            ref world, deleted_explorer.owner,
+        )
+            .into();
+
+        deleted_explorer.troops.count = 0;
+        iExplorerImpl::explorer_from_structure_delete(
+            ref world,
+            ref deleted_explorer,
+            explorer_owner_structure_explorers,
+            ref explorer_owner_structure,
+            deleted_explorer.owner,
+        );
+    }
+
     fn claim(
         ref world: WorldStorage, ref structure_base: StructureBase, ref explorer: ExplorerTroops, structure_id: ID,
     ) {
@@ -301,4 +390,3 @@ pub impl iStructureImpl of IStructureTrait {
         }
     }
 }
-

--- a/contracts/game/src/utils/testing/helpers.cairo
+++ b/contracts/game/src/utils/testing/helpers.cairo
@@ -619,6 +619,7 @@ pub fn namespace_def_combat() -> NamespaceDef {
             TestResource::Model("Wonder"), // Resource models
             TestResource::Model("Resource"),
             TestResource::Model("ResourceList"), TestResource::Model("ResourceFactoryConfig"),
+            TestResource::Model("PlayerRegisteredPoints"), TestResource::Model("SeasonPrize"),
             // Contracts
             TestResource::Contract("troop_management_systems"), TestResource::Contract("troop_movement_systems"),
             TestResource::Contract("troop_battle_systems"), TestResource::Contract("village_systems"),


### PR DESCRIPTION
Auto-garrisons surviving explorer troops into captured hyperstructures by moving cargo into the structure, placing the troops in Delta, and deleting the consumed explorer.

Adds combat coverage for initial captures, recaptures, guard-loss captures, cargo transfer, and non-hyperstructure captures.

Validation: scarb fmt; scarb test test_troop_battle.