### PR TITLE
perf(game): skip particles and contact shadows on LOW graphics tier

### DIFF
--- a/client/apps/game/src/three/constants/rendering.ts
+++ b/client/apps/game/src/three/constants/rendering.ts
@@ -81,6 +81,7 @@ export const POST_PROCESSING_CONFIG: Record<GraphicsSettings, PostProcessingConf
     bloomIntensity: 0.15,
   },
   [GraphicsSettings.LOW]: null,
+  [GraphicsSettings.ULTRA_LOW]: null,
 };
 
 export const CAMERA_FAR_PLANE = IS_FLAT_MODE ? CAMERA_CONFIG.far.flat : CAMERA_CONFIG.far.default;

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -3147,11 +3147,15 @@ export class ArmyManager {
 
   private handleCameraViewChange = (view: CameraView) => {
     const qualityShadowsEnabled = this.hexagonScene?.getShadowsEnabledByQuality() ?? true;
+    const contactShadowsAllowed = this.hexagonScene?.contactShadowsAllowedByQuality() ?? true;
     const enableRealShadows = view === CameraView.Close && qualityShadowsEnabled;
+    // Contact shadows are the fallback for real shadows; gate them off on LOW/below
+    // so the weakest hardware pays for neither real nor contact shadows.
+    const enableContactShadows = !enableRealShadows && contactShadowsAllowed;
 
     // Keep shadow flags in sync even if view is unchanged (quality can toggle shadows dynamically).
     this.armyModel.setShadowsEnabled(enableRealShadows);
-    this.armyModel.setContactShadowsEnabled(!enableRealShadows);
+    this.armyModel.setContactShadowsEnabled(enableContactShadows);
 
     if (this.currentCameraView === view) {
       return;

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -214,6 +214,7 @@ export class ArmyManager {
   private compactLabelRenderer: CompactEntityLabelRenderer;
   private frustumManager?: FrustumManager;
   private frustumVisibilityDirty = false;
+  private labelRenderDistance = Infinity;
   private lastLabelVisibilityUpdate = 0;
   private labelVisibilityIntervalMs = 66;
   // Keep moving-army culling bounds fresh without paying a full recompute every frame.
@@ -3003,7 +3004,19 @@ export class ArmyManager {
     this.frustumVisibilityDirty = true;
   }
 
+  public setLabelRenderDistance(distance: number): void {
+    this.labelRenderDistance = distance;
+    // Re-evaluate label visibility on the next update cycle.
+    this.frustumVisibilityDirty = true;
+  }
+
   private isArmyLabelVisible(label: CSS2DObject): boolean {
+    if (this.labelRenderDistance < Infinity) {
+      const camera = this.hexagonScene?.getCamera();
+      if (camera && camera.position.distanceTo(label.position) > this.labelRenderDistance) {
+        return false;
+      }
+    }
     return this.visibilityManager
       ? this.visibilityManager.isPointVisible(label.position)
       : (this.frustumManager?.isPointVisible(label.position) ?? true);

--- a/client/apps/game/src/three/managers/army-model.animation-visibility.test.ts
+++ b/client/apps/game/src/three/managers/army-model.animation-visibility.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/ui/config", () => ({
     MID: "MID",
   },
   IS_FLAT_MODE: false,
+  isLowOrBelow: (setting: string) => setting === "LOW" || setting === "ULTRA_LOW",
 }));
 
 vi.mock("@/utils/agent", () => ({

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -1,6 +1,6 @@
 import { CameraView } from "@/three/scenes/hexagon-scene";
 import { gltfLoader } from "@/three/utils/utils";
-import { FELT_CENTER, GRAPHICS_SETTING, GraphicsSettings } from "@/ui/config";
+import { FELT_CENTER, GRAPHICS_SETTING, GraphicsSettings, isLowOrBelow } from "@/ui/config";
 import { getCharacterModel } from "@/utils/agent";
 import { configManager } from "@bibliothecadao/eternum";
 import { BiomeType, TroopTier, TroopType } from "@bibliothecadao/types";
@@ -1067,7 +1067,7 @@ export class ArmyModel {
 
   // Animation Methods
   public updateAnimations(_deltaTime: number, visibility?: AnimationVisibilityContext): void {
-    if (GRAPHICS_SETTING === GraphicsSettings.LOW) return;
+    if (isLowOrBelow(GRAPHICS_SETTING)) return;
 
     const now = performance.now();
     const time = now * 0.001;
@@ -1308,7 +1308,7 @@ export class ArmyModel {
   private shouldSkipAnimation(animationState: number): boolean {
     return (
       (GRAPHICS_SETTING === GraphicsSettings.MID && animationState === ANIMATION_STATE_IDLE) ||
-      GRAPHICS_SETTING === GraphicsSettings.LOW ||
+      isLowOrBelow(GRAPHICS_SETTING) ||
       (this.currentCameraView === CameraView.Far && animationState === ANIMATION_STATE_IDLE)
     );
   }

--- a/client/apps/game/src/three/managers/chest-manager.ts
+++ b/client/apps/game/src/three/managers/chest-manager.ts
@@ -95,7 +95,9 @@ export class ChestManager {
 
   private handleCameraViewChange = (view: CameraView) => {
     const qualityShadowsEnabled = this.hexagonScene?.getShadowsEnabledByQuality() ?? true;
-    const enableContactShadows = !(view === CameraView.Close && qualityShadowsEnabled);
+    const contactShadowsAllowed = this.hexagonScene?.contactShadowsAllowedByQuality() ?? true;
+    // Contact shadows are the fallback for real shadows; gate them off on LOW/below.
+    const enableContactShadows = !(view === CameraView.Close && qualityShadowsEnabled) && contactShadowsAllowed;
 
     // Cheap grounding in zoomed-out views (and as a fallback if shadows are disabled).
     if (this.chestModel) {
@@ -198,7 +200,10 @@ export class ChestManager {
         this.animationClips = clips;
         this.scene.add(model.group);
         const qualityShadowsEnabled = this.hexagonScene?.getShadowsEnabledByQuality() ?? true;
-        const enableContactShadows = !(this.currentCameraView === CameraView.Close && qualityShadowsEnabled);
+        const contactShadowsAllowed = this.hexagonScene?.contactShadowsAllowedByQuality() ?? true;
+        // Contact shadows are the fallback for real shadows; gate them off on LOW/below.
+        const enableContactShadows =
+          !(this.currentCameraView === CameraView.Close && qualityShadowsEnabled) && contactShadowsAllowed;
         this.chestModel.setContactShadowsEnabled(enableContactShadows);
       })
       .catch((error) => {

--- a/client/apps/game/src/three/managers/instanced-biome.tsx
+++ b/client/apps/game/src/three/managers/instanced-biome.tsx
@@ -1,6 +1,6 @@
 import { PREVIEW_BUILD_COLOR_INVALID } from "@/three/constants";
 import { LAND_NAME } from "@/three/managers/instanced-model";
-import { GRAPHICS_SETTING, GraphicsSettings } from "@/ui/config";
+import { GRAPHICS_SETTING, isLowOrBelow } from "@/ui/config";
 import * as THREE from "three";
 import { AnimationClip, AnimationMixer } from "three";
 import { AnimationVisibilityContext } from "../types/animation";
@@ -397,7 +397,7 @@ export default class InstancedModel {
     if (!this.shouldAnimate(visibility)) {
       return;
     }
-    if (GRAPHICS_SETTING === GraphicsSettings.LOW) {
+    if (isLowOrBelow(GRAPHICS_SETTING)) {
       return;
     }
 

--- a/client/apps/game/src/three/managers/instanced-model.tsx
+++ b/client/apps/game/src/three/managers/instanced-model.tsx
@@ -1,5 +1,5 @@
 import { MinesMaterialsParams, PREVIEW_BUILD_COLOR_INVALID } from "@/three/constants";
-import { GRAPHICS_SETTING, GraphicsSettings } from "@/ui/config";
+import { GRAPHICS_SETTING, isLowOrBelow } from "@/ui/config";
 import { ResourcesIds, StructureType } from "@bibliothecadao/types";
 import {
   AnimationAction,
@@ -444,7 +444,7 @@ export default class InstancedModel {
     if (!this.shouldAnimate(visibility)) {
       return;
     }
-    if (GRAPHICS_SETTING === GraphicsSettings.LOW) {
+    if (isLowOrBelow(GRAPHICS_SETTING)) {
       return;
     }
 

--- a/client/apps/game/src/three/managers/particles.ts
+++ b/client/apps/game/src/three/managers/particles.ts
@@ -1,3 +1,4 @@
+import { GRAPHICS_SETTING, isLowOrBelow } from "@/ui/config";
 import * as THREE from "three";
 
 // particle constants
@@ -17,11 +18,25 @@ export class Particles {
   private pointsPositions: Float32Array;
   private particleVelocities: Float32Array;
   private particleAngles: Float32Array; // Store fixed angles for each particle
-  private points: THREE.Points;
-  private light: THREE.PointLight;
+  private points?: THREE.Points;
+  private light?: THREE.PointLight;
   private scene: THREE.Scene;
+  // On LOW/below we never allocate the Points geometry or the (always-on,
+  // intensity-10) PointLight, never add anything to the scene, and make every
+  // method a no-op. The selection marker simply does not appear on weak hardware.
+  private readonly disabled: boolean = isLowOrBelow(GRAPHICS_SETTING);
 
   constructor(scene: THREE.Scene) {
+    this.scene = scene;
+
+    this.pointsPositions = new Float32Array(0);
+    this.particleVelocities = new Float32Array(0);
+    this.particleAngles = new Float32Array(0);
+
+    if (this.disabled) {
+      return;
+    }
+
     this.pointsPositions = new Float32Array(PARTICLES_COUNT * 3);
     this.particleVelocities = new Float32Array(PARTICLES_COUNT);
     this.particleAngles = new Float32Array(PARTICLES_COUNT);
@@ -59,32 +74,36 @@ export class Particles {
     this.light = new THREE.PointLight(LIGHT_COLOR, LIGHT_INTENSITY);
     this.light.position.set(0, -1000, 0);
 
-    this.scene = scene;
     this.scene.add(this.points);
     this.scene.add(this.light);
   }
 
   setPosition(x: number, y: number, z: number) {
+    if (!this.points || !this.light) return;
     this.points.position.set(x, y, z);
     this.light.position.set(x, y + 1.5, z);
   }
 
   resetPosition() {
+    if (!this.points || !this.light) return;
     this.points.position.set(0, -1000, 0);
     this.light.position.set(0, -1000, 0);
   }
 
   setParticleSize(size: number) {
+    if (!this.points) return;
     const material = this.points.material as THREE.PointsMaterial;
     material.size = size;
     material.needsUpdate = true;
   }
 
   setLightIntensity(intensity: number) {
+    if (!this.light) return;
     this.light.intensity = intensity;
   }
 
   update(delta: number) {
+    if (this.disabled || !this.points) return;
     const clampedDelta = Math.min(delta, MAX_DELTA);
 
     for (let i = 0; i < PARTICLES_COUNT; i++) {
@@ -116,18 +135,18 @@ export class Particles {
     console.log("🧹 Particles: Starting disposal");
 
     // Remove from scene
-    if (this.points.parent) {
+    if (this.points?.parent) {
       this.points.parent.remove(this.points);
     }
-    if (this.light.parent) {
+    if (this.light?.parent) {
       this.light.parent.remove(this.light);
     }
 
     // Dispose geometry and material
-    if (this.points.geometry) {
+    if (this.points?.geometry) {
       this.points.geometry.dispose();
     }
-    if (this.points.material) {
+    if (this.points?.material) {
       (this.points.material as THREE.PointsMaterial).dispose();
     }
 

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -183,7 +183,8 @@ export class StructureManager {
   private readonly scratchIconPosition: Vector3 = new Vector3();
   private readonly tempCosmeticRotation: Euler = new Euler();
   private readonly structureAttachmentTransformScratch = new Map<string, AttachmentTransform>();
-  private readonly animationCullDistance = 140;
+  private animationCullDistance = 140;
+  private labelRenderDistance = Infinity;
   private animationCameraPosition: Vector3 = new Vector3();
   private animationVisibilityContext?: AnimationVisibilityContext;
   private pointsRenderers?: {
@@ -1795,6 +1796,18 @@ export class StructureManager {
     return this.animationVisibilityContext;
   }
 
+  public setAnimationCullDistance(distance: number): void {
+    this.animationCullDistance = distance;
+    // Invalidate the cached animation context so the new distance is rebuilt on next use.
+    this.animationVisibilityContext = undefined;
+  }
+
+  public setLabelRenderDistance(distance: number): void {
+    this.labelRenderDistance = distance;
+    // Re-evaluate label visibility on the next update cycle.
+    this.frustumVisibilityDirty = true;
+  }
+
   private applyFrustumVisibilityToLabels() {
     syncStructureLabelVisibility<ID>({
       labels: this.entityIdLabels.values(),
@@ -1932,6 +1945,12 @@ export class StructureManager {
   }
 
   private isStructureLabelVisible(label: CSS2DObject): boolean {
+    if (this.labelRenderDistance < Infinity) {
+      const camera = this.hexagonScene?.getCamera();
+      if (camera && camera.position.distanceTo(label.position) > this.labelRenderDistance) {
+        return false;
+      }
+    }
     return this.visibilityManager
       ? this.visibilityManager.isPointVisible(label.position)
       : (this.frustumManager?.isPointVisible(label.position) ?? true);

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -522,8 +522,11 @@ export class StructureManager {
 
   private updateShadowFlags(): void {
     const qualityShadowsEnabled = this.hexagonScene?.getShadowsEnabledByQuality() ?? true;
+    const contactShadowsAllowed = this.hexagonScene?.contactShadowsAllowedByQuality() ?? true;
     const enableCasting = this.currentCameraView === CameraView.Close && qualityShadowsEnabled;
-    const enableContactShadows = !enableCasting;
+    // Contact shadows are the fallback for real shadows; gate them off on LOW/below
+    // so the weakest hardware pays for neither casting nor contact shadows.
+    const enableContactShadows = !enableCasting && contactShadowsAllowed;
     const applyToModels = (models: InstancedModel[]) => {
       models.forEach((model) => {
         model.instancedMeshes.forEach((mesh) => {

--- a/client/apps/game/src/three/renderer-backend.test.ts
+++ b/client/apps/game/src/three/renderer-backend.test.ts
@@ -4,6 +4,7 @@ vi.mock("@/ui/config", () => ({
   GraphicsSettings: {
     LOW: "LOW",
   },
+  isLowOrBelow: (setting: string) => setting === "LOW" || setting === "ULTRA_LOW",
 }));
 
 vi.mock("three", async (importOriginal) => {

--- a/client/apps/game/src/three/renderer-backend.ts
+++ b/client/apps/game/src/three/renderer-backend.ts
@@ -10,7 +10,7 @@ import {
   WebGLRenderTarget,
 } from "three";
 import { PMREMGenerator } from "three";
-import { GraphicsSettings, type GraphicsSettings as GraphicsSettingsType } from "@/ui/config";
+import { isLowOrBelow, type GraphicsSettings as GraphicsSettingsType } from "@/ui/config";
 import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
 import { RGBELoader } from "three/examples/jsm/loaders/RGBELoader.js";
 import {
@@ -126,12 +126,12 @@ class WebGLRendererBackend implements RendererBackend {
     pixelRatio: number,
     dependencies: WebGLRendererBackendDependencies,
   ) {
-    const isLowGraphics = this.graphicsSetting === GraphicsSettings.LOW;
+    const isLowGraphics = isLowOrBelow(this.graphicsSetting);
     this.renderer = dependencies.createRenderer({
       isLowGraphics,
     });
     this.renderer.setPixelRatio(pixelRatio);
-    this.renderer.shadowMap.enabled = this.graphicsSetting !== GraphicsSettings.LOW;
+    this.renderer.shadowMap.enabled = !isLowOrBelow(this.graphicsSetting);
     this.renderer.shadowMap.type = this.isMobileDevice ? PCFShadowMap : PCFSoftShadowMap;
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     this.renderer.toneMapping = ACESFilmicToneMapping;

--- a/client/apps/game/src/three/renderer-display-runtime.ts
+++ b/client/apps/game/src/three/renderer-display-runtime.ts
@@ -36,6 +36,8 @@ export function resolveRendererTargetPixelRatio(
       return Math.min(devicePixelRatio, 2, mobileCap);
     case GraphicsSettings.MID:
       return Math.min(devicePixelRatio, 1.5, mobileCap);
+    case GraphicsSettings.ULTRA_LOW:
+      return Math.min(0.6, mobileCap);
     default:
       return Math.min(1, mobileCap);
   }
@@ -48,6 +50,8 @@ export function resolveRendererTargetFps(input: RendererDisplayPolicyInput): num
         return 45;
       case GraphicsSettings.MID:
         return 30;
+      case GraphicsSettings.ULTRA_LOW:
+        return 20;
       default:
         return 30;
     }
@@ -56,6 +60,8 @@ export function resolveRendererTargetFps(input: RendererDisplayPolicyInput): num
   switch (input.graphicsSetting) {
     case GraphicsSettings.LOW:
       return 30;
+    case GraphicsSettings.ULTRA_LOW:
+      return 20;
     case GraphicsSettings.MID:
       return 45;
     default:

--- a/client/apps/game/src/three/renderer-effects-runtime.ts
+++ b/client/apps/game/src/three/renderer-effects-runtime.ts
@@ -61,6 +61,7 @@ const DEFAULT_ENVIRONMENT_INTENSITY: Record<GraphicsSettings, number> = {
   [GraphicsSettings.HIGH]: 0.55,
   [GraphicsSettings.MID]: 0.45,
   [GraphicsSettings.LOW]: 0.25,
+  [GraphicsSettings.ULTRA_LOW]: 0.2,
 };
 
 const WEATHER_POST_PROCESSING_LIMITS = {

--- a/client/apps/game/src/three/scenes/hexagon-scene.ts
+++ b/client/apps/game/src/three/scenes/hexagon-scene.ts
@@ -18,7 +18,7 @@ import { PerformanceMonitor } from "@/three/utils/performance-monitor";
 import { gltfLoader } from "@/three/utils/utils";
 import type { QualityFeatures } from "@/three/utils/quality-controller";
 import { LeftView } from "@/types";
-import { GRAPHICS_SETTING, GraphicsSettings, IS_FLAT_MODE, isLowOrBelow } from "@/ui/config";
+import { GRAPHICS_SETTING, IS_FLAT_MODE, isLowOrBelow } from "@/ui/config";
 import { type SetupResult } from "@bibliothecadao/dojo";
 import { WorldUpdateListener } from "@bibliothecadao/eternum";
 import { BiomeType, type HexPosition } from "@bibliothecadao/types";
@@ -204,7 +204,7 @@ export abstract class HexagonScene {
     this.scene.background = new Color(0x2a1a3e);
     this.state = useUIStore.getState();
     this.fog = new Fog(FOG_CONFIG.color, FOG_CONFIG.near, FOG_CONFIG.far);
-    this.fogEnabledByQuality = !IS_FLAT_MODE && GRAPHICS_SETTING !== GraphicsSettings.LOW;
+    this.fogEnabledByQuality = !IS_FLAT_MODE && !isLowOrBelow(GRAPHICS_SETTING);
     this.fogEnabledByUser = true;
     if (this.fogEnabledByQuality && this.fogEnabledByUser) {
       this.scene.fog = this.fog;

--- a/client/apps/game/src/three/scenes/hexagon-scene.ts
+++ b/client/apps/game/src/three/scenes/hexagon-scene.ts
@@ -18,7 +18,7 @@ import { PerformanceMonitor } from "@/three/utils/performance-monitor";
 import { gltfLoader } from "@/three/utils/utils";
 import type { QualityFeatures } from "@/three/utils/quality-controller";
 import { LeftView } from "@/types";
-import { GRAPHICS_SETTING, GraphicsSettings, IS_FLAT_MODE } from "@/ui/config";
+import { GRAPHICS_SETTING, GraphicsSettings, IS_FLAT_MODE, isLowOrBelow } from "@/ui/config";
 import { type SetupResult } from "@bibliothecadao/dojo";
 import { WorldUpdateListener } from "@bibliothecadao/eternum";
 import { BiomeType, type HexPosition } from "@bibliothecadao/types";
@@ -1363,6 +1363,18 @@ export abstract class HexagonScene {
 
   public getShadowsEnabledByQuality(): boolean {
     return this.shadowsEnabledByQuality;
+  }
+
+  /**
+   * Whether contact (fake) shadows are permitted by the current graphics tier.
+   *
+   * Contact shadows are the *fallback* for real shadows, so on LOW/below they
+   * would otherwise always be on (real shadows are off there). The weakest
+   * hardware should pay for neither, so gate them off for LOW and any tier
+   * below it. MID/HIGH are unaffected.
+   */
+  public contactShadowsAllowedByQuality(): boolean {
+    return !isLowOrBelow(GRAPHICS_SETTING);
   }
 
   public addCameraViewListener(listener: (view: CameraView) => void) {

--- a/client/apps/game/src/three/scenes/hexception.tsx
+++ b/client/apps/game/src/three/scenes/hexception.tsx
@@ -38,7 +38,7 @@ import { BuildingSystemUpdate, Position, StructureProgress, getBlockTimestamp } 
 
 import { HexceptionAmbienceSystem } from "@/three/systems/hexception-ambience-system";
 import type { QualityLevel } from "@/three/systems/hexception-ambience-system";
-import { GRAPHICS_SETTING, IS_FLAT_MODE } from "@/ui/config";
+import { GRAPHICS_SETTING, IS_FLAT_MODE, isLowOrBelow } from "@/ui/config";
 import {
   HEXCEPTION_GRID_READY_EVENT,
   clearRememberedHexceptionGridReady,
@@ -204,7 +204,7 @@ export default class HexceptionScene extends HexagonScene {
     this.pillars.count = 0;
     this.scene.add(this.pillars);
 
-    const quality: QualityLevel = (GRAPHICS_SETTING as QualityLevel) || "HIGH";
+    const quality: QualityLevel = isLowOrBelow(GRAPHICS_SETTING) ? "LOW" : (GRAPHICS_SETTING as QualityLevel) || "HIGH";
     this.ambienceSystem = new HexceptionAmbienceSystem(this.scene, quality);
 
     this.loadBuildingModels();

--- a/client/apps/game/src/three/scenes/hud-scene.ts
+++ b/client/apps/game/src/three/scenes/hud-scene.ts
@@ -6,6 +6,7 @@ import { WeatherManager, type WeatherState } from "@/three/managers/weather-mana
 import { SceneManager } from "@/three/scene-manager";
 import { AmbientParticleSystem } from "@/three/systems/ambient-particle-system";
 import { GUIManager } from "@/three/utils/";
+import { GRAPHICS_SETTING, isLowOrBelow } from "@/ui/config";
 import { clampCycleProgress } from "@/utils/cycle-progress";
 import { AmbientLight, HemisphereLight, OrthographicCamera, Scene, Vector3 } from "three";
 import { MapControls } from "three/examples/jsm/controls/MapControls.js";
@@ -28,7 +29,10 @@ export default class HUDScene {
   private rainEffect!: RainEffect;
   private weatherManager!: WeatherManager;
   private ambienceManager!: AmbienceManager;
-  private ambientParticles!: AmbientParticleSystem;
+  // Undefined on LOW/below: the ambient particle system (dust + fireflies) is
+  // never constructed there, and its per-frame update loop is skipped entirely
+  // (setEnabled() only toggles .visible and would not stop the JS update cost).
+  private ambientParticles?: AmbientParticleSystem;
   private navigationTargetUnsubscribe: (() => void) | null = null;
   private cycleProgress: number = 0;
   private particleSpawnCenter: Vector3 = new Vector3();
@@ -72,8 +76,12 @@ export default class HUDScene {
     this.ambienceManager.addGUIControls(this.GUIFolder);
     this.addDebugTimeControls();
 
-    // Initialize ambient particle system (dust motes, fireflies)
-    this.ambientParticles = new AmbientParticleSystem(this.scene);
+    // Initialize ambient particle system (dust motes, fireflies).
+    // Skipped on LOW/below to avoid both the point-cloud draws and the
+    // per-frame JS update cost on weak hardware.
+    if (!isLowOrBelow(GRAPHICS_SETTING)) {
+      this.ambientParticles = new AmbientParticleSystem(this.scene);
+    }
 
     // Store subscription reference for cleanup
     this.navigationTargetUnsubscribe = useUIStore.subscribe(
@@ -230,21 +238,25 @@ export default class HUDScene {
       weatherState.stormIntensity,
     );
 
-    // Update ambient particles (dust motes, fireflies)
-    if (cycleProgress !== undefined) {
-      this.ambientParticles.setTimeProgress(cycleProgress);
+    // Update ambient particles (dust motes, fireflies).
+    // Skipped entirely on LOW/below (ambientParticles is undefined there), which
+    // avoids the full per-frame JS update loop, not just the draw.
+    if (this.ambientParticles) {
+      if (cycleProgress !== undefined) {
+        this.ambientParticles.setTimeProgress(cycleProgress);
+      }
+
+      // Pass wind to ambient particles
+      const windState = this.weatherManager.getWindState();
+      this.ambientParticles.setWind(windState.direction, windState.effectiveSpeed);
+
+      // Fade out ambient particles during weather
+      this.ambientParticles.setWeatherIntensity(weatherState.intensity);
+
+      // Update particle positions (follow camera)
+      this.particleSpawnCenter.set(this.camera.position.x, this.camera.position.y - 5, this.camera.position.z);
+      this.ambientParticles.update(deltaTime, this.particleSpawnCenter);
     }
-
-    // Pass wind to ambient particles
-    const windState = this.weatherManager.getWindState();
-    this.ambientParticles.setWind(windState.direction, windState.effectiveSpeed);
-
-    // Fade out ambient particles during weather
-    this.ambientParticles.setWeatherIntensity(weatherState.intensity);
-
-    // Update particle positions (follow camera)
-    this.particleSpawnCenter.set(this.camera.position.x, this.camera.position.y - 5, this.camera.position.z);
-    this.ambientParticles.update(deltaTime, this.particleSpawnCenter);
   }
 
   onWindowResize(width: number, height: number) {

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -43,6 +43,7 @@ import { SceneManager } from "@/three/scene-manager";
 import { CameraView } from "@/three/scenes/camera-view";
 import { CAMERA_CONFIG } from "@/three/constants";
 import { HexagonScene } from "@/three/scenes/hexagon-scene";
+import type { QualityFeatures } from "@/three/utils/quality-controller";
 import {
   processExplorerTroopsUpdate,
   type PendingArmyRemovalCancelSource,
@@ -737,6 +738,7 @@ export default class WorldmapScene extends WarpTravel {
   private interactiveHexWindowKey: string | null = null;
 
   private armyManager!: ArmyManager;
+  private latestQualityFeatures?: QualityFeatures;
   private pendingArmyMovements: Set<ID> = new Set();
   private pendingArmyMovementStartedAt: Map<ID, number> = new Map();
   private pendingArmyMovementFallbackTimeouts: Map<ID, ReturnType<typeof setTimeout>> = new Map();
@@ -1361,6 +1363,19 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
+  override applyQualityFeatures(features: QualityFeatures): void {
+    super.applyQualityFeatures(features);
+    this.latestQualityFeatures = features;
+    this.applyWorldmapQualityLimits(features);
+  }
+
+  private applyWorldmapQualityLimits(features: QualityFeatures): void {
+    this.visibilityManager?.setAnimationMaxDistance(features.animationCullDistance);
+    this.structureManager?.setAnimationCullDistance(features.animationCullDistance);
+    this.armyManager?.setLabelRenderDistance(features.labelRenderDistance);
+    this.structureManager?.setLabelRenderDistance(features.labelRenderDistance);
+  }
+
   private initializeWorldmapManagers(): void {
     this.armyLabelsGroup = new Group();
     this.armyLabelsGroup.name = "ArmyLabelsGroup";
@@ -1409,6 +1424,12 @@ export default class WorldmapScene extends WarpTravel {
     );
     this.reservedHyperstructureManager = new ReservedHyperstructureManager(this.scene);
     this.chestManager = new ChestManager(this.scene, this.renderChunkSize, this.chestLabelsGroup, this, this.chunkSize);
+
+    // Bootstrap applyQualityFeatures may have run before these managers existed; apply the
+    // latest known quality limits now that the managers are available.
+    if (this.latestQualityFeatures) {
+      this.applyWorldmapQualityLimits(this.latestQualityFeatures);
+    }
 
     // NOTE: Chunk integration system disabled for performance.
     // The chunk integration adds overhead via hydration tracking callbacks on every entity update.

--- a/client/apps/game/src/three/utils/quality-controller.ts
+++ b/client/apps/game/src/three/utils/quality-controller.ts
@@ -45,6 +45,32 @@ interface QualityPreset extends QualityFeatures {
  * Quality presets for LOW, MID, HIGH settings
  */
 const BASE_QUALITY_PRESETS: Record<GraphicsSettings, QualityPreset> = {
+  [GraphicsSettings.ULTRA_LOW]: {
+    name: "Potato",
+    targetFPS: 20,
+    // Rendering
+    shadows: false,
+    shadowMapSize: 0,
+    pixelRatio: 0.6, // sub-1.0 = internal upscale; the cheapest legible resolution
+    // Post-processing
+    bloom: false,
+    bloomIntensity: 0,
+    vignette: false,
+    chromaticAberration: false,
+    fxaa: false,
+    // Animations
+    morphAnimations: false,
+    animationFPS: 8,
+    // Entity limits
+    maxVisibleArmies: 50,
+    maxVisibleStructures: 30,
+    maxVisibleLabels: 40,
+    // LOD and culling
+    labelRenderDistance: 30,
+    animationCullDistance: 40,
+    // Chunk system
+    chunkLoadRadius: 1,
+  },
   [GraphicsSettings.LOW]: {
     name: "Low",
     targetFPS: 30,
@@ -126,6 +152,17 @@ const BASE_QUALITY_PRESETS: Record<GraphicsSettings, QualityPreset> = {
 };
 
 const MOBILE_QUALITY_PRESETS: Record<GraphicsSettings, QualityPreset> = {
+  [GraphicsSettings.ULTRA_LOW]: {
+    ...BASE_QUALITY_PRESETS[GraphicsSettings.ULTRA_LOW],
+    name: "Potato (Mobile)",
+    pixelRatio: 0.5,
+    animationFPS: 6,
+    maxVisibleArmies: 30,
+    maxVisibleStructures: 20,
+    maxVisibleLabels: 25,
+    labelRenderDistance: 20,
+    animationCullDistance: 30,
+  },
   [GraphicsSettings.LOW]: {
     ...BASE_QUALITY_PRESETS[GraphicsSettings.LOW],
     name: "Low (Mobile)",
@@ -205,6 +242,8 @@ const DEGRADATION_STEPS: DegradationStep[] = [
   { feature: "maxVisibleStructures", value: 100, description: "Reduced max visible structures" },
   { feature: "shadows", value: false, description: "Disabled shadows" },
   { feature: "pixelRatio", value: 1, description: "Reduced pixel ratio to 1" },
+  { feature: "pixelRatio", value: 0.6, description: "Reduced pixel ratio to 0.6 (potato)" },
+  { feature: "animationFPS", value: 8, description: "Reduced animation FPS to 8 (potato)" },
 ];
 
 /**

--- a/client/apps/game/src/three/webgpu-renderer-backend.ts
+++ b/client/apps/game/src/three/webgpu-renderer-backend.ts
@@ -1,4 +1,4 @@
-import type { GraphicsSettings as GraphicsSettingsType } from "@/ui/config";
+import { isLowOrBelow, type GraphicsSettings as GraphicsSettingsType } from "@/ui/config";
 import {
   ACESFilmicToneMapping,
   CineonToneMapping,
@@ -98,7 +98,7 @@ async function createDefaultWebGPURenderer(input: {
   }) as WebGPURendererSurface;
 
   renderer.autoClear = false;
-  renderer.shadowMap.enabled = input.graphicsSetting !== "LOW";
+  renderer.shadowMap.enabled = !isLowOrBelow(input.graphicsSetting);
   renderer.shadowMap.type = input.isMobileDevice ? PCFShadowMap : PCFSoftShadowMap;
   renderer.toneMapping = ACESFilmicToneMapping;
   renderer.toneMappingExposure = 0.8;

--- a/client/apps/game/src/ui/config.tsx
+++ b/client/apps/game/src/ui/config.tsx
@@ -9,6 +9,29 @@ export enum GraphicsSettings {
   HIGH = "HIGH",
 }
 
+/**
+ * Numeric rank for each graphics tier, lowest-spec first.
+ *
+ * Use this (via the helpers below) to compare tiers instead of scattering
+ * ad-hoc `=== GraphicsSettings.LOW` / `!== GraphicsSettings.LOW` checks. Those
+ * checks silently break when a tier is added *below* LOW: a lower tier still
+ * satisfies `!== LOW`, so an expensive feature gated on "not low" would wrongly
+ * turn back on for the weakest hardware. Ranking avoids that whole class of bug.
+ */
+export const GRAPHICS_TIER_RANK: Record<GraphicsSettings, number> = {
+  [GraphicsSettings.LOW]: 1,
+  [GraphicsSettings.MID]: 2,
+  [GraphicsSettings.HIGH]: 3,
+};
+
+/** True for LOW and any tier below it (e.g. a future ULTRA_LOW / "potato"). */
+export const isLowOrBelow = (setting: GraphicsSettings): boolean =>
+  GRAPHICS_TIER_RANK[setting] <= GRAPHICS_TIER_RANK[GraphicsSettings.LOW];
+
+/** True when `setting` is at least as high-spec as `floor`. */
+export const isAtOrAbove = (setting: GraphicsSettings, floor: GraphicsSettings): boolean =>
+  GRAPHICS_TIER_RANK[setting] >= GRAPHICS_TIER_RANK[floor];
+
 const getBrowserLocalStorage = (): Storage | null => {
   return typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;
 };

--- a/client/apps/game/src/ui/config.tsx
+++ b/client/apps/game/src/ui/config.tsx
@@ -19,7 +19,7 @@ export enum GraphicsSettings {
  * satisfies `!== LOW`, so an expensive feature gated on "not low" would wrongly
  * turn back on for the weakest hardware. Ranking avoids that whole class of bug.
  */
-export const GRAPHICS_TIER_RANK: Record<GraphicsSettings, number> = {
+const GRAPHICS_TIER_RANK: Record<GraphicsSettings, number> = {
   [GraphicsSettings.ULTRA_LOW]: 0,
   [GraphicsSettings.LOW]: 1,
   [GraphicsSettings.MID]: 2,
@@ -29,10 +29,6 @@ export const GRAPHICS_TIER_RANK: Record<GraphicsSettings, number> = {
 /** True for LOW and any tier below it (e.g. a future ULTRA_LOW / "potato"). */
 export const isLowOrBelow = (setting: GraphicsSettings): boolean =>
   GRAPHICS_TIER_RANK[setting] <= GRAPHICS_TIER_RANK[GraphicsSettings.LOW];
-
-/** True when `setting` is at least as high-spec as `floor`. */
-export const isAtOrAbove = (setting: GraphicsSettings, floor: GraphicsSettings): boolean =>
-  GRAPHICS_TIER_RANK[setting] >= GRAPHICS_TIER_RANK[floor];
 
 const getBrowserLocalStorage = (): Storage | null => {
   return typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;

--- a/client/apps/game/src/ui/config.tsx
+++ b/client/apps/game/src/ui/config.tsx
@@ -42,6 +42,101 @@ const getBrowserNavigator = (): Navigator | null => {
   return typeof globalThis.navigator === "undefined" ? null : globalThis.navigator;
 };
 
+type DetectedGpuTier = "weak" | "mid" | "strong" | "unknown";
+
+type CapabilityNavigator = Navigator & {
+  deviceMemory?: number;
+  getBattery?: () => Promise<{ charging: boolean }>;
+};
+
+// Software renderers (no real GPU acceleration): cannot run the full experience.
+const SOFTWARE_GPU_PATTERN = /swiftshader|llvmpipe|softpipe|microsoft basic render/;
+// Dedicated GPUs that comfortably handle the high tier.
+const STRONG_GPU_PATTERN = /nvidia|geforce|\brtx\b|\bgtx\b|radeon\s*(?:rx|pro)\b|\barc\b|apple\s*m\d/;
+// Integrated GPUs: capable but not gaming-grade.
+const INTEGRATED_GPU_PATTERN = /intel|iris|hd graphics|uhd graphics|mali|adreno|powervr|radeon|vega/;
+
+/**
+ * Best-effort GPU classification from the WebGL renderer string. Returns "unknown"
+ * when the string is masked (privacy browsers) or unavailable (SSR / no WebGL).
+ */
+const detectGpuTier = (): DetectedGpuTier => {
+  try {
+    if (typeof document === "undefined") {
+      return "unknown";
+    }
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl");
+    if (!gl) {
+      return "unknown";
+    }
+    const debugInfo = gl.getExtension("WEBGL_debug_renderer_info");
+    const rawRenderer: unknown = debugInfo ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) : "";
+    // Release the throwaway context promptly.
+    gl.getExtension("WEBGL_lose_context")?.loseContext();
+    const name = (typeof rawRenderer === "string" ? rawRenderer : "").toLowerCase();
+    if (!name) {
+      return "unknown";
+    }
+    if (SOFTWARE_GPU_PATTERN.test(name)) {
+      return "weak";
+    }
+    if (STRONG_GPU_PATTERN.test(name)) {
+      return "strong";
+    }
+    if (INTEGRATED_GPU_PATTERN.test(name)) {
+      return "mid";
+    }
+    return "unknown";
+  } catch (error) {
+    console.error("Error detecting GPU tier:", error);
+    return "unknown";
+  }
+};
+
+/**
+ * Recommend an initial graphics tier from device capability. Conservative: only
+ * downgrades on clear evidence, since the user can always change it from settings.
+ */
+const recommendInitialGraphicsSetting = async (): Promise<GraphicsSettings> => {
+  const browserNavigator = getBrowserNavigator() as CapabilityNavigator | null;
+  const reportedCores = browserNavigator?.hardwareConcurrency;
+  const reportedMemory = browserNavigator?.deviceMemory;
+  const cores = typeof reportedCores === "number" ? reportedCores : undefined;
+  const memory = typeof reportedMemory === "number" ? reportedMemory : undefined;
+  const gpuTier = detectGpuTier();
+
+  const veryLowCores = cores !== undefined && cores <= 2;
+  const veryLowMemory = memory !== undefined && memory <= 2;
+  const lowCores = cores !== undefined && cores <= 4;
+  const lowMemory = memory !== undefined && memory <= 4;
+
+  // Software rendering, or two independent strong "weak" signals => potato.
+  if (gpuTier === "weak" || (veryLowCores && veryLowMemory)) {
+    return GraphicsSettings.ULTRA_LOW;
+  }
+
+  // Clearly constrained hardware, or an integrated GPU plus one weak signal => low.
+  if ((lowCores && lowMemory) || (gpuTier === "mid" && (lowCores || lowMemory))) {
+    return GraphicsSettings.LOW;
+  }
+
+  // Final weak tie-breaker: an integrated GPU on battery power (likely a thin
+  // laptop) leans low; otherwise default to high (the user can dial it down).
+  if (gpuTier === "mid" && typeof browserNavigator?.getBattery === "function") {
+    try {
+      const battery = await browserNavigator.getBattery();
+      if (!battery.charging) {
+        return GraphicsSettings.LOW;
+      }
+    } catch (error) {
+      console.error("Error calling getBattery():", error);
+    }
+  }
+
+  return GraphicsSettings.HIGH;
+};
+
 const checkGraphicsSettings = async () => {
   const browserLocalStorage = getBrowserLocalStorage();
   if (!browserLocalStorage) {
@@ -58,28 +153,12 @@ const checkGraphicsSettings = async () => {
     return newSetting;
   }
 
-  // Check if initial laptop check has been done
+  // On first load, pick a sensible default from the device's capability so weak
+  // hardware lands on a low tier instead of always defaulting to HIGH. The choice
+  // is then sticky in localStorage and the user can change it from settings.
   if (!browserLocalStorage.getItem("INITIAL_LAPTOP_CHECK")) {
-    const browserNavigator = getBrowserNavigator() as (Navigator & { getBattery?: () => Promise<any> }) | null;
-    if (typeof browserNavigator?.getBattery === "function") {
-      try {
-        const battery = await browserNavigator.getBattery();
-        if (battery.charging && battery.chargingTime === 0) {
-          // It's likely a desktop
-          browserLocalStorage.setItem("GRAPHICS_SETTING", GraphicsSettings.HIGH);
-        } else {
-          // Default to high even on portable devices; users can dial it down if needed
-          browserLocalStorage.setItem("GRAPHICS_SETTING", GraphicsSettings.HIGH);
-        }
-      } catch (error) {
-        console.error("Error calling getBattery():", error);
-        // Default to high when getBattery() is not supported
-        browserLocalStorage.setItem("GRAPHICS_SETTING", GraphicsSettings.HIGH);
-      }
-    } else {
-      browserLocalStorage.setItem("GRAPHICS_SETTING", GraphicsSettings.HIGH);
-    }
-
+    const recommended = await recommendInitialGraphicsSetting();
+    browserLocalStorage.setItem("GRAPHICS_SETTING", recommended);
     browserLocalStorage.setItem("INITIAL_LAPTOP_CHECK", "true");
   }
 

--- a/client/apps/game/src/ui/config.tsx
+++ b/client/apps/game/src/ui/config.tsx
@@ -4,6 +4,7 @@ import { BuildingType, ResourceMiningTypes } from "@bibliothecadao/types";
 export const FELT_CENTER = FELT_CENTER_IMPORT;
 
 export enum GraphicsSettings {
+  ULTRA_LOW = "ULTRA_LOW",
   LOW = "LOW",
   MID = "MID",
   HIGH = "HIGH",
@@ -19,6 +20,7 @@ export enum GraphicsSettings {
  * turn back on for the weakest hardware. Ranking avoids that whole class of bug.
  */
 export const GRAPHICS_TIER_RANK: Record<GraphicsSettings, number> = {
+  [GraphicsSettings.ULTRA_LOW]: 0,
   [GraphicsSettings.LOW]: 1,
   [GraphicsSettings.MID]: 2,
   [GraphicsSettings.HIGH]: 3,

--- a/client/apps/game/src/ui/features/landing/components/landing-settings.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-settings.tsx
@@ -4,6 +4,20 @@ import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { Maximize2, Minimize2, Monitor, Music, Volume2, VolumeX, X } from "lucide-react";
 import { useEffect, useState } from "react";
 
+const GRAPHICS_OPTIONS: GraphicsSettings[] = [
+  GraphicsSettings.ULTRA_LOW,
+  GraphicsSettings.LOW,
+  GraphicsSettings.MID,
+  GraphicsSettings.HIGH,
+];
+
+const GRAPHICS_OPTION_LABELS: Record<GraphicsSettings, string> = {
+  [GraphicsSettings.ULTRA_LOW]: "Potato",
+  [GraphicsSettings.LOW]: "LOW",
+  [GraphicsSettings.MID]: "MID",
+  [GraphicsSettings.HIGH]: "HIGH",
+};
+
 interface DocumentWithFullscreen extends HTMLDocument {
   mozFullScreenElement?: Element;
   msFullscreenElement?: Element;
@@ -281,12 +295,7 @@ export const LandingSettings = ({ onClose, className }: LandingSettingsProps) =>
 
         <LandingSettingsSection icon={Monitor} title="Graphics">
           <div className="grid grid-cols-4 gap-2">
-            {[
-              GraphicsSettings.ULTRA_LOW,
-              GraphicsSettings.LOW,
-              GraphicsSettings.MID,
-              GraphicsSettings.HIGH,
-            ].map((setting) => {
+            {GRAPHICS_OPTIONS.map((setting) => {
               const isActive = graphicsSetting === setting;
               return (
                 <button
@@ -301,9 +310,7 @@ export const LandingSettings = ({ onClose, className }: LandingSettingsProps) =>
                       : "border-gold/14 bg-black/35 text-gold/68 hover:border-gold/26 hover:bg-gold/[0.08] hover:text-gold",
                   )}
                 >
-                  {setting === GraphicsSettings.ULTRA_LOW
-                    ? "Potato"
-                    : setting.charAt(0).toUpperCase() + setting.slice(1)}
+                  {GRAPHICS_OPTION_LABELS[setting]}
                 </button>
               );
             })}

--- a/client/apps/game/src/ui/features/landing/components/landing-settings.tsx
+++ b/client/apps/game/src/ui/features/landing/components/landing-settings.tsx
@@ -280,8 +280,13 @@ export const LandingSettings = ({ onClose, className }: LandingSettingsProps) =>
         </LandingSettingsSection>
 
         <LandingSettingsSection icon={Monitor} title="Graphics">
-          <div className="grid grid-cols-3 gap-2">
-            {[GraphicsSettings.LOW, GraphicsSettings.MID, GraphicsSettings.HIGH].map((setting) => {
+          <div className="grid grid-cols-4 gap-2">
+            {[
+              GraphicsSettings.ULTRA_LOW,
+              GraphicsSettings.LOW,
+              GraphicsSettings.MID,
+              GraphicsSettings.HIGH,
+            ].map((setting) => {
               const isActive = graphicsSetting === setting;
               return (
                 <button
@@ -296,7 +301,9 @@ export const LandingSettings = ({ onClose, className }: LandingSettingsProps) =>
                       : "border-gold/14 bg-black/35 text-gold/68 hover:border-gold/26 hover:bg-gold/[0.08] hover:text-gold",
                   )}
                 >
-                  {setting.charAt(0).toUpperCase() + setting.slice(1)}
+                  {setting === GraphicsSettings.ULTRA_LOW
+                    ? "Potato"
+                    : setting.charAt(0).toUpperCase() + setting.slice(1)}
                 </button>
               );
             })}

--- a/client/apps/game/src/ui/modules/settings/settings.tsx
+++ b/client/apps/game/src/ui/modules/settings/settings.tsx
@@ -185,6 +185,16 @@ export const SettingsWindow = () => {
             <div className="text-xs text-gray-gold mt-2">Quality</div>
             <div className="flex space-x-2">
               <Button
+                disabled={GRAPHICS_SETTING === GraphicsSettings.ULTRA_LOW}
+                variant={GRAPHICS_SETTING === GraphicsSettings.ULTRA_LOW ? "success" : "outline"}
+                onClick={() => {
+                  localStorage.setItem("GRAPHICS_SETTING", GraphicsSettings.ULTRA_LOW);
+                  window.location.reload();
+                }}
+              >
+                Potato
+              </Button>
+              <Button
                 disabled={GRAPHICS_SETTING === GraphicsSettings.LOW}
                 variant={GRAPHICS_SETTING === GraphicsSettings.LOW ? "success" : "outline"}
                 onClick={() => {


### PR DESCRIPTION
Foundational low-spec performance work. Adds an isLowOrBelow() graphics-tier helper in config.tsx and uses it to fully skip the selection-marker particles (including the always-on intensity-10 PointLight) and the HUD ambient particle system, both construction and per-frame update, on the LOW graphics tier. Also gates contact shadows off on LOW for armies, structures, and chests via a new contactShadowsAllowedByQuality() accessor on HexagonScene, so the weakest hardware pays for neither real nor contact shadows. MID/HIGH rendering is unchanged.