### PR TITLE
fix(game): scale blitz wheat farm target with realm level (2/4/8/12)

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.test.ts
@@ -165,7 +165,7 @@ describe("buildBlitzRealmSuggestions", () => {
     ).toEqual([]);
   });
 
-  it("prioritizes wheat before resource buildings until the sprint target is met", () => {
+  it("prioritizes wheat before resource buildings until the realm-level target is met", () => {
     expect(
       actionsFor(
         baseInput({
@@ -176,6 +176,40 @@ describe("buildBlitzRealmSuggestions", () => {
         }),
       ),
     ).toEqual(["build-wheat"]);
+  });
+
+  it("scales the wheat farm target with realm level (2/4/8/12)", () => {
+    const wheatReasonAt = (realmLevel: number, wheat: number) =>
+      buildBlitzRealmSuggestions(baseInput({ realmLevel, buildingCounts: { ...emptyCounts, wheat } }))[0];
+
+    // Target per level: L0=2, L1=4, L2=8, L3+=12.
+    const cases: Array<{ level: number; target: number }> = [
+      { level: 0, target: 2 },
+      { level: 1, target: 4 },
+      { level: 2, target: 8 },
+      { level: 3, target: 12 },
+      { level: 5, target: 12 }, // clamps to the last entry
+    ];
+
+    for (const { level, target } of cases) {
+      // One below target -> still suggests wheat, labelled against the level target.
+      expect(wheatReasonAt(level, target - 1)).toMatchObject({
+        action: "build-wheat",
+        reason: `${target - 1}/${target} farms.`,
+      });
+      // At target -> wheat is satisfied, no longer the top suggestion.
+      expect(wheatReasonAt(level, target)?.action).not.toBe("build-wheat");
+    }
+  });
+
+  it("stops the level-1 wheat target at 4 farms instead of jumping to 8", () => {
+    // Regression: at realm level 1, 4 farms completes wheat (was sprinting to 8).
+    expect(actionsFor(baseInput({ realmLevel: 1, buildingCounts: { ...emptyCounts, wheat: 4 } }))).not.toContain(
+      "build-wheat",
+    );
+    expect(actionsFor(baseInput({ realmLevel: 1, buildingCounts: { ...emptyCounts, wheat: 3 } }))).toEqual([
+      "build-wheat",
+    ]);
   });
 
   it("does not emit build actions when autobuild cannot currently submit them", () => {

--- a/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.ts
@@ -75,12 +75,15 @@ export type BlitzSuggestionDraft = {
 
 const BLITZ_TARGETS = {
   foundationWheat: 2,
-  sprintWheat: 8,
   resourcesPerRealmLevel: 2,
 };
 
 const MIN_AVAILABLE_POPULATION_BEFORE_WORKER_HUT = 3;
 const MILITARY_TARGETS_BY_REALM_LEVEL = [0, 1, 3, 5];
+// Wheat farm target by realm level (index = realm level). Levels beyond the
+// last entry clamp to the final value. Scales the food economy with the realm
+// instead of jumping straight from the foundation (2) to a flat sprint target.
+const WHEAT_TARGETS_BY_REALM_LEVEL = [2, 4, 8, 12];
 const RESOURCE_BUILD_ORDER: BlitzResourceBuildKey[] = ["wood", "coal", "copper"];
 const RESOURCE_BUILD_LABELS: Record<BlitzResourceBuildKey, string> = {
   wood: "wood camps",
@@ -171,6 +174,11 @@ const resolveMilitaryTargetCount = ({ realmLevel }: BlitzRealmSuggestionInput) =
   return MILITARY_TARGETS_BY_REALM_LEVEL[clampedLevel] ?? 0;
 };
 
+const resolveWheatTargetCount = ({ realmLevel }: BlitzRealmSuggestionInput) => {
+  const clampedLevel = Math.max(0, Math.min(realmLevel, WHEAT_TARGETS_BY_REALM_LEVEL.length - 1));
+  return WHEAT_TARGETS_BY_REALM_LEVEL[clampedLevel] ?? BLITZ_TARGETS.foundationWheat;
+};
+
 const hasRealmLevelBuildingTargets = (input: BlitzRealmSuggestionInput) => {
   const resourceTarget = resolveRealmResourceTarget(input);
   const militaryTargetCount = resolveMilitaryTargetCount(input);
@@ -254,21 +262,12 @@ const resolvePopulationSuggestion = (input: BlitzRealmSuggestionInput): BlitzSug
 };
 
 const resolveWheatSuggestion = (input: BlitzRealmSuggestionInput): BlitzSuggestionDraft | null => {
-  const { buildingCounts } = input;
-
-  if (buildingCounts.wheat < BLITZ_TARGETS.foundationWheat) {
-    return resolveBuildSuggestion(
-      input,
-      "wheat",
-      `${buildingCounts.wheat}/${BLITZ_TARGETS.foundationWheat} foundation farms.`,
-    );
+  const wheatTarget = resolveWheatTargetCount(input);
+  if (input.buildingCounts.wheat >= wheatTarget) {
+    return null;
   }
 
-  if (buildingCounts.wheat < BLITZ_TARGETS.sprintWheat) {
-    return resolveBuildSuggestion(input, "wheat", `${buildingCounts.wheat}/${BLITZ_TARGETS.sprintWheat} farms.`);
-  }
-
-  return null;
+  return resolveBuildSuggestion(input, "wheat", `${input.buildingCounts.wheat}/${wheatTarget} farms.`);
 };
 
 const resolveResourceSuggestion = (input: BlitzRealmSuggestionInput): BlitzSuggestionDraft | null => {


### PR DESCRIPTION
## Problem
The blitz wheat-farm suggestion jumped from a foundation of **2** straight to a flat sprint target of **8** at *every* realm level, with no level gating. So a **level-1** realm was told to build 8 wheat farms — ahead of wood/coal/copper (wheat is resolved first). Every other resource scales with realm level (`realmLevel * 2`); wheat did not.

## Fix
Replace `foundationWheat`/`sprintWheat` with a per-realm-level wheat target, mirroring the existing `MILITARY_TARGETS_BY_REALM_LEVEL` pattern:

| Realm level | 0 | 1 | 2 | 3+ |
|---|---|---|---|---|
| Wheat target | 2 | 4 | 8 | 12 |

- `WHEAT_TARGETS_BY_REALM_LEVEL = [2, 4, 8, 12]`, clamped to the last entry for higher levels.
- `resolveWheatSuggestion` now uses the single level target (`X/N farms.`).
- `foundationWheat` (2) is retained for the `hasFoundationEconomy` garrison gate (unchanged behaviour).

## Tests
- New: asserts the per-level targets (2/4/8/12 + clamp) and that level 1 stops at 4, not 8.
- Existing blitz-suggestion tests still pass.
- Full game-app typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)