### PR TITLE
Add icon-rich game toast notifications

### DIFF
--- a/client/apps/game/src/game-entry/bootstrap-controller.ts
+++ b/client/apps/game/src/game-entry/bootstrap-controller.ts
@@ -14,7 +14,7 @@ import {
 } from "@/init/bootstrap";
 import { addNetworkBreadcrumb } from "@/observability/network-health-reporting";
 import { markGameEntryMilestone, recordGameEntryDuration } from "@/ui/layouts/game-entry-timeline";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { resolveEntryContextCacheKey, type ResolvedEntryContext } from "./context";
 
@@ -304,7 +304,7 @@ export const useGameEntryBootstrapController = ({
           if (forceFresh) {
             markConnectionRecoveredAfterRouteRebootstrap();
             recordRouteRebootstrapSucceeded(reason);
-            toast.success("Game state refreshed", {
+            gameToast.success("Game state refreshed", {
               description: "Reconnected after a prolonged outage.",
             });
           }

--- a/client/apps/game/src/hooks/helpers/use-entity-resync.ts
+++ b/client/apps/game/src/hooks/helpers/use-entity-resync.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 const ENTITY_RESYNC_COOLDOWN_MS = 10_000;
 const ENTITY_RESYNC_TIMEOUT_MS = 20_000;
@@ -40,7 +40,7 @@ export const useEntityResync = ({
 
       if (elapsedMs < cooldownMs) {
         const remainingSeconds = Math.ceil((cooldownMs - elapsedMs) / 1000);
-        toast.info(`Please wait ${remainingSeconds}s before re-syncing this ${normalizedEntityLabel}.`);
+        gameToast.info(`Please wait ${remainingSeconds}s before re-syncing this ${normalizedEntityLabel}.`);
         return false;
       }
 
@@ -56,11 +56,11 @@ export const useEntityResync = ({
 
           void runSync().then(resolve).catch(reject);
         });
-        toast.success(successMessage);
+        gameToast.success(successMessage);
         return true;
       } catch (error) {
         console.error(`[resync] Failed to sync ${normalizedEntityLabel}`, error);
-        toast.error(errorMessage ?? `Could not sync ${normalizedEntityLabel}. Please try again.`);
+        gameToast.error(errorMessage ?? `Could not sync ${normalizedEntityLabel}. Please try again.`);
         return false;
       } finally {
         if (timeoutId !== null) {

--- a/client/apps/game/src/hooks/use-automation.tsx
+++ b/client/apps/game/src/hooks/use-automation.tsx
@@ -37,7 +37,7 @@ import {
 } from "@bibliothecadao/eternum";
 import { ResourcesIds } from "@bibliothecadao/types";
 import { useCallback, useEffect, useRef } from "react";
-import { toast } from "sonner";
+import { gameToast, type GameToastModel, type GameToastResourceItem } from "@/ui/shared/game-toast";
 import { isVillageLikeStructureCategory } from "@/ui/lib/structure-capabilities";
 import { extractReadableErrorMessage } from "@/utils/error-message";
 import { scheduleAutomationResourceCleanup } from "./automation-resource-cleanup";
@@ -101,6 +101,17 @@ const buildProductionResourceDebits = (plan: RealmProductionPlan) =>
     resourceId: Number(resourceId) as ResourcesIds,
     amount: -humanAmount,
   }));
+
+const buildProducedResourceToastItems = (outputsByResource: Record<number, number>): GameToastResourceItem[] =>
+  Object.entries(outputsByResource).map(([resourceId, amount]) => ({
+    resourceId: Number(resourceId),
+    amount,
+  }));
+
+const buildProductionSuccessToast = (realmName: string, outputsByResource: Record<number, number>): GameToastModel => ({
+  title: `Automation executed for ${realmName}`,
+  resources: buildProducedResourceToastItems(outputsByResource),
+});
 
 type ProcessRealmsResult = { ran: boolean; anyExecuted: boolean };
 
@@ -522,20 +533,9 @@ export const useAutomation = () => {
           });
           anyExecuted = true;
 
-          const producedResources = Object.entries(plan.outputsByResource);
-          if (producedResources.length > 0) {
-            const detail = producedResources
-              .map(([resId, amount]) => {
-                const label = resolveResourceLabel(Number(resId));
-                return `${Math.round(amount).toLocaleString()} ${label}`;
-              })
-              .join(", ");
-            toast.success(
-              `Automation executed for ${activeRealmConfig.realmName ?? `Realm ${plan.realmId}`}: ${detail}`,
-            );
-          } else {
-            toast.success(`Automation executed for ${activeRealmConfig.realmName ?? `Realm ${plan.realmId}`}.`);
-          }
+          gameToast.success(
+            buildProductionSuccessToast(activeRealmConfig.realmName ?? `Realm ${plan.realmId}`, plan.outputsByResource),
+          );
         } catch (rawError) {
           removeResourceOverrides();
           const errorMessage = extractReadableErrorMessage(rawError, "Automation transaction failed");
@@ -560,10 +560,10 @@ export const useAutomation = () => {
             skipRemainingRealmsMessage = "Skipped: signer error earlier in pass — next tick will retry";
             if (!signerFaultSurfacedForTick) {
               signerFaultSurfacedForTick = true;
-              toast.error(`Automation paused this tick: signer error — next tick will retry (${errorMessage})`);
+              gameToast.error(`Automation paused this tick: signer error — next tick will retry (${errorMessage})`);
             }
           } else {
-            toast.error(`Automation failed for ${realmLabel}: ${errorMessage}`);
+            gameToast.error(`Automation failed for ${realmLabel}: ${errorMessage}`);
           }
         }
       }

--- a/client/apps/game/src/hooks/use-exploration-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-exploration-automation-runner.ts
@@ -12,7 +12,7 @@ import { ContractAddress } from "@bibliothecadao/types";
 import { getComponentValue, getEntityString } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import type { Account, AccountInterface } from "starknet";
 
 import { getExplorationStrategy } from "@/automation/exploration";
@@ -370,7 +370,7 @@ export const useExplorationAutomationRunner = () => {
               lastError: message,
               blockedReason: "error",
             });
