### PR TITLE
fix: stop army 3D models ghosting on instance-slot reassignment

### DIFF
--- a/client/apps/game/src/three/managers/army-model.spline-rebind.test.ts
+++ b/client/apps/game/src/three/managers/army-model.spline-rebind.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AnimationClip,
+  AnimationMixer,
+  BoxGeometry,
+  Group,
+  InstancedMesh,
+  Matrix4,
+  Mesh,
+  MeshBasicMaterial,
+  Scene,
+  Vector3,
+} from "three";
+import { ModelType } from "@/three/types/army";
+import { TroopTier, TroopType } from "@bibliothecadao/types";
+import { ArmyModel } from "./army-model";
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: vi.fn(() => null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    },
+  });
+});
+
+vi.mock("@/ui/config", () => ({
+  FELT_CENTER: 0,
+  GRAPHICS_SETTING: "HIGH",
+  GraphicsSettings: {
+    HIGH: "HIGH",
+    LOW: "LOW",
+    MID: "MID",
+  },
+  IS_FLAT_MODE: false,
+}));
+
+vi.mock("@/three/scenes/hexagon-scene", () => ({
+  CameraView: {
+    Close: "Close",
+    Medium: "Medium",
+    Far: "Far",
+  },
+}));
+
+vi.mock("../../../env", () => ({
+  env: {
+    VITE_PUBLIC_ENABLE_MEMORY_MONITORING: false,
+  },
+}));
+
+vi.mock("@/utils/agent", () => ({
+  getCharacterModel: vi.fn(() => null),
+}));
+
+vi.mock("@/three/utils/utils", () => ({
+  gltfLoader: {
+    load: vi.fn(),
+  },
+}));
+
+vi.mock("../utils", () => ({
+  getHexForWorldPosition: vi.fn(() => ({ col: 0, row: 0 })),
+}));
+
+vi.mock("../utils/contact-shadow", () => ({
+  getContactShadowResources: vi.fn(() => ({
+    geometry: new BoxGeometry(1, 1, 1),
+    material: new MeshBasicMaterial(),
+  })),
+}));
+
+vi.mock("../utils/material-pool", () => ({
+  MaterialPool: {
+    getInstance: vi.fn(() => ({
+      get: vi.fn(),
+      release: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("../utils/memory-monitor", () => ({
+  MemoryMonitor: class MockMemoryMonitor {},
+}));
+
+vi.mock("./army-model-materials", () => ({
+  createPooledInstancedMaterial: vi.fn(() => new MeshBasicMaterial()),
+  releasePooledInstancedMaterial: vi.fn(),
+}));
+
+vi.mock("./army-model-debug-hooks", () => ({
+  installArmyModelDebugHooks: vi.fn(),
+}));
+
+vi.mock("../cosmetics/skin-asset-source", () => ({
+  resolvePrimarySkinGltf: vi.fn(),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => {
+  const scalar = new Proxy(
+    {},
+    {
+      get: (_, key) => key,
+    },
+  );
+
+  return new Proxy(
+    {
+      Biome: {
+        getBiome: vi.fn(() => "NONE"),
+      },
+      FELT_CENTER: 0,
+    } as Record<string, unknown>,
+    {
+      get: (target, prop) => (prop in target ? target[prop as string] : scalar),
+      has: () => true,
+    },
+  );
+});
+
+vi.mock("@bibliothecadao/types", () => {
+  const enumProxy = new Proxy(
+    {},
+    {
+      get: (_, key) => key,
+    },
+  );
+
+  return new Proxy(
+    {
+      BiomeType: enumProxy,
+      ResourcesIds: { StaminaRelic1: 1 },
+      TroopTier: { T1: "T1", T2: "T2", T3: "T3" },
+      TroopType: { Knight: "Knight", Crossbowman: "Crossbowman", Paladin: "Paladin" },
+    } as Record<string, unknown>,
+    {
+      get: (target, prop) => (prop in target ? target[prop as string] : enumProxy),
+      has: () => true,
+    },
+  );
+});
+
+function createLoadedModelData() {
+  const geometry = new BoxGeometry(1, 1, 1);
+  const material = new MeshBasicMaterial();
+  const mesh = new InstancedMesh(geometry, material, 4);
+
+  return {
+    mesh,
+    modelData: {
+      group: new Group(),
+      instancedMeshes: [mesh],
+      baseMeshes: [new Mesh(geometry, material)],
+      mixer: new AnimationMixer(new Group()),
+      animations: {
+        idle: new AnimationClip("idle", 1, []),
+        moving: new AnimationClip("moving", 1, []),
+      },
+      animationActions: new Map(),
+      activeInstances: new Set<number>(),
+      lastAnimationUpdate: 0,
+      animationUpdateInterval: 50,
+      contactShadowMesh: null,
+      contactShadowScale: 1,
+    },
+  };
+}
+
+const ZERO_SCALE_ELEMENTS = new Matrix4().makeScale(0, 0, 0).elements;
+
+function getMatrix(mesh: InstancedMesh, slot: number): Matrix4 {
+  const matrix = new Matrix4();
+  mesh.getMatrixAt(slot, matrix);
+  return matrix;
+}
+
+function expectZeroScaleMatrix(mesh: InstancedMesh, slot: number) {
+  expect(getMatrix(mesh, slot).elements).toEqual(ZERO_SCALE_ELEMENTS);
+}
+
+function expectNonZeroMatrix(mesh: InstancedMesh, slot: number) {
+  expect(getMatrix(mesh, slot).elements).not.toEqual(ZERO_SCALE_ELEMENTS);
+}
+
+describe("ArmyModel spline rebind on slot compaction", () => {
+  // Regression for ghosting units: a moving army whose instance slot is
+  // reassigned (slot compaction when a lower-indexed army leaves view) must
+  // keep rendering its 3D model at the NEW slot. Before the single-source-of-
+  // truth fix, the spline kept writing to the stale slot, leaving a ghost at
+  // the old slot while the new slot froze (labels, keyed by entityId, stayed
+  // correct — matching the reported symptom).
+  it("renders the moving army at its new slot and leaves no ghost at the old slot", () => {
+    const subject = new ArmyModel(new Scene());
+    const { mesh, modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const stationaryId = 101;
+    const movingId = 202;
+
+    const stationarySlot = subject.allocateInstanceSlot(stationaryId); // 0
+    const movingSlot = subject.allocateInstanceSlot(movingId); // 1
+
+    subject.assignModelToEntity(stationaryId, ModelType.Knight1);
+    subject.assignModelToEntity(movingId, ModelType.Knight1);
+
+    subject.updateInstance(stationaryId, stationarySlot, new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+    subject.updateInstance(movingId, movingSlot, new Vector3(5, 0, 5), new Vector3(1, 1, 1));
+
+    subject.startMovement(
+      movingId,
+      [new Vector3(5, 0, 5), new Vector3(6, 0, 6), new Vector3(7, 0, 7)],
+      movingSlot,
+      TroopType.Knight as never,
+      TroopTier.T1 as never,
+    );
+
+    // One frame with the moving army still at slot 1.
+    subject.updateMovements(0.016);
+
+    // Slot compaction: the stationary army leaves view, freeing slot 0, and the
+    // moving army is compacted down from slot 1 into slot 0.
+    subject.freeInstanceSlot(stationaryId, stationarySlot);
+    subject.moveInstanceSlot(movingId, stationarySlot); // 1 -> 0
+
+    expect((subject as any).instanceData.get(movingId).matrixIndex).toBe(stationarySlot);
+
+    // The next animation frame must drive the NEW slot, not the old one.
+    subject.updateMovements(0.016);
+
+    expectNonZeroMatrix(mesh, stationarySlot); // moving army present at new slot 0
+    expectZeroScaleMatrix(mesh, movingSlot); // no ghost left behind at old slot 1
+  });
+});

--- a/client/apps/game/src/three/managers/army-model.spline-rebind.test.ts
+++ b/client/apps/game/src/three/managers/army-model.spline-rebind.test.ts
@@ -31,7 +31,7 @@ vi.hoisted(() => {
 });
 
 vi.mock("@/ui/config", () => ({
-  FELT_CENTER: 0,
+  FELT_CENTER: () => 0,
   GRAPHICS_SETTING: "HIGH",
   GraphicsSettings: {
     HIGH: "HIGH",
@@ -235,5 +235,97 @@ describe("ArmyModel spline rebind on slot compaction", () => {
 
     expectNonZeroMatrix(mesh, stationarySlot); // moving army present at new slot 0
     expectZeroScaleMatrix(mesh, movingSlot); // no ghost left behind at old slot 1
+  });
+
+  // The original ghost had two halves: a ghost at the OLD slot AND a frozen
+  // model at the NEW slot. The test above proves "no ghost / present at new
+  // slot"; this proves the new slot is actively DRIVEN — its transform advances
+  // along the spline frame-over-frame rather than freezing.
+  it("keeps advancing the new slot's transform along the spline after compaction (not frozen)", () => {
+    const subject = new ArmyModel(new Scene());
+    const { mesh, modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const stationaryId = 401;
+    const movingId = 402;
+
+    const stationarySlot = subject.allocateInstanceSlot(stationaryId); // 0
+    const movingSlot = subject.allocateInstanceSlot(movingId); // 1
+
+    subject.assignModelToEntity(stationaryId, ModelType.Knight1);
+    subject.assignModelToEntity(movingId, ModelType.Knight1);
+
+    subject.updateInstance(stationaryId, stationarySlot, new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+    subject.updateInstance(movingId, movingSlot, new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+
+    // Long, straight +x path so the journey does not complete (and settle/freeze)
+    // within the frames we sample.
+    subject.startMovement(
+      movingId,
+      [new Vector3(0, 0, 0), new Vector3(10, 0, 0), new Vector3(20, 0, 0), new Vector3(30, 0, 0)],
+      movingSlot,
+      TroopType.Knight as never,
+      TroopTier.T1 as never,
+    );
+
+    // Compact 1 -> 0 while moving.
+    subject.freeInstanceSlot(stationaryId, stationarySlot);
+    subject.moveInstanceSlot(movingId, stationarySlot);
+    expect((subject as any).instanceData.get(movingId).matrixIndex).toBe(stationarySlot);
+
+    // elements[12] is the matrix's x-translation (the travel axis).
+    const travelX = (slot: number) => getMatrix(mesh, slot).elements[12];
+
+    // Advance past the anticipation phase (0.15s) so the spline actually moves.
+    for (let i = 0; i < 6; i++) subject.updateMovements(0.05);
+    const xAfterStart = travelX(stationarySlot);
+
+    for (let i = 0; i < 4; i++) subject.updateMovements(0.05);
+    const xLater = travelX(stationarySlot);
+
+    // New slot is actively driven along +x; old slot stays empty (no ghost).
+    expect(xLater).toBeGreaterThan(xAfterStart);
+    expectZeroScaleMatrix(mesh, movingSlot);
+  });
+});
+
+describe("ArmyModel lost-slot movement teardown", () => {
+  // Defensive path: if a moving entity's instance slot is reassigned away
+  // (matrixIndex cleared) without its movement entry being removed first,
+  // updateMovements must tear the movement down — NOT route it through
+  // stopMovement, which (when the unit is mid-float) spins up a descent tween
+  // that can never progress without a slot, stranding the entry forever.
+  it("fully tears down a moving entity that has lost its instance slot (no stranded descent)", () => {
+    const subject = new ArmyModel(new Scene());
+    const { modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const entityId = 303;
+    const slot = subject.allocateInstanceSlot(entityId);
+    subject.assignModelToEntity(entityId, ModelType.Knight1);
+    subject.updateInstance(entityId, slot, new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+
+    subject.startMovement(
+      entityId,
+      [new Vector3(0, 0, 0), new Vector3(1, 0, 1), new Vector3(2, 0, 2)],
+      slot,
+      TroopType.Knight as never,
+      TroopTier.T1 as never,
+    );
+
+    expect(subject.isEntityMoving(entityId)).toBe(true);
+
+    // Unit is mid-float — the case stopMovement would convert into a descent.
+    (subject as any).movingInstances.get(entityId).floatingHeight = 1;
+
+    // Simulate the lost-slot state: slot cleared without removing the movement
+    // entry first.
+    (subject as any).instanceData.get(entityId).matrixIndex = undefined;
+
+    subject.updateMovements(0.016);
+
+    // Movement is gone, not revived as a non-progressing descent.
+    expect(subject.isEntityMoving(entityId)).toBe(false);
+    expect((subject as any).splineMovingInstances.has(entityId)).toBe(false);
   });
 });

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -1434,7 +1434,6 @@ export class ArmyModel {
         spline,
         totalLength,
         journeyProgress: 0,
-        matrixIndex,
         floatingHeight: 0,
         currentRotation,
         easingType,
@@ -1482,7 +1481,6 @@ export class ArmyModel {
         startPos: new Vector3().copy(currentPos), // Create once per movement
         endPos: new Vector3().copy(nextPos), // Create once per movement
         progress: 0,
-        matrixIndex,
         currentPathIndex: 0,
         floatingHeight: 0,
         currentRotation: this.dummyEuler.y,
@@ -1493,7 +1491,6 @@ export class ArmyModel {
         startPos: new Vector3().copy(currentPos), // Create once per movement
         endPos: new Vector3().copy(nextPos), // Create once per movement
         progress: 0,
-        matrixIndex,
         currentPathIndex: 0,
         floatingHeight: 0,
         currentRotation: 0,
@@ -1515,19 +1512,30 @@ export class ArmyModel {
         return;
       }
 
+      // Single source of truth for the instance slot. instanceData.matrixIndex is
+      // updated synchronously by every slot reassignment (compaction / re-add), so
+      // reading it each frame keeps the model on the live slot. Reading a cached
+      // copy here is what produced ghosting (model written to a stale slot while
+      // the label, keyed by entityId, stayed correct).
+      const matrixIndex = instanceData.matrixIndex;
+      if (matrixIndex === undefined) {
+        this.stopMovement(entityId);
+        return;
+      }
+
       if (movement.currentPathIndex === -1) {
-        this.handleDescent(movement, entityId, instanceData, deltaTime);
+        this.handleDescent(movement, entityId, instanceData, matrixIndex, deltaTime);
         return;
       }
 
       // Use spline movement if available
       const splineData = this.splineMovingInstances.get(entityId);
       if (splineData) {
-        this.updateSplineMovement(splineData, movement, entityId, instanceData, deltaTime);
+        this.updateSplineMovement(splineData, movement, entityId, instanceData, matrixIndex, deltaTime);
         return;
       }
 
-      this.updateMovingInstance(movement, entityId, instanceData, deltaTime);
+      this.updateMovingInstance(movement, entityId, instanceData, matrixIndex, deltaTime);
     });
   }
 
@@ -1535,6 +1543,7 @@ export class ArmyModel {
     movement: MovementData,
     entityId: number,
     instanceData: ArmyInstanceData,
+    matrixIndex: number,
     deltaTime: number,
   ): void {
     const modelType = this.entityModelMap.get(entityId);
@@ -1553,7 +1562,7 @@ export class ArmyModel {
     this.updateRotation(movement, deltaTime);
     this.updateInstance(
       entityId,
-      movement.matrixIndex,
+      matrixIndex,
       this.tempVector1,
       instanceData.scale,
       this.dummyObject.rotation,
@@ -1571,6 +1580,7 @@ export class ArmyModel {
     movement: MovementData,
     entityId: number,
     instanceData: ArmyInstanceData,
+    matrixIndex: number,
     deltaTime: number,
   ): void {
     const modelType = this.entityModelMap.get(entityId);
@@ -1598,7 +1608,7 @@ export class ArmyModel {
 
     this.updateInstance(
       entityId,
-      movement.matrixIndex,
+      matrixIndex,
       this.tempVector2,
       instanceData.scale,
       this.dummyObject.rotation,
@@ -1630,6 +1640,7 @@ export class ArmyModel {
     movement: MovementData,
     entityId: number,
     instanceData: ArmyInstanceData,
+    matrixIndex: number,
     deltaTime: number,
   ): void {
     const modelType = this.entityModelMap.get(entityId);
@@ -1666,7 +1677,7 @@ export class ArmyModel {
       }
       this.updateInstance(
         entityId,
-        splineData.matrixIndex,
+        matrixIndex,
         this.tempVector2,
         instanceData.scale,
         this.dummyObject.rotation,
@@ -1758,7 +1769,7 @@ export class ArmyModel {
       }
       this.updateInstance(
         entityId,
-        splineData.matrixIndex,
+        matrixIndex,
         this.tempVector2,
         instanceData.scale,
         this.dummyObject.rotation,
@@ -1829,7 +1840,7 @@ export class ArmyModel {
 
     this.updateInstance(
       entityId,
-      splineData.matrixIndex,
+      matrixIndex,
       this.tempVector2,
       instanceData.scale,
       this.dummyObject.rotation,
@@ -1962,13 +1973,18 @@ export class ArmyModel {
   }
 
   private clearMovementState(entityId: number): void {
+    const instanceData = this.instanceData.get(entityId);
     const movement = this.movingInstances.get(entityId);
     if (movement) {
-      this.setAnimationState(movement.matrixIndex, false);
+      if (instanceData?.matrixIndex !== undefined) {
+        this.setAnimationState(instanceData.matrixIndex, false);
+      }
       this.movingInstances.delete(entityId);
     }
+    // Tear down spline state too (parity with stopMovement/cancelMovement) so a
+    // freed slot never strands an orphaned spline entry.
+    this.splineMovingInstances.delete(entityId);
 
-    const instanceData = this.instanceData.get(entityId);
     if (instanceData) {
       instanceData.isMoving = false;
       instanceData.path = undefined;
@@ -1982,7 +1998,10 @@ export class ArmyModel {
     const movement = this.movingInstances.get(entityId);
     if (!movement) return;
 
-    this.setAnimationState(movement.matrixIndex, false);
+    const instanceData = this.instanceData.get(entityId);
+    if (instanceData?.matrixIndex !== undefined) {
+      this.setAnimationState(instanceData.matrixIndex, false);
+    }
 
     if (movement.floatingHeight > 0) {
       this.initializeDescentAnimation(entityId, movement);
@@ -1990,7 +2009,6 @@ export class ArmyModel {
       this.movingInstances.delete(entityId);
     }
 
-    const instanceData = this.instanceData.get(entityId);
     if (instanceData) {
       instanceData.isMoving = false;
       instanceData.path = undefined;
@@ -2010,7 +2028,6 @@ export class ArmyModel {
       startPos: new Vector3().copy(instanceData.position), // Create once for descent
       endPos: new Vector3().copy(instanceData.position), // Create once for descent
       progress: 0,
-      matrixIndex: movement.matrixIndex,
       currentPathIndex: -1,
       floatingHeight: movement.floatingHeight,
       currentRotation: movement.currentRotation,
@@ -2100,12 +2117,12 @@ export class ArmyModel {
    */
   public cancelMovement(entityId: number): void {
     this.splineMovingInstances.delete(entityId);
+    const instanceData = this.instanceData.get(entityId);
     const movement = this.movingInstances.get(entityId);
-    if (movement) {
-      this.setAnimationState(movement.matrixIndex, false);
+    if (movement && instanceData?.matrixIndex !== undefined) {
+      this.setAnimationState(instanceData.matrixIndex, false);
     }
     this.movingInstances.delete(entityId);
-    const instanceData = this.instanceData.get(entityId);
     if (instanceData) {
       instanceData.isMoving = false;
       instanceData.path = undefined;
@@ -2113,24 +2130,14 @@ export class ArmyModel {
     this.movementCompleteCallbacks.delete(entityId);
   }
 
+  // Keeps a moving entity's animation flag aligned with its CURRENT instance slot
+  // after a slot reassignment. The slot itself lives in instanceData.matrixIndex
+  // (the single source of truth) and is updated by the caller before this runs;
+  // the caller also clears the previous slot (moveInstanceSlot -> clearInstanceSlot).
+  // This only re-asserts the walking/idle animation flag on the new slot.
   public rebindMovementMatrixIndex(entityId: number, newMatrixIndex: number): void {
     const movement = this.movingInstances.get(entityId);
     if (!movement) return;
-
-    const previousIndex = movement.matrixIndex;
-    if (previousIndex === newMatrixIndex) {
-      return;
-    }
-
-    // Reset animation state for the old slot so it no longer appears active
-    this.setAnimationState(previousIndex, false);
-
-    movement.matrixIndex = newMatrixIndex;
-
-    const instanceData = this.instanceData.get(entityId);
-    if (instanceData) {
-      instanceData.matrixIndex = newMatrixIndex;
-    }
 
     const isMoving = movement.currentPathIndex !== -1 || movement.floatingHeight > 0;
     this.setAnimationState(newMatrixIndex, isMoving);

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -767,15 +767,6 @@ export class ArmyModel {
     }
   }
 
-  public rebindInstanceSlot(entityId: number, newSlot: number): void {
-    const instanceData = this.instanceData.get(entityId);
-    if (instanceData) {
-      instanceData.matrixIndex = newSlot;
-    }
-    this.matrixIndexOwners.set(newSlot, entityId);
-    this.rebindMovementMatrixIndex(entityId, newSlot);
-  }
-
   public moveInstanceSlot(entityId: number, newSlot: number): void {
     const instanceData = this.instanceData.get(entityId);
     const previousSlot = instanceData?.matrixIndex;
@@ -1519,7 +1510,11 @@ export class ArmyModel {
       // the label, keyed by entityId, stayed correct).
       const matrixIndex = instanceData.matrixIndex;
       if (matrixIndex === undefined) {
-        this.stopMovement(entityId);
+        // The slot was reassigned away without removing this movement entry.
+        // Tear the movement down directly — routing through stopMovement() could
+        // spin up a descent tween that can never progress without a live slot,
+        // stranding the entry forever.
+        this.clearMovementState(entityId);
         return;
       }
 

--- a/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.source.test.ts
@@ -8,46 +8,58 @@ function readSource(relativePath: string): string {
   return readFileSync(resolve(currentDir, relativePath), "utf8");
 }
 
-// updateArmyHexes maintains the spatial/clickability cache (armiesPositions,
-// armyHexes, worker hex map) — separate from the 3D model. Two silent failures
-// previously let a bogus owner:0n poison that cache (army wrongly treated as
-// unowned/defeated) with no signal. These guards keep those paths observable
-// and prevent caching a known-bad owner. The worldmap scene cannot be
-// instantiated in isolation, so we assert on the source like the sibling
-// ghosting guards (see army-manager.chunk-eviction-ghost.test.ts).
-function updateArmyHexesBody(): string {
+// Wiring guard for the worldmap owner-resolution integration. The decision
+// itself is unit-tested in worldmap-army-owner-resolution.test.ts; here we only
+// assert the scene routes updateArmyHexes through that pure helper and keeps the
+// ECS lookup observable (the original bug was a bare `catch {}` that let a bogus
+// owner:0n silently poison the spatial cache). The worldmap scene cannot be
+// instantiated in isolation, so we guard the source like the sibling
+// *.wiring.test.ts files.
+function ownerResolutionRegion(): string {
   const src = readSource("worldmap.tsx");
   const start = src.indexOf("public updateArmyHexes(");
   expect(start).toBeGreaterThan(-1);
+  // Region spans updateArmyHexes + its extracted private helpers
+  // (findCachedArmyOwner, resolveArmyOwnerFromEcs), up to the next public method.
   const end = src.indexOf("public updateStructureHexes(", start);
   expect(end).toBeGreaterThan(start);
   return src.slice(start, end);
 }
 
-describe("worldmap updateArmyHexes owner resolution", () => {
-  it("no longer swallows the structure-owner ECS lookup failure silently", () => {
-    const body = updateArmyHexesBody();
-
-    // The previous bare `catch {}` swallowed the failure with no signal.
-    expect(body).not.toMatch(/catch\s*\{/);
-    expect(body).toContain("catch (error)");
-    expect(body).toContain("Structure owner ECS lookup failed");
+describe("worldmap updateArmyHexes owner resolution wiring", () => {
+  it("imports the pure decision helper", () => {
+    const src = readSource("worldmap.tsx");
+    expect(src).toContain('import { resolveArmyOwnerCacheAction } from "./worldmap-army-owner-resolution"');
   });
 
-  it("skips the spatial-cache write for a new army whose owner stays unresolved (0n)", () => {
-    const body = updateArmyHexesBody();
+  it("routes the owner decision through resolveArmyOwnerCacheAction and handles every action kind", () => {
+    const region = ownerResolutionRegion();
 
-    // Anchor on the unique guard message (the method also has a separate 0n
-    // branch that evicts an already-cached army — not this one).
-    const skipPos = body.indexOf("Skipping spatial cache write");
+    expect(region).toContain("resolveArmyOwnerCacheAction({");
+    expect(region).toContain('action.kind === "evict"');
+    expect(region).toContain('action.kind === "skip"');
+    expect(region).toContain("action.owner");
+  });
+
+  it("no longer swallows the structure-owner ECS lookup failure silently", () => {
+    const region = ownerResolutionRegion();
+
+    // The original bug was a bare `catch {}` that hid the failure.
+    expect(region).not.toMatch(/catch\s*\{/);
+    expect(region).toContain("catch (error)");
+    expect(region).toContain("Structure owner ECS lookup failed");
+  });
+
+  it("keeps the skip guard ahead of (and short-circuiting) the spatial-cache write", () => {
+    const region = ownerResolutionRegion();
+
+    const skipPos = region.indexOf("Skipping spatial cache write");
     expect(skipPos).toBeGreaterThan(-1);
 
-    // The guard must bail out (return) rather than fall through to the
-    // armyHexData write, which would persist owner: 0n.
-    expect(body.slice(skipPos, skipPos + 220)).toContain("return;");
+    // The skip branch must bail out rather than fall through to the cache write.
+    expect(region.slice(skipPos, skipPos + 260)).toContain("return;");
 
-    // And it must sit before the cache write it is meant to skip.
-    const writePos = body.indexOf("const armyHexData = { id: entityId, owner: actualOwnerAddress }");
+    const writePos = region.indexOf("const armyHexData = { id: entityId, owner: actualOwnerAddress }");
     expect(writePos).toBeGreaterThan(-1);
     expect(skipPos).toBeLessThan(writePos);
   });

--- a/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.source.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readSource(relativePath: string): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, relativePath), "utf8");
+}
+
+// updateArmyHexes maintains the spatial/clickability cache (armiesPositions,
+// armyHexes, worker hex map) — separate from the 3D model. Two silent failures
+// previously let a bogus owner:0n poison that cache (army wrongly treated as
+// unowned/defeated) with no signal. These guards keep those paths observable
+// and prevent caching a known-bad owner. The worldmap scene cannot be
+// instantiated in isolation, so we assert on the source like the sibling
+// ghosting guards (see army-manager.chunk-eviction-ghost.test.ts).
+function updateArmyHexesBody(): string {
+  const src = readSource("worldmap.tsx");
+  const start = src.indexOf("public updateArmyHexes(");
+  expect(start).toBeGreaterThan(-1);
+  const end = src.indexOf("public updateStructureHexes(", start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+describe("worldmap updateArmyHexes owner resolution", () => {
+  it("no longer swallows the structure-owner ECS lookup failure silently", () => {
+    const body = updateArmyHexesBody();
+
+    // The previous bare `catch {}` swallowed the failure with no signal.
+    expect(body).not.toMatch(/catch\s*\{/);
+    expect(body).toContain("catch (error)");
+    expect(body).toContain("Structure owner ECS lookup failed");
+  });
+
+  it("skips the spatial-cache write for a new army whose owner stays unresolved (0n)", () => {
+    const body = updateArmyHexesBody();
+
+    // Anchor on the unique guard message (the method also has a separate 0n
+    // branch that evicts an already-cached army — not this one).
+    const skipPos = body.indexOf("Skipping spatial cache write");
+    expect(skipPos).toBeGreaterThan(-1);
+
+    // The guard must bail out (return) rather than fall through to the
+    // armyHexData write, which would persist owner: 0n.
+    expect(body.slice(skipPos, skipPos + 220)).toContain("return;");
+
+    // And it must sit before the cache write it is meant to skip.
+    const writePos = body.indexOf("const armyHexData = { id: entityId, owner: actualOwnerAddress }");
+    expect(writePos).toBeGreaterThan(-1);
+    expect(skipPos).toBeLessThan(writePos);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { resolveArmyOwnerCacheAction } from "./worldmap-army-owner-resolution";
+
+// Behavioral coverage for the owner→cache-action decision that updateArmyHexes
+// makes before touching the spatial/clickability cache. A real (non-zero) owner
+// is always authoritative; a 0n owner means "defeated/deleted OR not-yet-synced"
+// and is resolved against the existing cache (for a known army) or the ECS
+// fallback (for a brand-new army), never persisted as-is.
+
+const OWNER_A = 0xa11cen;
+const OWNER_B = 0xb0bn;
+
+describe("resolveArmyOwnerCacheAction", () => {
+  it("writes the incoming owner when it is non-zero (authoritative)", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: OWNER_A,
+      isAlreadyCached: false,
+    });
+    expect(action).toEqual({ kind: "write", owner: OWNER_A });
+  });
+
+  it("writes the incoming owner even when the army is already cached", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: OWNER_A,
+      isAlreadyCached: true,
+      cachedOwner: OWNER_B,
+    });
+    expect(action).toEqual({ kind: "write", owner: OWNER_A });
+  });
+
+  it("preserves a cached non-zero owner when an already-cached army reports 0n", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: 0n,
+      isAlreadyCached: true,
+      cachedOwner: OWNER_B,
+    });
+    expect(action).toEqual({ kind: "write", owner: OWNER_B });
+  });
+
+  it("evicts an already-cached army whose owner is 0n with no recoverable cached owner", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: 0n,
+      isAlreadyCached: true,
+      cachedOwner: undefined,
+    });
+    expect(action).toEqual({ kind: "evict" });
+  });
+
+  it("evicts an already-cached army when even the cached owner is 0n", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: 0n,
+      isAlreadyCached: true,
+      cachedOwner: 0n,
+    });
+    expect(action).toEqual({ kind: "evict" });
+  });
+
+  it("writes an ECS-resolved owner for a new army that reported 0n", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: 0n,
+      isAlreadyCached: false,
+      ecsResolvedOwner: OWNER_A,
+    });
+    expect(action).toEqual({ kind: "write", owner: OWNER_A });
+  });
+
+  it("skips the cache write for a new army whose 0n owner stays unresolved", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: 0n,
+      isAlreadyCached: false,
+      ecsResolvedOwner: undefined,
+    });
+    expect(action).toEqual({ kind: "skip" });
+  });
+
+  it("skips when the ECS fallback itself resolved to 0n (lookup found a zero owner)", () => {
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress: 0n,
+      isAlreadyCached: false,
+      ecsResolvedOwner: 0n,
+    });
+    expect(action).toEqual({ kind: "skip" });
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.ts
@@ -1,0 +1,57 @@
+/**
+ * Decision for how `WorldmapScene.updateArmyHexes` should treat an army's owner
+ * before touching the spatial/clickability cache (`armiesPositions`,
+ * `armyHexes`, the worker hex map). Pure so it can be unit-tested in isolation —
+ * the scene itself cannot be instantiated headless.
+ */
+export type ArmyOwnerCacheAction =
+  | { kind: "write"; owner: bigint }
+  | { kind: "evict" }
+  | { kind: "skip" };
+
+export interface ArmyOwnerCacheResolutionInput {
+  /** Owner address carried by the incoming update. */
+  ownerAddress: bigint;
+  /** Whether this army already has a cached spatial position. */
+  isAlreadyCached: boolean;
+  /**
+   * Non-zero owner recovered from the existing spatial cache, if any. Only
+   * meaningful for an already-cached army whose incoming owner is 0n.
+   */
+  cachedOwner?: bigint;
+  /**
+   * Owner resolved from the ECS Structure component, if the lookup ran and
+   * succeeded. Only meaningful for a brand-new army whose incoming owner is 0n.
+   */
+  ecsResolvedOwner?: bigint;
+}
+
+/**
+ * A non-zero incoming owner is always authoritative. A 0n owner means
+ * "defeated/deleted OR not-yet-synced":
+ *  - already-cached army: preserve its last known non-zero owner, else evict it.
+ *  - brand-new army: use the ECS fallback if it produced a non-zero owner, else
+ *    SKIP the write entirely. Persisting owner:0n would mis-flag the army as
+ *    unowned/defeated for clicks and ownership coloring; skipping lets the next
+ *    authoritative update (which carries a real owner) register it.
+ */
+export function resolveArmyOwnerCacheAction(input: ArmyOwnerCacheResolutionInput): ArmyOwnerCacheAction {
+  const { ownerAddress, isAlreadyCached, cachedOwner, ecsResolvedOwner } = input;
+
+  if (ownerAddress !== 0n) {
+    return { kind: "write", owner: ownerAddress };
+  }
+
+  if (isAlreadyCached) {
+    if (cachedOwner !== undefined && cachedOwner !== 0n) {
+      return { kind: "write", owner: cachedOwner };
+    }
+    return { kind: "evict" };
+  }
+
+  if (ecsResolvedOwner !== undefined && ecsResolvedOwner !== 0n) {
+    return { kind: "write", owner: ecsResolvedOwner };
+  }
+
+  return { kind: "skip" };
+}

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -234,6 +234,7 @@ import {
 import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
+import { resolveArmyOwnerCacheAction } from "./worldmap-army-owner-resolution";
 import { resolveOwnershipPulseHexes } from "./worldmap-ownership-pulse-policy";
 import {
   resolveDuplicateTileReconcilePlan,
@@ -4968,80 +4969,62 @@ export default class WorldmapScene extends WarpTravel {
       this.armyStructureOwners.delete(entityId);
     }
 
-    let actualOwnerAddress = ownerAddress;
+    const isAlreadyCached = this.armiesPositions.has(entityId);
+
+    // A 0n owner means "defeated/deleted OR not-yet-synced". Gather the fallback
+    // owners the decision may use: the last known owner from the spatial cache
+    // (for a known army) or an ECS Structure lookup (for a brand-new army).
+    let cachedOwner: bigint | undefined;
+    let ecsResolvedOwner: bigint | undefined;
     if (ownerAddress === 0n) {
       if (import.meta.env.DEV) {
         console.warn(`[DEBUG] Army ${entityId} has zero owner address (0n) - army defeated/deleted`);
       }
-
-      // Check if we already have this army with a valid owner
-      const existingArmy = this.armiesPositions.has(entityId);
-      if (existingArmy) {
-        // Try to find existing army data in armyHexes to preserve owner
-        for (const rowMap of this.armyHexes.values()) {
-          for (const armyData of rowMap.values()) {
-            if (armyData.id === entityId && armyData.owner !== 0n) {
-              actualOwnerAddress = armyData.owner;
-              break;
-            }
-          }
-          if (actualOwnerAddress !== 0n) break;
-        }
-
-        // If we still have 0n owner, the army was defeated/deleted - clean up the cache
-        if (actualOwnerAddress === 0n) {
-          if (import.meta.env.DEV) {
-            console.warn(`[DEBUG] Removing army ${entityId} from cache (0n owner indicates defeat/deletion)`);
-          }
-          const oldPos = this.armiesPositions.get(entityId);
-          if (oldPos) {
-            this.armyHexes.get(oldPos.col)?.delete(oldPos.row);
-            gameWorkerManager.updateArmyHex(oldPos.col, oldPos.row, null);
-            this.invalidateAllChunkCachesContainingHex(oldPos.col, oldPos.row);
-          }
-          this.armiesPositions.delete(entityId);
-          this.armyStructureOwners.delete(entityId);
-          return;
-        }
+      if (isAlreadyCached) {
+        cachedOwner = this.findCachedArmyOwner(entityId);
       } else {
-        // New army with 0n owner - MapDataStore likely hasn't cached it yet.
-        // Resolve owner directly from ECS Structure component using ownerStructureId.
-        const resolvedStructureId = ownerStructureId ?? this.armyStructureOwners.get(entityId);
-        if (resolvedStructureId) {
-          try {
-            const components = this.dojo.components as Parameters<typeof ensureStructureSynced>[0];
-            const structureEntity = getEntityIdFromKeys([BigInt(resolvedStructureId)]);
-            const structureComponent = components.Structure;
-            if (structureComponent) {
-              const structure = getComponentValue(structureComponent, structureEntity);
-              if (structure?.owner) {
-                actualOwnerAddress = BigInt(structure.owner);
-              }
-            }
-          } catch (error) {
-            // Owner stays 0n if the ECS lookup throws. Surface it instead of
-            // silently treating the army as unowned (which would poison the
-            // spatial cache with a bogus owner).
-            if (import.meta.env.DEV) {
-              console.warn(`[Worldmap] Structure owner ECS lookup failed for army ${entityId}`, error);
-            }
-          }
-        }
-
-        // Still unresolved: do NOT write a bogus owner:0n entry into the spatial
-        // cache (it would mis-flag the army as unowned/defeated for clicks and
-        // ownership coloring). Skip and let the next authoritative update — which
-        // carries a real owner — register it.
-        if (actualOwnerAddress === 0n) {
-          if (import.meta.env.DEV) {
-            console.warn(
-              `[Worldmap] Skipping spatial cache write for new army ${entityId}: owner unresolved (0n), awaiting authoritative update`,
-            );
-          }
-          return;
-        }
+        ecsResolvedOwner = this.resolveArmyOwnerFromEcs(entityId, ownerStructureId);
       }
     }
+
+    const action = resolveArmyOwnerCacheAction({
+      ownerAddress,
+      isAlreadyCached,
+      cachedOwner,
+      ecsResolvedOwner,
+    });
+
+    if (action.kind === "evict") {
+      // Already-cached army confirmed defeated/deleted (0n owner, nothing to
+      // preserve) — purge it from the spatial cache.
+      if (import.meta.env.DEV) {
+        console.warn(`[DEBUG] Removing army ${entityId} from cache (0n owner indicates defeat/deletion)`);
+      }
+      const oldPos = this.armiesPositions.get(entityId);
+      if (oldPos) {
+        this.armyHexes.get(oldPos.col)?.delete(oldPos.row);
+        gameWorkerManager.updateArmyHex(oldPos.col, oldPos.row, null);
+        this.invalidateAllChunkCachesContainingHex(oldPos.col, oldPos.row);
+      }
+      this.armiesPositions.delete(entityId);
+      this.armyStructureOwners.delete(entityId);
+      return;
+    }
+
+    if (action.kind === "skip") {
+      // New army whose owner stayed unresolved (0n). Do NOT write a bogus
+      // owner:0n entry — it would mis-flag the army as unowned/defeated for
+      // clicks and ownership coloring. Let the next authoritative update, which
+      // carries a real owner, register it.
+      if (import.meta.env.DEV) {
+        console.warn(
+          `[Worldmap] Skipping spatial cache write for new army ${entityId}: owner unresolved (0n), awaiting authoritative update`,
+        );
+      }
+      return;
+    }
+
+    const actualOwnerAddress = action.owner;
 
     const normalized = new Position({ x: col, y: row }).getNormalized();
     const newPos = { col: normalized.x, row: normalized.y };
@@ -5071,6 +5054,52 @@ export default class WorldmapScene extends WarpTravel {
     this.armyHexes.get(newPos.col)?.set(newPos.row, armyHexData);
     gameWorkerManager.updateArmyHex(newPos.col, newPos.row, armyHexData);
     this.invalidateAllChunkCachesContainingHex(newPos.col, newPos.row);
+  }
+
+  /**
+   * Search the spatial cache for the army's last known non-zero owner. Used to
+   * preserve ownership when an already-cached army reports a transient 0n owner.
+   */
+  private findCachedArmyOwner(entityId: ID): bigint | undefined {
+    for (const rowMap of this.armyHexes.values()) {
+      for (const armyData of rowMap.values()) {
+        if (armyData.id === entityId && armyData.owner !== 0n) {
+          return armyData.owner;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolve an army's owner directly from the ECS Structure component — used for
+   * a brand-new army that MapDataStore has not cached yet. Returns undefined if
+   * there is no structure to resolve against or the lookup throws; the failure
+   * is surfaced (DEV) rather than silently poisoning the cache with a 0n owner.
+   */
+  private resolveArmyOwnerFromEcs(entityId: ID, ownerStructureId?: ID | null): bigint | undefined {
+    const resolvedStructureId = ownerStructureId ?? this.armyStructureOwners.get(entityId);
+    if (!resolvedStructureId) {
+      return undefined;
+    }
+    try {
+      const components = this.dojo.components as Parameters<typeof ensureStructureSynced>[0];
+      const structureEntity = getEntityIdFromKeys([BigInt(resolvedStructureId)]);
+      const structureComponent = components.Structure;
+      if (structureComponent) {
+        const structure = getComponentValue(structureComponent, structureEntity);
+        if (structure?.owner) {
+          return BigInt(structure.owner);
+        }
+      }
+    } catch (error) {
+      // Surface the failure instead of silently treating the army as unowned
+      // (which would poison the spatial cache with a bogus owner).
+      if (import.meta.env.DEV) {
+        console.warn(`[Worldmap] Structure owner ECS lookup failed for army ${entityId}`, error);
+      }
+    }
+    return undefined;
   }
 
   public updateStructureHexes(update: {

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -5018,9 +5018,27 @@ export default class WorldmapScene extends WarpTravel {
                 actualOwnerAddress = BigInt(structure.owner);
               }
             }
-          } catch {
-            // Fall through with 0n if ECS lookup fails
+          } catch (error) {
+            // Owner stays 0n if the ECS lookup throws. Surface it instead of
+            // silently treating the army as unowned (which would poison the
+            // spatial cache with a bogus owner).
+            if (import.meta.env.DEV) {
+              console.warn(`[Worldmap] Structure owner ECS lookup failed for army ${entityId}`, error);
+            }
           }
+        }
+
+        // Still unresolved: do NOT write a bogus owner:0n entry into the spatial
+        // cache (it would mis-flag the army as unowned/defeated for clicks and
+        // ownership coloring). Skip and let the next authoritative update — which
+        // carries a real owner — register it.
+        if (actualOwnerAddress === 0n) {
+          if (import.meta.env.DEV) {
+            console.warn(
+              `[Worldmap] Skipping spatial cache write for new army ${entityId}: owner unresolved (0n), awaiting authoritative update`,
+            );
+          }
+          return;
         }
       }
     }

--- a/client/apps/game/src/three/types/army.ts
+++ b/client/apps/game/src/three/types/army.ts
@@ -18,7 +18,6 @@ export interface MovementData {
   startPos: Vector3;
   endPos: Vector3;
   progress: number;
-  matrixIndex: number;
   currentPathIndex: number;
   floatingHeight: number;
   currentRotation: number;
@@ -29,7 +28,6 @@ export interface SplineMovementData {
   spline: CatmullRomCurve3;
   totalLength: number;
   journeyProgress: number;
-  matrixIndex: number;
   floatingHeight: number;
   currentRotation: number;
   easingType: EasingType;


### PR DESCRIPTION
Army 3D models could ghost at stale positions while their labels stayed correct, because the instance `matrixIndex` was cached in the movement structs and never rebound when slot compaction reassigned a moving army (the spline kept writing the model to the old slot). This makes `instanceData.matrixIndex` the single source of truth read every frame and removes the duplicated field from `MovementData`/`SplineMovementData`, so the model always renders on the live slot, with `clearMovementState` also tearing down spline state for parity with stop/cancel. Separately, `updateArmyHexes` in `worldmap.tsx` now surfaces the previously-silent structure-owner ECS lookup failure and skips writing a bogus `owner: 0n` spatial-cache entry for unresolved new armies. Adds regression tests for both fixes (`army-model.spline-rebind`, `worldmap-army-owner-resolution`); existing army-model/army-manager/worldmap suites pass.