### PR TITLE
Fix army slot ghosting

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.movement-slot-source.test.ts
+++ b/client/apps/game/src/three/managers/army-manager.movement-slot-source.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+function readSource(relativePath: string): string {
+  const currentDir = dirname(fileURLToPath(import.meta.url));
+  return readFileSync(resolve(currentDir, relativePath), "utf8");
+}
+
+// The reported ghost (frozen duplicate at a unit's OLD position after it moves)
+// comes from the move-start path seeding the army-model's source-of-truth slot
+// (instanceData.matrixIndex) from the army-manager's stale *mirror*
+// (ArmyData.matrixIndex). These guards lock in the two manager-side rules that,
+// together with the army-model fixes, keep the slot a single source of truth.
+describe("ArmyManager movement uses the model's live slot, not the cached mirror", () => {
+  it("applyMovementPlan sources the move slot from the army-model SSOT (getEntitySlot)", () => {
+    const src = readSource("army-manager.ts");
+
+    const start = src.indexOf("public async applyMovementPlan");
+    expect(start).toBeGreaterThan(-1);
+
+    const body = src.slice(start, start + 3200);
+
+    // Must consult the model's live slot rather than blindly trusting the mirror.
+    expect(body).toContain("getEntitySlot");
+    // The mirror is allowed only as a fallback (?? armyData.matrixIndex).
+    expect(body).toMatch(/getEntitySlot\([^)]*\)\s*\?\?\s*armyData\.matrixIndex/);
+  });
+
+  it("compactVisibleArmySlots mirrors only the slot moveInstanceSlot actually took", () => {
+    const src = readSource("army-manager.ts");
+
+    const start = src.indexOf("private compactVisibleArmySlots");
+    expect(start).toBeGreaterThan(-1);
+
+    const body = src.slice(start, start + 1000);
+
+    // The reassignment must capture moveInstanceSlot's resulting slot...
+    expect(body).toMatch(/const \w+ = this\.armyModel\.moveInstanceSlot\(/);
+    // ...guard the no-slot case...
+    expect(body).toContain("=== undefined");
+    // ...and must NOT mirror the *planned* toSlot unconditionally.
+    expect(body).not.toContain("matrixIndex: toSlot");
+    expect(body).not.toContain("this.visibleArmyIndices.set(entityId, toSlot)");
+  });
+});

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -102,6 +102,7 @@ import { reconcileVisibleArmySet } from "./army-visible-set-reconciler";
 import { resolvePointLabelTextureFlipY } from "./point-label-texture-policy";
 import { PointsLabelRenderer } from "./points-label-renderer";
 import { resolveArmySlotCompactionPlan } from "./army-slot-compaction";
+import { auditArmySlots, type ArmySlotAuditEntry } from "./army-slot-auditor";
 import { resolveMovementPath } from "./army-move-path";
 import { shouldUseWorkerPathForArmy } from "./army-movement-path-strategy";
 import { addVisibleArmyOrderEntry, removeVisibleArmyOrderEntry, replaceVisibleArmyOrder } from "./army-visible-order";
@@ -1050,14 +1051,20 @@ export class ArmyManager {
 
     plan.reassignments.forEach(({ entityId, toSlot }) => {
       const numericId = this.toNumericId(entityId);
-      this.armyModel.moveInstanceSlot(numericId, toSlot);
-      this.visibleArmyIndices.set(entityId, toSlot);
+      // Mirror EXACTLY the slot the model actually took. If the model declined
+      // the move (no live slot), skip — advancing the mirror to a slot the model
+      // never wrote is what desyncs the SSOT and strands ghosts.
+      const movedSlot = this.armyModel.moveInstanceSlot(numericId, toSlot);
+      if (movedSlot === undefined) {
+        return;
+      }
+      this.visibleArmyIndices.set(entityId, movedSlot);
 
       const army = this.armies.get(entityId);
       if (army) {
         this.armies.set(entityId, {
           ...army,
-          matrixIndex: toSlot,
+          matrixIndex: movedSlot,
         });
       }
     });
@@ -1937,7 +1944,10 @@ export class ArmyManager {
       });
     }
 
