### PR TITLE
blitz: deploy-explorer suggestion (≥2) + relax explorer_guard_swap cross-structure

### DIFF
--- a/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.test.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.test.ts
@@ -50,6 +50,8 @@ const baseInput = (overrides: Partial<BlitzRealmSuggestionInput> = {}): BlitzRea
   populationCapacity: 10,
   occupiedGuards: 0,
   maxGuards: 0,
+  occupiedExplorers: 0,
+  maxExplorers: 0,
   buildability,
   ...overrides,
 });
@@ -278,6 +280,70 @@ describe("buildBlitzRealmSuggestions", () => {
         }),
       ),
     ).toEqual([]);
+  });
+
+  it("suggests deploying explorers (after wheat) until two are on the map", () => {
+    // Wheat target met for level 1 (4), explorer slots available, none deployed.
+    const [first] = buildBlitzRealmSuggestions(
+      baseInput({
+        realmLevel: 1,
+        buildingCounts: { ...emptyCounts, wheat: 4 },
+        maxExplorers: 5,
+        occupiedExplorers: 0,
+      }),
+    );
+    expect(first).toMatchObject({ action: "deploy-explorer", reason: "0/2 explorers deployed." });
+
+    // Explorers take priority over resource buildings once wheat is satisfied.
+    expect(
+      actionsFor(
+        baseInput({
+          realmLevel: 1,
+          buildingCounts: { ...emptyCounts, wheat: 4 },
+          maxExplorers: 5,
+          occupiedExplorers: 1,
+        }),
+      ),
+    ).toEqual(["deploy-explorer"]);
+  });
+
+  it("stops suggesting explorers once two are deployed", () => {
+    expect(
+      actionsFor(
+        baseInput({
+          realmLevel: 1,
+          buildingCounts: { ...emptyCounts, wheat: 4 },
+          maxExplorers: 5,
+          occupiedExplorers: 2,
+        }),
+      ),
+    ).not.toContain("deploy-explorer");
+  });
+
+  it("does not suggest explorers when the realm has no explorer slots", () => {
+    expect(
+      actionsFor(
+        baseInput({
+          realmLevel: 1,
+          buildingCounts: { ...emptyCounts, wheat: 4 },
+          maxExplorers: 0,
+          occupiedExplorers: 0,
+        }),
+      ),
+    ).not.toContain("deploy-explorer");
+  });
+
+  it("keeps wheat ahead of explorer deployment when the wheat target is unmet", () => {
+    expect(
+      actionsFor(
+        baseInput({
+          realmLevel: 1,
+          buildingCounts: { ...emptyCounts, wheat: 2 },
+          maxExplorers: 5,
+          occupiedExplorers: 0,
+        }),
+      ),
+    ).toEqual(["build-wheat"]);
   });
 
   it("gates garrison suggestions behind a foundation economy", () => {

--- a/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-facets/blitz-suggestions.ts
@@ -9,6 +9,7 @@ export type EmpireSuggestionAction =
   | "build-wheat"
   | "build-wood"
   | "build-worker-hut"
+  | "deploy-explorer"
   | "expand-population"
   | "garrison"
   | "provision"
@@ -56,6 +57,8 @@ export type BlitzRealmSuggestionInput = {
   populationCapacity: number;
   occupiedGuards: number;
   maxGuards: number;
+  occupiedExplorers: number;
+  maxExplorers: number;
   militaryTarget?: BlitzMilitaryTarget | null;
   buildability: Record<BlitzBuildKey, BlitzBuildability>;
 };
@@ -79,6 +82,9 @@ const BLITZ_TARGETS = {
 };
 
 const MIN_AVAILABLE_POPULATION_BEFORE_WORKER_HUT = 3;
+// Always nudge toward keeping at least this many explorer armies on the map.
+// Deploying requires picking a hex, so the suggestion only opens the army modal.
+const EXPLORER_DEPLOYMENT_TARGET = 2;
 const MILITARY_TARGETS_BY_REALM_LEVEL = [0, 1, 3, 5];
 // Wheat farm target by realm level (index = realm level). Levels beyond the
 // last entry clamp to the final value. Scales the food economy with the realm
@@ -303,6 +309,20 @@ const resolveGarrisonSuggestion = (input: BlitzRealmSuggestionInput): BlitzSugge
   return createBaseSuggestion(input, "garrison", "Garrison realm", 100, "No defenders stationed.");
 };
 
+const resolveExplorerDeploymentSuggestion = (input: BlitzRealmSuggestionInput): BlitzSuggestionDraft | null => {
+  if (input.maxExplorers <= 0) return null;
+  if (input.occupiedExplorers >= EXPLORER_DEPLOYMENT_TARGET) return null;
+
+  // We can't auto-pick a deploy hex, so this only opens the army modal.
+  return createBaseSuggestion(
+    input,
+    "deploy-explorer",
+    "Deploy explorer army",
+    15,
+    `${input.occupiedExplorers}/${EXPLORER_DEPLOYMENT_TARGET} explorers deployed.`,
+  );
+};
+
 export const buildBlitzRealmSuggestions = (input: BlitzRealmSuggestionInput): BlitzSuggestionDraft[] => {
   if (!input.isBlitzActive) return [];
 
@@ -322,6 +342,7 @@ export const buildBlitzRealmSuggestions = (input: BlitzRealmSuggestionInput): Bl
     resolveUpgradeSuggestion(input) ??
     resolvePopulationSuggestion(input) ??
     resolveWheatSuggestion(input) ??
+    resolveExplorerDeploymentSuggestion(input) ??
     resolveResourceSuggestion(input) ??
     resolveMilitarySuggestion(input) ??
     resolveGarrisonSuggestion(input);

--- a/client/apps/game/src/ui/features/world/containers/left-facets/use-empire-suggestions.ts
+++ b/client/apps/game/src/ui/features/world/containers/left-facets/use-empire-suggestions.ts
@@ -26,6 +26,7 @@ import { getEntityIdFromKeys } from "@dojoengine/utils";
 import type { LucideIcon } from "lucide-react";
 import ArrowUpCircle from "lucide-react/dist/esm/icons/arrow-up-circle";
 import Building2 from "lucide-react/dist/esm/icons/building-2";
+import Compass from "lucide-react/dist/esm/icons/compass";
 import HomeIcon from "lucide-react/dist/esm/icons/home";
 import Pickaxe from "lucide-react/dist/esm/icons/pickaxe";
 import Shield from "lucide-react/dist/esm/icons/shield";
@@ -78,6 +79,7 @@ const ACTION_ICONS: Record<EmpireSuggestionAction, LucideIcon> = {
   "build-wheat": Wheat,
   "build-wood": Building2,
   "build-worker-hut": HomeIcon,
+  "deploy-explorer": Compass,
   "expand-population": Sparkles,
   garrison: Shield,
   provision: Pickaxe,
@@ -320,6 +322,8 @@ export const useEmpireSuggestions = (): EmpireSuggestion[] => {
           populationCapacity: structure.populationCapacity,
           occupiedGuards: Number(base?.troop_guard_count ?? 0),
           maxGuards: Number(base?.troop_max_guard_count ?? 0),
+          occupiedExplorers: Number(base?.troop_explorer_count ?? 0),
+          maxExplorers: Number(base?.troop_max_explorer_count ?? 0),
           militaryTarget,
           buildability: resolveBlitzBuildability(buildabilityContext, militaryTarget),
         });

--- a/client/apps/game/src/ui/features/world/containers/left-facets/use-suggestion-actions.tsx
+++ b/client/apps/game/src/ui/features/world/containers/left-facets/use-suggestion-actions.tsx
@@ -118,6 +118,7 @@ export const useSuggestionActions = () => {
           await fireProvision(suggestion.realmId);
           return;
         case "garrison":
+        case "deploy-explorer":
           setLeftNavigationView(LeftView.MilitaryView);
           return;
         case "build-wheat":

--- a/contracts/game/src/systems/combat/contracts/troop_management.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_management.cairo
@@ -619,8 +619,13 @@ pub mod troop_management_systems {
                 from_explorer.coord.is_adjacent(to_structure_base.coord()), "explorer is not adjacent to structure",
             );
 
-            // ensure troops belong to owner structure
-            assert!(from_explorer.owner == to_structure_id, "explorer must belong to the same structure");
+            // Intentionally relaxed: an explorer may deposit troops into a different structure's
+            // guard (cross-structure). Caller ownership is still enforced above via
+            // assert_caller_owner on both the source explorer's owner and the target structure,
+            // so this only permits cross-structure moves within the same owner. Keep this
+            // commented (do not re-enable) — the client allows it and
+            // test_explorer_guard_swap_allows_different_structure depends on it.
+            // assert!(from_explorer.owner == to_structure_id, "explorer must belong to the same structure");
 
             // ensure count is valid
             assert!(count <= from_explorer.troops.count, "insufficient troops in explorer");


### PR DESCRIPTION
Two related troop-management changes (the contract relaxation + the matching client nudge).

## 1. Relax `explorer_guard_swap` (explorer → structure)
The explorer→structure same-structure assert was relaxed on both client and contract, but a later commit (`30c4cef`) re-enabled only the **contract** assert — leaving the client (`transfer-eligibility.ts`) and the contract's own test `test_explorer_guard_swap_allows_different_structure` expecting the relaxed behavior while the contract rejected it.

Re-relaxed (commented out, not deleted, with a do-not-re-enable note). Caller ownership is still enforced via `assert_caller_owner` on **both** sides, so only **same-owner cross-structure** deposits are permitted. `explorer_explorer_swap` and `guard_explorer_swap` remain strict.

## 2. New "Deploy explorer army" blitz suggestion (≥2)
Nudges toward keeping at least **2 explorer armies** on the map. Like garrison it can't auto-pick a deploy hex, so it opens the army modal (`LeftView.MilitaryView`). Reads `troop_explorer_count` / `troop_max_explorer_count` off the structure base (mirroring the guard fields). Sits **right after wheat** in the resolution order (explorers fuel upgrades), gated on `maxExplorers > 0 && occupiedExplorers < 2`. Garrison (≥1) and the other directions unchanged.

## Tests
- Cairo `troop_management` module — **42 passed, 0 failed** (snforge 0.51.0): relaxed test passes; the two strict revert tests still pass.
- `blitz-suggestions.test.ts` — 17 tests (wheat per-level + explorer-deploy gating). Full game-app typecheck clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)