### PR TITLE
Add hyperstructure auto-garrison

### DIFF
--- a/client/apps/game/src/ui/features/military/battle/combat-container.tsx
+++ b/client/apps/game/src/ui/features/military/battle/combat-container.tsx
@@ -1,6 +1,6 @@
 import { env } from "@/../env";
 import { playUnitCommandSound } from "@/audio/unit-command-audio";
-import { useCurrentArmiesTick } from "@/hooks/helpers/use-block-timestamp";
+import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import {
@@ -13,6 +13,7 @@ import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import TwitterShareButton from "@/ui/design-system/molecules/twitter-share-button";
 import { formatSocialText, twitterTemplates } from "@/ui/socials";
 import { getRelicBonusSummary } from "@/ui/utils/relic-utils";
+import { extractTransactionHash, waitForTransactionConfirmation } from "@/ui/utils/transactions";
 import { currencyFormat } from "@/ui/utils/utils";
 
 import {
@@ -26,9 +27,11 @@ import {
   getGuildFromPlayerAddress,
   getRemainingCapacityInKg,
   getTroopResourceId,
+  ResourceManager,
   StaminaManager,
 } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
+import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@bibliothecadao/torii";
 import {
   CapacityConfig,
   ClientComponents,
@@ -36,6 +39,7 @@ import {
   DISPLAYED_SLOT_NUMBER_MAP,
   getDirectionBetweenAdjacentHexes,
   ID,
+  RELICS,
   RelicEffectWithEndTick,
   RESOURCE_PRECISION,
   resources,
@@ -46,7 +50,7 @@ import {
 } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import Users from "lucide-react/dist/esm/icons/users";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { ActiveRelicEffects } from "../../world/components/entities/active-relic-effects";
 import { GuardStaminaBar } from "../components/guard-stamina-bar";
 import { getGuardStaminaSnapshot } from "../utils/guard-stamina";
@@ -57,12 +61,33 @@ import {
 } from "./attack-stamina-state";
 import { BattleCooldownTimer } from "./battle-cooldown-timer";
 import { BattleStats, CombatLoading, ResourceStealing, TroopDisplay } from "./components";
+import {
+  addressesMatch,
+  AutoGarrisonPlan,
+  resolveAutoGarrisonPlan,
+  resolveAutoGarrisonResources,
+  resolveLiveAutoGarrisonCount,
+} from "./hyperstructure-auto-garrison";
 import { AttackTarget, TargetType } from "./types";
 
 enum AttackerType {
   Structure,
   Army,
 }
+
+const AUTO_GARRISON_MAX_POLL_ATTEMPTS = 8;
+const AUTO_GARRISON_POLL_INTERVAL_MS = 750;
+const RELIC_RESOURCE_IDS: number[] = RELICS.map((relic) => Number(relic.id));
+
+type CapturedAutoGarrisonState = {
+  explorer: Awaited<ReturnType<typeof getExplorerFromToriiClient>>["explorer"];
+  explorerResources: Awaited<ReturnType<typeof getExplorerFromToriiClient>>["resources"];
+};
+
+type ToriiClient = Parameters<typeof getExplorerFromToriiClient>[0];
+
+const waitForAutoGarrisonPollInterval = () =>
+  new Promise((resolve) => setTimeout(resolve, AUTO_GARRISON_POLL_INTERVAL_MS));
 
 const buildProjectedTroopSnapshot = (input: {
   troops: Troops;
@@ -85,7 +110,39 @@ const buildProjectedTroopSnapshot = (input: {
   battle_cooldown_end: input.troops.battle_cooldown_end || 0,
 });
 
-// Add the new function before the CombatContainer component
+const pollCapturedAutoGarrisonState = async ({
+  toriiClient,
+  explorerId,
+  structureId,
+  ownerAddress,
+}: {
+  toriiClient: ToriiClient;
+  explorerId: ID;
+  structureId: ID;
+  ownerAddress: string;
+}): Promise<CapturedAutoGarrisonState | null> => {
+  for (let attempt = 0; attempt < AUTO_GARRISON_MAX_POLL_ATTEMPTS; attempt += 1) {
+    const [structureData, explorerData] = await Promise.all([
+      getStructureFromToriiClient(toriiClient, structureId),
+      getExplorerFromToriiClient(toriiClient, explorerId),
+    ]);
+
+    const explorerCount = resolveLiveAutoGarrisonCount(explorerData.explorer);
+    if (addressesMatch(structureData.structure?.owner, ownerAddress) && explorerCount > 0) {
+      return {
+        explorer: explorerData.explorer,
+        explorerResources: explorerData.resources,
+      };
+    }
+
+    if (attempt < AUTO_GARRISON_MAX_POLL_ATTEMPTS - 1) {
+      await waitForAutoGarrisonPollInterval();
+    }
+  }
+
+  return null;
+};
+
 const getFormattedCombatTweet = ({
   attackerArmyData,
   target,
@@ -130,16 +187,24 @@ export const CombatContainer = ({
 }) => {
   const {
     account: { account },
+    network: { provider, toriiClient },
     setup: {
-      systemCalls: { attack_explorer_vs_explorer, attack_explorer_vs_guard, attack_guard_vs_explorer },
+      systemCalls: {
+        attack_explorer_vs_explorer,
+        attack_explorer_vs_guard,
+        attack_explorer_vs_guard_and_garrison,
+        attack_guard_vs_explorer,
+        explorer_guard_swap,
+        troop_structure_adjacent_transfer,
+      },
       components,
-      components: { Structure, ExplorerTroops },
+      components: { Structure, ExplorerTroops, Resource },
     },
   } = useDojo();
 
   const [loading, setLoading] = useState(false);
   const [selectedGuardSlot, setSelectedGuardSlot] = useState<number | null>(null);
-  const currentArmiesTick = useCurrentArmiesTick();
+  const { currentArmiesTick, currentDefaultTick } = useBlockTimestamp();
 
   const accountName = useAccountStore((state) => state.accountName);
 
@@ -148,6 +213,27 @@ export const CombatContainer = ({
   const toggleModal = useUIStore((state) => state.toggleModal);
 
   const selectedHex = useUIStore((state) => state.selectedHex);
+
+  const attackerResources = useMemo(
+    () => getComponentValue(Resource, getEntityIdFromKeys([BigInt(attackerEntityId)])),
+    [attackerEntityId, Resource],
+  );
+
+  const resolveExplorerRelicResources = useCallback(
+    (explorerResources = attackerResources) => {
+      if (!explorerResources) {
+        return [];
+      }
+
+      return resolveAutoGarrisonResources({
+        resourceIds: RELIC_RESOURCE_IDS,
+        readBalance: (resourceId) =>
+          ResourceManager.balanceWithProduction(explorerResources, currentDefaultTick, resourceId as ResourcesIds)
+            .balance,
+      });
+    },
+    [attackerResources, currentDefaultTick],
+  );
 
   const combatConfig = useMemo(() => {
     return configManager.getCombatConfig();
@@ -405,6 +491,20 @@ export const CombatContainer = ({
 
   const remainingTroops = battleSimulation?.getRemainingTroops();
   const winner = battleSimulation?.winner;
+  const attackerTroopCount = Number(attackerArmyData?.troops.count ?? 0n);
+  const projectedAttackerTroopCount = remainingTroops
+    ? Math.max(0, Math.floor(remainingTroops.attackerTroops * RESOURCE_PRECISION))
+    : attackerTroopCount;
+  const autoGarrisonPlan = useMemo(
+    () =>
+      resolveAutoGarrisonPlan({
+        attackerType: attackerType === AttackerType.Army ? "army" : "structure",
+        target,
+        attackerTroopCount,
+        projectedAttackerTroopCount,
+      }),
+    [attackerTroopCount, attackerType, projectedAttackerTroopCount, target],
+  );
 
   const totalDefenderTroopsRaw = useMemo(() => {
     if (!target?.info || target.info.length === 0) return 0;
@@ -472,27 +572,107 @@ export const CombatContainer = ({
     }
   };
 
+  const submitPostConfirmationAutoGarrison = async ({
+    attackResult,
+    direction,
+    plan,
+  }: {
+    attackResult: unknown;
+    direction: number;
+    plan: Extract<AutoGarrisonPlan, { mode: "post-confirmation" }>;
+  }) => {
+    const txHash = extractTransactionHash(attackResult);
+    if (!txHash) {
+      return;
+    }
+
+    await waitForTransactionConfirmation({
+      txHash,
+      provider,
+      account,
+      label: "hyperstructure capture",
+    });
+
+    try {
+      const capturedState = await pollCapturedAutoGarrisonState({
+        toriiClient,
+        explorerId: attackerEntityId,
+        structureId: target.id,
+        ownerAddress: account.address,
+      });
+      if (!capturedState?.explorer) {
+        return;
+      }
+
+      const liveCount = resolveLiveAutoGarrisonCount(capturedState.explorer);
+      if (liveCount <= 0) {
+        return;
+      }
+
+      const relicResources = resolveExplorerRelicResources(capturedState.explorerResources);
+      if (relicResources.length > 0) {
+        await troop_structure_adjacent_transfer({
+          signer: account,
+          from_explorer_id: attackerEntityId,
+          to_structure_id: target.id,
+          resources: relicResources,
+        });
+      }
+
+      await explorer_guard_swap({
+        signer: account,
+        from_explorer_id: attackerEntityId,
+        to_structure_id: target.id,
+        to_structure_direction: direction,
+        to_guard_slot: plan.toGuardSlot,
+        count: liveCount,
+      });
+    } catch (error) {
+      console.error("Auto-garrison failed:", error);
+    }
+  };
+
   const onExplorerVsGuardAttack = async () => {
     if (!selectedHex) return;
     const direction = getDirectionBetweenAdjacentHexes(selectedHex, { col: target.hex.x, row: target.hex.y });
     if (direction === null) return;
 
-    await attack_explorer_vs_guard({
+    if (autoGarrisonPlan.mode === "atomic") {
+      await attack_explorer_vs_guard_and_garrison({
+        signer: account,
+        explorer_id: attackerEntityId,
+        structure_id: target.id,
+        structure_direction: direction,
+        to_guard_slot: autoGarrisonPlan.toGuardSlot,
+        count: autoGarrisonPlan.count,
+        resources: resolveExplorerRelicResources(),
+      });
+      return;
+    }
+
+    const attackResult = await attack_explorer_vs_guard({
       signer: account,
       explorer_id: attackerEntityId,
-      structure_id: target?.id || 0,
+      structure_id: target.id,
       structure_direction: direction,
     });
+
+    if (autoGarrisonPlan.mode === "post-confirmation") {
+      await submitPostConfirmationAutoGarrison({
+        attackResult,
+        direction,
+        plan: autoGarrisonPlan,
+      });
+    }
   };
 
   const remainingCapacity = useMemo(() => {
-    const resource = getComponentValue(components.Resource, getEntityIdFromKeys([BigInt(attackerEntityId)]));
-    const remainingCapacity = resource ? getRemainingCapacityInKg(resource) : 0;
+    const remainingCapacity = attackerResources ? getRemainingCapacityInKg(attackerResources) : 0;
     const remainingCapacityAfterRaid =
       remainingCapacity -
       (battleSimulation?.defenderDamage || 0) * configManager.getCapacityConfigKg(CapacityConfig.Army);
     return { beforeRaid: remainingCapacity, afterRaid: remainingCapacityAfterRaid };
-  }, [battleSimulation]);
+  }, [attackerResources, battleSimulation]);
 
   const stealableResources = useMemo(() => {
     let capacityAfterRaid = remainingCapacity.afterRaid;

--- a/client/apps/game/src/ui/features/military/battle/hooks/use-attack-target.ts
+++ b/client/apps/game/src/ui/features/military/battle/hooks/use-attack-target.ts
@@ -16,9 +16,10 @@ import { getExplorerFromToriiClient, getStructureFromToriiClient } from "@biblio
 import { getComponentValue } from "@dojoengine/recs";
 import { useEffect, useMemo, useState } from "react";
 
+import { getStructureDefenseSlotLimit, MAX_GUARD_SLOT_COUNT } from "../../utils/defense-slot-utils";
 import { AttackTarget, TargetType } from "../types";
 
-import type { ID, RelicEffectWithEndTick } from "@bibliothecadao/types";
+import type { ID, RelicEffectWithEndTick, StructureType } from "@bibliothecadao/types";
 import { STEALABLE_RESOURCES } from "@bibliothecadao/types";
 
 const orderResourcesByPriority = (resourceBalances: Array<{ resourceId: number; amount: number }>) => {
@@ -39,6 +40,28 @@ interface UseAttackTargetResult {
 
 type StructureTargetFetchResult = Awaited<ReturnType<typeof getStructureFromToriiClient>>;
 type ExplorerTargetFetchResult = Awaited<ReturnType<typeof getExplorerFromToriiClient>>;
+
+const resolveStructureGuardSlotLimit = (structure: NonNullable<StructureTargetFetchResult["structure"]>) => {
+  const limits: number[] = [];
+  const derivedLimit = getStructureDefenseSlotLimit(
+    structure.category as StructureType | undefined,
+    structure.base?.level,
+  );
+  if (typeof derivedLimit === "number" && Number.isFinite(derivedLimit)) {
+    limits.push(derivedLimit);
+  }
+
+  const baseLimit = Number(structure.base?.troop_max_guard_count);
+  if (Number.isFinite(baseLimit)) {
+    limits.push(baseLimit);
+  }
+
+  if (limits.length === 0) {
+    return null;
+  }
+
+  return Math.max(0, Math.min(Math.min(...limits), MAX_GUARD_SLOT_COUNT));
+};
 
 type FetchedAttackTarget =
   | {
@@ -193,6 +216,8 @@ export const useAttackTargetData = (
         id: fetchedTarget.id,
         targetType: TargetType.Structure,
         structureCategory: fetchedTarget.structure.category,
+        structureLevel: Number(fetchedTarget.structure.base?.level ?? 0),
+        guardSlotLimit: resolveStructureGuardSlotLimit(fetchedTarget.structure),
         hex: fetchedTarget.hex,
         addressOwner: fetchedTarget.structure.owner,
       };
@@ -208,6 +233,8 @@ export const useAttackTargetData = (
       id: fetchedTarget.id,
       targetType: TargetType.Army,
       structureCategory: null,
+      structureLevel: null,
+      guardSlotLimit: null,
       hex: fetchedTarget.hex,
       addressOwner: fetchedTarget.addressOwner,
     };

--- a/client/apps/game/src/ui/features/military/battle/hyperstructure-auto-garrison.test.ts
+++ b/client/apps/game/src/ui/features/military/battle/hyperstructure-auto-garrison.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { GuardSlot, StructureType } from "@bibliothecadao/types";
+import {
+  resolveAutoGarrisonPlan,
+  resolveAutoGarrisonResources,
+  resolveLiveAutoGarrisonCount,
+} from "./hyperstructure-auto-garrison";
+import { TargetType } from "./types";
+
+const makeTarget = (overrides: Partial<Parameters<typeof resolveAutoGarrisonPlan>[0]["target"]> = {}) => ({
+  id: 200,
+  targetType: TargetType.Structure,
+  structureCategory: StructureType.Hyperstructure,
+  info: [],
+  hex: { x: 5, y: 6 },
+  addressOwner: 0n,
+  guardSlotLimit: 3,
+  ...overrides,
+});
+
+describe("resolveAutoGarrisonPlan", () => {
+  it("uses an atomic multicall when the targeted hyperstructure has no active guards", () => {
+    expect(
+      resolveAutoGarrisonPlan({
+        attackerType: "army",
+        target: makeTarget(),
+        attackerTroopCount: 123_000,
+        projectedAttackerTroopCount: 123_000,
+      }),
+    ).toEqual({
+      mode: "atomic",
+      toGuardSlot: GuardSlot.Delta,
+      count: 123_000,
+    });
+  });
+
+  it("uses post-confirmation garrisoning when exactly one guard remains", () => {
+    expect(
+      resolveAutoGarrisonPlan({
+        attackerType: "army",
+        target: makeTarget({ info: [{ count: 100n } as never] }),
+        attackerTroopCount: 123_000,
+        projectedAttackerTroopCount: 45_000,
+      }),
+    ).toEqual({
+      mode: "post-confirmation",
+      toGuardSlot: GuardSlot.Delta,
+      count: 45_000,
+    });
+  });
+
+  it("does not auto-garrison when more than one guard remains", () => {
+    expect(
+      resolveAutoGarrisonPlan({
+        attackerType: "army",
+        target: makeTarget({ info: [{ count: 100n } as never, { count: 200n } as never] }),
+        attackerTroopCount: 123_000,
+        projectedAttackerTroopCount: 45_000,
+      }),
+    ).toEqual({ mode: "none" });
+  });
+
+  it("does not auto-garrison non-hyperstructure or structure attacks", () => {
+    expect(
+      resolveAutoGarrisonPlan({
+        attackerType: "army",
+        target: makeTarget({ structureCategory: StructureType.Realm }),
+        attackerTroopCount: 123_000,
+        projectedAttackerTroopCount: 45_000,
+      }),
+    ).toEqual({ mode: "none" });
+
+    expect(
+      resolveAutoGarrisonPlan({
+        attackerType: "structure",
+        target: makeTarget(),
+        attackerTroopCount: 123_000,
+        projectedAttackerTroopCount: 45_000,
+      }),
+    ).toEqual({ mode: "none" });
+  });
+
+  it("uses the first functional hyperstructure guard slot", () => {
+    expect(
+      resolveAutoGarrisonPlan({
+        attackerType: "army",
+        target: makeTarget({ guardSlotLimit: 1 }),
+        attackerTroopCount: 123_000,
+        projectedAttackerTroopCount: 123_000,
+      }),
+    ).toMatchObject({ toGuardSlot: GuardSlot.Delta });
+  });
+});
+
+describe("resolveLiveAutoGarrisonCount", () => {
+  it("uses the full surviving live explorer troop count", () => {
+    expect(resolveLiveAutoGarrisonCount({ troops: { count: 77_000n } })).toBe(77_000);
+  });
+});
+
+describe("resolveAutoGarrisonResources", () => {
+  it("filters zero-balance resources before preserving explorer cargo", () => {
+    const resources = resolveAutoGarrisonResources({
+      resourceIds: [1, 2, 3],
+      readBalance: (resourceId) => (resourceId === 2 ? 50 : 0),
+    });
+
+    expect(resources).toEqual([{ resourceId: 2, amount: 50 }]);
+  });
+});

--- a/client/apps/game/src/ui/features/military/battle/hyperstructure-auto-garrison.ts
+++ b/client/apps/game/src/ui/features/military/battle/hyperstructure-auto-garrison.ts
@@ -1,0 +1,130 @@
+import { GuardSlot, StructureType } from "@bibliothecadao/types";
+import { getStructureDefenseSlotLimit, getUnlockedGuardSlots } from "../utils/defense-slot-utils";
+import { AttackTarget, TargetType } from "./types";
+
+export type AutoGarrisonPlan =
+  | { mode: "none" }
+  | {
+      mode: "atomic";
+      toGuardSlot: GuardSlot;
+      count: number;
+    }
+  | {
+      mode: "post-confirmation";
+      toGuardSlot: GuardSlot;
+      count: number;
+    };
+
+interface ResolveAutoGarrisonPlanParams {
+  attackerType: "army" | "structure";
+  target: AttackTarget | null;
+  attackerTroopCount: number;
+  projectedAttackerTroopCount: number;
+}
+
+interface ResolveAutoGarrisonResourcesParams {
+  resourceIds: number[];
+  readBalance: (resourceId: number) => number;
+}
+
+export const resolveAutoGarrisonPlan = ({
+  attackerType,
+  target,
+  attackerTroopCount,
+  projectedAttackerTroopCount,
+}: ResolveAutoGarrisonPlanParams): AutoGarrisonPlan => {
+  if (!shouldAutoGarrisonHyperstructure(attackerType, target)) {
+    return { mode: "none" };
+  }
+
+  const toGuardSlot = resolveFirstFunctionalGuardSlot(target);
+  if (toGuardSlot === null) {
+    return { mode: "none" };
+  }
+
+  const activeGuardCount = countActiveGuards(target);
+  if (activeGuardCount === 0) {
+    return {
+      mode: "atomic",
+      toGuardSlot,
+      count: Math.max(0, Math.floor(attackerTroopCount)),
+    };
+  }
+
+  if (activeGuardCount === 1) {
+    return {
+      mode: "post-confirmation",
+      toGuardSlot,
+      count: Math.max(0, Math.floor(projectedAttackerTroopCount)),
+    };
+  }
+
+  return { mode: "none" };
+};
+
+export const resolveLiveAutoGarrisonCount = (
+  explorer: { troops?: { count?: bigint | number | string } } | null | undefined,
+) => {
+  const count = Number(explorer?.troops?.count ?? 0);
+  return Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+};
+
+export const resolveAutoGarrisonResources = ({
+  resourceIds,
+  readBalance,
+}: ResolveAutoGarrisonResourcesParams): Array<{ resourceId: number; amount: number }> =>
+  resourceIds
+    .map((resourceId) => ({
+      resourceId,
+      amount: Number(readBalance(resourceId)),
+    }))
+    .filter((resource) => Number.isFinite(resource.amount) && resource.amount > 0);
+
+export const addressesMatch = (
+  left: bigint | number | string | null | undefined,
+  right: bigint | number | string | null | undefined,
+): boolean => {
+  const normalizedLeft = normalizeAddress(left);
+  const normalizedRight = normalizeAddress(right);
+  return normalizedLeft !== null && normalizedLeft === normalizedRight;
+};
+
+const shouldAutoGarrisonHyperstructure = (
+  attackerType: ResolveAutoGarrisonPlanParams["attackerType"],
+  target: AttackTarget | null,
+): target is AttackTarget => {
+  return (
+    attackerType === "army" &&
+    target?.targetType === TargetType.Structure &&
+    target.structureCategory === StructureType.Hyperstructure
+  );
+};
+
+const resolveFirstFunctionalGuardSlot = (target: AttackTarget): GuardSlot | null => {
+  const slotLimit = resolveGuardSlotLimit(target);
+  const [firstSlot] = getUnlockedGuardSlots(slotLimit);
+  return firstSlot === undefined ? null : (firstSlot as GuardSlot);
+};
+
+const resolveGuardSlotLimit = (target: AttackTarget): number | null => {
+  if (typeof target.guardSlotLimit === "number" && Number.isFinite(target.guardSlotLimit)) {
+    return target.guardSlotLimit;
+  }
+
+  return getStructureDefenseSlotLimit(target.structureCategory ?? undefined, target.structureLevel ?? null);
+};
+
+const countActiveGuards = (target: AttackTarget): number =>
+  target.info.filter((troops) => Number(troops.count ?? 0n) > 0).length;
+
+const normalizeAddress = (value: bigint | number | string | null | undefined): string | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  try {
+    return BigInt(value).toString(16);
+  } catch {
+    return String(value).trim().toLowerCase();
+  }
+};

--- a/client/apps/game/src/ui/features/military/battle/types.ts
+++ b/client/apps/game/src/ui/features/military/battle/types.ts
@@ -10,6 +10,8 @@ export interface AttackTarget {
   id: ID;
   targetType: TargetType;
   structureCategory: StructureType | null;
+  structureLevel?: number | null;
+  guardSlotLimit?: number | null;
   hex: { x: number; y: number };
   addressOwner: ContractAddress | null;
 }

--- a/client/apps/game/src/ui/features/military/components/transfer-troops-container.tsx
+++ b/client/apps/game/src/ui/features/military/components/transfer-troops-container.tsx
@@ -35,6 +35,7 @@ import { useQuery } from "@tanstack/react-query";
 import AlertTriangle from "lucide-react/dist/esm/icons/alert-triangle";
 import ArrowLeftRight from "lucide-react/dist/esm/icons/arrow-left-right";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { resolveAutoGarrisonResources } from "../battle/hyperstructure-auto-garrison";
 import { getStructureDefenseSlotLimit, getUnlockedGuardSlots, MAX_GUARD_SLOT_COUNT } from "../utils/defense-slot-utils";
 import { getGuardStaminaSnapshot } from "../utils/guard-stamina";
 import { TransferBalanceCardData, TransferBalanceCards } from "./transfer-troops/transfer-balance-cards";
@@ -57,11 +58,6 @@ interface TransferTroopsContainerProps {
 const BALANCE_SLOT = BALANCE_TRANSFER_SLOT;
 
 type GuardSelection = number | typeof BALANCE_SLOT | null;
-
-type RelicResourceTransfer = {
-  resourceId: number;
-  amount: number;
-};
 
 const RELIC_RESOURCE_IDS: number[] = RELICS.map((relic) => Number(relic.id));
 
@@ -170,15 +166,19 @@ export const TransferTroopsContainer = ({
         selectedEntityId,
         targetEntityId,
         selectedExplorerOwner: selectedExplorerTroops?.owner ?? null,
+        selectedExplorerOwnerAddress: selectedExplorerConnectedStructure?.owner ?? null,
         targetExplorerOwner: targetExplorerTroops?.owner ?? null,
+        targetStructureOwnerAddress: targetStructure?.owner ?? null,
         guardSlot,
       }),
     [
       guardSlot,
       selectedEntityId,
+      selectedExplorerConnectedStructure?.owner,
       selectedExplorerTroops?.owner,
       targetEntityId,
       targetExplorerTroops?.owner,
+      targetStructure?.owner,
       transferDirection,
     ],
   );
@@ -845,17 +845,15 @@ export const TransferTroopsContainer = ({
           throw new Error("Unable to load explorer resources for auto relic transfer");
         }
 
-        const relicResources: RelicResourceTransfer[] = RELIC_RESOURCE_IDS.map((resourceId) => {
-          const { balance } = ResourceManager.balanceWithProduction(
-            resolvedExplorerResources,
-            currentDefaultTick,
-            resourceId as ResourcesIds,
-          );
-          return {
-            resourceId,
-            amount: balance,
-          };
-        }).filter((entry) => entry.amount > 0);
+        const relicResources = resolveAutoGarrisonResources({
+          resourceIds: RELIC_RESOURCE_IDS,
+          readBalance: (resourceId) =>
+            ResourceManager.balanceWithProduction(
+              resolvedExplorerResources,
+              currentDefaultTick,
+              resourceId as ResourcesIds,
+            ).balance,
+        });
 
         if (relicResources.length > 0) {
           if (transferDirection === TransferDirection.ExplorerToExplorer) {

--- a/client/apps/game/src/ui/features/military/components/transfer-troops/transfer-eligibility.test.ts
+++ b/client/apps/game/src/ui/features/military/components/transfer-troops/transfer-eligibility.test.ts
@@ -51,10 +51,27 @@ describe("getSameStructureTransferBlockReason", () => {
         selectedEntityId: 1,
         targetEntityId: 202,
         selectedExplorerOwner: 101,
+        selectedExplorerOwnerAddress: 0xaaa,
+        targetStructureOwnerAddress: 0xbbb,
         targetExplorerOwner: 0,
         guardSlot: 1,
       }),
     ).toBe("Cannot transfer troops: Explorer must belong to the target structure");
+  });
+
+  it("allows explorer-to-structure transfers when the source and target structures share an owner", () => {
+    expect(
+      getSameStructureTransferBlockReason({
+        transferDirection: TransferDirection.ExplorerToStructure,
+        selectedEntityId: 1,
+        targetEntityId: 202,
+        selectedExplorerOwner: 101,
+        selectedExplorerOwnerAddress: 0xaaa,
+        targetStructureOwnerAddress: 0xaaa,
+        targetExplorerOwner: 0,
+        guardSlot: 1,
+      }),
+    ).toBeNull();
   });
 
   it("allows structure-to-explorer guard transfers when the explorer belongs to the selected structure", () => {

--- a/client/apps/game/src/ui/features/military/components/transfer-troops/transfer-eligibility.ts
+++ b/client/apps/game/src/ui/features/military/components/transfer-troops/transfer-eligibility.ts
@@ -9,17 +9,30 @@ interface SameStructureTransferParams {
   transferDirection: TransferDirection;
   selectedEntityId: ID;
   targetEntityId: ID;
-  selectedExplorerOwner?: ID | bigint | null;
-  targetExplorerOwner?: ID | bigint | null;
+  selectedExplorerOwner?: ID | bigint | number | string | null;
+  selectedExplorerOwnerAddress?: ID | bigint | number | string | null;
+  targetExplorerOwner?: ID | bigint | number | string | null;
+  targetStructureOwnerAddress?: ID | bigint | number | string | null;
   guardSlot: GuardSelection;
 }
 
-const idsMatch = (left: ID | bigint | null | undefined, right: ID | bigint | null | undefined): boolean => {
+const idsMatch = (
+  left: ID | bigint | number | string | null | undefined,
+  right: ID | bigint | number | string | null | undefined,
+): boolean => {
   if (left === null || left === undefined || right === null || right === undefined) {
     return false;
   }
 
-  return String(left) === String(right);
+  return normalizeComparableId(left) === normalizeComparableId(right);
+};
+
+const normalizeComparableId = (value: ID | bigint | number | string): string => {
+  try {
+    return BigInt(value).toString();
+  } catch {
+    return String(value).trim().toLowerCase();
+  }
 };
 
 export const getSameStructureTransferBlockReason = ({
@@ -27,7 +40,9 @@ export const getSameStructureTransferBlockReason = ({
   selectedEntityId,
   targetEntityId,
   selectedExplorerOwner,
+  selectedExplorerOwnerAddress,
   targetExplorerOwner,
+  targetStructureOwnerAddress,
   guardSlot,
 }: SameStructureTransferParams): string | null => {
   if (transferDirection === TransferDirection.ExplorerToExplorer) {
@@ -37,7 +52,9 @@ export const getSameStructureTransferBlockReason = ({
   }
 
   if (transferDirection === TransferDirection.ExplorerToStructure) {
-    return idsMatch(selectedExplorerOwner, targetEntityId)
+    const sourceBelongsToTarget = idsMatch(selectedExplorerOwner, targetEntityId);
+    const sourceOwnerMatchesTargetOwner = idsMatch(selectedExplorerOwnerAddress, targetStructureOwnerAddress);
+    return sourceBelongsToTarget || sourceOwnerMatchesTargetOwner
       ? null
       : "Cannot transfer troops: Explorer must belong to the target structure";
   }

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -22,6 +22,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-05-27",
+    title: "Hyperstructure Auto-Garrison",
+    description:
+      "Armies that capture an unguarded hyperstructure now automatically move their surviving troops into the first available guard slot.",
+    type: "improvement",
+    gameSlug: "world",
+  },
+  {
     date: "2026-05-26",
     title: "Faster Dashboard Loading",
     description:

--- a/packages/client/src/transactions/combat.ts
+++ b/packages/client/src/transactions/combat.ts
@@ -40,6 +40,28 @@ export class CombatTransactions {
     });
   }
 
+  async attackGuardAndGarrison(
+    signer: Signer,
+    props: {
+      explorerId: number;
+      structureId: number;
+      structureDirection: number;
+      toGuardSlot: number;
+      count: number;
+      resources?: { resourceId: number; amount: number }[];
+    },
+  ) {
+    return this.provider.attack_explorer_vs_guard_and_garrison({
+      signer,
+      explorer_id: props.explorerId,
+      structure_id: props.structureId,
+      structure_direction: props.structureDirection,
+      to_guard_slot: props.toGuardSlot,
+      count: props.count,
+      resources: props.resources ?? [],
+    });
+  }
+
   async guardAttackExplorer(
     signer: Signer,
     props: {

--- a/packages/client/tests/transactions/mapping.test.ts
+++ b/packages/client/tests/transactions/mapping.test.ts
@@ -31,6 +31,7 @@ function createProvider() {
 
     attack_explorer_vs_explorer: vi.fn().mockResolvedValue({}),
     attack_explorer_vs_guard: vi.fn().mockResolvedValue({}),
+    attack_explorer_vs_guard_and_garrison: vi.fn().mockResolvedValue({}),
     attack_guard_vs_explorer: vi.fn().mockResolvedValue({}),
     raid_explorer_vs_guard: vi.fn().mockResolvedValue({}),
 
@@ -247,6 +248,24 @@ describe("transaction payload mapping", () => {
       explorer_id: 6,
       structure_id: 7,
       structure_direction: 8,
+    });
+
+    await tx.attackGuardAndGarrison(signer, {
+      explorerId: 6,
+      structureId: 7,
+      structureDirection: 8,
+      toGuardSlot: 3,
+      count: 90,
+      resources: [{ resourceId: 12, amount: 34 }],
+    });
+    expect(provider.attack_explorer_vs_guard_and_garrison).toHaveBeenCalledWith({
+      signer,
+      explorer_id: 6,
+      structure_id: 7,
+      structure_direction: 8,
+      to_guard_slot: 3,
+      count: 90,
+      resources: [{ resourceId: 12, amount: 34 }],
     });
 
     await tx.guardAttackExplorer(signer, {

--- a/packages/provider/src/attack-and-garrison.test.ts
+++ b/packages/provider/src/attack-and-garrison.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import { EternumProvider, NAMESPACE } from "./index";
+import { TransactionType } from "./types";
+
+const signer = { address: "0xabc" } as any;
+
+const makeProvider = () => {
+  const provider = Object.create(EternumProvider.prototype) as any;
+  provider.manifest = {
+    contracts: [
+      { tag: `${NAMESPACE}-troop_battle_systems`, address: "0xbattle" },
+      { tag: `${NAMESPACE}-resource_systems`, address: "0xresource" },
+      { tag: `${NAMESPACE}-troop_management_systems`, address: "0xtroop" },
+    ],
+  };
+  provider.promiseQueue = {
+    enqueue: vi.fn().mockResolvedValue({ transaction_hash: "0xtx" }),
+  };
+  return provider;
+};
+
+describe("EternumProvider.attack_explorer_vs_guard_and_garrison", () => {
+  it("submits attack then garrison calls in one queued transaction", async () => {
+    const provider = makeProvider();
+
+    await provider.attack_explorer_vs_guard_and_garrison({
+      signer,
+      explorer_id: 11,
+      structure_id: 22,
+      structure_direction: 3,
+      to_guard_slot: 1,
+      count: 400,
+    });
+
+    expect(provider.promiseQueue.enqueue).toHaveBeenCalledWith({
+      signer,
+      calls: [
+        {
+          contractAddress: "0xbattle",
+          entrypoint: "attack_explorer_vs_guard",
+          calldata: [11, 22, 3],
+        },
+        {
+          contractAddress: "0xtroop",
+          entrypoint: "explorer_guard_swap",
+          calldata: [11, 22, 3, 1, 400],
+        },
+      ],
+      transactionType: TransactionType.ATTACK_EXPLORER_VS_GUARD_AND_GARRISON,
+    });
+  });
+
+  it("preserves resources before garrisoning when resources are provided", async () => {
+    const provider = makeProvider();
+
+    await provider.attack_explorer_vs_guard_and_garrison({
+      signer,
+      explorer_id: 11,
+      structure_id: 22,
+      structure_direction: 3,
+      to_guard_slot: 1,
+      count: 400,
+      resources: [
+        { resourceId: 101, amount: 5 },
+        { resourceId: 102, amount: 9 },
+      ],
+    });
+
+    expect(provider.promiseQueue.enqueue).toHaveBeenCalledWith({
+      signer,
+      calls: [
+        {
+          contractAddress: "0xbattle",
+          entrypoint: "attack_explorer_vs_guard",
+          calldata: [11, 22, 3],
+        },
+        {
+          contractAddress: "0xresource",
+          entrypoint: "troop_structure_adjacent_transfer",
+          calldata: [11, 22, 2, 101, 5, 102, 9],
+        },
+        {
+          contractAddress: "0xtroop",
+          entrypoint: "explorer_guard_swap",
+          calldata: [11, 22, 3, 1, 400],
+        },
+      ],
+      transactionType: TransactionType.ATTACK_EXPLORER_VS_GUARD_AND_GARRISON,
+    });
+  });
+});

--- a/packages/provider/src/batch-config.ts
+++ b/packages/provider/src/batch-config.ts
@@ -42,6 +42,7 @@ export const TRANSACTION_COST_CATEGORY: Partial<Record<TransactionType, Transact
   // Combat (complex calculations)
   [TransactionType.ATTACK_EXPLORER_VS_EXPLORER]: TransactionCostCategory.HIGH,
   [TransactionType.ATTACK_EXPLORER_VS_GUARD]: TransactionCostCategory.HIGH,
+  [TransactionType.ATTACK_EXPLORER_VS_GUARD_AND_GARRISON]: TransactionCostCategory.HIGH,
   [TransactionType.ATTACK_GUARD_VS_EXPLORER]: TransactionCostCategory.HIGH,
   [TransactionType.RAID_EXPLORER_VS_GUARD]: TransactionCostCategory.HIGH,
   [TransactionType.BATTLE_START]: TransactionCostCategory.HIGH,

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -491,6 +491,44 @@ export const getContractByName = (manifest: Manifest, name: string) => {
   return contract.address;
 };
 
+const buildExplorerVsGuardAttackCall = (
+  manifest: Manifest,
+  { explorer_id, structure_id, structure_direction }: SystemProps.AttackExplorerVsGuardProps,
+): Call => ({
+  contractAddress: getContractByName(manifest, `${NAMESPACE}-troop_battle_systems`),
+  entrypoint: "attack_explorer_vs_guard",
+  calldata: [explorer_id, structure_id, structure_direction],
+});
+
+const buildTroopStructureAdjacentTransferCall = (
+  manifest: Manifest,
+  { explorer_id, structure_id, resources }: SystemProps.AttackExplorerVsGuardAndGarrisonProps,
+): Call => ({
+  contractAddress: getContractByName(manifest, `${NAMESPACE}-resource_systems`),
+  entrypoint: "troop_structure_adjacent_transfer",
+  calldata: [
+    explorer_id,
+    structure_id,
+    resources?.length ?? 0,
+    ...(resources ?? []).flatMap(({ resourceId, amount }) => [resourceId, amount]),
+  ],
+});
+
+const buildExplorerGuardSwapCall = (
+  manifest: Manifest,
+  {
+    explorer_id,
+    structure_id,
+    structure_direction,
+    to_guard_slot,
+    count,
+  }: SystemProps.AttackExplorerVsGuardAndGarrisonProps,
+): Call => ({
+  contractAddress: getContractByName(manifest, `${NAMESPACE}-troop_management_systems`),
+  entrypoint: "explorer_guard_swap",
+  calldata: [explorer_id, structure_id, structure_direction, to_guard_slot, count],
+});
+
 /**
  * Higher order function that adds event emitter functionality to a class
  *
@@ -3397,6 +3435,34 @@ export class EternumProvider extends EnhancedDojoProvider {
         calldata: [explorer_id, structure_id, structure_direction],
       },
       transactionType: TransactionType.ATTACK_EXPLORER_VS_GUARD,
+    });
+  }
+
+  /**
+   * Attack a guard with an explorer and garrison surviving troops into the captured structure.
+   *
+   * @param props - Properties for explorer vs guard attack and garrison
+   * @param props.explorer_id - ID of the attacking explorer
+   * @param props.structure_id - ID of the structure with defending guard
+   * @param props.structure_direction - Direction to the structure
+   * @param props.to_guard_slot - Guard slot to place surviving troops in
+   * @param props.count - Number of surviving troops to garrison
+   * @param props.resources - Optional resources to transfer before emptying the explorer
+   * @param props.signer - Account executing the transaction
+   * @returns Transaction receipt
+   */
+  public async attack_explorer_vs_guard_and_garrison(props: SystemProps.AttackExplorerVsGuardAndGarrisonProps) {
+    const { resources = [], signer } = props;
+    const calls = [
+      buildExplorerVsGuardAttackCall(this.manifest, props),
+      ...(resources.length > 0 ? [buildTroopStructureAdjacentTransferCall(this.manifest, props)] : []),
+      buildExplorerGuardSwapCall(this.manifest, props),
+    ];
+
+    return await this.promiseQueue.enqueue({
+      signer,
+      calls,
+      transactionType: TransactionType.ATTACK_EXPLORER_VS_GUARD_AND_GARRISON,
     });
   }
 

--- a/packages/provider/src/types.ts
+++ b/packages/provider/src/types.ts
@@ -72,6 +72,7 @@ export enum TransactionType {
   // Combat
   ATTACK_EXPLORER_VS_EXPLORER = "attack_explorer_vs_explorer",
   ATTACK_EXPLORER_VS_GUARD = "attack_explorer_vs_guard",
+  ATTACK_EXPLORER_VS_GUARD_AND_GARRISON = "attack_explorer_vs_guard_and_garrison",
   ATTACK_GUARD_VS_EXPLORER = "attack_guard_vs_explorer",
   RAID_EXPLORER_VS_GUARD = "raid_explorer_vs_guard",
   BATTLE_START = "battle_start",

--- a/packages/types/src/dojo/create-system-calls.ts
+++ b/packages/types/src/dojo/create-system-calls.ts
@@ -387,6 +387,12 @@ export function createSystemCalls({ provider, authHandler }: { provider: any; au
     return await provider.attack_explorer_vs_guard(props);
   };
 
+  const attack_explorer_vs_guard_and_garrison = async (
+    props: SystemProps.AttackExplorerVsGuardAndGarrisonProps,
+  ): Promise<GetTransactionReceiptResponse> => {
+    return await provider.attack_explorer_vs_guard_and_garrison(props);
+  };
+
   const attack_guard_vs_explorer = async (
     props: SystemProps.AttackGuardVsExplorerProps,
   ): Promise<GetTransactionReceiptResponse> => {
@@ -621,6 +627,7 @@ export function createSystemCalls({ provider, authHandler }: { provider: any; au
     explorer_explore: withAuth(explorer_explore),
     attack_explorer_vs_explorer: withAuth(attack_explorer_vs_explorer),
     attack_explorer_vs_guard: withAuth(attack_explorer_vs_guard),
+    attack_explorer_vs_guard_and_garrison: withAuth(attack_explorer_vs_guard_and_garrison),
     attack_guard_vs_explorer: withAuth(attack_guard_vs_explorer),
     raid_explorer_vs_guard: withAuth(raid_explorer_vs_guard),
 

--- a/packages/types/src/types/provider.ts
+++ b/packages/types/src/types/provider.ts
@@ -996,6 +996,24 @@ export interface AttackExplorerVsGuardProps extends SystemSigner {
 }
 
 /**
+ * Properties for atomically attacking a guard and garrisoning the captured structure
+ */
+export interface AttackExplorerVsGuardAndGarrisonProps extends SystemSigner {
+  /** ID of the attacking explorer */
+  explorer_id: number;
+  /** ID of the structure with defending guard */
+  structure_id: number;
+  /** Direction to the structure */
+  structure_direction: number;
+  /** Guard slot to place surviving troops in */
+  to_guard_slot: number;
+  /** Number of surviving troops to garrison */
+  count: number;
+  /** Resources to preserve before emptying the explorer */
+  resources?: Resource[];
+}
+
+/**
  * Properties for guard vs explorer attack
  */
 export interface AttackGuardVsExplorerProps extends SystemSigner {


### PR DESCRIPTION
Adds hyperstructure auto-garrisoning so capturing armies preserve relic cargo and move surviving troops into an available guard slot, using an atomic multicall for unguarded captures and a post-confirmation follow-up when a final guard is defeated.

Adds shared provider/system-call/client transaction support for `attack_explorer_vs_guard_and_garrison` plus focused tests for the call payloads and planning helpers.

Updates same-owner explorer-to-structure transfer eligibility and records the UX change in latest features.

Validation: `pnpm run format`; `pnpm run knip`; focused Vitest coverage for hyperstructure auto-garrison, transfer eligibility, provider attack-and-garrison, and client transaction mapping; `client/apps/game` typecheck.