-    const matrixIndex = armyData.matrixIndex;
+    // Use the army-model's live slot (the single source of truth), not the
+    // cached ArmyData.matrixIndex mirror. Seeding a movement from a stale mirror
+    // animates the wrong slot and strands a frozen ghost at the unit's old slot.
+    const matrixIndex = this.armyModel.getEntitySlot(numericEntityId) ?? armyData.matrixIndex;
     if (matrixIndex === undefined) {
       this.armyPaths.delete(entityId);
       this.armyModel.setMovementCompleteCallback(numericEntityId, undefined);
@@ -2586,6 +2596,11 @@ export class ArmyManager {
     });
   }
 
+  // Dev-only ghost tripwire: throttled audit that the manager's slot mirror
+  // matches the army-model source of truth (see army-slot-auditor).
+  private slotAuditFrameCounter = 0;
+  private readonly loggedSlotViolations = new Set<string>();
+
   update(deltaTime: number, animationContext?: AnimationVisibilityContext) {
     // Update movements in ArmyModel
     this.armyModel.updateMovements(deltaTime);
@@ -2623,6 +2638,40 @@ export class ArmyManager {
 
     // Flush batched label pool operations to minimize layout thrashing
     this.labelPool.flushBatch();
+
+    if (import.meta.env?.DEV) {
+      // Throttled (~1.5s at 60fps) so the per-frame cost stays negligible.
+      this.slotAuditFrameCounter = (this.slotAuditFrameCounter + 1) % 90;
+      if (this.slotAuditFrameCounter === 0) {
+        this.auditArmySlotsForGhosts();
+      }
+    }
+  }
+
+  // Reports when the manager's slot mirror (visibleArmyIndices) drifts from the
+  // army-model source of truth, or when two entities share a live slot — the two
+  // states that surface as a frozen ghost. Each unique violation is logged once.
+  private auditArmySlotsForGhosts(): void {
+    const entries: ArmySlotAuditEntry[] = [];
+    this.visibleArmyIndices.forEach((mirrorSlot, entityId) => {
+      entries.push({
+        entityId,
+        mirrorSlot,
+        ssotSlot: this.armyModel.getEntitySlot(this.toNumericId(entityId)),
+      });
+    });
+
+    for (const violation of auditArmySlots(entries)) {
+      const signature =
+        violation.kind === "mirror-mismatch"
+          ? `mirror:${violation.entityId}:${violation.mirrorSlot}:${violation.ssotSlot}`
+          : `shared:${violation.slot}:${violation.entityIds.join(",")}`;
+      if (this.loggedSlotViolations.has(signature)) {
+        continue;
+      }
+      this.loggedSlotViolations.add(signature);
+      console.warn("[ArmyManager] slot-audit ghost risk", violation);
+    }
   }
 
   private updateCompactLabelCamera(): void {

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1202,7 +1202,10 @@ export class ArmyManager {
       this.runMovementVisualCancelListeners(numericId);
     }
 
-    this.armyModel.freeInstanceSlot(numericId, slot);
+    // Free the army-model's live slot (the single source of truth), falling back
+    // to the mirror only when the model has no live slot. Freeing the cached
+    // mirror slot during a transient desync would strand a ghost at the real slot.
+    this.armyModel.freeInstanceSlot(numericId, this.armyModel.getEntitySlot(numericId) ?? slot);
     return slot;
   }
 

--- a/client/apps/game/src/three/managers/army-model.movement-slot-source-of-truth.test.ts
+++ b/client/apps/game/src/three/managers/army-model.movement-slot-source-of-truth.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AnimationClip,
+  AnimationMixer,
+  BoxGeometry,
+  Group,
+  InstancedMesh,
+  Matrix4,
+  Mesh,
+  MeshBasicMaterial,
+  Scene,
+  Vector3,
+} from "three";
+import { ModelType } from "@/three/types/army";
+import { TroopTier, TroopType } from "@bibliothecadao/types";
+import { ArmyModel } from "./army-model";
+
+vi.hoisted(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: vi.fn(() => null),
+      removeItem: vi.fn(),
+      setItem: vi.fn(),
+    },
+  });
+});
+
+vi.mock("@/ui/config", () => ({
+  FELT_CENTER: () => 0,
+  GRAPHICS_SETTING: "HIGH",
+  GraphicsSettings: {
+    HIGH: "HIGH",
+    LOW: "LOW",
+    MID: "MID",
+  },
+  IS_FLAT_MODE: false,
+}));
+
+vi.mock("@/three/scenes/hexagon-scene", () => ({
+  CameraView: {
+    Close: "Close",
+    Medium: "Medium",
+    Far: "Far",
+  },
+}));
+
+vi.mock("../../../env", () => ({
+  env: {
+    VITE_PUBLIC_ENABLE_MEMORY_MONITORING: false,
+  },
+}));
+
+vi.mock("@/utils/agent", () => ({
+  getCharacterModel: vi.fn(() => null),
+}));
+
+vi.mock("@/three/utils/utils", () => ({
+  gltfLoader: {
+    load: vi.fn(),
+  },
+}));
+
+vi.mock("../utils", () => ({
+  getHexForWorldPosition: vi.fn(() => ({ col: 0, row: 0 })),
+}));
+
+vi.mock("../utils/contact-shadow", () => ({
+  getContactShadowResources: vi.fn(() => ({
+    geometry: new BoxGeometry(1, 1, 1),
+    material: new MeshBasicMaterial(),
+  })),
+}));
+
+vi.mock("../utils/material-pool", () => ({
+  MaterialPool: {
+    getInstance: vi.fn(() => ({
+      get: vi.fn(),
+      release: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock("../utils/memory-monitor", () => ({
+  MemoryMonitor: class MockMemoryMonitor {},
+}));
+
+vi.mock("./army-model-materials", () => ({
+  createPooledInstancedMaterial: vi.fn(() => new MeshBasicMaterial()),
+  releasePooledInstancedMaterial: vi.fn(),
+}));
+
+vi.mock("./army-model-debug-hooks", () => ({
+  installArmyModelDebugHooks: vi.fn(),
+}));
+
+vi.mock("../cosmetics/skin-asset-source", () => ({
+  resolvePrimarySkinGltf: vi.fn(),
+}));
+
+vi.mock("@bibliothecadao/eternum", () => {
+  const scalar = new Proxy(
+    {},
+    {
+      get: (_, key) => key,
+    },
+  );
+
+  return new Proxy(
+    {
+      Biome: {
+        getBiome: vi.fn(() => "NONE"),
+      },
+      FELT_CENTER: 0,
+    } as Record<string, unknown>,
+    {
+      get: (target, prop) => (prop in target ? target[prop as string] : scalar),
+      has: () => true,
+    },
+  );
+});
+
+vi.mock("@bibliothecadao/types", () => {
+  const enumProxy = new Proxy(
+    {},
+    {
+      get: (_, key) => key,
+    },
+  );
+
+  return new Proxy(
+    {
+      BiomeType: enumProxy,
+      ResourcesIds: { StaminaRelic1: 1 },
+      TroopTier: { T1: "T1", T2: "T2", T3: "T3" },
+      TroopType: { Knight: "Knight", Crossbowman: "Crossbowman", Paladin: "Paladin" },
+    } as Record<string, unknown>,
+    {
+      get: (target, prop) => (prop in target ? target[prop as string] : enumProxy),
+      has: () => true,
+    },
+  );
+});
+
+function createLoadedModelData() {
+  const geometry = new BoxGeometry(1, 1, 1);
+  const material = new MeshBasicMaterial();
+  const mesh = new InstancedMesh(geometry, material, 8);
+
+  return {
+    mesh,
+    modelData: {
+      group: new Group(),
+      instancedMeshes: [mesh],
+      baseMeshes: [new Mesh(geometry, material)],
+      mixer: new AnimationMixer(new Group()),
+      animations: {
+        idle: new AnimationClip("idle", 1, []),
+        moving: new AnimationClip("moving", 1, []),
+      },
+      animationActions: new Map(),
+      activeInstances: new Set<number>(),
+      lastAnimationUpdate: 0,
+      animationUpdateInterval: 50,
+      contactShadowMesh: null,
+      contactShadowScale: 1,
+    },
+  };
+}
+
+const ZERO_SCALE_ELEMENTS = new Matrix4().makeScale(0, 0, 0).elements;
+
+function getMatrix(mesh: InstancedMesh, slot: number): Matrix4 {
+  const matrix = new Matrix4();
+  mesh.getMatrixAt(slot, matrix);
+  return matrix;
+}
+
+function expectNonZeroMatrix(mesh: InstancedMesh, slot: number) {
+  expect(getMatrix(mesh, slot).elements).not.toEqual(ZERO_SCALE_ELEMENTS);
+}
+
+describe("ArmyModel slot single-source-of-truth on movement start", () => {
+  // The reported ghost: a frozen duplicate at a unit's OLD position after it
+  // moves. Root cause — the move-start path seeds the model's source-of-truth
+  // slot (instanceData.matrixIndex) from the army-manager's *mirror*
+  // (ArmyData.matrixIndex). When the mirror is stale, startMovement relocates
+  // the entity onto the stale slot and leaves the real slot drawn forever
+  // (a ghost), until a full chunk reconcile repacks slots.
+  //
+  // startMovement must IGNORE a stale caller-supplied slot when the entity
+  // already has a live instanceData slot, and keep driving that live slot.
+  it("ignores a stale caller-supplied slot and keeps driving the entity's live slot", () => {
+    const subject = new ArmyModel(new Scene());
+    const { mesh, modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const entityId = 777;
+    const liveSlot = subject.allocateInstanceSlot(entityId); // 0
+    subject.assignModelToEntity(entityId, ModelType.Knight1);
+    subject.updateInstance(entityId, liveSlot, new Vector3(2, 0, 2), new Vector3(1, 1, 1));
+    expect((subject as any).instanceData.get(entityId).matrixIndex).toBe(liveSlot);
+
+    // Simulate the army-manager passing a STALE mirror slot (entity is really
+    // at `liveSlot`, but the cached mirror thinks it is at `staleSlot`).
+    const staleSlot = 3;
+    expect(staleSlot).not.toBe(liveSlot);
+
+    subject.startMovement(
+      entityId,
+      [new Vector3(2, 0, 2), new Vector3(3, 0, 3), new Vector3(4, 0, 4)],
+      staleSlot,
+      TroopType.Knight as never,
+      TroopTier.T1 as never,
+    );
+
+    // The source of truth must be preserved, not overwritten with the mirror.
+    expect((subject as any).instanceData.get(entityId).matrixIndex).toBe(liveSlot);
+
+    subject.updateMovements(0.016);
+
+    // The unit is driven at its real slot, and was never relocated onto the
+    // stale slot (the buggy path would assign matrixIndexOwners[staleSlot] to
+    // this entity and freeze a ghost at the real slot).
+    expect(subject.getEntitySlot(entityId)).toBe(liveSlot);
+    expectNonZeroMatrix(mesh, liveSlot);
+    expect((subject as any).matrixIndexOwners.get(staleSlot)).not.toBe(entityId);
+  });
+
+  // A brand-new entity (no instanceData yet) must still adopt the supplied slot
+  // — the caller value is a fallback, only ignored when a live slot exists.
+  it("adopts the supplied slot when the entity has no live slot yet", () => {
+    const subject = new ArmyModel(new Scene());
+    const { modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const entityId = 778;
+    const slot = subject.allocateInstanceSlot(entityId);
+    subject.assignModelToEntity(entityId, ModelType.Knight1);
+    // Note: no updateInstance — instanceData has no entry until movement starts.
+    expect((subject as any).instanceData.get(entityId)).toBeUndefined();
+
+    subject.startMovement(
+      entityId,
+      [new Vector3(0, 0, 0), new Vector3(1, 0, 1)],
+      slot,
+      TroopType.Knight as never,
+      TroopTier.T1 as never,
+    );
+
+    expect((subject as any).instanceData.get(entityId).matrixIndex).toBe(slot);
+  });
+});
+
+describe("ArmyModel freeInstanceSlot clears the live slot unconditionally", () => {
+  // Defensive invariant: freeInstanceSlot must never leave an entity's
+  // instanceData.matrixIndex pointing at a slot that is back in the free pool —
+  // a later allocateInstanceSlot would hand that (possibly reused) slot back,
+  // sharing it between two entities (a ghost).
+  it("clears instanceData.matrixIndex even when the freed slot is already pooled", () => {
+    const subject = new ArmyModel(new Scene());
+    const { modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const entityId = 555;
+    const slot = subject.allocateInstanceSlot(entityId); // 0
+    subject.assignModelToEntity(entityId, ModelType.Knight1);
+    subject.updateInstance(entityId, slot, new Vector3(1, 0, 1), new Vector3(1, 1, 1));
+
+    // Force the "already pooled" early-return condition while the entity's
+    // source of truth still points at the slot.
+    (subject as any).freeSlotSet.add(slot);
+    (subject as any).freeSlots.push(slot);
+
+    subject.freeInstanceSlot(entityId, slot);
+
+    expect((subject as any).instanceData.get(entityId)?.matrixIndex).toBeUndefined();
+  });
+});
+
+describe("ArmyModel moveInstanceSlot reports the resulting slot", () => {
+  // Slot compaction in the manager must mirror exactly the slot the MODEL
+  // actually took — never a planned slot the model declined to move to.
+  // moveInstanceSlot therefore returns the entity's resulting live slot.
+  it("returns the new slot on a real move, the current slot on a no-op, and undefined for an unknown entity", () => {
+    const subject = new ArmyModel(new Scene());
+    const { modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const entityId = 888;
+    const slot = subject.allocateInstanceSlot(entityId); // 0
+    subject.assignModelToEntity(entityId, ModelType.Knight1);
+    subject.updateInstance(entityId, slot, new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+
+    // Real move 0 -> 2.
+    expect(subject.moveInstanceSlot(entityId, 2)).toBe(2);
+    expect((subject as any).instanceData.get(entityId).matrixIndex).toBe(2);
+
+    // No-op: already at slot 2 — must report the live slot, not undefined.
+    expect(subject.moveInstanceSlot(entityId, 2)).toBe(2);
+
+    // Unknown entity: nothing to mirror.
+    expect(subject.moveInstanceSlot(999999, 1)).toBeUndefined();
+  });
+});
+
+describe("ArmyModel getEntitySlot exposes the live source-of-truth slot", () => {
+  it("returns the entity's current instanceData.matrixIndex, or undefined when unslotted", () => {
+    const subject = new ArmyModel(new Scene());
+    const { modelData } = createLoadedModelData();
+    (subject as any).models.set(ModelType.Knight1, modelData);
+
+    const entityId = 999;
+    expect(subject.getEntitySlot(entityId)).toBeUndefined();
+
+    const slot = subject.allocateInstanceSlot(entityId);
+    subject.assignModelToEntity(entityId, ModelType.Knight1);
+    subject.updateInstance(entityId, slot, new Vector3(0, 0, 0), new Vector3(1, 1, 1));
+
+    expect(subject.getEntitySlot(entityId)).toBe(slot);
+  });
+});

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -729,6 +729,13 @@ export class ArmyModel {
     return this.entityModelMap.get(entityId);
   }
 
+  // The single source of truth for an entity's live instance slot. Callers
+  // (e.g. the army-manager move path) must consult this rather than a cached
+  // mirror, so a stale mirror can never relocate the unit onto the wrong slot.
+  public getEntitySlot(entityId: number): number | undefined {
+    return this.instanceData.get(entityId)?.matrixIndex;
+  }
+
   public allocateInstanceSlot(entityId: number): number {
     const existingSlot = this.instanceData.get(entityId)?.matrixIndex;
     if (existingSlot !== undefined) {
@@ -757,21 +764,33 @@ export class ArmyModel {
     this.hiddenSlots.delete(resolvedSlot);
     this.matrixIndexOwners.delete(resolvedSlot);
 
+    // Detach the entity from the freed slot up front. If the slot is already
+    // pooled we early-return below; leaving instanceData.matrixIndex pointing at
+    // a pooled slot lets a later allocateInstanceSlot hand that (reused) slot
+    // back and share it between two entities — a ghost. Only clear when we are
+    // freeing the entity's *current* slot.
+    if (instanceData && instanceData.matrixIndex === resolvedSlot) {
+      instanceData.matrixIndex = undefined;
+    }
+
     if (this.freeSlotSet.has(resolvedSlot)) return;
 
     this.freeSlotSet.add(resolvedSlot);
     this.freeSlots.push(resolvedSlot);
-
-    if (instanceData) {
-      instanceData.matrixIndex = undefined;
-    }
   }
 
-  public moveInstanceSlot(entityId: number, newSlot: number): void {
+  // Returns the entity's resulting live slot so callers can mirror EXACTLY what
+  // the model did: the new slot on a real move, the current slot on a no-op, or
+  // undefined when the entity has no live slot (nothing to mirror). Mirroring a
+  // planned slot the model declined to take is what strands ghosts.
+  public moveInstanceSlot(entityId: number, newSlot: number): number | undefined {
     const instanceData = this.instanceData.get(entityId);
     const previousSlot = instanceData?.matrixIndex;
-    if (!instanceData || previousSlot === undefined || previousSlot === newSlot) {
-      return;
+    if (!instanceData || previousSlot === undefined) {
+      return undefined;
+    }
+    if (previousSlot === newSlot) {
+      return previousSlot;
     }
 
     this.takeFreedSlot(newSlot);
@@ -793,6 +812,7 @@ export class ArmyModel {
     this.matrixIndexOwners.delete(previousSlot);
     instanceData.matrixIndex = newSlot;
     this.rebindMovementMatrixIndex(entityId, newSlot);
+    return newSlot;
   }
 
   private takeFreedSlot(slot: number): void {
@@ -1405,8 +1425,14 @@ export class ArmyModel {
     this.stopMovement(entityId);
     const [currentPos, nextPos] = [path[0], path[1]];
 
-    this.initializeMovement(entityId, currentPos, nextPos, path, matrixIndex, category, tier);
-    this.setAnimationState(matrixIndex, true);
+    // instanceData.matrixIndex is the single source of truth for an entity's
+    // live slot. The caller-supplied slot is only a fallback for an entity that
+    // has no instance yet — trusting it blindly lets a stale army-manager mirror
+    // relocate the unit onto the wrong slot and strand a frozen ghost at the old
+    // one (the reported "duplicate at the old position after a move").
+    const liveSlot = this.instanceData.get(entityId)?.matrixIndex ?? matrixIndex;
+    this.initializeMovement(entityId, currentPos, nextPos, path, liveSlot, category, tier);
+    this.setAnimationState(liveSlot, true);
     this.updateInstanceDirection(entityId, currentPos, nextPos);
 
     // Build spline for smooth whole-path movement

--- a/client/apps/game/src/three/managers/army-slot-auditor.test.ts
+++ b/client/apps/game/src/three/managers/army-slot-auditor.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { auditArmySlots } from "./army-slot-auditor";
+
+// The ghost bug is, at its core, the army-manager's mirror of an entity's slot
+// (visibleArmyIndices / ArmyData.matrixIndex) drifting from the army-model's
+// single source of truth (instanceData.matrixIndex). This auditor is the
+// dev-only tripwire for exactly that divergence (and for two entities sharing a
+// live slot, which is how a drawn ghost manifests).
+describe("auditArmySlots", () => {
+  it("reports no violations when every mirror matches its SSOT and slots are unique", () => {
+    expect(
+      auditArmySlots([
+        { entityId: 1, mirrorSlot: 0, ssotSlot: 0 },
+        { entityId: 2, mirrorSlot: 1, ssotSlot: 1 },
+        { entityId: 3, mirrorSlot: 2, ssotSlot: 2 },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("flags a mirror that disagrees with the model's source-of-truth slot", () => {
+    const violations = auditArmySlots([
+      { entityId: 1, mirrorSlot: 0, ssotSlot: 0 },
+      { entityId: 42, mirrorSlot: 3, ssotSlot: 0 }, // mirror stale: model really at 0
+    ]);
+
+    expect(violations).toContainEqual({
+      kind: "mirror-mismatch",
+      entityId: 42,
+      mirrorSlot: 3,
+      ssotSlot: 0,
+    });
+  });
+
+  it("flags a mirror present while the model has no live slot", () => {
+    const violations = auditArmySlots([{ entityId: 7, mirrorSlot: 5, ssotSlot: undefined }]);
+
+    expect(violations).toContainEqual({
+      kind: "mirror-mismatch",
+      entityId: 7,
+      mirrorSlot: 5,
+      ssotSlot: undefined,
+    });
+  });
+
+  it("flags two entities sharing the same live slot (a drawn ghost)", () => {
+    const violations = auditArmySlots([
+      { entityId: 10, mirrorSlot: 2, ssotSlot: 2 },
+      { entityId: 11, mirrorSlot: 2, ssotSlot: 2 },
+    ]);
+
+    expect(violations).toContainEqual({
+      kind: "shared-slot",
+      slot: 2,
+      entityIds: [10, 11],
+    });
+  });
+
+  it("does not treat multiple unrendered entities (undefined slot) as a shared slot", () => {
+    expect(
+      auditArmySlots([
+        { entityId: 20, mirrorSlot: undefined, ssotSlot: undefined },
+        { entityId: 21, mirrorSlot: undefined, ssotSlot: undefined },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/client/apps/game/src/three/managers/army-slot-auditor.ts
+++ b/client/apps/game/src/three/managers/army-slot-auditor.ts
@@ -1,0 +1,69 @@
+/**
+ * Dev-only tripwire for army InstancedMesh slot integrity.
+ *
+ * A unit's slot is tracked in two layers: the army-manager's mirror
+ * (visibleArmyIndices / ArmyData.matrixIndex) and the army-model's single
+ * source of truth (instanceData.matrixIndex). The reported ghost — a frozen
+ * duplicate at a unit's OLD position after it moves — is what happens when those
+ * diverge and a movement is seeded from the stale mirror. This auditor reports
+ * that divergence (and two entities sharing one live slot, which is how a drawn
+ * ghost actually manifests) so regressions are caught at their source.
+ */
+
+export interface ArmySlotAuditEntry {
+  entityId: number | string;
+  /** What the army-manager believes (visibleArmyIndices / ArmyData.matrixIndex). */
+  mirrorSlot: number | undefined;
+  /** The army-model source of truth (instanceData.matrixIndex). */
+  ssotSlot: number | undefined;
+}
+
+export type ArmySlotViolation =
+  | {
+      kind: "mirror-mismatch";
+      entityId: number | string;
+      mirrorSlot: number | undefined;
+      ssotSlot: number | undefined;
+    }
+  | {
+      kind: "shared-slot";
+      slot: number;
+      entityIds: Array<number | string>;
+    };
+
+export function auditArmySlots(entries: ArmySlotAuditEntry[]): ArmySlotViolation[] {
+  const violations: ArmySlotViolation[] = [];
+
+  // I2 — the manager's mirror must equal the model's source-of-truth slot.
+  for (const entry of entries) {
+    if (entry.mirrorSlot !== entry.ssotSlot) {
+      violations.push({
+        kind: "mirror-mismatch",
+        entityId: entry.entityId,
+        mirrorSlot: entry.mirrorSlot,
+        ssotSlot: entry.ssotSlot,
+      });
+    }
+  }
+
+  // I3 — no two entities may occupy the same live slot (a drawn ghost).
+  const entityIdsBySlot = new Map<number, Array<number | string>>();
+  for (const entry of entries) {
+    if (entry.ssotSlot === undefined) {
+      continue;
+    }
+    const ids = entityIdsBySlot.get(entry.ssotSlot);
+    if (ids) {
+      ids.push(entry.entityId);
+    } else {
+      entityIdsBySlot.set(entry.ssotSlot, [entry.entityId]);
+    }
+  }
+  for (const [slot, entityIds] of entityIdsBySlot) {
+    if (entityIds.length > 1) {
+      violations.push({ kind: "shared-slot", slot, entityIds });
+    }
+  }
+
+  return violations;
+}


### PR DESCRIPTION
## Summary
Fixes army ghosting by making ArmyModel's live instance slot the authority for movement start and compaction mirror updates.
Adds a dev-only slot auditor that warns when manager mirrors drift or entities share a live slot.
Adds regression coverage for stale movement slots, freed-slot cleanup, manager source guards, and auditor invariants.

## Verification
- pnpm run format
- pnpm run knip
- NODE20=$(cd /tmp && npx -y node@20.19.0 -p 'process.execPath'); PATH="$(dirname "$NODE20"):$PATH" pnpm --dir client/apps/game test -- src/three/managers/army-model.movement-slot-source-of-truth.test.ts src/three/managers/army-manager.movement-slot-source.test.ts src/three/managers/army-slot-auditor.test.ts src/three/managers/army-model.spline-rebind.test.ts src/three/managers/army-model.hidden-slot-persistence.test.ts