### PR TITLE
Add unit spawn ghosts

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -34,7 +34,7 @@ import {
 
 import { gameWorkerManager } from "@/managers/game-worker-manager";
 import { Biome, configManager } from "@bibliothecadao/eternum";
-import { ClientComponents, ContractAddress, ID, TroopTier, TroopType } from "@bibliothecadao/types";
+import { ClientComponents, ContractAddress, HexPosition, ID, TroopTier, TroopType } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { shortString } from "starknet";
@@ -42,7 +42,7 @@ import * as THREE from "three";
 import { Color, Euler, Group, Object3D, Raycaster, Scene, Vector3 } from "three";
 import { CSS2DObject } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 import { env } from "../../../env";
-import type { AttachmentTransform, CosmeticAttachmentTemplate } from "../cosmetics";
+import type { AttachmentTransform, CosmeticAttachmentTemplate, ResolvedCosmeticSkin } from "../cosmetics";
 import {
   CosmeticAttachmentManager,
   findCosmeticById,
@@ -146,6 +146,11 @@ export interface ArmyMovementPlan {
   worldPath: Vector3[];
   armyCategory: TroopType;
   armyTier: TroopTier;
+}
+
+export interface PendingCreationGhostSource {
+  armyColor: string;
+  sourceScene: Object3D;
 }
 
 interface AddArmyParams {
@@ -2291,6 +2296,88 @@ export class ArmyManager {
       armyColor: army.color,
       sourceScene: modelData.sourceScene,
     };
+  }
+
+  public async resolvePendingCreationGhostSource(input: {
+    entityId: ID;
+    hexCoords: HexPosition;
+    troopType: TroopType;
+    troopTier: TroopTier;
+  }): Promise<PendingCreationGhostSource> {
+    const ownerAddress = this.resolvePendingCreationOwnerAddress();
+    this.hydratePendingCreationCosmetics(ownerAddress);
+
+    const baseModelType = this.resolvePendingCreationBaseModel(input);
+    const cosmetic = resolveArmyCosmetic({
+      owner: ownerAddress,
+      troopType: input.troopType,
+      tier: input.troopTier,
+      defaultModelType: baseModelType,
+    });
+    const sourceScene = await this.resolvePendingCreationSourceScene({
+      baseModelType: cosmetic.skin.modelType ?? baseModelType,
+      cosmeticSkin: cosmetic.skin,
+    });
+
+    return {
+      armyColor: this.resolvePendingCreationGhostColor(ownerAddress),
+      sourceScene,
+    };
+  }
+
+  private resolvePendingCreationOwnerAddress(): bigint {
+    return ContractAddress(useAccountStore.getState().account?.address || "0");
+  }
+
+  private hydratePendingCreationCosmetics(ownerAddress: bigint): void {
+    if (!this.components || ownerAddress === 0n) {
+      return;
+    }
+
+    playerCosmeticsStore.hydrateFromBlitzComponent(this.components, ownerAddress);
+  }
+
+  private resolvePendingCreationBaseModel(input: {
+    entityId: ID;
+    hexCoords: HexPosition;
+    troopType: TroopType;
+    troopTier: TroopTier;
+  }): ModelType {
+    const contractHex = new Position({ x: input.hexCoords.col, y: input.hexCoords.row }).getContract();
+    const biome = Biome.getBiome(contractHex.x, contractHex.y);
+    return this.armyModel.getModelTypeForEntity(
+      this.toNumericId(input.entityId),
+      input.troopType,
+      input.troopTier,
+      biome,
+    );
+  }
+
+  private async resolvePendingCreationSourceScene(input: {
+    baseModelType: ModelType;
+    cosmeticSkin: ResolvedCosmeticSkin;
+  }): Promise<Object3D> {
+    if (this.shouldUsePendingCreationCosmeticSource(input.cosmeticSkin)) {
+      try {
+        return await this.armyModel.getCosmeticModelSourceScene(input.cosmeticSkin);
+      } catch (error) {
+        console.warn("[ArmyManager] Failed to load pending creation cosmetic ghost, falling back to base model", error);
+      }
+    }
+
+    return this.armyModel.getModelSourceScene(input.baseModelType);
+  }
+
+  private shouldUsePendingCreationCosmeticSource(skin: ResolvedCosmeticSkin): boolean {
+    return !skin.isFallback && skin.assetPaths.length > 0;
+  }
+
+  private resolvePendingCreationGhostColor(ownerAddress: bigint): string {
+    return this.getArmyColor({
+      isMine: true,
+      isDaydreamsAgent: false,
+      owner: { address: ownerAddress },
+    });
   }
 
   public syncAttachedArmiesOwnerForStructure(params: {

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -641,6 +641,16 @@ export class ArmyModel {
     }
   }
 
+  public async getModelSourceScene(modelType: ModelType): Promise<Object3D> {
+    const modelData = await this.ensureModel(modelType);
+    return modelData.sourceScene;
+  }
+
+  public async getCosmeticModelSourceScene(skin: ResolvedCosmeticSkin): Promise<Object3D> {
+    const modelData = await this.ensureCosmeticModel(skin);
+    return modelData.sourceScene;
+  }
+
   public assignModelToEntity(entityId: number, modelType: ModelType): void {
     const oldModelType = this.entityModelMap.get(entityId);
     if (oldModelType === modelType) return;

--- a/client/apps/game/src/three/scenes/worldmap-create-army-ghost.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-create-army-ghost.source.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(currentDir, relativePath), "utf8");
+}
+
+function extractSourceBetween(source: string, startSignature: string, endSignature: string): string {
+  const start = source.indexOf(startSignature);
+  const end = source.indexOf(endSignature, start + startSignature.length);
+  if (start === -1 || end === -1) {
+    return "";
+  }
+
+  return source.slice(start, end);
+}
+
+describe("worldmap create-army ghost wiring", () => {
+  it("dispatches create-army pending feedback with troop identity instead of a resource icon id", () => {
+    const pendingFxSource = readSource("../../utils/pending-worldmap-fx.ts");
+    const armyCardSource = readSource("../../ui/features/military/components/army-management-card.tsx");
+    const unifiedModalSource = readSource(
+      "../../ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx",
+    );
+
+    expect(pendingFxSource).toContain("troopType: TroopType");
+    expect(pendingFxSource).toContain("troopTier: TroopTier");
+    expect(pendingFxSource).not.toContain("troopResourceId");
+
+    expect(armyCardSource).toContain("troopType");
+    expect(armyCardSource).toContain("troopTier");
+    expect(extractSourceBetween(armyCardSource, 'kind: "create-army"', "});")).not.toContain("troopResourceId");
+
+    expect(unifiedModalSource).toContain("troopType");
+    expect(unifiedModalSource).toContain("troopTier");
+    expect(extractSourceBetween(unifiedModalSource, 'kind: "create-army"', "});")).not.toContain("troopResourceId");
+  });
+
+  it("routes create-army pending feedback through arrival ghosts instead of resource-icon FX", () => {
+    const source = readSource("worldmap.tsx");
+    const startPendingActionFx = extractSourceBetween(
+      source,
+      "private startPendingActionFx(payload: PendingWorldmapFxStartPayload): void",
+      "private startPendingCreateArmyGhost(",
+    );
+    const createArmyGhostFlow = extractSourceBetween(
+      source,
+      "private startPendingCreateArmyGhost(",
+      "private playPendingFxAtHex(",
+    );
+
+    expect(startPendingActionFx).toContain("this.startPendingCreateArmyGhost(payload)");
+    expect(source).not.toContain("create-army-resource-");
+    expect(createArmyGhostFlow).toContain("resolveCreateArmyEffectTargetHex");
+    expect(createArmyGhostFlow).not.toContain("playPendingFxAtHex");
+    expect(createArmyGhostFlow).toContain("this.armyManager.resolvePendingCreationGhostSource");
+    expect(createArmyGhostFlow).toContain("this.arrivalGhostManager.upsertLocalArrivalGhost");
+    expect(createArmyGhostFlow).toContain("resolveArrivalGhostVisualStyle");
+  });
+
+  it("guards async create-army ghost rendering after the pending key has cleared", () => {
+    const source = readSource("worldmap.tsx");
+    const renderPendingCreateArmyGhost = extractSourceBetween(
+      source,
+      "private async renderPendingCreateArmyGhost(",
+      "private playPendingFxAtHex(",
+    );
+
+    expect(renderPendingCreateArmyGhost).toContain("this.pendingCreateArmyEffectsByKey.get(input.key)");
+    expect(renderPendingCreateArmyGhost).toContain("pending.ghostEntityId !== input.ghostEntityId");
+    expect(renderPendingCreateArmyGhost.indexOf("this.pendingCreateArmyEffectsByKey.get(input.key)")).toBeLessThan(
+      renderPendingCreateArmyGhost.indexOf("this.arrivalGhostManager.upsertLocalArrivalGhost"),
+    );
+  });
+
+  it("clears pending create-army ghosts with explicit lifecycle reasons", () => {
+    const source = readSource("worldmap.tsx");
+    const startPendingCreateArmyGhost = extractSourceBetween(
+      source,
+      "private startPendingCreateArmyGhost(",
+      "private allocatePendingCreateArmyGhostId()",
+    );
+    const clearAllPendingActionFx = extractSourceBetween(
+      source,
+      "private clearAllPendingActionFx()",
+      "private resolvePendingCreateArmyGhostOnArmyUpdate(",
+    );
+    const resolvePendingCreateArmyGhostOnArmyUpdate = extractSourceBetween(
+      source,
+      "private resolvePendingCreateArmyGhostOnArmyUpdate(",
+      "private clearPendingCreateArmyGhostsForOccupiedTiles()",
+    );
+    const clearPendingCreateArmyGhostsForOccupiedTiles = extractSourceBetween(
+      source,
+      "private clearPendingCreateArmyGhostsForOccupiedTiles()",
+      "private resolvePendingAttackFxOnBattleUpdate(",
+    );
+
+    expect(source).toContain('this.clearPendingActionFx(detail.key, "tx_failed")');
+    expect(startPendingCreateArmyGhost).toContain('this.clearPendingActionFx(payload.key, "stale_timeout")');
+    expect(clearAllPendingActionFx).toContain("...this.pendingCreateArmyEffectsByKey.keys()");
+    expect(clearAllPendingActionFx).toContain('this.clearPendingActionFx(key, "scene_destroyed")');
+    expect(resolvePendingCreateArmyGhostOnArmyUpdate).toContain("shouldClearPendingCreateArmyEffect");
+    expect(resolvePendingCreateArmyGhostOnArmyUpdate).toContain("removed: Boolean(update.removed)");
+    expect(resolvePendingCreateArmyGhostOnArmyUpdate).toContain('this.clearPendingActionFx(key, "arrived")');
+    expect(resolvePendingCreateArmyGhostOnArmyUpdate).toContain("this.clearPendingCreateArmyGhostsForOccupiedTiles()");
+    expect(clearPendingCreateArmyGhostsForOccupiedTiles).toContain(
+      "this.armyHexes.get(pending.targetHex.col)?.get(pending.targetHex.row)",
+    );
+    expect(clearPendingCreateArmyGhostsForOccupiedTiles).toContain('this.clearPendingActionFx(key, "arrived")');
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -96,6 +96,8 @@ import {
   ResourcesIds,
   Structure,
   StructureType,
+  TroopTier,
+  TroopType,
 } from "@bibliothecadao/types";
 import { getComponentEntities, getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
@@ -220,6 +222,7 @@ import {
   resolveArrivalGhostVisualStyle,
   shouldCreatePredictiveArrivalGhost,
   shouldHideSourceArmyOnTileRemoval,
+  type ArrivalGhostClearReason,
 } from "../managers/arrival-ghost-policy";
 import {
   resolveExploreCompletionPendingClearPlan,
@@ -919,7 +922,7 @@ export default class WorldmapScene extends WarpTravel {
   private pendingWorldmapFxStopHandler = (event: Event) => {
     const detail = (event as CustomEvent<PendingWorldmapFxStopPayload>).detail;
     if (!detail?.key) return;
-    this.clearPendingActionFx(detail.key);
+    this.clearPendingActionFx(detail.key, "tx_failed");
   };
   private handleWorldmapControlsChange = () => {
     if (this.sceneManager.getCurrentScene() !== SceneName.WorldMap) return;
@@ -1004,13 +1007,21 @@ export default class WorldmapScene extends WarpTravel {
   private travelEffects: Map<string, () => void> = new Map();
   private travelEffectsByEntity: Map<ID, { key: string; cleanup: () => void; effectType: TravelEffectType }> =
     new Map();
-  private pendingActionEffectsByKey: Map<string, () => void> = new Map();
+  private pendingActionEffectsByKey: Map<string, (reason: ArrivalGhostClearReason) => void> = new Map();
   private pendingActionEffectTimeoutsByKey: Map<string, ReturnType<typeof setTimeout>> = new Map();
   private pendingCreateArmyEffectsByKey: Map<
     string,
-    { structureId: ID; direction: Direction; targetHex: HexPosition; troopResourceId: number }
+    {
+      direction: Direction;
+      ghostEntityId: ID;
+      structureId: ID;
+      targetHex: HexPosition;
+      troopTier: TroopTier;
+      troopType: TroopType;
+    }
   > = new Map();
   private pendingAttackEffectsByKey: Map<string, { attackerId: ID; defenderId?: ID }> = new Map();
+  private nextPendingCreateArmyGhostId = -1;
   private cancelHexGridComputation?: () => void;
 
   // Global chunk switching coordination
@@ -1509,7 +1520,7 @@ export default class WorldmapScene extends WarpTravel {
         }
 
         this.updateArmyHexes(update);
-        this.resolvePendingCreateArmyFxOnArmyUpdate(update);
+        this.resolvePendingCreateArmyGhostOnArmyUpdate(update);
 
         if (update.battleData?.latestAttackerId) {
           this.addCombatRelationship(update.battleData.latestAttackerId, update.entityId);
@@ -3517,39 +3528,10 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private startPendingActionFx(payload: PendingWorldmapFxStartPayload): void {
-    this.clearPendingActionFx(payload.key);
+    this.clearPendingActionFx(payload.key, "superseded");
 
     if (payload.kind === "create-army") {
-      const structureHex = this.structuresPositions.get(payload.structureId);
-      const targetHex = resolveCreateArmyEffectTargetHex(structureHex, payload.direction);
-      if (!targetHex) {
-        return;
-      }
-
-      const fxType = `create-army-resource-${payload.troopResourceId}`;
-      const textureUrl = `/images/resources/${payload.troopResourceId}.png`;
-      this.fxManager.ensureInfiniteIconFx(fxType, textureUrl, { renderMode: "ground" });
-
-      const createCleanup = this.playPendingFxAtHex({
-        type: fxType,
-        hex: targetHex,
-        size: 1.2,
-        yOffset: 0.45,
-      });
-      this.pendingActionEffectsByKey.set(payload.key, createCleanup);
-      this.pendingCreateArmyEffectsByKey.set(payload.key, {
-        structureId: payload.structureId,
-        direction: payload.direction,
-        targetHex,
-        troopResourceId: payload.troopResourceId,
-      });
-
-      const timeout = setTimeout(
-        () => this.clearPendingActionFx(payload.key),
-        Math.max(5_000, payload.timeoutMs ?? 45_000),
-      );
-      this.pendingActionEffectTimeoutsByKey.set(payload.key, timeout);
-      this.clearPendingCreateArmyFxForOccupiedTiles();
+      this.startPendingCreateArmyGhost(payload);
       return;
     }
 
@@ -3578,10 +3560,87 @@ export default class WorldmapScene extends WarpTravel {
     });
 
     const timeout = setTimeout(
-      () => this.clearPendingActionFx(payload.key),
+      () => this.clearPendingActionFx(payload.key, "stale_timeout"),
       Math.max(5_000, payload.timeoutMs ?? 45_000),
     );
     this.pendingActionEffectTimeoutsByKey.set(payload.key, timeout);
+  }
+
+  private startPendingCreateArmyGhost(payload: Extract<PendingWorldmapFxStartPayload, { kind: "create-army" }>): void {
+    const structureHex = this.structuresPositions.get(payload.structureId);
+    const targetHex = resolveCreateArmyEffectTargetHex(structureHex, payload.direction);
+    if (!targetHex) {
+      return;
+    }
+
+    const ghostEntityId = this.allocatePendingCreateArmyGhostId();
+    this.pendingActionEffectsByKey.set(payload.key, (reason) => {
+      this.arrivalGhostManager.clearArrivalGhost(ghostEntityId, reason);
+    });
+    this.pendingCreateArmyEffectsByKey.set(payload.key, {
+      structureId: payload.structureId,
+      direction: payload.direction,
+      targetHex,
+      troopType: payload.troopType,
+      troopTier: payload.troopTier,
+      ghostEntityId,
+    });
+
+    const timeout = setTimeout(
+      () => this.clearPendingActionFx(payload.key, "stale_timeout"),
+      Math.max(5_000, payload.timeoutMs ?? 45_000),
+    );
+    this.pendingActionEffectTimeoutsByKey.set(payload.key, timeout);
+    void this.renderPendingCreateArmyGhost({
+      key: payload.key,
+      ghostEntityId,
+      targetHex,
+      troopType: payload.troopType,
+      troopTier: payload.troopTier,
+    }).catch((error) => this.handlePendingCreateArmyGhostError(payload.key, error));
+    this.clearPendingCreateArmyGhostsForOccupiedTiles();
+  }
+
+  private allocatePendingCreateArmyGhostId(): ID {
+    const ghostEntityId = this.nextPendingCreateArmyGhostId;
+    this.nextPendingCreateArmyGhostId -= 1;
+    return ghostEntityId;
+  }
+
+  private async renderPendingCreateArmyGhost(input: {
+    ghostEntityId: ID;
+    key: string;
+    targetHex: HexPosition;
+    troopTier: TroopTier;
+    troopType: TroopType;
+  }): Promise<void> {
+    const ghostSource = await this.armyManager.resolvePendingCreationGhostSource({
+      entityId: input.ghostEntityId,
+      hexCoords: input.targetHex,
+      troopType: input.troopType,
+      troopTier: input.troopTier,
+    });
+    const pending = this.pendingCreateArmyEffectsByKey.get(input.key);
+    if (!pending || pending.ghostEntityId !== input.ghostEntityId) {
+      return;
+    }
+
+    this.arrivalGhostManager.upsertLocalArrivalGhost({
+      entityId: input.ghostEntityId,
+      hexCoords: input.targetHex,
+      sourceScene: ghostSource.sourceScene,
+      visualStyle: resolveArrivalGhostVisualStyle({
+        armyColor: ghostSource.armyColor,
+      }),
+    });
+  }
+
+  private handlePendingCreateArmyGhostError(key: string, error: unknown): void {
+    if (!this.pendingCreateArmyEffectsByKey.has(key)) {
+      return;
+    }
+
+    console.warn("[WorldMap] Failed to show pending create-army ghost", error);
   }
 
   private playPendingFxAtHex(input: {
@@ -3610,10 +3669,10 @@ export default class WorldmapScene extends WarpTravel {
     };
   }
 
-  private clearPendingActionFx(key: string): void {
+  private clearPendingActionFx(key: string, reason: ArrivalGhostClearReason): void {
     const cleanup = this.pendingActionEffectsByKey.get(key);
     if (cleanup) {
-      cleanup();
+      cleanup(reason);
       this.pendingActionEffectsByKey.delete(key);
     }
 
@@ -3628,12 +3687,13 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private clearAllPendingActionFx(): void {
-    for (const key of Array.from(this.pendingActionEffectsByKey.keys())) {
-      this.clearPendingActionFx(key);
+    const keys = new Set([...this.pendingActionEffectsByKey.keys(), ...this.pendingCreateArmyEffectsByKey.keys()]);
+    for (const key of keys) {
+      this.clearPendingActionFx(key, "scene_destroyed");
     }
   }
 
-  private resolvePendingCreateArmyFxOnArmyUpdate(update: { hexCoords: HexPosition; removed?: boolean }): void {
+  private resolvePendingCreateArmyGhostOnArmyUpdate(update: { hexCoords: HexPosition; removed?: boolean }): void {
     const normalized = new Position({ x: update.hexCoords.col, y: update.hexCoords.row }).getNormalized();
     const updateHex = { col: normalized.x, row: normalized.y };
     const keysToClear: string[] = [];
@@ -3651,13 +3711,13 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     for (const key of keysToClear) {
-      this.clearPendingActionFx(key);
+      this.clearPendingActionFx(key, "arrived");
     }
 
-    this.clearPendingCreateArmyFxForOccupiedTiles();
+    this.clearPendingCreateArmyGhostsForOccupiedTiles();
   }
 
-  private clearPendingCreateArmyFxForOccupiedTiles(): void {
+  private clearPendingCreateArmyGhostsForOccupiedTiles(): void {
     const keysToClear: string[] = [];
 
     for (const [key, pending] of this.pendingCreateArmyEffectsByKey.entries()) {
@@ -3667,7 +3727,7 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     for (const key of keysToClear) {
-      this.clearPendingActionFx(key);
+      this.clearPendingActionFx(key, "arrived");
     }
   }
 
@@ -3685,7 +3745,7 @@ export default class WorldmapScene extends WarpTravel {
         battleDefenderId,
       });
       if (shouldClear) {
-        this.clearPendingActionFx(key);
+        this.clearPendingActionFx(key, "arrived");
       }
     }
   }

--- a/client/apps/game/src/ui/features/military/components/army-management-card.tsx
+++ b/client/apps/game/src/ui/features/military/components/army-management-card.tsx
@@ -205,7 +205,8 @@ export const ArmyCreate = ({
             kind: "create-army",
             structureId: owner_entity,
             direction: selectedDirection,
-            troopResourceId: getTroopResourceId(troopType, troopTier),
+            troopType,
+            troopTier,
           });
           await armyManager.createExplorerArmy(account, troopType, troopTier, troopCount, selectedDirection);
         }

--- a/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx
+++ b/client/apps/game/src/ui/features/military/components/unified-army-creation-modal/unified-army-creation-modal.tsx
@@ -530,7 +530,8 @@ export const UnifiedArmyCreationModal = ({
           kind: "create-army",
           structureId: activeStructureId,
           direction: selectedDirection,
-          troopResourceId: getTroopResourceId(selectedTroopCombo.type, selectedTroopCombo.tier),
+          troopType: selectedTroopCombo.type,
+          troopTier: selectedTroopCombo.tier,
         });
         await armyManager.createExplorerArmy(
           account,

--- a/client/apps/game/src/ui/features/world/latest-features.test.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.test.ts
@@ -33,4 +33,15 @@ describe("latestFeatures landing feed", () => {
       }),
     );
   });
+
+  it("announces unit creation ghosts in the latest feed", () => {
+    expect(latestFeatures).toContainEqual(
+      expect.objectContaining({
+        date: "2026-05-26",
+        title: "Unit Creation Ghosts",
+        type: "improvement",
+        gameSlug: "world",
+      }),
+    );
+  });
 });

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-26",
+    title: "Unit Creation Ghosts",
+    description:
+      "Added unit-shaped creation previews so newly submitted armies appear as ghosts on their spawn hex while the world catches up.",
+    type: "improvement",
+    gameSlug: "world",
+  },
+  {
     date: "2026-05-25",
     title: "Explore Arrival Previews",
     description:

--- a/client/apps/game/src/utils/pending-worldmap-fx.ts
+++ b/client/apps/game/src/utils/pending-worldmap-fx.ts
@@ -1,4 +1,4 @@
-import { Direction, HexPosition, ID } from "@bibliothecadao/types";
+import { Direction, HexPosition, ID, TroopTier, TroopType } from "@bibliothecadao/types";
 
 export const WORLDMAP_PENDING_FX_START_EVENT = "worldmapPendingFxStart";
 export const WORLDMAP_PENDING_FX_STOP_EVENT = "worldmapPendingFxStop";
@@ -9,7 +9,8 @@ export type PendingWorldmapFxStartPayload =
       kind: "create-army";
       structureId: ID;
       direction: Direction;
-      troopResourceId: number;
+      troopType: TroopType;
+      troopTier: TroopTier;
       timeoutMs?: number;
     }
   | {


### PR DESCRIPTION
Adds model-backed pending creation ghosts so newly submitted armies appear on their spawn hex while the world update catches up. The create-army pending FX payload now carries troop type and tier, and the worldmap resolves the correct base or cosmetic army model for the ghost. It also records the feature in the latest feed and adds source-level coverage for the create-army ghost wiring and lifecycle cleanup. Validation: pnpm run format, pnpm run knip, game three typecheck, game typecheck, focused Vitest files, and git diff --check.