-            toast.error("Exploration automation failed.");
+            gameToast.error("Exploration automation failed.");
             scheduleNext(entry.id, nowMs);
           }
         }

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.test.tsx
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.test.tsx
@@ -54,8 +54,8 @@ vi.mock("@/ui/lib/structure-capabilities", () => ({
   canTransferMilitaryInventoryBetweenStructureIds: () => true,
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
+vi.mock("@/ui/shared/game-toast", () => ({
+  gameToast: {
     success: mocks.toastSuccess,
     error: mocks.toastError,
     warning: mocks.toastWarning,

--- a/client/apps/game/src/hooks/use-transfer-automation-runner.ts
+++ b/client/apps/game/src/hooks/use-transfer-automation-runner.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { toast } from "sonner";
+import { gameToast, type GameToastResourceItem } from "@/ui/shared/game-toast";
 import { useDojo } from "@bibliothecadao/react";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import {
@@ -15,6 +15,14 @@ import { canTransferMilitaryInventoryBetweenStructureIds } from "@/ui/lib/struct
 import { isEntityOwnedByAccount } from "@/utils/entity-ownership";
 import { useTransferAutomationStore } from "./store/use-transfer-automation-store";
 import { assessDonkeyCapacity, buildSendResourcesArgs, planTransferAmounts } from "./transfer-automation-planner";
+
+const buildTransferResourceToastItems = (
+  transferList: Array<{ resourceId: ResourcesIds; humanAmount: number }>,
+): GameToastResourceItem[] =>
+  transferList.map((transfer) => ({
+    resourceId: transfer.resourceId,
+    amount: transfer.humanAmount,
+  }));
 
 export const useTransferAutomationRunner = () => {
   const {
@@ -137,13 +145,13 @@ export const useTransferAutomationRunner = () => {
             }
 
             if (!isEntityOwnedByAccount(components, sourceId, account.address)) {
-              toast.warning("Scheduled transfer skipped: source structure is no longer owned.");
+              gameToast.warning("Scheduled transfer skipped: source structure is no longer owned.");
               scheduleNext(entry.id, nowMs);
               continue;
             }
 
             if (!isEntityOwnedByAccount(components, destId, account.address)) {
-              toast.warning("Scheduled transfer skipped: destination structure is no longer owned.");
+              gameToast.warning("Scheduled transfer skipped: destination structure is no longer owned.");
               scheduleNext(entry.id, nowMs);
               continue;
             }
@@ -158,7 +166,7 @@ export const useTransferAutomationRunner = () => {
                 destinationEntityId: destId,
               });
               if (!validTransfer) {
-                toast.warning(
+                gameToast.warning(
                   mode.id === "blitz"
                     ? "Scheduled transfer skipped: troops can only move between your owned structures in Blitz."
                     : "Scheduled transfer skipped: troops can only move Realm ↔ Realm.",
@@ -184,7 +192,7 @@ export const useTransferAutomationRunner = () => {
 
             const capacity = assessDonkeyCapacity(transferList, donkeyBalHuman);
             if (!capacity.ok) {
-              toast.error("Scheduled transfer blocked: insufficient donkeys at source.");
+              gameToast.error("Scheduled transfer blocked: insufficient donkeys at source.");
               scheduleNext(entry.id, nowMs);
               continue;
             }
@@ -216,14 +224,14 @@ export const useTransferAutomationRunner = () => {
 
             update(entry.id, { lastRunAt: nowMs });
             scheduleNext(entry.id, nowMs);
-            const summary = transferList
-              .map((t) => `${t.humanAmount.toLocaleString()} ${ResourcesIds[t.resourceId]}`)
-              .join(", ");
-            toast.success(`Transfer scheduled: ${summary}`);
+            gameToast.success({
+              title: "Transfer scheduled",
+              resources: buildTransferResourceToastItems(transferList),
+            });
           } catch (err) {
             console.error("Transfer automation: execution failed", err);
             scheduleNext(entry.id, nowMs);
-            toast.error("Scheduled transfer failed. Check console for details.");
+            gameToast.error("Scheduled transfer failed. Check console for details.");
           }
         }
       } finally {

--- a/client/apps/game/src/three/scenes/hexception-build-affordability.source.test.ts
+++ b/client/apps/game/src/three/scenes/hexception-build-affordability.source.test.ts
@@ -15,7 +15,7 @@ describe("Hexception build affordability", () => {
     expect(source).toContain(
       "if (!this.canAffordPreviewBuilding(structureEntityId, buildingType.type, useSimpleCost))",
     );
-    expect(source).toContain('toast.error("Insufficient resources to build here.");');
+    expect(source).toContain('gameToast.error("Insufficient resources to build here.");');
     expect(source).toMatch(
       /if \(!this\.canAffordPreviewBuilding\(structureEntityId, buildingType\.type, useSimpleCost\)\) \{[\s\S]*reserveOccupiedBuildSpot\(structureEntityId, normalizedCoords\);/,
     );

--- a/client/apps/game/src/three/scenes/hexception.tsx
+++ b/client/apps/game/src/three/scenes/hexception.tsx
@@ -82,7 +82,7 @@ import {
 } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import gsap from "gsap";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import {
   AnimationClip,
   AnimationMixer,
@@ -655,14 +655,14 @@ export default class HexceptionScene extends HexagonScene {
       });
 
       if (!buildability.canSubmit) {
-        toast.error(buildability.reason ?? "Building cannot be submitted.");
+        gameToast.error(buildability.reason ?? "Building cannot be submitted.");
         AudioManager.getInstance().play("ui.build_invalid");
         this.updateHexceptionGrid(this.hexceptionRadius);
         return;
       }
 
       if (!this.canAffordPreviewBuilding(structureEntityId, buildingType.type, useSimpleCost)) {
-        toast.error("Insufficient resources to build here.");
+        gameToast.error("Insufficient resources to build here.");
         AudioManager.getInstance().play("ui.build_invalid");
         this.updateHexceptionGrid(this.hexceptionRadius);
         return;

--- a/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-owner-resolution.ts
@@ -4,10 +4,7 @@
  * `armyHexes`, the worker hex map). Pure so it can be unit-tested in isolation —
  * the scene itself cannot be instantiated headless.
  */
-export type ArmyOwnerCacheAction =
-  | { kind: "write"; owner: bigint }
-  | { kind: "evict" }
-  | { kind: "skip" };
+export type ArmyOwnerCacheAction = { kind: "write"; owner: bigint } | { kind: "evict" } | { kind: "skip" };
 
 export interface ArmyOwnerCacheResolutionInput {
   /** Owner address carried by the incoming update. */

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -1,5 +1,5 @@
 import { playUnitCommandSound, playUnitCommandSoundForWorldmapAction } from "@/audio/unit-command-audio";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { ensureStructureSynced } from "@/dojo/queries";
 import { initializeSyncSimulator } from "@/dojo/sync-simulator";
@@ -2402,7 +2402,7 @@ export default class WorldmapScene extends WarpTravel {
     const defenderLabel = this.getEntityLabel(defenderId);
     const attackerLabel = typeof attackerId === "number" ? this.getEntityLabel(attackerId) : "Unknown attacker";
 
-    toast(
+    gameToast(
       <div className="flex flex-col gap-2">
         <div className="text-gold font-bold">⚠️ {defenderLabel} under attack</div>
         <div className="text-light-pink">Engaged by {attackerLabel}.</div>
@@ -2505,7 +2505,7 @@ export default class WorldmapScene extends WarpTravel {
 
     const account = useAccountStore.getState().account;
     if (!account) {
-      toast.error("Connect a controller account before creating a Hyperstructure.");
+      gameToast.error("Connect a controller account before creating a Hyperstructure.");
       return;
     }
 
@@ -2519,10 +2519,10 @@ export default class WorldmapScene extends WarpTravel {
         return;
       }
 
-      toast.success("Creating Hyperstructure...");
+      gameToast.success("Creating Hyperstructure...");
     } catch (error) {
       console.error("[Worldmap] Failed to create reserved hyperstructure", error);
-      toast.error("Unable to create this Hyperstructure right now.");
+      gameToast.error("Unable to create this Hyperstructure right now.");
     }
   }
 
@@ -2934,7 +2934,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private onArmyMovement(account: Account | AccountInterface, actionPath: ActionPath[], selectedEntityId: ID) {
     if (actionPath.length > 0 && this.isArmyMovementInputLocked(selectedEntityId)) {
-      toast.info("Army movement is still resolving");
+      gameToast.info("Army movement is still resolving");
       this.state.updateEntityActionHoveredHex(null);
       this.clearMovementActionOptionsForSelectedArmy(selectedEntityId);
       return;
@@ -2955,7 +2955,7 @@ export default class WorldmapScene extends WarpTravel {
         actionPath,
         movementStamina,
       });
-      toast.error("Not enough stamina for this move");
+      gameToast.error("Not enough stamina for this move");
       this.state.updateEntityActionHoveredHex(null);
       this.clearSelection();
       return;

--- a/client/apps/game/src/ui/features/cosmetics/chest-opening/hooks/use-open-chest.ts
+++ b/client/apps/game/src/ui/features/cosmetics/chest-opening/hooks/use-open-chest.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_COSMETICS_NETWORK,
 } from "@/ui/features/cosmetics/config/networks";
 import { useCallback, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { useLandingDojo } from "../../providers/landing-dojo-provider";
 
 interface OpenChestParams {
@@ -38,7 +38,7 @@ export function useOpenChest(network: CosmeticsNetwork = DEFAULT_COSMETICS_NETWO
       if (!account) {
         const error = new Error("No account connected");
         onError?.(error);
-        toast.error("Please connect your wallet first");
+        gameToast.error("Please connect your wallet first");
         return;
       }
 
@@ -61,14 +61,14 @@ export function useOpenChest(network: CosmeticsNetwork = DEFAULT_COSMETICS_NETWO
           claim_address: claimAddress,
         });
 
-        toast.success("Transaction sent! Opening chest...");
+        gameToast.success("Transaction sent! Opening chest...");
         onSuccess?.();
       } catch (err) {
         const error = err instanceof Error ? err : new Error("Failed to open chest");
         console.error("Failed to open chest:", error);
         setError(error);
         onError?.(error);
-        toast.error(error.message);
+        gameToast.error(error.message);
       } finally {
         setIsLoading(false);
       }

--- a/client/apps/game/src/ui/features/economy/transfers/transfer-automation-modal.tsx
+++ b/client/apps/game/src/ui/features/economy/transfers/transfer-automation-modal.tsx
@@ -4,7 +4,7 @@ import Button from "@/ui/design-system/atoms/button";
 import { ClientComponents, ResourcesIds, RESOURCE_PRECISION } from "@bibliothecadao/types";
 import { ResourceManager, getTotalResourceWeightKg, calculateDonkeysNeeded } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { DialogShell } from "@/ui/design-system/molecules";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 const formatResourceSummary = (entry: TransferAutomationEntry): string => {
@@ -73,7 +73,7 @@ export const TransferAutomationAdvancedModal = ({ embedded = false }: { embedded
           })
           .filter((x): x is { rid: ResourcesIds; amt: number } => Boolean(x));
         if (per.length === 0) {
-          toast.warning("Nothing to send now.");
+          gameToast.warning("Nothing to send now.");
           return;
         }
         const totalKg = getTotalResourceWeightKg(per.map((p) => ({ resourceId: p.rid, amount: p.amt })));
@@ -81,7 +81,7 @@ export const TransferAutomationAdvancedModal = ({ embedded = false }: { embedded
         const donkeyBalRaw = rm.balance(ResourcesIds.Donkey);
         const donkeyHuman = Number(donkeyBalRaw) / RESOURCE_PRECISION;
         if (donkeyHuman < need) {
-          toast.error("Insufficient donkeys at source.");
+          gameToast.error("Insufficient donkeys at source.");
           return;
         }
 
@@ -100,10 +100,10 @@ export const TransferAutomationAdvancedModal = ({ embedded = false }: { embedded
         });
 
         update(entry.id, { lastRunAt: Date.now() });
-        toast.success("Transfer executed.");
+        gameToast.success("Transfer executed.");
       } catch (e) {
         console.error(e);
-        toast.error("Execution failed.");
+        gameToast.error("Execution failed.");
       }
     },
     [components, systemCalls, account, update],
@@ -138,9 +138,9 @@ export const TransferAutomationAdvancedModal = ({ embedded = false }: { embedded
       }
     });
     if (paused > 0) {
-      toast.success(`Paused ${paused} transfers.`);
+      gameToast.success(`Paused ${paused} transfers.`);
     } else {
-      toast.info("No active transfers to pause.");
+      gameToast.info("No active transfers to pause.");
     }
   }, [filtered, toggleActive]);
 
@@ -153,9 +153,9 @@ export const TransferAutomationAdvancedModal = ({ embedded = false }: { embedded
       }
     });
     if (resumed > 0) {
-      toast.success(`Resumed ${resumed} transfers.`);
+      gameToast.success(`Resumed ${resumed} transfers.`);
     } else {
-      toast.info("No paused transfers to resume.");
+      gameToast.info("No paused transfers to resume.");
     }
   }, [filtered, toggleActive]);
 
@@ -163,7 +163,7 @@ export const TransferAutomationAdvancedModal = ({ embedded = false }: { embedded
     if (isRunningAll) return;
     const activeEntries = filtered.filter((entry) => entry.active);
     if (activeEntries.length === 0) {
-      toast.info("No active transfers to run.");
+      gameToast.info("No active transfers to run.");
       return;
     }
     setIsRunningAll(true);

--- a/client/apps/game/src/ui/features/economy/transfers/transfer-automation-panel.tsx
+++ b/client/apps/game/src/ui/features/economy/transfers/transfer-automation-panel.tsx
@@ -38,7 +38,7 @@ import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import Star from "lucide-react/dist/esm/icons/star";
 import Tent from "lucide-react/dist/esm/icons/tent";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 const BLITZ_FRAGMENT_MINE_ALLOWED_RESOURCES = new Set<ResourcesIds>([ResourcesIds.Donkey, ResourcesIds.Essence]);
 const ETERNUM_FRAGMENT_MINE_ALLOWED_RESOURCES = new Set<ResourcesIds>([
@@ -648,22 +648,22 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
   const submit = useCallback(async () => {
     if (!components) return;
     if (!account || !account.address || account.address === "0x0") {
-      toast.error("Connect wallet to transfer.");
+      gameToast.error("Connect wallet to transfer.");
       return;
     }
     if (selectedResources.length === 0) {
-      toast.error("Select at least one resource.");
+      gameToast.error("Select at least one resource.");
       return;
     }
     if (!selectedSourceId) {
-      toast.error("Select a source location.");
+      gameToast.error("Select a source location.");
       return;
     }
 
     const resolvedDestinationIds = allowMultiDestination ? destinationIds : destinationIds.slice(0, 1);
 
     if (resolvedDestinationIds.length === 0) {
-      toast.error("Select at least one destination.");
+      gameToast.error("Select at least one destination.");
       return;
     }
 
@@ -672,7 +672,7 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
       .filter((structure): structure is Structure => Boolean(structure));
 
     if (resolvedDestinations.length !== resolvedDestinationIds.length) {
-      toast.error("Selected destination is no longer available.");
+      gameToast.error("Selected destination is no longer available.");
       return;
     }
 
@@ -691,7 +691,7 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
             }),
         );
       if (invalid) {
-        toast.error(
+        gameToast.error(
           mode.id === "blitz"
             ? "Troops can only be transferred between your owned structures in Blitz."
             : "Troops can only be transferred Realm ↔ Realm.",
@@ -703,25 +703,25 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
     const fragmentMineDestinationInvalid =
       !allowFragmentMineDestinationPayload && resolvedDestinations.some((dst) => isFragmentMine(dst));
     if (fragmentMineDestinationInvalid) {
-      toast.error(fragmentMineTransferMessage);
+      gameToast.error(fragmentMineTransferMessage);
       return;
     }
 
     if (!transferPreview) {
-      toast.error("Unable to compute transfer amounts.");
+      gameToast.error("Unable to compute transfer amounts.");
       return;
     }
 
     const perTransferDonkeyNeed = transferPreview.donkeys.need;
     const totalDonkeysNeeded = perTransferDonkeyNeed * resolvedDestinationIds.length;
     if (resolvedDestinationIds.length > 0 && transferPreview.donkeys.have < totalDonkeysNeeded) {
-      toast.error("Insufficient donkeys at source.");
+      gameToast.error("Insufficient donkeys at source.");
       return;
     }
 
     const currentAmounts = transferPreview.perResource;
     if (currentAmounts.length === 0) {
-      toast.error("Nothing to send.");
+      gameToast.error("Nothing to send.");
       return;
     }
 
@@ -748,11 +748,11 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
           signer: account,
           calls,
         });
-        toast.success(resolvedDestinationIds.length > 1 ? "Transfers sent." : "Transfer sent.");
+        gameToast.success(resolvedDestinationIds.length > 1 ? "Transfers sent." : "Transfer sent.");
         setStatusMessage(resolvedDestinationIds.length > 1 ? "Transfers started" : "Transfer started");
       } catch (e) {
         console.error(e);
-        toast.error("Transfer failed.");
+        gameToast.error("Transfer failed.");
         setStatusMessage("Transfer failed");
       } finally {
         setIsSubmitting(false);
@@ -776,19 +776,19 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
           calls,
         });
         immediateRunTimestamp = Date.now();
-        toast.success(
+        gameToast.success(
           resolvedDestinationIds.length > 1 ? "Transfers sent and scheduled." : "Transfer sent and scheduled.",
         );
         setStatusMessage(
           resolvedDestinationIds.length > 1 ? "Transfers started and scheduled" : "Transfer started and scheduled",
         );
       } else {
-        toast.warning("Nothing to send now. Scheduling for later.");
+        gameToast.warning("Nothing to send now. Scheduling for later.");
         setStatusMessage("Scheduled for later");
       }
     } catch (e) {
       console.error(e);
-      toast.error("Immediate run failed. Scheduled for later.");
+      gameToast.error("Immediate run failed. Scheduled for later.");
       setStatusMessage("Scheduled; immediate run failed");
     }
 
@@ -813,7 +813,9 @@ export const TransferAutomationPanel = ({ initialSourceId }: TransferAutomationP
         lastRunAt: immediateRunTimestamp,
       });
     });
-    toast.success(resolvedDestinationIds.length > 1 ? "Scheduled transfers created." : "Scheduled transfer created.");
+    gameToast.success(
+      resolvedDestinationIds.length > 1 ? "Scheduled transfers created." : "Scheduled transfer created.",
+    );
     setIsSubmitting(false);
   }, [
     components,

--- a/client/apps/game/src/ui/features/factory-v2/hooks/use-factory-v2-developer-config.ts
+++ b/client/apps/game/src/ui/features/factory-v2/hooks/use-factory-v2-developer-config.ts
@@ -21,7 +21,7 @@ import type {
   FactoryDeveloperConfigDraft,
 } from "../developer/types";
 import type { FactoryGameMode, FactoryLaunchChain } from "../types";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 type FactoryConfigManifestState = {
   status: "loading" | "ready" | "error";
@@ -339,7 +339,7 @@ export const useFactoryV2DeveloperConfig = ({ mode, chain }: { mode: FactoryGame
     }
 
     if (hasConnectedWallet && status === "detecting") {
-      toast.info("Detecting wallet network. Try again in a moment.");
+      gameToast.info("Detecting wallet network. Try again in a moment.");
       return;
     }
 

--- a/client/apps/game/src/ui/features/landing/components/game-review-modal.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-review-modal.tsx
@@ -18,7 +18,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toPng } from "html-to-image";
 import { ArrowLeft, ArrowRight, Copy, Flag, Gift, Loader2, Share2, Shield, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MutableRefObject } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { useGameReviewData } from "../hooks/use-game-review-data";
 import { UnifiedGameGrid, type GameData, type WorldSelection } from "./game-selector/game-card-grid";
@@ -813,11 +813,11 @@ export const GameReviewModal = ({
     onSuccess: async (result) => {
       setSubmitTxError(null);
       if (result.mmrError) {
-        toast("Score submission completed with MMR pending.", {
+        gameToast("Score submission completed with MMR pending.", {
           description: `${result.totalPlayers} players processed. Retry MMR independently from this step.`,
         });
       } else {
-        toast.success("Score submission completed.", {
+        gameToast.success("Score submission completed.", {
           description: result.mmrSubmitted
             ? `${result.totalPlayers} players processed. MMR committed.`
             : `${result.totalPlayers} players processed. MMR was optional or unavailable.`,
@@ -839,14 +839,14 @@ export const GameReviewModal = ({
       if (isSubmissionWindowError && reviewData) {
         const description = getScoreSubmissionLockedDescription(reviewData.finalization, nowTs);
         setSubmitTxError(`Score submission is not open yet. ${description}`);
-        toast.error("Score submission is not open yet.", {
+        gameToast.error("Score submission is not open yet.", {
           description,
         });
         return;
       }
 
       setSubmitTxError(errorMessage);
-      toast.error("Failed to submit score or MMR.", { description: errorMessage });
+      gameToast.error("Failed to submit score or MMR.", { description: errorMessage });
     },
   });
 
@@ -884,7 +884,7 @@ export const GameReviewModal = ({
           claimBlockedReason: "Rewards already claimed.",
         };
       });
-      toast.success("Rewards claimed.");
+      gameToast.success("Rewards claimed.");
       await queryClient.invalidateQueries({ queryKey: reviewQueryKey });
       await queryClient.invalidateQueries({ queryKey: reviewClaimSummaryQueryKey });
     },
@@ -892,7 +892,7 @@ export const GameReviewModal = ({
       console.error("Failed to claim rewards", caughtError);
       const errorMessage = getErrorMessage(caughtError, "Unknown error while claiming rewards.");
       setClaimTxError(errorMessage);
-      toast.error("Failed to claim rewards.", { description: errorMessage });
+      gameToast.error("Failed to claim rewards.", { description: errorMessage });
     },
   });
 
@@ -904,14 +904,14 @@ export const GameReviewModal = ({
 
     if (reviewData) {
       if (reviewData.finalization.devModeOn) {
-        toast.error("Score submission is disabled for dev mode games.");
+        gameToast.error("Score submission is disabled for dev mode games.");
         return;
       }
 
       const retryAvailable = canRetryMmrUpdate(reviewData);
       if (reviewData.finalization.rankingFinalized) {
         if (!retryAvailable) {
-          toast.error("MMR retry is unavailable.", {
+          gameToast.error("MMR retry is unavailable.", {
             description: getMmrStatus(reviewData),
           });
           return;
@@ -920,7 +920,7 @@ export const GameReviewModal = ({
         const secondsUntilOpen = getSecondsUntilScoreSubmissionOpen(reviewData.finalization, nowTs);
         if (secondsUntilOpen == null || secondsUntilOpen > 0) {
           const description = getScoreSubmissionLockedDescription(reviewData.finalization, nowTs);
-          toast.error("Score submission is not open yet.", {
+          gameToast.error("Score submission is not open yet.", {
             description,
           });
           return;
@@ -943,12 +943,12 @@ export const GameReviewModal = ({
     if (!isStepShareable || !captureRef.current) return;
 
     if (typeof window === "undefined") {
-      toast.error("Copying images is not supported in this environment.");
+      gameToast.error("Copying images is not supported in this environment.");
       return;
     }
 
     if (!("ClipboardItem" in window) || !navigator.clipboard?.write) {
-      toast.error("Copying images is not supported in this browser.");
+      gameToast.error("Copying images is not supported in this browser.");
       return;
     }
 
@@ -1016,10 +1016,10 @@ export const GameReviewModal = ({
         }, "image/png");
       });
       await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-      toast.success("Step image copied to clipboard.");
+      gameToast.success("Step image copied to clipboard.");
     } catch (caughtError) {
       console.error("Failed to copy review step image", caughtError);
-      toast.error("Could not copy the image.");
+      gameToast.error("Could not copy the image.");
     } finally {
       setIsCopying(false);
     }
@@ -1045,7 +1045,7 @@ export const GameReviewModal = ({
   const handleNextStep = useCallback(() => {
     if (!canProceedToNextStep) {
       if (nextStepBlockedReason) {
-        toast.error(nextStepBlockedReason);
+        gameToast.error(nextStepBlockedReason);
       }
       return;
     }

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -35,7 +35,7 @@ import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, Eye, Loader2, LogIn, Play, RefreshCw, Sparkles, Trophy, UserPlus, Users } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import {
   createPendingNetworkAction,
   resolvePendingNetworkSwitchOutcome,
@@ -377,7 +377,7 @@ const GameCard = ({
   const runWithNetworkGuard = useCallback(
     (action: () => void, targetChain: Chain = game.chain, context: "game" | "market" = "game") => {
       if (hasConnectedWallet && status === "detecting") {
-        toast.info("Detecting wallet network. Try again in a moment.");
+        gameToast.info("Detecting wallet network. Try again in a moment.");
         return;
       }
 
@@ -411,7 +411,7 @@ const GameCard = ({
   const canEnterRegisteredBlitz = isBlitzMode && showRegistered && (isUpcoming || isOngoing);
   const canPlay = !isUnknownMode && (canEnterRegisteredBlitz || canOpenEternumEntry);
 
-  // Handle settle entry with toast notification.
+  // Handle settle entry with gameToast notification.
   const handleSettle = useCallback(() => {
     runWithNetworkGuard(() => {
       void settle().catch((err) => {
@@ -462,7 +462,7 @@ const GameCard = ({
     [marketSnapshot, runWithNetworkGuard, toggleModal],
   );
 
-  // Show success toast when settlement completes.
+  // Show success gameToast when settlement completes.
   useEffect(() => {
     if (entryStage !== "done") {
       handledSettlementStageRef.current = false;
@@ -472,7 +472,7 @@ const GameCard = ({
     if (handledSettlementStageRef.current) return;
     handledSettlementStageRef.current = true;
 
-    toast.success("Settlement successful!", {
+    gameToast.success("Settlement successful!", {
       description: `You are now settled in ${game.name}.`,
     });
     onRegistrationComplete?.(game.worldKey);

--- a/client/apps/game/src/ui/features/landing/components/player-profile.tsx
+++ b/client/apps/game/src/ui/features/landing/components/player-profile.tsx
@@ -44,7 +44,7 @@ import Loader2 from "lucide-react/dist/esm/icons/loader-2";
 import Share2 from "lucide-react/dist/esm/icons/share-2";
 import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { hash } from "starknet";
 import { env } from "../../../../../env";
@@ -357,32 +357,32 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
 
   const handleGenerateAvatar = useCallback(async () => {
     if (!avatarPrompt.trim()) {
-      toast.error("Please enter a description for your avatar.");
+      gameToast.error("Please enter a description for your avatar.");
       return;
     }
     if (hasReachedDailyLimit) {
-      toast.error("Daily avatar generation limit reached. Try again later.");
+      gameToast.error("Daily avatar generation limit reached. Try again later.");
       return;
     }
 
     try {
       const result = await generateAvatar.mutateAsync({ prompt: avatarPrompt.trim() });
-      toast.success("Avatar generated successfully!");
+      gameToast.success("Avatar generated successfully!");
       setLastGeneratedImages(result.imageUrls ?? []);
       setAvatarPrompt("");
     } catch (error: unknown) {
       console.error("Failed to generate avatar:", error);
-      toast.error(getErrorMessage(error, "Failed to generate avatar. Please try again."));
+      gameToast.error(getErrorMessage(error, "Failed to generate avatar. Please try again."));
     }
   }, [avatarPrompt, generateAvatar, hasReachedDailyLimit]);
 
   const handleDeleteAvatar = useCallback(async () => {
     try {
       await deleteAvatar.mutateAsync();
-      toast.success("Avatar deleted. Using default avatar now.");
+      gameToast.success("Avatar deleted. Using default avatar now.");
     } catch (error) {
       console.error("Failed to delete avatar:", error);
-      toast.error("Failed to delete avatar. Please try again.");
+      gameToast.error("Failed to delete avatar. Please try again.");
     }
   }, [deleteAvatar]);
 
@@ -393,16 +393,16 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
       }
 
       if (!connectedPlayerAddress || !hasOwnDisplayName) {
-        toast.error("Connect with Cartridge to select an avatar.");
+        gameToast.error("Connect with Cartridge to select an avatar.");
         return;
       }
 
       try {
         await selectAvatar.mutateAsync(imageUrl);
-        toast.success("Avatar updated.");
+        gameToast.success("Avatar updated.");
       } catch (error: unknown) {
         console.error("Failed to set avatar:", error);
-        toast.error(getErrorMessage(error, "Failed to set avatar. Please try again."));
+        gameToast.error(getErrorMessage(error, "Failed to set avatar. Please try again."));
       }
     },
     [connectedPlayerAddress, hasOwnDisplayName, myAvatar?.avatarUrl, selectAvatar],
@@ -483,7 +483,7 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
 
   const handleCopyProfilePng = useCallback(async () => {
     if (!profileCardRef.current) {
-      toast.error("Profile card is still loading.");
+      gameToast.error("Profile card is still loading.");
       return;
     }
 
@@ -497,13 +497,13 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
       });
 
       if (result === "copied") {
-        toast.success("Profile image copied to clipboard!");
+        gameToast.success("Profile image copied to clipboard!");
       } else {
-        toast.info("Clipboard not available; downloaded image instead.");
+        gameToast.info("Clipboard not available; downloaded image instead.");
       }
     } catch (error) {
       console.error("Failed to copy profile image", error);
-      toast.error("Copy failed. Please try again.");
+      gameToast.error("Copy failed. Please try again.");
     } finally {
       setIsCopyingProfileCard(false);
     }
@@ -512,7 +512,7 @@ export const LandingPlayer = ({ selectedPlayerAddress, selectedPlayerName, varia
   const handleShareProfileOnX = useCallback(() => {
     const didOpen = openShareOnX(profileShareMessage);
     if (!didOpen) {
-      toast.error("Sharing is not supported in this environment.");
+      gameToast.error("Sharing is not supported in this environment.");
     }
   }, [profileShareMessage]);
 

--- a/client/apps/game/src/ui/features/landing/components/score-card-content.tsx
+++ b/client/apps/game/src/ui/features/landing/components/score-card-content.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { Copy, Loader2, Share2 } from "lucide-react";
 
 import { Button } from "@/ui/design-system/atoms";
@@ -80,7 +80,7 @@ export const ScoreCardContent = ({
 
   const handleCopyImage = useCallback(async () => {
     if (!highlightPlayer || !cardRef.current) {
-      toast.error("Your highlight card is still loading.");
+      gameToast.error("Your highlight card is still loading.");
       return;
     }
 
@@ -106,13 +106,13 @@ export const ScoreCardContent = ({
       });
 
       if (result === "copied") {
-        toast.success("Copied highlight image to clipboard!");
+        gameToast.success("Copied highlight image to clipboard!");
       } else {
-        toast.info("Clipboard not available; downloaded image instead.");
+        gameToast.info("Clipboard not available; downloaded image instead.");
       }
     } catch (caughtError) {
       console.error("Failed to copy highlight image", caughtError);
-      toast.error("Copy failed. Please try again.");
+      gameToast.error("Copy failed. Please try again.");
     } finally {
       setIsCopyingImage(false);
     }
@@ -120,13 +120,13 @@ export const ScoreCardContent = ({
 
   const handleShareOnX = useCallback(() => {
     if (!highlightPlayer) {
-      toast.error("Final standings are still loading.");
+      gameToast.error("Final standings are still loading.");
       return;
     }
 
     const didOpen = openShareOnX(shareMessage);
     if (!didOpen) {
-      toast.error("Sharing is not supported in this environment.");
+      gameToast.error("Sharing is not supported in this environment.");
     }
   }, [highlightPlayer, shareMessage]);
 
@@ -135,8 +135,8 @@ export const ScoreCardContent = ({
 
     navigator.clipboard
       .writeText(shareMessage)
-      .then(() => toast.success("Message copied to clipboard!"))
-      .catch(() => toast.error("Failed to copy message"));
+      .then(() => gameToast.success("Message copied to clipboard!"))
+      .catch(() => gameToast.error("Failed to copy message"));
   }, [shareMessage]);
 
   if (isLoading) {

--- a/client/apps/game/src/ui/features/landing/views/markets-view.tsx
+++ b/client/apps/game/src/ui/features/landing/views/markets-view.tsx
@@ -40,7 +40,7 @@ import { MaybeController } from "@/ui/features/market/landing-markets/maybe-cont
 import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { hash } from "starknet";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { MarketDetailsModal } from "./market-details-modal";
 
 interface MarketsViewProps {
@@ -606,7 +606,7 @@ const MarketsViewContent = ({ className }: MarketsViewProps) => {
   const handleOpenSwitchNetworkPrompt = useCallback(
     (chain: MarketDataChain) => {
       if (status === "detecting") {
-        toast.info("Detecting wallet network. Try again in a moment.");
+        gameToast.info("Detecting wallet network. Try again in a moment.");
         return;
       }
 

--- a/client/apps/game/src/ui/features/market/hooks/use-quick-market-create.ts
+++ b/client/apps/game/src/ui/features/market/hooks/use-quick-market-create.ts
@@ -1,6 +1,6 @@
 import { useCall } from "@starknet-react/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { CairoCustomEnum, Call, CallData, uint256, type Abi, type RawArgsObject, type Uint256 } from "starknet";
 
 import { useAccountStore } from "@/hooks/store/use-account-store";
@@ -438,7 +438,7 @@ export const useQuickMarketCreate = (
     const checkForExistingMarket = async () => {
       const exists = await checkMarketExists(oracleAddress);
       if (exists) {
-        toast.info("A market was just created for this game!");
+        gameToast.info("A market was just created for this game!");
         onMarketFoundRef.current?.();
       }
     };
@@ -467,7 +467,7 @@ export const useQuickMarketCreate = (
         } else {
           // Add player (if under limit)
           if (current.length >= MAX_SELECTED_PLAYERS) {
-            toast.error(`Maximum ${MAX_SELECTED_PLAYERS} players can be selected`);
+            gameToast.error(`Maximum ${MAX_SELECTED_PLAYERS} players can be selected`);
             return current;
           }
           return [...current, player];
@@ -569,7 +569,7 @@ export const useQuickMarketCreate = (
       if (marketAlreadyExists) {
         const errorMsg = "A market already exists for this game. Refreshing...";
         setCreateError(errorMsg);
-        toast.error(errorMsg);
+        gameToast.error(errorMsg);
         setIsCreating(false);
         // Notify parent to refresh and show existing market
         onMarketFoundRef.current?.();
@@ -604,7 +604,7 @@ export const useQuickMarketCreate = (
     if (!params) {
       const errorMsg = "Failed to build market parameters";
       setCreateError(errorMsg);
-      toast.error(errorMsg);
+      gameToast.error(errorMsg);
       return;
     }
 
@@ -612,7 +612,7 @@ export const useQuickMarketCreate = (
     if (fundingBase == null) {
       const errorMsg = "Invalid funding amount";
       setCreateError(errorMsg);
-      toast.error(errorMsg);
+      gameToast.error(errorMsg);
       return;
     }
 
@@ -644,12 +644,12 @@ export const useQuickMarketCreate = (
         worldName,
       });
 
-      toast.success(`Prediction market created for ${worldName}!`);
+      gameToast.success(`Prediction market created for ${worldName}!`);
     } catch (e) {
       console.error("[useQuickMarketCreate] Error:", e);
       const message = e instanceof Error ? e.message : "Failed to create market";
       setCreateError(message);
-      toast.error(message);
+      gameToast.error(message);
     } finally {
       setIsCreating(false);
     }

--- a/client/apps/game/src/ui/features/market/landing-markets/details/market-resolution.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/details/market-resolution.tsx
@@ -9,7 +9,7 @@ import { getContractByName } from "@dojoengine/core";
 import { HStack, VStack } from "@pm/ui";
 import { useAccount } from "@starknet-react/core";
 import Loader2 from "lucide-react/dist/esm/icons/loader-2";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { Call, uint256 } from "starknet";
 
 import { buildWorldProfile, getFactorySqlBaseUrl, patchManifestWithFactory, useRuntimeChain } from "@/runtime/world";
@@ -92,7 +92,7 @@ const waitForTxConfirmationIfAvailable = async (
   } catch (error) {
     // Keep UX responsive when providers fail to report confirmation despite successful execution.
     // The tx is already submitted at this point.
-    toast.message("Transaction submitted. Confirmation is delayed in wallet RPC; data may update after refresh.");
+    gameToast.message("Transaction submitted. Confirmation is delayed in wallet RPC; data may update after refresh.");
     return false;
   }
 };
@@ -361,13 +361,13 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
       const { suppressErrorToast = false, suppressSuccessToast = false } = options;
       if (serverLookupStatus !== "done") {
         if (!suppressErrorToast) {
-          toast.error("Resolving game name… please wait.");
+          gameToast.error("Resolving game name… please wait.");
         }
         return false;
       }
       if (!account) {
         if (!suppressErrorToast) {
-          toast.error("Connect a wallet to resolve the market.");
+          gameToast.error("Connect a wallet to resolve the market.");
         }
         return false;
       }
@@ -375,7 +375,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
       const marketAddress = getContractByName(manifest, "pm", "Markets")?.address;
       if (!marketAddress) {
         if (!suppressErrorToast) {
-          toast.error("Market contract not found in manifest.");
+          gameToast.error("Market contract not found in manifest.");
         }
         return false;
       }
@@ -409,13 +409,13 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
           "Resolve transaction",
         );
         if (!suppressSuccessToast) {
-          toast.success("Market resolved");
+          gameToast.success("Market resolved");
         }
         return true;
       } catch (error) {
         console.error("Failed to resolve market", error);
         if (!suppressErrorToast) {
-          toast.error("Failed to resolve market");
+          gameToast.error("Failed to resolve market");
         }
         return false;
       } finally {
@@ -430,25 +430,25 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
       const { suppressErrorToast = false, suppressSuccessToast = false } = options;
       if (hasFinalRanking) {
         if (!suppressSuccessToast) {
-          toast.success("Scores are already computed (PlayersRankFinal exists).");
+          gameToast.success("Scores are already computed (PlayersRankFinal exists).");
         }
         return "already-computed";
       }
       if (!market.isEnded()) {
         if (!suppressErrorToast) {
-          toast.error("Scores can only be computed after the game ends.");
+          gameToast.error("Scores can only be computed after the game ends.");
         }
         return "skipped";
       }
       if (!account) {
         if (!suppressErrorToast) {
-          toast.error("Connect a wallet to compute scores.");
+          gameToast.error("Connect a wallet to compute scores.");
         }
         return "skipped";
       }
       if (!serverName) {
         if (!suppressErrorToast) {
-          toast.error("Could not determine the game name to load players.");
+          gameToast.error("Could not determine the game name to load players.");
         }
         return "skipped";
       }
@@ -462,7 +462,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
         if (playerAddresses.length === 0) {
           setComputeStatus(null);
           if (!suppressErrorToast) {
-            toast.error("No registered players found for this game.");
+            gameToast.error("No registered players found for this game.");
           }
           return "failed";
         }
@@ -479,7 +479,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
         if (!prizeContract?.address) {
           setComputeStatus(null);
           if (!suppressErrorToast) {
-            toast.error("Prize distribution contract not found for this world.");
+            gameToast.error("Prize distribution contract not found for this world.");
           }
           return "failed";
         }
@@ -489,7 +489,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
           if (!solePlayer) {
             setComputeStatus(null);
             if (!suppressErrorToast) {
-              toast.error("Could not determine the registered player address.");
+              gameToast.error("Could not determine the registered player address.");
             }
             return "failed";
           }
@@ -524,7 +524,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
           );
           setComputeStatus("Single-player claim submitted.");
           if (!suppressSuccessToast) {
-            toast.success("Single registered player — prize claim submitted.");
+            gameToast.success("Single registered player — prize claim submitted.");
           }
           return "submitted";
         }
@@ -569,7 +569,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
 
         setComputeStatus("Score computation submitted.");
         if (!suppressSuccessToast) {
-          toast.success("Scores computation submitted.");
+          gameToast.success("Scores computation submitted.");
         }
         refetchRanks();
         return "submitted";
@@ -577,7 +577,7 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
         console.error("Failed to compute scores", error);
         setComputeStatus("Failed to compute scores.");
         if (!suppressErrorToast) {
-          toast.error("Failed to compute scores");
+          gameToast.error("Failed to compute scores");
         }
         return "failed";
       } finally {
@@ -607,14 +607,14 @@ export const useMarketResolutionController = (market: MarketClass, chain?: Chain
       });
 
       if (resolved) {
-        toast.success("Market resolved");
+        gameToast.success("Market resolved");
         return true;
       }
 
       if (computeResult === "failed") {
-        toast.error("Failed to compute scores and resolve market.");
+        gameToast.error("Failed to compute scores and resolve market.");
       } else {
-        toast.error("Failed to resolve market");
+        gameToast.error("Failed to resolve market");
       }
       return false;
     } finally {

--- a/client/apps/game/src/ui/features/market/landing-markets/details/market-trade.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/details/market-trade.tsx
@@ -3,7 +3,7 @@ import Loader2 from "lucide-react/dist/esm/icons/loader-2";
 import TrendingUp from "lucide-react/dist/esm/icons/trending-up";
 import { useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { BigNumberish, Call, uint256 } from "starknet";
 
 import { useAccountStore } from "@/hooks/store/use-account-store";
@@ -425,23 +425,23 @@ export function MarketTrade({
 
   const onBuy = async (outcomeIndex: number) => {
     if (!account) {
-      toast.error("Connect a wallet to trade.");
+      gameToast.error("Connect a wallet to trade.");
       return;
     }
     if (!marketContractAddress) {
-      toast.error("Market contract address is not configured.");
+      gameToast.error("Market contract address is not configured.");
       return;
     }
 
     const collateralAddress = market.collateral_token || market.collateralToken?.contract_address;
     if (!collateralAddress) {
-      toast.error("Collateral token address is missing.");
+      gameToast.error("Collateral token address is missing.");
       return;
     }
 
     const baseAmount = parseLordsToBaseUnits(amount, collateralDecimals);
     if (baseAmount == null || baseAmount <= 0n) {
-      toast.error("Enter a valid amount greater than 0.");
+      gameToast.error("Enter a valid amount greater than 0.");
       return;
     }
 
@@ -472,7 +472,7 @@ export function MarketTrade({
         operation: "market_buy",
       });
 
-      toast.success("Trade submitted successfully!");
+      gameToast.success("Trade submitted successfully!");
       if (onTradeSuccess) {
         void Promise.resolve(onTradeSuccess()).catch((callbackError) => {
           console.error("[MarketTrade] post-trade sync callback failed:", callbackError);
@@ -480,7 +480,7 @@ export function MarketTrade({
       }
     } catch (error) {
       console.error(error);
-      toast.error(tryBetterErrorMsg(error));
+      gameToast.error(tryBetterErrorMsg(error));
     } finally {
       setIsSubmitting(false);
     }

--- a/client/apps/game/src/ui/features/market/landing-markets/details/market-vault-fees.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/details/market-vault-fees.tsx
@@ -14,7 +14,7 @@ import { useQuery } from "@tanstack/react-query";
 import ArrowDown from "lucide-react/dist/esm/icons/arrow-down";
 import Loader2 from "lucide-react/dist/esm/icons/loader-2";
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { addAddressPadding, Call, uint256 } from "starknet";
 import { TokenIcon } from "../token-icon";
 
@@ -130,11 +130,11 @@ export function MarketVaultFees({
   // TODO: multicall with redeem tokens
   const claim = async () => {
     if (!account) {
-      toast.error("Connect a wallet to claim fees.");
+      gameToast.error("Connect a wallet to claim fees.");
       return;
     }
     if (!canClaim) {
-      toast.error("You can only claim after the market is resolved.");
+      gameToast.error("You can only claim after the market is resolved.");
       return;
     }
 
@@ -167,7 +167,7 @@ export function MarketVaultFees({
       }
 
       if (calls.length === 0) {
-        toast.error("No claimable fees found.");
+        gameToast.error("No claimable fees found.");
         return;
       }
 
@@ -178,10 +178,10 @@ export function MarketVaultFees({
         operation: "market_claim_vault_fees",
       });
 
-      toast.success("Vault Fees claimed!");
+      gameToast.success("Vault Fees claimed!");
     } catch (error) {
       console.error(error);
-      toast.error(error instanceof Error ? error.message : "Failed to claim vault fees.");
+      gameToast.error(error instanceof Error ? error.message : "Failed to claim vault fees.");
     } finally {
       setIsSubmitting(false);
     }

--- a/client/apps/game/src/ui/features/market/landing-markets/use-market-redeem.ts
+++ b/client/apps/game/src/ui/features/market/landing-markets/use-market-redeem.ts
@@ -14,7 +14,7 @@ import { formatUnits } from "@/pm/utils";
 import { getContractByName } from "@dojoengine/core";
 import { useAccount } from "@starknet-react/core";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { addAddressPadding, Call, uint256 } from "starknet";
 
 type MarketDataChain = "slot" | "mainnet";
@@ -217,7 +217,7 @@ export const useMarketRedeem = (
   const redeem = async () => {
     if (!market) return;
     if (!account) {
-      toast.error("Connect a wallet to claim.");
+      gameToast.error("Connect a wallet to claim.");
       return;
     }
 
@@ -226,12 +226,12 @@ export const useMarketRedeem = (
     const vaultPositionsAddress = getContractByName(config.manifest, "pm", "VaultPositions")?.address;
 
     if (!marketContractAddress || !conditionalTokensAddress || !vaultPositionsAddress) {
-      toast.error("Missing contract addresses for redeem.");
+      gameToast.error("Missing contract addresses for redeem.");
       return;
     }
 
     if (!market.isResolved()) {
-      toast.error("Claims unlock once the market is resolved.");
+      gameToast.error("Claims unlock once the market is resolved.");
       return;
     }
 
@@ -323,7 +323,7 @@ export const useMarketRedeem = (
       }
 
       if (calls.length === 0) {
-        toast.error("No claims to process.");
+        gameToast.error("No claims to process.");
         return;
       }
 
@@ -358,12 +358,12 @@ export const useMarketRedeem = (
             },
             txHash,
           );
-          toast.success(confirmed ? "Claim confirmed." : "Claim submitted.");
+          gameToast.success(confirmed ? "Claim confirmed." : "Claim submitted.");
         } catch (confirmError) {
-          toast.success("Claim submitted. Confirmation is delayed; refresh shortly.");
+          gameToast.success("Claim submitted. Confirmation is delayed; refresh shortly.");
         }
       } else {
-        toast.success("Claim submitted.");
+        gameToast.success("Claim submitted.");
       }
 
       // Hide stale claim CTA immediately after a successful claim submit/confirm
@@ -382,7 +382,7 @@ export const useMarketRedeem = (
         setSuppressClaimUi(true);
         setTimeout(() => setSuppressClaimUi(false), 5 * 60_000);
       }
-      toast.error(error instanceof Error ? error.message : "Failed to submit claim transaction.");
+      gameToast.error(error instanceof Error ? error.message : "Failed to submit claim transaction.");
     } finally {
       setIsRedeeming(false);
     }

--- a/client/apps/game/src/ui/features/market/landing-markets/use-market-watch.ts
+++ b/client/apps/game/src/ui/features/market/landing-markets/use-market-watch.ts
@@ -5,7 +5,7 @@ import { buildEntryHref } from "@/play/navigation/play-route";
 import { buildWorldProfile, getFactorySqlBaseUrl, patchManifestWithFactory } from "@/runtime/world";
 import { isToriiAvailable } from "@/runtime/world/factory-resolver";
 import { Chain, getGameManifest } from "@contracts";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { decodePaddedFeltAscii } from "./market-utils";
 
@@ -192,7 +192,7 @@ export const useMarketWatch = (chain: Chain) => {
       try {
         const worldName = await checkWatchability(market);
         if (!worldName) {
-          toast.error("This game is offline or unavailable.");
+          gameToast.error("This game is offline or unavailable.");
           return;
         }
 
@@ -206,11 +206,11 @@ export const useMarketWatch = (chain: Chain) => {
         });
         const newTab = window.open(playUrl, "_blank", "noopener,noreferrer");
         if (!newTab) {
-          toast.error("Enable pop-ups to watch this game.");
+          gameToast.error("Enable pop-ups to watch this game.");
         }
       } catch (error) {
         console.error("[market-watch] Failed to open game for market", error);
-        toast.error("Failed to open the game for this market.");
+        gameToast.error("Failed to open the game for this market.");
       } finally {
         setWatchingMarketId((current) => (current === marketId ? null : current));
       }

--- a/client/apps/game/src/ui/features/military/components/exploration-automation-dashboard.test.tsx
+++ b/client/apps/game/src/ui/features/military/components/exploration-automation-dashboard.test.tsx
@@ -106,8 +106,8 @@ vi.mock("lucide-react", () => {
   };
 });
 
-vi.mock("sonner", () => ({
-  toast: mocks.toast,
+vi.mock("@/ui/shared/game-toast", () => ({
+  gameToast: mocks.toast,
 }));
 
 const waitForAsyncWork = async () => {

--- a/client/apps/game/src/ui/features/military/components/exploration-automation-dashboard.tsx
+++ b/client/apps/game/src/ui/features/military/components/exploration-automation-dashboard.tsx
@@ -15,7 +15,7 @@ import { getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import { Bot, MapPin, Pause, Play, RotateCw, Square, Trash2 } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { useShallow } from "zustand/react/shallow";
 
 const formatRelativeTime = (timestamp?: number | null): string => {
@@ -248,28 +248,28 @@ const ExplorationAutomationContent = ({ onNavigate, compact = false }: Explorati
   const handlePauseAll = useCallback(() => {
     const activeCount = list.filter((e) => e.active).length;
     if (activeCount === 0) {
-      toast.info("No active automations to pause.");
+      gameToast.info("No active automations to pause.");
       return;
     }
     pauseAll();
-    toast.success(`Paused ${activeCount} exploration${activeCount > 1 ? "s" : ""}.`);
+    gameToast.success(`Paused ${activeCount} exploration${activeCount > 1 ? "s" : ""}.`);
   }, [list, pauseAll]);
 
   const handleResumeAll = useCallback(() => {
     const pausedCount = list.filter((e) => !e.active).length;
     if (pausedCount === 0) {
-      toast.info("No paused automations to resume.");
+      gameToast.info("No paused automations to resume.");
       return;
     }
     resumeAll();
-    toast.success(`Resumed ${pausedCount} exploration${pausedCount > 1 ? "s" : ""}.`);
+    gameToast.success(`Resumed ${pausedCount} exploration${pausedCount > 1 ? "s" : ""}.`);
   }, [list, resumeAll]);
 
   const handleGoToExplorer = useCallback(
     (entry: ExplorationAutomationEntry) => {
       const pos = explorerPositions[entry.id];
       if (!pos) {
-        toast.error("Explorer position unknown.");
+        gameToast.error("Explorer position unknown.");
         return;
       }
       onNavigate?.();
@@ -281,7 +281,7 @@ const ExplorationAutomationContent = ({ onNavigate, compact = false }: Explorati
   const handleRemove = useCallback(
     (entry: ExplorationAutomationEntry) => {
       remove(entry.id);
-      toast.success("Automation removed.");
+      gameToast.success("Automation removed.");
     },
     [remove],
   );
@@ -289,7 +289,7 @@ const ExplorationAutomationContent = ({ onNavigate, compact = false }: Explorati
   const handleRunNow = useCallback(
     (entry: ExplorationAutomationEntry) => {
       runNow(entry.id);
-      toast.success("Running exploration now.");
+      gameToast.success("Running exploration now.");
     },
     [runNow],
   );

--- a/client/apps/game/src/ui/features/prize/prize-panel.tsx
+++ b/client/apps/game/src/ui/features/prize/prize-panel.tsx
@@ -14,7 +14,7 @@ import Info from "lucide-react/dist/esm/icons/info";
 import Trophy from "lucide-react/dist/esm/icons/trophy";
 import Users from "lucide-react/dist/esm/icons/users";
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { dojoConfig } from "../../../../dojo-config";
 import { env } from "../../../../env";
 import { ClaimBlitzPrizeButton } from "./components/claim-blitz-prize-button";
@@ -340,7 +340,7 @@ export const PrizePanel = () => {
         setSubmission({ phase: "submitting_ranks", message: "Submitting single-player prize claim..." });
         await blitz_prize_claim_no_game({ signer: account, registered_player: onlyRegistered.toString() });
         setSubmission({ phase: "success", message: "Single-player prize claim submitted." });
-        toast("Submitted single-player prize claim", {
+        gameToast("Submitted single-player prize claim", {
           description: `Entry fee returned to ${displayAddress(toHexString(onlyRegistered))}.`,
         });
         return;
@@ -402,7 +402,7 @@ export const PrizePanel = () => {
             phase: "success",
             message: `Rankings and MMR submitted for ${sortedAddresses.length} players.`,
           });
-          toast("Submitted blitz rankings and MMR update", {
+          gameToast("Submitted blitz rankings and MMR update", {
             description: `Ranking finalized and MMR updated for ${sortedAddresses.length} players.`,
           });
         } catch (mmrError: unknown) {
@@ -414,7 +414,7 @@ export const PrizePanel = () => {
             errorStage: "mmr",
             errorMessage,
           });
-          toast("Submitted blitz rankings", {
+          gameToast("Submitted blitz rankings", {
             description: `Ranking finalized. MMR update failed: ${errorMessage}`,
           });
         }
@@ -432,7 +432,7 @@ export const PrizePanel = () => {
           phase: "success",
           message: mmrSkipReason ? `Rankings submitted. ${mmrSkipReason}` : "Rankings submitted.",
         });
-        toast("Submitted blitz rankings", { description: `Ranking reference ${String(trialId)} updated.` });
+        gameToast("Submitted blitz rankings", { description: `Ranking reference ${String(trialId)} updated.` });
       }
     } catch (e: unknown) {
       console.error(e);
@@ -443,7 +443,7 @@ export const PrizePanel = () => {
         errorStage: "ranking",
         errorMessage,
       });
-      toast("❌ Blitz ranking failed", { description: errorMessage });
+      gameToast("❌ Blitz ranking failed", { description: errorMessage });
     }
   };
 
@@ -542,7 +542,7 @@ export const PrizePanel = () => {
         phase: "success",
         message: `MMR updated for ${sortedAddresses.length} players.`,
       });
-      toast("Submitted MMR update", {
+      gameToast("Submitted MMR update", {
         description: `MMR updated for ${sortedAddresses.length} players.`,
       });
     } catch (e: unknown) {
@@ -552,7 +552,7 @@ export const PrizePanel = () => {
         phase: "error",
         message: errorMessage,
       });
-      toast("MMR update failed", { description: errorMessage });
+      gameToast("MMR update failed", { description: errorMessage });
     }
   };
 

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.test.ts
@@ -36,8 +36,8 @@ const {
   toastError: vi.fn(),
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
+vi.mock("@/ui/shared/game-toast", () => ({
+  gameToast: {
     error: toastError,
   },
 }));

--- a/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
+++ b/client/apps/game/src/ui/features/settlement/construction/realm-build-actions.ts
@@ -1,6 +1,6 @@
 import { BUILDINGS_CENTER, BuildingType, getNeighborHexes, ResourcesIds } from "@bibliothecadao/types";
 import { TileManager } from "@bibliothecadao/eternum";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import {
   getBuildReservationState,
   releaseOccupiedBuildSpot,
@@ -225,7 +225,7 @@ export const buildRealmBuilding = async ({
   onBuildSuccess,
 }: RealmBuildActionOptions) => {
   if (!realmPosition) {
-    toast.error("Select a realm before building.");
+    gameToast.error("Select a realm before building.");
     return false;
   }
 
@@ -239,7 +239,7 @@ export const buildRealmBuilding = async ({
   });
 
   if (!baseBuildability.canSubmit) {
-    toast.error(baseBuildability.reason ?? "Building cannot be submitted.");
+    gameToast.error(baseBuildability.reason ?? "Building cannot be submitted.");
     return false;
   }
 
@@ -250,7 +250,7 @@ export const buildRealmBuilding = async ({
   const availableSpots = resolveAvailableBuildSpots(tileManager, reservedSpots, candidates);
 
   if (availableSpots.length === 0) {
-    toast.error("No empty building tiles available.");
+    gameToast.error("No empty building tiles available.");
     return false;
   }
 
@@ -306,18 +306,18 @@ export const buildRealmBuilding = async ({
     }
 
     if (occupiedTileFailures > 0) {
-      toast.error("All auto-selected tiles became occupied. Please try again.");
+      gameToast.error("All auto-selected tiles became occupied. Please try again.");
       return false;
     }
 
-    toast.error("No empty building tiles available.");
+    gameToast.error("No empty building tiles available.");
     return false;
   } catch (error) {
     console.error("Failed to auto-build", error);
     if (isOccupiedSpaceError(error)) {
-      toast.error("This tile is occupied. Please try again.");
+      gameToast.error("This tile is occupied. Please try again.");
     } else {
-      toast.error("Building failed. Please try again.");
+      gameToast.error("Building failed. Please try again.");
     }
     return false;
   }

--- a/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
+++ b/client/apps/game/src/ui/features/settlement/construction/select-preview-building.tsx
@@ -69,7 +69,7 @@ import Pause from "lucide-react/dist/esm/icons/pause";
 import Play from "lucide-react/dist/esm/icons/play";
 import Trash from "lucide-react/dist/esm/icons/trash";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 type ArmyTypeLabel = (typeof MILITARY_BUILDING_GROUP_ORDER)[number];
 type ArmyGroup = {
@@ -308,7 +308,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const handleDestroyBuilding = useCallback(
     async (target: { type: BuildingType; resource?: ResourcesIds }) => {
       if (!realm?.position) {
-        toast.error("Select a realm before destroying.");
+        gameToast.error("Select a realm before destroying.");
         return;
       }
 
@@ -322,7 +322,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
 
       const existing = tileManager.existingBuildings().find((building) => building.category === target.type);
       if (!existing) {
-        toast.error("No building of this type found to destroy.");
+        gameToast.error("No building of this type found to destroy.");
         return;
       }
       setPendingDestroys((prev) => ({ ...prev, [buildingKey]: true }));
@@ -338,7 +338,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
         }
       } catch (error) {
         console.error("Failed to destroy building", error);
-        toast.error("Destroy failed. Please try again.");
+        gameToast.error("Destroy failed. Please try again.");
       } finally {
         setPendingDestroys((prev) => {
           const next = { ...prev };
@@ -362,7 +362,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
   const handlePauseResumeAll = useCallback(
     async (target: { type: BuildingType; resource?: ResourcesIds }) => {
       if (!realm?.position) {
-        toast.error("Select a realm before managing production.");
+        gameToast.error("Select a realm before managing production.");
         return;
       }
 
@@ -378,7 +378,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
       const categoryBuildings = currentBuildings.filter((b) => b.category === target.type);
 
       if (categoryBuildings.length === 0) {
-        toast.error("No buildings of this type found.");
+        gameToast.error("No buildings of this type found.");
         return;
       }
 
@@ -401,7 +401,7 @@ export const SelectPreviewBuildingMenu = ({ className, entityId }: { className?:
         );
       } catch (error) {
         console.error(`Failed to ${action} production`, error);
-        toast.error(`Failed to ${action} production. Please try again.`);
+        gameToast.error(`Failed to ${action} production. Please try again.`);
       } finally {
         setPendingPauseResume((prev) => {
           const next = { ...prev };

--- a/client/apps/game/src/ui/features/social/realtime-chat/model/store.ts
+++ b/client/apps/game/src/ui/features/social/realtime-chat/model/store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { AudioManager } from "@/audio/core/AudioManager";
 import { RealtimeClient } from "@bibliothecadao/types";
@@ -568,7 +568,7 @@ export const useRealtimeChatStore = create<RealtimeChatStore>((set, get) => ({
         const senderName =
           onlinePlayers[normalizedMessage.senderId]?.displayName ?? normalizedMessage.senderId.slice(0, 8);
         const preview = normalizedMessage.content.slice(0, 60);
-        toast(`${senderName}: ${preview}`);
+        gameToast(`${senderName}: ${preview}`);
       }
 
       const updatedAt =

--- a/client/apps/game/src/ui/features/story-events/battle-toast.tsx
+++ b/client/apps/game/src/ui/features/story-events/battle-toast.tsx
@@ -1,6 +1,6 @@
 import Navigation from "lucide-react/dist/esm/icons/navigation";
 import X from "lucide-react/dist/esm/icons/x";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 
@@ -54,7 +54,7 @@ export function BattleToast({
               evt.stopPropagation();
               if (!location) return;
               onNavigate(location);
-              toast.dismiss(toastId);
+              gameToast.dismiss(toastId);
             }}
             className={cn(
               "btn-bronze inline-flex items-center gap-1.5 rounded border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors",
@@ -67,7 +67,7 @@ export function BattleToast({
           </button>
           <button
             type="button"
-            onClick={() => toast.dismiss(toastId)}
+            onClick={() => gameToast.dismiss(toastId)}
             className="rounded p-0.5 text-gold/40 hover:text-gold transition-colors"
           >
             <X className="h-3 w-3" />

--- a/client/apps/game/src/ui/features/story-events/story-event-toast-bridge.tsx
+++ b/client/apps/game/src/ui/features/story-events/story-event-toast-bridge.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { AudioManager } from "@/audio/core/AudioManager";
 import { MAP_DATA_REFRESH_INTERVAL, MapDataStore, Position } from "@bibliothecadao/eternum";
@@ -66,10 +66,10 @@ export function StoryEventToastBridge() {
 
   // Track which event keys we've already shown as toasts
   const shownIdsRef = useRef(new Set<string>());
-  // Track initial load so we don't toast all existing events on mount
+  // Track initial load so we don't gameToast all existing events on mount
   const initializedRef = useRef(false);
 
-  // Keep navigation helpers in refs so the toast callback always uses the latest values
+  // Keep navigation helpers in refs so the gameToast callback always uses the latest values
   const navRef = useRef({ goToStructure, navigateToMapView, setSelectedHex, isMapView });
   useEffect(() => {
     navRef.current = { goToStructure, navigateToMapView, setSelectedHex, isMapView };
@@ -269,7 +269,7 @@ export function StoryEventToastBridge() {
           event.battle_defender_troops_tier,
         );
 
-      toast.custom(
+      gameToast.custom(
         (id) => (
           <BattleToast
             toastId={id}

--- a/client/apps/game/src/ui/features/world/components/actions/faith-devotion-action-panel.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/faith-devotion-action-panel.tsx
@@ -16,7 +16,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Loader from "lucide-react/dist/esm/icons/loader";
 import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { useStructureEntityDetail } from "../entities/hooks/use-structure-entity-detail";
 
@@ -420,7 +420,7 @@ const FaithDevotionModal = ({ structureEntityId, structureLabel }: FaithDevotion
     }
 
     if (!account) {
-      toast.error("Connect a wallet before devoting.");
+      gameToast.error("Connect a wallet before devoting.");
       return;
     }
 
@@ -455,10 +455,10 @@ const FaithDevotionModal = ({ structureEntityId, structureLabel }: FaithDevotion
         queryClient.invalidateQueries({ queryKey: ["faith-devotion-status", String(structureEntityId)] }),
       ]);
 
-      toast.success("Devotion updated.");
+      gameToast.success("Devotion updated.");
       closeModal();
     } catch (error) {
-      toast.error(getErrorMessage(error, "Failed to update devotion."));
+      gameToast.error(getErrorMessage(error, "Failed to update devotion."));
     } finally {
       setIsSubmitting(false);
     }

--- a/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
+++ b/client/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
@@ -31,7 +31,7 @@ import {
 } from "@bibliothecadao/eternum";
 import { useDojo, useQuery } from "@bibliothecadao/react";
 import { type ReactNode, useCallback, useMemo } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 // Layout: vertical column of bubbles. The outer parent (TileDetails atom in
 // bottom-right-panel) already provides positioning + scroll, so this layout
@@ -306,7 +306,7 @@ const ReservedHyperstructurePanel = ({ selectedHex }: { selectedHex: HexPosition
       await createHyperstructure();
     } catch (error) {
       console.error("[ReservedHyperstructurePanel] Failed to create reserved hyperstructure", error);
-      toast.error(error instanceof Error ? error.message : "Failed to create the hyperstructure.");
+      gameToast.error(error instanceof Error ? error.message : "Failed to create the hyperstructure.");
     }
   }, [createHyperstructure]);
 

--- a/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
+++ b/client/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
@@ -61,7 +61,7 @@ import Pickaxe from "lucide-react/dist/esm/icons/pickaxe";
 import Play from "lucide-react/dist/esm/icons/play";
 import RefreshCw from "lucide-react/dist/esm/icons/refresh-cw";
 import Trash2 from "lucide-react/dist/esm/icons/trash-2";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 import { BOTTOM_PANEL_HEIGHT, BOTTOM_PANEL_MARGIN, LEFT_ACTIONS_GAP_FROM_MINIMAP, MINIMAP_SIZE } from "./constants";
 import { HexMinimap, normalizeMinimapTile, type MinimapTile } from "./hex-minimap";
@@ -240,7 +240,7 @@ const MapTilePanel = () => {
     if (!syncableEntityType || syncableEntityId === null) return;
 
     if (!toriiClient || !contractComponents) {
-      toast.error("Unable to sync right now.");
+      gameToast.error("Unable to sync right now.");
       return;
     }
 
@@ -522,7 +522,7 @@ const LocalTilePanel = () => {
   const handleResyncStructure = useCallback(() => {
     if (!structureSyncTarget) return;
     if (!toriiClient || !contractComponents) {
-      toast.error("Unable to sync right now.");
+      gameToast.error("Unable to sync right now.");
       return;
     }
 

--- a/client/apps/game/src/ui/features/world/components/network-status.source.test.ts
+++ b/client/apps/game/src/ui/features/world/components/network-status.source.test.ts
@@ -22,7 +22,7 @@ describe("network status wiring", () => {
     expect(source).toContain("NetworkStatusBanner");
     expect(source).toContain("triggerConnectionForceReconnect");
     expect(source).toContain("onRecovery:");
-    expect(source).toContain('toast.success("Back online"');
+    expect(source).toContain('gameToast.success("Back online"');
   });
 
   it("lets the active worldmap clear stuck map loading when stream reconnect fails", () => {

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -34,6 +34,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 // are surfaced in the What's New popup.
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-06-01",
+    title: "Icon-Rich Notifications",
+    description:
+      "Improved game notifications so resources, markets, quests, transfers, and other key actions are easier to scan with compact inline icons.",
+    type: "improvement",
+    gameSlug: "world",
+  },
+  {
     date: "2026-05-30",
     title: "Smarter Blitz Suggestions",
     description:

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -22,7 +22,7 @@ import { EndgameModal, NotLoggedInMessage } from "@/ui/shared";
 import { useDojo } from "@bibliothecadao/react";
 import { Leva } from "leva";
 import { useEffect, useRef } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { dojoConfig } from "../../../dojo-config";
 import { env } from "../../../env";
 import { useUIStore } from "../../hooks/store/use-ui-store";
@@ -237,7 +237,7 @@ const ConnectionMonitor = () => {
       },
       healthCheckFn: () => probeToriiHealth(toriiBaseUrl),
       onRecovery: (outageMs, attempts) => {
-        toast.success("Back online", {
+        gameToast.success("Back online", {
           description: `Reconnected after ${Math.max(1, Math.round(outageMs / 1000))}s offline.`,
         });
         reportNetworkOutageResolved({ streamType: "both", outageMs, attempts });

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.test.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.test.tsx
@@ -33,8 +33,8 @@ vi.mock("@/config/game-modes/use-game-mode-config", () => ({
   useResolvedWorldGameMode: () => mocks.worldMode,
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
+vi.mock("@/ui/shared/game-toast", () => ({
+  gameToast: {
     error: mocks.toastError,
   },
 }));

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-blitz-realm-provision.ts
@@ -3,7 +3,7 @@ import { useCurrentBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { executeObservedClientTransaction } from "@/observability/observed-client-transaction";
 import { useResolvedWorldGameMode } from "@/config/game-modes/use-game-mode-config";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { getContractByName } from "@dojoengine/core";
 import { useComponentValue } from "@dojoengine/react";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
@@ -219,7 +219,7 @@ export const useBlitzRealmProvision = (structureEntityId: number | null): Struct
 
       if (attempts >= maxAttempts) {
         setProvisionActionState("syncTimeout");
-        toast.error("Provision confirmed. Waiting for synced realm data before enabling the button again.");
+        gameToast.error("Provision confirmed. Waiting for synced realm data before enabling the button again.");
         return;
       }
 

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-realm-actions.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-realm-actions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { CallData, type Call } from "starknet";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { getContractByName } from "@dojoengine/core";
 
 import { dojoConfig } from "../../../../../dojo-config";
@@ -57,7 +57,7 @@ export const useRealmActions = () => {
   const execute = useCallback(
     async (realmId: ID, calls: Call[], operation: string) => {
       if (calls.length === 0) {
-        toast.error("Unable to resolve realm system contracts.");
+        gameToast.error("Unable to resolve realm system contracts.");
         return;
       }
 
@@ -71,7 +71,7 @@ export const useRealmActions = () => {
         });
       } catch (error) {
         console.error(`[realm-actions] ${operation} failed`, error);
-        toast.error(error instanceof Error ? error.message : "Failed to submit the transaction.");
+        gameToast.error(error instanceof Error ? error.message : "Failed to submit the transaction.");
         throw error;
       } finally {
         setPendingRealmId((current) => (current === realmId ? null : current));
@@ -84,7 +84,7 @@ export const useRealmActions = () => {
     async (realmId: ID) => {
       const call = buildUpgradeCall(realmId);
       if (!call) {
-        toast.error("Unable to resolve realm system contracts.");
+        gameToast.error("Unable to resolve realm system contracts.");
         return;
       }
       await execute(realmId, [call], "realm_systems.upgrade");
@@ -96,7 +96,7 @@ export const useRealmActions = () => {
     async (realmId: ID) => {
       const call = buildProvisionCall(realmId);
       if (!call) {
-        toast.error("Unable to resolve realm system contracts.");
+        gameToast.error("Unable to resolve realm system contracts.");
         return;
       }
       await execute(realmId, [call], "realm_systems.provision");
@@ -109,7 +109,7 @@ export const useRealmActions = () => {
       const upgradeCall = buildUpgradeCall(realmId);
       const provisionCall = buildProvisionCall(realmId);
       if (!upgradeCall || !provisionCall) {
-        toast.error("Unable to resolve realm system contracts.");
+        gameToast.error("Unable to resolve realm system contracts.");
         return;
       }
       // Provision FIRST: provision_realm grants the realm's starting resources

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-realm-upgrade-and-provision.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-realm-upgrade-and-provision.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { CallData, type Call } from "starknet";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { getContractByName } from "@dojoengine/core";
 
 import { dojoConfig } from "../../../../../dojo-config";
@@ -73,7 +73,7 @@ export const useRealmUpgradeAndProvision = (structureEntityId: number | null): R
     // Affordable: bundle provision + upgrade in one signature. provision_realm
     // FIRST — it grants the starting resources level_up spends.
     if (!structureSystemsAddress || !blitzRealmSystemsAddress) {
-      toast.error("Unable to resolve realm system contracts.");
+      gameToast.error("Unable to resolve realm system contracts.");
       return;
     }
 
@@ -100,7 +100,7 @@ export const useRealmUpgradeAndProvision = (structureEntityId: number | null): R
       });
     } catch (error) {
       console.error("[realm-upgrade-and-provision] Failed to submit provision multicall", error);
-      toast.error(error instanceof Error ? error.message : "Failed to submit the provision.");
+      gameToast.error(error instanceof Error ? error.message : "Failed to submit the provision.");
       throw error;
     } finally {
       setIsPending(false);

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.test.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.test.tsx
@@ -29,8 +29,8 @@ vi.mock("@/ui/utils/transactions", () => ({
   waitForTransactionConfirmation: mocks.waitForTransactionConfirmation,
 }));
 
-vi.mock("sonner", () => ({
-  toast: {
+vi.mock("@/ui/shared/game-toast", () => ({
+  gameToast: {
     error: mocks.toastError,
   },
 }));

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts
@@ -18,7 +18,7 @@ import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress, getLevelName, ResourcesIds } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
 import { useCallback, useEffect, useMemo } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 
 const REALM_UPGRADE_SYNC_TIMEOUT_MS = 30_000;
 const REALM_UPGRADE_SYNC_POLL_INTERVAL_MS = 1_000;
@@ -335,7 +335,7 @@ export const useStructureUpgrade = (structureEntityId: number | null): Structure
       }
 
       setUpgradeStatus(structureInfo.entityId, "syncTimeout");
-      toast.error("Realm upgrade confirmed. Waiting for synced realm data before enabling the next upgrade.");
+      gameToast.error("Realm upgrade confirmed. Waiting for synced realm data before enabling the next upgrade.");
     } catch (error) {
       clearUpgrade(structureInfo.entityId);
       throw error;

--- a/client/apps/game/src/ui/modules/settings/settings.tsx
+++ b/client/apps/game/src/ui/modules/settings/settings.tsx
@@ -19,7 +19,7 @@ import { addressToNumber } from "@/ui/utils/utils";
 import { useGuilds, useScreenOrientation } from "@bibliothecadao/react";
 import { useDojo } from "@bibliothecadao/react";
 import { useState } from "react";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { RENDERER_MODE_STORAGE_KEY, usesExperimentalWebGPUThreeBuild } from "@/three/renderer-build-mode";
 import { env as gameEnv } from "../../../../env";
 
@@ -74,7 +74,7 @@ export const SettingsWindow = () => {
     setSelectedGuilds((prev) => {
       const newGuilds = prev.includes(guildId) ? prev.filter((id) => id !== guildId) : [...prev, guildId];
       localStorage.setItem("WHITELIST", newGuilds.join(","));
-      toast(prev.includes(guildId) ? "Guild removed from whitelist!" : "Guild added to whitelist!");
+      gameToast(prev.includes(guildId) ? "Guild removed from whitelist!" : "Guild added to whitelist!");
       return newGuilds;
     });
   };
@@ -82,7 +82,7 @@ export const SettingsWindow = () => {
   const handleClearGuilds = () => {
     setSelectedGuilds([]);
     localStorage.removeItem("WHITELIST");
-    toast("Guild whitelist cleared!");
+    gameToast("Guild whitelist cleared!");
   };
 
   if (!isOpen) return null;
@@ -119,7 +119,7 @@ export const SettingsWindow = () => {
               <Button
                 size="xs"
                 onClick={() => {
-                  toast("Redirecting to the landing page to change games…");
+                  gameToast("Redirecting to the landing page to change games…");
                   try {
                     redirectToLandingWorldSelection();
                   } catch {

--- a/client/apps/game/src/ui/shared/components/tx-emit.test.tsx
+++ b/client/apps/game/src/ui/shared/components/tx-emit.test.tsx
@@ -1,4 +1,5 @@
 import { act } from "react";
+import type { ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TransactionNotification } from "./tx-emit";
@@ -24,7 +25,12 @@ const provider = vi.hoisted(() => {
   };
 });
 
-const toastMock = vi.hoisted(() => vi.fn());
+const toastMock = vi.hoisted(() => {
+  const base = vi.fn();
+  return Object.assign(base, {
+    error: vi.fn(),
+  });
+});
 const playMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@bibliothecadao/react", () => ({
@@ -37,8 +43,9 @@ vi.mock("@bibliothecadao/react", () => ({
   }),
 }));
 
-vi.mock("sonner", () => ({
-  toast: toastMock,
+vi.mock("@/ui/shared/game-toast", () => ({
+  gameToast: toastMock,
+  GameToastContent: ({ content }: { content: ReactNode }) => <span>{content}</span>,
 }));
 
 vi.mock("@/audio/core/AudioManager", () => ({
@@ -86,11 +93,12 @@ describe("TransactionNotification", () => {
       });
     });
 
-    expect(toastMock).toHaveBeenCalledWith("⚠️ Transaction status uncertain", {
-      description: expect.stringContaining(
-        "Submission timed out before a tx hash was returned. Check wallet/activity before retrying.",
-      ),
+    expect(toastMock.error).toHaveBeenCalledWith("Transaction status uncertain", {
+      description: expect.objectContaining({ type: expect.any(Function) }),
     });
+    expect(toastMock.error.mock.calls[0]?.[1]?.description.props.content).toContain(
+      "Submission timed out before a tx hash was returned. Check wallet/activity before retrying.",
+    );
     expect(playMock).toHaveBeenCalledWith("ui.tx_fail");
   });
 });

--- a/client/apps/game/src/ui/shared/components/tx-emit.tsx
+++ b/client/apps/game/src/ui/shared/components/tx-emit.tsx
@@ -1,16 +1,14 @@
 import { SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE, TransactionType } from "@bibliothecadao/provider";
 import { useDojo } from "@bibliothecadao/react";
 import { useEffect } from "react";
-import { toast } from "sonner";
+import { gameToast, GameToastContent } from "@/ui/shared/game-toast";
 import { AudioManager } from "@/audio/core/AudioManager";
-import { getTxMessage as getBaseMessage, getTxIcon } from "@/ui/components/transaction-center/types";
+import { getTxMessage as getBaseMessage } from "@/ui/components/transaction-center/types";
 import { extractReadableErrorMessage } from "@/utils/error-message";
 
-const getTxMessage = (type: TransactionType): string => {
-  const icon = getTxIcon(type);
-  const message = getBaseMessage(type);
-  return `${icon} ${message}`;
-};
+const getTxMessage = (type: TransactionType): string => getBaseMessage(type);
+
+const buildTransactionDescription = (description: string) => <GameToastContent content={description} />;
 
 type TransactionFailurePayload = {
   message?: string;
@@ -33,7 +31,7 @@ export function TransactionNotification() {
       console.log("Transaction pending:", receipt);
       const description = getTxMessage(receipt.type);
       const txCount = receipt.transactionCount ? ` (${receipt.transactionCount} transactions)` : "";
-      toast("⏳ Transaction pending", { description: description + txCount });
+      gameToast("Transaction pending", { description: buildTransactionDescription(description + txCount) });
       AudioManager.getInstance().play("ui.toast_info");
     };
 
@@ -41,7 +39,7 @@ export function TransactionNotification() {
       console.log("Transaction completed:", receipt);
       const description = getTxMessage(receipt.type);
       const txCount = receipt.transactionCount ? ` (${receipt.transactionCount} transactions)` : "";
-      toast("Completed Action", { description: description + txCount });
+      gameToast("Completed Action", { description: buildTransactionDescription(description + txCount) });
       AudioManager.getInstance().play("ui.tx_success");
     };
 
@@ -52,10 +50,10 @@ export function TransactionNotification() {
       const action = type ? getTxMessage(type) : "Action failed";
       const txCount = transactionCount ? ` (${transactionCount} transactions)` : "";
       const isNoHashTimeout = payload.failureKind === "submission_timeout_no_hash";
-      const title = isNoHashTimeout ? "⚠️ Transaction status uncertain" : "❌ Transaction failed";
+      const title = isNoHashTimeout ? "Transaction status uncertain" : "Transaction failed";
       const description = `${action}${txCount} - ${isNoHashTimeout ? SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE : message}`;
       console.error("Transaction failed:", message);
-      toast(title, { description });
+      gameToast.error(title, { description: buildTransactionDescription(description) });
       AudioManager.getInstance().play("ui.tx_fail");
     };
 

--- a/client/apps/game/src/ui/shared/game-toast-wrapper.test.tsx
+++ b/client/apps/game/src/ui/shared/game-toast-wrapper.test.tsx
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sonnerToastMock = vi.hoisted(() => {
+  const base = vi.fn();
+  return Object.assign(base, {
+    success: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+    loading: vi.fn(),
+    custom: vi.fn(),
+    dismiss: vi.fn(),
+  });
+});
+
+vi.mock("sonner", () => ({
+  toast: sonnerToastMock,
+}));
+
+import { gameToast } from "./game-toast";
+
+describe("gameToast", () => {
+  beforeEach(() => {
+    sonnerToastMock.mockReset();
+    sonnerToastMock.success.mockReset();
+  });
+
+  it("keeps lazy descriptions callable", () => {
+    gameToast.success("Market resolved", {
+      description: () => "Rewards are ready.",
+    });
+
+    const options = sonnerToastMock.success.mock.calls[0]?.[1];
+
+    expect(typeof options?.description).toBe("function");
+  });
+});

--- a/client/apps/game/src/ui/shared/game-toast.source.test.ts
+++ b/client/apps/game/src/ui/shared/game-toast.source.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = join(process.cwd(), "src");
+const ALLOWED_SONNER_IMPORTS = new Set(["ui/shared/components/toaster.tsx", "ui/shared/game-toast.tsx"]);
+
+const collectSourceFiles = (directory: string): string[] =>
+  readdirSync(directory).flatMap((entry) => {
+    const fullPath = join(directory, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) return collectSourceFiles(fullPath);
+    if (!/\.(ts|tsx)$/.test(entry)) return [];
+    return [fullPath];
+  });
+
+describe("game toast source", () => {
+  it("routes game-client Sonner usage through the shared gameToast wrapper", () => {
+    const directSonnerImports = collectSourceFiles(SRC_ROOT)
+      .map((filePath) => ({
+        filePath,
+        source: readFileSync(filePath, "utf8"),
+      }))
+      .filter(({ source }) => /from\s+["']sonner["']/.test(source))
+      .map(({ filePath }) => relative(SRC_ROOT, filePath))
+      .filter((relativePath) => !ALLOWED_SONNER_IMPORTS.has(relativePath));
+
+    expect(directSonnerImports).toEqual([]);
+  });
+});

--- a/client/apps/game/src/ui/shared/game-toast.test.tsx
+++ b/client/apps/game/src/ui/shared/game-toast.test.tsx
@@ -1,0 +1,83 @@
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { GameToastContent } from "./game-toast";
+
+const waitForRender = async () => {
+  await Promise.resolve();
+};
+
+const renderContent = async (content: ReactNode) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(<GameToastContent content={content} />);
+    await waitForRender();
+  });
+
+  return { container, root };
+};
+
+describe("GameToastContent", () => {
+  let roots: Root[] = [];
+  let containers: HTMLDivElement[] = [];
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    roots = [];
+    containers = [];
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      roots.forEach((root) => root.unmount());
+      await waitForRender();
+    });
+    containers.forEach((container) => container.remove());
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  const mount = async (content: ReactNode) => {
+    const rendered = await renderContent(content);
+    roots.push(rendered.root);
+    containers.push(rendered.container);
+    return rendered.container;
+  };
+
+  it("renders resource amounts as compact icon chips", async () => {
+    const container = await mount("Moved 6,030 Coal, 12 Cold Iron, and 1 Ancient Fragment.");
+
+    expect(container.textContent).toContain("Moved");
+    expect(container.textContent).toContain("6,030 Coal");
+    expect(container.querySelector('[data-game-toast-resource="Coal"]')).not.toBeNull();
+    expect(container.querySelector('[data-game-toast-resource="Cold Iron"]')).not.toBeNull();
+    expect(container.querySelector('[data-game-toast-resource="Ancient Fragment"]')).not.toBeNull();
+  });
+
+  it("keeps icons for longer multi-word resource labels", async () => {
+    const container = await mount("Found 1 Damage Reduction Relic 1.");
+    const chip = container.querySelector('[data-game-toast-resource="Damage Reduction Relic 1"]');
+
+    expect(chip).not.toBeNull();
+    expect(chip?.querySelector("img")).not.toBeNull();
+  });
+
+  it("leaves unknown labels as plain text", async () => {
+    const container = await mount("Mystery Ore arrived.");
+
+    expect(container.textContent).toBe("Mystery Ore arrived.");
+    expect(container.querySelector("[data-game-toast-resource]")).toBeNull();
+    expect(container.querySelector("[data-game-toast-thing]")).toBeNull();
+  });
+
+  it("renders known game objects as icon chips", async () => {
+    const container = await mount("Hyperstructure Quest Market updated.");
+
+    expect(container.querySelector('[data-game-toast-thing="Hyperstructure"]')).not.toBeNull();
+    expect(container.querySelector('[data-game-toast-thing="Quest"]')).not.toBeNull();
+    expect(container.querySelector('[data-game-toast-thing="Market"]')).not.toBeNull();
+  });
+});

--- a/client/apps/game/src/ui/shared/game-toast.tsx
+++ b/client/apps/game/src/ui/shared/game-toast.tsx
@@ -1,0 +1,298 @@
+import { ResourcesIds, resources } from "@bibliothecadao/types";
+import type { ReactNode } from "react";
+import { isValidElement } from "react";
+import { toast as sonnerToast, type ExternalToast } from "sonner";
+
+import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
+
+export type GameToastResourceItem = {
+  resourceId: ResourcesIds | number;
+  amount?: number | string;
+  label?: string;
+};
+
+type GameToastThingItem = {
+  label: string;
+  icon?: string;
+};
+
+export type GameToastModel = {
+  title: ReactNode;
+  description?: ReactNode;
+  resources?: GameToastResourceItem[];
+  things?: GameToastThingItem[];
+};
+
+type GameToastInput = ReactNode | GameToastModel;
+type GameToastFunction = ((message: GameToastInput, data?: ExternalToast) => string | number) & {
+  success: (message: GameToastInput, data?: ExternalToast) => string | number;
+  info: (message: GameToastInput, data?: ExternalToast) => string | number;
+  warning: (message: GameToastInput, data?: ExternalToast) => string | number;
+  error: (message: GameToastInput, data?: ExternalToast) => string | number;
+  message: (message: GameToastInput, data?: ExternalToast) => string | number;
+  loading: (message: GameToastInput, data?: ExternalToast) => string | number;
+  custom: typeof sonnerToast.custom;
+  dismiss: typeof sonnerToast.dismiss;
+};
+
+type ToastTerm =
+  | {
+      kind: "resource";
+      label: string;
+      iconLabel: string;
+      resourceId: ResourcesIds;
+      aliases: string[];
+    }
+  | {
+      kind: "thing";
+      label: string;
+      icon: string;
+      aliases: string[];
+    };
+
+const GAME_TOAST_THINGS: ToastTerm[] = [
+  { kind: "thing", label: "Realm", icon: "/images/labels/realm.png", aliases: ["Realm", "Realms"] },
+  { kind: "thing", label: "Village", icon: "/images/labels/village.png", aliases: ["Village", "Villages"] },
+  { kind: "thing", label: "Army", icon: "/images/labels/army.png", aliases: ["Army", "Armies", "Troops"] },
+  { kind: "thing", label: "Chest", icon: "/images/labels/chest.png", aliases: ["Chest", "Chests"] },
+  { kind: "thing", label: "Quest", icon: "/images/labels/quest.png", aliases: ["Quest", "Quests"] },
+  {
+    kind: "thing",
+    label: "Hyperstructure",
+    icon: "/images/labels/hyperstructure.png",
+    aliases: ["Hyperstructure", "Hyperstructures"],
+  },
+  { kind: "thing", label: "Automation", icon: "/image-icons/robot.png", aliases: ["Automation", "Automations"] },
+  { kind: "thing", label: "Transfer", icon: "/image-icons/transfer.png", aliases: ["Transfer", "Transfers"] },
+  { kind: "thing", label: "Market", icon: "/image-icons/trade.png", aliases: ["Market", "Markets"] },
+  { kind: "thing", label: "Guild", icon: "/image-icons/guild.png", aliases: ["Guild", "Guilds", "Tribe", "Tribes"] },
+  { kind: "thing", label: "Building", icon: "/image-icons/construction.png", aliases: ["Building", "Buildings"] },
+  { kind: "thing", label: "Wallet", icon: "/image-icons/network.png", aliases: ["Wallet", "Network"] },
+  { kind: "thing", label: "Rewards", icon: "/images/buildings/thumb/rewards.png", aliases: ["Reward", "Rewards"] },
+  { kind: "thing", label: "Relic", icon: "/image-icons/relics.png", aliases: ["Relic", "Relics"] },
+  { kind: "thing", label: "Resources", icon: "/image-icons/resources.png", aliases: ["Resource", "Resources"] },
+];
+
+const enumResourceTerms = Object.values(ResourcesIds)
+  .filter((value): value is string => typeof value === "string")
+  .map((label) => ({
+    label,
+    resourceId: ResourcesIds[label as keyof typeof ResourcesIds],
+  }))
+  .filter((entry): entry is { label: string; resourceId: ResourcesIds } => typeof entry.resourceId === "number");
+
+const RESOURCE_TERMS: ToastTerm[] = resources.map((resource) => {
+  const enumLabel = enumResourceTerms.find((entry) => entry.resourceId === resource.id)?.label;
+  return {
+    kind: "resource",
+    label: resource.trait,
+    iconLabel: enumLabel ?? resource.trait,
+    resourceId: resource.id,
+    aliases: [...new Set([resource.trait, enumLabel].filter((alias): alias is string => Boolean(alias)))],
+  };
+});
+
+const TOAST_TERMS = [...RESOURCE_TERMS, ...GAME_TOAST_THINGS] as const;
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const amountPattern = String.raw`\d+(?:,\d{3})*(?:\.\d+)?`;
+const termPattern = TOAST_TERMS.flatMap((term) => term.aliases)
+  .toSorted((left, right) => right.length - left.length)
+  .map(escapeRegExp)
+  .join("|");
+const termRegex = new RegExp(`(?<![A-Za-z0-9])(?:(${amountPattern})\\s+)?(${termPattern})(?![A-Za-z0-9])`, "gi");
+
+const normalizeTerm = (value: string): string => value.toLowerCase().replace(/\s+/g, "");
+const TERM_BY_ALIAS = new Map<string, ToastTerm>(
+  TOAST_TERMS.flatMap((term) => term.aliases.map((alias) => [normalizeTerm(alias), term] as const)),
+);
+
+const resolveResourceLabel = (resourceId: ResourcesIds | number, fallback?: string): string => {
+  const resource = resources.find((entry) => entry.id === resourceId);
+  if (resource) return resource.trait;
+  const enumLabel = ResourcesIds[resourceId as ResourcesIds];
+  if (typeof enumLabel === "string") return enumLabel;
+  return fallback ?? `Resource ${resourceId}`;
+};
+
+const resolveResourceIconLabel = (resourceId: ResourcesIds | number, label: string): string => {
+  const enumLabel = ResourcesIds[resourceId as ResourcesIds];
+  return typeof enumLabel === "string" ? enumLabel : label;
+};
+
+const resolveThingIcon = (item: GameToastThingItem): string | null => {
+  const registryTerm = TERM_BY_ALIAS.get(normalizeTerm(item.label));
+  if (registryTerm?.kind === "thing") return registryTerm.icon;
+  return item.icon ?? null;
+};
+
+const formatResourceAmount = (amount: GameToastResourceItem["amount"]): string | null => {
+  if (amount === undefined || amount === null) return null;
+  if (typeof amount === "string") return amount;
+  return Math.round(amount).toLocaleString();
+};
+
+const ResourceToastChip = ({
+  amount,
+  iconLabel,
+  label,
+}: {
+  amount?: string | null;
+  iconLabel: string;
+  label: string;
+}) => (
+  <span
+    data-game-toast-resource={label}
+    className="inline-flex items-center gap-1 rounded bg-gold/10 px-1.5 py-0.5 align-middle text-gold"
+  >
+    <ResourceIcon resource={iconLabel} size="xs" withTooltip={false} className="!h-4 !w-4 shrink-0" />
+    <span>{amount ? `${amount} ${label}` : label}</span>
+  </span>
+);
+
+const ThingToastChip = ({ icon, label }: { icon: string; label: string }) => (
+  <span
+    data-game-toast-thing={label}
+    className="inline-flex items-center gap-1 rounded bg-gold/10 px-1.5 py-0.5 align-middle text-gold"
+  >
+    <img src={icon} alt="" className="h-4 w-4 shrink-0 object-contain" />
+    <span>{label}</span>
+  </span>
+);
+
+const renderMatchedTerm = (term: ToastTerm, amount: string | undefined, key: string): ReactNode => {
+  if (term.kind === "resource") {
+    return <ResourceToastChip key={key} amount={amount} iconLabel={term.iconLabel} label={term.label} />;
+  }
+
+  return (
+    <span key={key}>
+      {amount ? `${amount} ` : null}
+      <ThingToastChip icon={term.icon} label={term.label} />
+    </span>
+  );
+};
+
+const renderTextWithIcons = (text: string): ReactNode => {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(termRegex)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      nodes.push(text.slice(lastIndex, matchIndex));
+    }
+
+    const amount = match[1];
+    const matchedTerm = match[2] ?? "";
+    const term = TERM_BY_ALIAS.get(normalizeTerm(matchedTerm));
+    nodes.push(term ? renderMatchedTerm(term, amount, `${matchIndex}-${matchedTerm}`) : match[0]);
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes.length > 0 ? nodes : text;
+};
+
+const isGameToastModel = (value: GameToastInput): value is GameToastModel =>
+  typeof value === "object" && value !== null && !Array.isArray(value) && !isValidElement(value) && "title" in value;
+
+const renderGameToastContent = (content: ReactNode): ReactNode =>
+  typeof content === "string" ? renderTextWithIcons(content) : content;
+
+const renderStructuredResources = (items: GameToastResourceItem[] | undefined) =>
+  items?.map((item) => {
+    const label = item.label ?? resolveResourceLabel(item.resourceId);
+    return (
+      <ResourceToastChip
+        key={`${item.resourceId}-${label}-${String(item.amount ?? "")}`}
+        amount={formatResourceAmount(item.amount)}
+        iconLabel={resolveResourceIconLabel(item.resourceId, label)}
+        label={label}
+      />
+    );
+  });
+
+const renderStructuredThings = (items: GameToastThingItem[] | undefined) =>
+  items?.map((item) => {
+    const icon = resolveThingIcon(item);
+    return icon ? (
+      <ThingToastChip key={`${item.label}-${icon}`} icon={icon} label={item.label} />
+    ) : (
+      <span key={item.label}>{item.label}</span>
+    );
+  });
+
+const GameToastDescription = ({
+  description,
+  resources: resourceItems,
+  things,
+}: Pick<GameToastModel, "description" | "resources" | "things">) => {
+  const resourceChips = renderStructuredResources(resourceItems);
+  const thingChips = renderStructuredThings(things);
+  const hasChips = Boolean(resourceChips?.length || thingChips?.length);
+
+  if (!description && !hasChips) return null;
+
+  return (
+    <span className="flex flex-col gap-1.5">
+      {description ? <span>{renderGameToastContent(description)}</span> : null}
+      {hasChips ? (
+        <span className="flex flex-wrap gap-1.5">{[...(thingChips ?? []), ...(resourceChips ?? [])]}</span>
+      ) : null}
+    </span>
+  );
+};
+
+export const GameToastContent = ({ content }: { content: ReactNode }) => <>{renderGameToastContent(content)}</>;
+
+const buildToastMessage = (message: GameToastInput): ReactNode => {
+  if (isGameToastModel(message)) {
+    return <GameToastContent content={message.title} />;
+  }
+
+  return <GameToastContent content={message} />;
+};
+
+const buildToastDescription = (message: GameToastInput, data?: ExternalToast): ExternalToast["description"] => {
+  const baseDescription = data?.description;
+  const isModel = isGameToastModel(message);
+  const description = isModel ? (message.description ?? baseDescription) : baseDescription;
+  const resources = isModel ? message.resources : undefined;
+  const things = isModel ? message.things : undefined;
+  const hasChips = Boolean(resources?.length || things?.length);
+
+  if (!description && !hasChips) return undefined;
+
+  if (typeof description === "function") {
+    return () => <GameToastDescription description={description()} resources={resources} things={things} />;
+  }
+
+  return <GameToastDescription description={description} resources={resources} things={things} />;
+};
+
+const buildToastOptions = (message: GameToastInput, data?: ExternalToast): ExternalToast | undefined => {
+  const description = buildToastDescription(message, data);
+
+  return description ? { ...data, description } : data;
+};
+
+const callToast =
+  (method: (message: ReactNode, data?: ExternalToast) => string | number) =>
+  (message: GameToastInput, data?: ExternalToast): string | number =>
+    method(buildToastMessage(message), buildToastOptions(message, data));
+
+export const gameToast = Object.assign(callToast(sonnerToast), {
+  success: callToast(sonnerToast.success),
+  info: callToast(sonnerToast.info),
+  warning: callToast(sonnerToast.warning),
+  error: callToast(sonnerToast.error),
+  message: callToast(sonnerToast.message),
+  loading: callToast(sonnerToast.loading),
+  custom: sonnerToast.custom,
+  dismiss: sonnerToast.dismiss,
+}) as GameToastFunction;

--- a/client/apps/game/src/ui/utils/network-switch.ts
+++ b/client/apps/game/src/ui/utils/network-switch.ts
@@ -1,6 +1,6 @@
 import type { Chain } from "@contracts";
 import { mainnet, sepolia } from "@starknet-react/chains";
-import { toast } from "sonner";
+import { gameToast } from "@/ui/shared/game-toast";
 import { constants, shortString } from "starknet";
 
 const KATANA_CHAIN_ID = shortString.encodeShortString("KATANA");
@@ -136,7 +136,7 @@ export const switchWalletToChain = async ({
   const targetLabel = getChainLabel(targetChain);
 
   if (!controller?.switchStarknetChain) {
-    toast.error(`Please switch to ${targetLabel} in your wallet, then retry.`);
+    gameToast.error(`Please switch to ${targetLabel} in your wallet, then retry.`);
     controller?.openSettings?.();
     return false;
   }
@@ -144,16 +144,16 @@ export const switchWalletToChain = async ({
   try {
     const switched = await controller.switchStarknetChain(getSwitchChainIdForChain(targetChain));
     if (!switched) {
-      toast.error(`Could not switch to ${targetLabel}. Please switch manually in your wallet.`);
+      gameToast.error(`Could not switch to ${targetLabel}. Please switch manually in your wallet.`);
       controller.openSettings?.();
       return false;
     }
 
-    toast.success(`Switched to ${targetLabel}.`);
+    gameToast.success(`Switched to ${targetLabel}.`);
     return true;
   } catch (error) {
     console.error("Failed to switch network:", error);
-    toast.error(`Could not switch to ${targetLabel}. Please switch manually in your wallet.`);
+    gameToast.error(`Could not switch to ${targetLabel}. Please switch manually in your wallet.`);
     controller.openSettings?.();
     return false;
   }


### PR DESCRIPTION
Adds a shared `gameToast` wrapper that enriches resource, market, quest, transfer, and other game notification text with compact inline icons while routing game-client Sonner usage through one place.
Migrates existing transaction, automation, market, landing, world, settings, and settlement notifications to the wrapper and adds a What's New entry for the notification refresh.
Adds wrapper/content/source tests, including coverage that lazy Sonner descriptions remain callable after the wrapper adds game rendering.
Validation: focused Vitest toast suites, related migration tests, `pnpm run format`, and `pnpm run knip`.