### PR TITLE
[codex] Fix worldmap army removal recovery

### DIFF
--- a/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
+++ b/client/apps/game/src/three/scenes/__tests__/worldmap-update-helpers.test.ts
@@ -81,4 +81,26 @@ describe("processExplorerTroopsUpdate", () => {
 
     expect(callOrder).toEqual(["hexes", "army", "live-signal", "pending-clear", "recovery"]);
   });
+
+  it("applies live troop updates without recovering pending removals when recovery is rejected", () => {
+    const update = {
+      entityId: 11,
+      troopCount: 18,
+      hexCoords: { col: 2107, row: 2108 },
+    } as any;
+    const recoverPendingArmyRemovalFromExplorerTroops = vi.fn();
+
+    processExplorerTroopsUpdate(update, {
+      cancelPendingArmyRemoval: vi.fn(),
+      scheduleArmyRemoval: vi.fn(),
+      updateArmyHexes: vi.fn(),
+      updateArmyFromExplorerTroopsUpdate: vi.fn(),
+      recordLiveArmyPresenceUpdate: vi.fn(),
+      onAuthoritativePositionApplied: vi.fn(),
+      recoverPendingArmyRemovalFromExplorerTroops,
+      shouldRecoverPendingArmyRemovalFromExplorerTroops: vi.fn(() => false),
+    });
+
+    expect(recoverPendingArmyRemovalFromExplorerTroops).not.toHaveBeenCalled();
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
+import {
+  findSupersededArmyRemoval,
+  isStaleTrackedArmyTileRemoval,
+  shouldRecoverPendingArmyRemovalFromExplorerTroops,
+} from "./worldmap-army-removal";
 
 describe("isStaleTrackedArmyTileRemoval", () => {
   it("treats a tile removal as stale when the tracked army already moved elsewhere", () => {
@@ -38,6 +42,48 @@ describe("isStaleTrackedArmyTileRemoval", () => {
         removalPosition: { col: 10, row: 10 },
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldRecoverPendingArmyRemovalFromExplorerTroops", () => {
+  it("does not recover tile removals from troop updates still pointing at the removed tile", () => {
+    expect(
+      shouldRecoverPendingArmyRemovalFromExplorerTroops({
+        reason: "tile",
+        removalPosition: { col: 10, row: 10 },
+        troopsPosition: { col: 10, row: 10 },
+      }),
+    ).toBe(false);
+  });
+
+  it("recovers tile removals when troops have moved away from the removed tile", () => {
+    expect(
+      shouldRecoverPendingArmyRemovalFromExplorerTroops({
+        reason: "tile",
+        removalPosition: { col: 10, row: 10 },
+        troopsPosition: { col: 11, row: 10 },
+      }),
+    ).toBe(true);
+  });
+
+  it("requires explicit position evidence for tile removals", () => {
+    expect(
+      shouldRecoverPendingArmyRemovalFromExplorerTroops({
+        reason: "tile",
+        removalPosition: undefined,
+        troopsPosition: { col: 10, row: 10 },
+      }),
+    ).toBe(false);
+  });
+
+  it("allows live troop updates to recover zero-count removals", () => {
+    expect(
+      shouldRecoverPendingArmyRemovalFromExplorerTroops({
+        reason: "zero",
+        removalPosition: { col: 10, row: 10 },
+        troopsPosition: { col: 10, row: 10 },
+      }),
+    ).toBe(true);
   });
 });
 

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.test.ts
@@ -76,14 +76,14 @@ describe("shouldRecoverPendingArmyRemovalFromExplorerTroops", () => {
     ).toBe(false);
   });
 
-  it("allows live troop updates to recover zero-count removals", () => {
+  it("does not recover zero-count removals from later troop updates", () => {
     expect(
       shouldRecoverPendingArmyRemovalFromExplorerTroops({
         reason: "zero",
         removalPosition: { col: 10, row: 10 },
         troopsPosition: { col: 10, row: 10 },
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.ts
@@ -9,6 +9,12 @@ interface StaleTrackedArmyTileRemovalInput {
   removalPosition?: ArmyHexPosition;
 }
 
+interface PendingArmyRemovalExplorerTroopsRecoveryInput {
+  reason: "tile" | "zero";
+  removalPosition?: ArmyHexPosition;
+  troopsPosition: ArmyHexPosition;
+}
+
 interface PendingArmyRemovalCandidate<TArmyId> {
   entityId: TArmyId;
   scheduledAt: number;
@@ -49,6 +55,22 @@ export function isStaleTrackedArmyTileRemoval(input: StaleTrackedArmyTileRemoval
   }
 
   return !isExactPosition(trackedPosition, removalPosition);
+}
+
+export function shouldRecoverPendingArmyRemovalFromExplorerTroops(
+  input: PendingArmyRemovalExplorerTroopsRecoveryInput,
+): boolean {
+  const { reason, removalPosition, troopsPosition } = input;
+
+  if (reason !== "tile") {
+    return true;
+  }
+
+  if (!removalPosition) {
+    return false;
+  }
+
+  return !isExactPosition(removalPosition, troopsPosition);
 }
 
 /**

--- a/client/apps/game/src/three/scenes/worldmap-army-removal.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-removal.ts
@@ -62,8 +62,8 @@ export function shouldRecoverPendingArmyRemovalFromExplorerTroops(
 ): boolean {
   const { reason, removalPosition, troopsPosition } = input;
 
-  if (reason !== "tile") {
-    return true;
+  if (reason === "zero") {
+    return false;
   }
 
   if (!removalPosition) {

--- a/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
@@ -41,12 +41,12 @@ describe("worldmap army tile-sync recovery", () => {
     expect(listenerBody).not.toContain("this.armyLastTileSyncAt.set(update.entityId");
   });
 
-  it("uses the aggregated live-update helper for scheduled removal cancellation and deferred retry", () => {
+  it("uses tile-sync timestamps for scheduled removal cancellation and deferred retry", () => {
     const src = readSource("worldmap.tsx");
 
     const scheduleStart = src.indexOf("private scheduleArmyRemoval(");
     const retryStart = src.indexOf("private retryDeferredChunkRemovals()");
-    const helperStart = src.indexOf("private resolveLastArmyLiveUpdateAt(");
+    const helperStart = src.indexOf("private resolveLastArmyTileSyncAt(");
     expect(scheduleStart).toBeGreaterThan(-1);
     expect(retryStart).toBeGreaterThan(-1);
     expect(helperStart).toBeGreaterThan(-1);
@@ -55,9 +55,9 @@ describe("worldmap army tile-sync recovery", () => {
     const retryBody = src.slice(retryStart, retryStart + 900);
     const helperBody = src.slice(helperStart, helperStart + 300);
 
-    expect(scheduleBody).toContain("this.resolveLastArmyLiveUpdateAt(entityId)");
-    expect(retryBody).toContain("this.resolveLastArmyLiveUpdateAt(entityId)");
+    expect(scheduleBody).toContain("this.resolveLastArmyTileSyncAt(entityId)");
+    expect(retryBody).toContain("this.resolveLastArmyTileSyncAt(entityId)");
     expect(helperBody).toContain("this.armyLastTileSyncAt.get(entityId)");
-    expect(helperBody).toContain("this.armyLastLiveUpdateAt.get(entityId)");
+    expect(helperBody).not.toContain("this.armyLastLiveUpdateAt.get(entityId)");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-deferred-army-removal-runtime.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-deferred-army-removal-runtime.test.ts
@@ -55,4 +55,23 @@ describe("retryDeferredWorldmapArmyRemovals", () => {
     expect(onRecoveredArmy).not.toHaveBeenCalled();
     expect(onRetryRemoval).toHaveBeenCalledWith(9, "zero");
   });
+
+  it("requeues removals with their original removal position", () => {
+    const onRecoveredArmy = vi.fn();
+    const onRetryRemoval = vi.fn();
+    const deferredChunkRemovals = new Map<
+      number,
+      { reason: "tile" | "zero"; scheduledAt: number; position?: { col: number; row: number } }
+    >([[9, { reason: "tile", scheduledAt: 200, position: { col: 10, row: 11 } }]]);
+
+    retryDeferredWorldmapArmyRemovals({
+      deferredChunkRemovals,
+      onRecoveredArmy,
+      onRetryRemoval,
+      resolveLastTileSyncAt: () => 150,
+    });
+
+    expect(onRecoveredArmy).not.toHaveBeenCalled();
+    expect(onRetryRemoval).toHaveBeenCalledWith(9, "tile", { position: { col: 10, row: 11 } });
+  });
 });

--- a/client/apps/game/src/three/scenes/worldmap-deferred-army-removal-runtime.ts
+++ b/client/apps/game/src/three/scenes/worldmap-deferred-army-removal-runtime.ts
@@ -1,8 +1,27 @@
+interface ArmyHexPosition {
+  col: number;
+  row: number;
+}
+
+export interface DeferredWorldmapArmyRemoval {
+  reason: "tile" | "zero";
+  scheduledAt: number;
+  ownerAddress?: bigint;
+  ownerStructureId?: number | null;
+  position?: ArmyHexPosition;
+}
+
 interface RetryDeferredWorldmapArmyRemovalsInput<TEntityId> {
-  deferredChunkRemovals: Map<TEntityId, { reason: "tile" | "zero"; scheduledAt: number }>;
+  deferredChunkRemovals: Map<TEntityId, DeferredWorldmapArmyRemoval>;
   onRecoveredArmy: (entityId: TEntityId) => void;
-  onRetryRemoval: (entityId: TEntityId, reason: "tile" | "zero") => void;
+  onRetryRemoval: (entityId: TEntityId, reason: "tile" | "zero", context?: DeferredWorldmapArmyRemovalContext) => void;
   resolveLastTileSyncAt: (entityId: TEntityId) => number;
+}
+
+interface DeferredWorldmapArmyRemovalContext {
+  ownerAddress?: bigint;
+  ownerStructureId?: number | null;
+  position?: ArmyHexPosition;
 }
 
 export function retryDeferredWorldmapArmyRemovals<TEntityId>(
@@ -15,15 +34,41 @@ export function retryDeferredWorldmapArmyRemovals<TEntityId>(
   const deferred = Array.from(input.deferredChunkRemovals.entries());
   input.deferredChunkRemovals.clear();
 
-  deferred.forEach(([entityId, { reason, scheduledAt }]) => {
+  deferred.forEach(([entityId, removal]) => {
+    const { reason, scheduledAt } = removal;
     const lastUpdate = input.resolveLastTileSyncAt(entityId);
     if (lastUpdate > scheduledAt) {
       input.onRecoveredArmy(entityId);
       return;
     }
 
-    input.onRetryRemoval(entityId, reason);
+    retryDeferredRemoval(input, entityId, removal);
   });
 
   return deferred.length;
+}
+
+function retryDeferredRemoval<TEntityId>(
+  input: RetryDeferredWorldmapArmyRemovalsInput<TEntityId>,
+  entityId: TEntityId,
+  removal: DeferredWorldmapArmyRemoval,
+): void {
+  const context = buildDeferredRemovalRetryContext(removal);
+  if (context) {
+    input.onRetryRemoval(entityId, removal.reason, context);
+    return;
+  }
+
+  input.onRetryRemoval(entityId, removal.reason);
+}
+
+function buildDeferredRemovalRetryContext(
+  removal: DeferredWorldmapArmyRemoval,
+): DeferredWorldmapArmyRemovalContext | undefined {
+  const { ownerAddress, ownerStructureId, position } = removal;
+  if (ownerAddress === undefined && ownerStructureId === undefined && position === undefined) {
+    return undefined;
+  }
+
+  return { ownerAddress, ownerStructureId, position };
 }

--- a/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.ts
+++ b/client/apps/game/src/three/scenes/worldmap-runtime-lifecycle.ts
@@ -5,7 +5,6 @@ interface WorldmapSwitchOffRuntimeStateInput<TEntityId, TTimeout> {
   pendingArmyRemovalMeta: Map<TEntityId, unknown>;
   deferredChunkRemovals: Map<TEntityId, unknown>;
   armyLastTileSyncAt: Map<TEntityId, number>;
-  armyLastLiveUpdateAt?: Map<TEntityId, number>;
   pendingArmyMovements: Set<TEntityId>;
   pendingArmyMovementStartedAt: Map<TEntityId, number>;
   pendingArmyMovementFallbackTimeouts: Map<TEntityId, TTimeout>;
@@ -58,7 +57,6 @@ export const applyWorldmapSwitchOffRuntimeState = <TEntityId, TTimeout>({
   pendingArmyRemovalMeta,
   deferredChunkRemovals,
   armyLastTileSyncAt,
-  armyLastLiveUpdateAt,
   pendingArmyMovements,
   pendingArmyMovementStartedAt,
   pendingArmyMovementFallbackTimeouts,
@@ -84,7 +82,6 @@ export const applyWorldmapSwitchOffRuntimeState = <TEntityId, TTimeout>({
   pendingArmyRemovalMeta.clear();
   deferredChunkRemovals.clear();
   armyLastTileSyncAt.clear();
-  armyLastLiveUpdateAt?.clear();
   pendingArmyMovements.forEach((entityId) => clearPendingArmyMovement(entityId));
   pendingArmyMovements.clear();
   pendingArmyMovementStartedAt.clear();

--- a/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
+++ b/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
@@ -17,6 +17,7 @@ type ExplorerTroopsUpdateHandlers = {
   onAuthoritativePositionApplied?: (update: ExplorerTroopsSystemUpdate) => void;
   onManagerUpdateApplied?: (update: ExplorerTroopsSystemUpdate) => void;
   recoverPendingArmyRemovalFromExplorerTroops?: (update: ExplorerTroopsSystemUpdate) => void;
+  shouldRecoverPendingArmyRemovalFromExplorerTroops?: (update: ExplorerTroopsSystemUpdate) => boolean;
   shouldSkipStalePositionUpdate?: (entityId: ID, normalized: { x: number; y: number }) => boolean;
 };
 
@@ -49,6 +50,15 @@ export function processExplorerTroopsUpdate(
   if (!shouldSkipPosition) {
     handlers.recordLiveArmyPresenceUpdate?.(update);
     handlers.onAuthoritativePositionApplied?.(update);
-    handlers.recoverPendingArmyRemovalFromExplorerTroops?.(update);
+    if (shouldRecoverPendingArmyRemovalFromExplorerTroops(update, handlers)) {
+      handlers.recoverPendingArmyRemovalFromExplorerTroops?.(update);
+    }
   }
+}
+
+function shouldRecoverPendingArmyRemovalFromExplorerTroops(
+  update: ExplorerTroopsSystemUpdate,
+  handlers: ExplorerTroopsUpdateHandlers,
+): boolean {
+  return handlers.shouldRecoverPendingArmyRemovalFromExplorerTroops?.(update) ?? true;
 }

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -69,6 +69,7 @@ import {
   ChestSystemUpdate,
   DEFAULT_COORD_ALT,
   ExplorerRewardSystemUpdate,
+  ExplorerTroopsSystemUpdate,
   ExplorerTroopsTileSystemUpdate,
   getBlockTimestamp,
   getGuardsByStructure,

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -207,7 +207,10 @@ import {
   recordWorldmapTerrainReadyDuration,
 } from "./worldmap-terrain-commit-runtime";
 import { runWorldmapArmySelectionRecovery } from "./worldmap-army-selection-recovery-runtime";
-import { retryDeferredWorldmapArmyRemovals } from "./worldmap-deferred-army-removal-runtime";
+import {
+  retryDeferredWorldmapArmyRemovals,
+  type DeferredWorldmapArmyRemoval,
+} from "./worldmap-deferred-army-removal-runtime";
 import {
   resolveArmyTabSelectionPosition,
   resolvePendingArmyMovementFallbackPlan,
@@ -234,7 +237,11 @@ import {
   type PendingArmyMovementEffectClearReason,
   type TravelEffectType,
 } from "./worldmap-travel-effect-policy";
-import { findSupersededArmyRemoval, isStaleTrackedArmyTileRemoval } from "./worldmap-army-removal";
+import {
+  findSupersededArmyRemoval,
+  isStaleTrackedArmyTileRemoval,
+  shouldRecoverPendingArmyRemovalFromExplorerTroops as shouldRecoverArmyRemovalFromTroopsPosition,
+} from "./worldmap-army-removal";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
 import { resolveArmyOwnerCacheAction } from "./worldmap-army-owner-resolution";
@@ -872,7 +879,6 @@ export default class WorldmapScene extends WarpTravel {
   // normalized coordinates
   private armiesPositions: Map<ID, HexPosition> = new Map();
   private armyLastTileSyncAt: Map<ID, number> = new Map();
-  private armyLastLiveUpdateAt: Map<ID, number> = new Map();
   // normalized coordinates
   private structuresPositions: Map<ID, HexPosition> = new Map();
 
@@ -1069,7 +1075,7 @@ export default class WorldmapScene extends WarpTravel {
       position?: HexPosition;
     }
   > = new Map();
-  private deferredChunkRemovals: Map<ID, { reason: "tile" | "zero"; scheduledAt: number }> = new Map();
+  private deferredChunkRemovals: Map<ID, DeferredWorldmapArmyRemoval> = new Map();
 
   private fxManager!: FXManager;
   private arrivalGhostManager!: ArrivalGhostManager;
@@ -1583,7 +1589,6 @@ export default class WorldmapScene extends WarpTravel {
             row: update.hexCoords.row,
           },
         });
-        this.recordAuthoritativeArmyLiveUpdate(update.entityId);
         this.armyLastTileSyncAt.set(update.entityId, Date.now());
         if (recoveredPendingRemoval) {
           void this.armyManager.restoreArmyVisualIfVisible(update.entityId);
@@ -1609,8 +1614,9 @@ export default class WorldmapScene extends WarpTravel {
           updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
           updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
           onManagerUpdateApplied: () => this.reconcileHoverLabels(),
-          recordLiveArmyPresenceUpdate: (update) => this.recordAuthoritativeArmyLiveUpdate(update.entityId),
           onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
+          shouldRecoverPendingArmyRemovalFromExplorerTroops: (update) =>
+            this.shouldRecoverPendingArmyRemovalFromExplorerTroopsUpdate(update),
           recoverPendingArmyRemovalFromExplorerTroops: (update) =>
             this.recoverPendingArmyRemovalFromExplorerTroops(update),
           shouldSkipStalePositionUpdate: (entityId, normalized) =>
@@ -4677,7 +4683,6 @@ export default class WorldmapScene extends WarpTravel {
       pendingArmyRemovalMeta: this.pendingArmyRemovalMeta,
       deferredChunkRemovals: this.deferredChunkRemovals,
       armyLastTileSyncAt: this.armyLastTileSyncAt,
-      armyLastLiveUpdateAt: this.armyLastLiveUpdateAt,
       pendingArmyMovements: this.pendingArmyMovements,
       pendingArmyMovementStartedAt: this.pendingArmyMovementStartedAt,
       pendingArmyMovementFallbackTimeouts: this.pendingArmyMovementFallbackTimeouts,
@@ -4745,7 +4750,6 @@ export default class WorldmapScene extends WarpTravel {
     }
     this.armiesPositions.delete(entityId);
     this.armyLastTileSyncAt.delete(entityId);
-    this.armyLastLiveUpdateAt.delete(entityId);
     this.pendingArmyRemovalMeta.delete(entityId);
     this.armyStructureOwners.delete(entityId);
     this.clearArmyMovementTxEntriesForEntity(entityId);
@@ -4856,17 +4860,18 @@ export default class WorldmapScene extends WarpTravel {
         }
 
         if (reason === "tile") {
-          const lastUpdate = this.resolveLastArmyLiveUpdateAt(entityId);
+          const lastUpdate = this.resolveLastArmyTileSyncAt(entityId);
           if (lastUpdate > meta.scheduledAt) {
             this.pendingArmyRemovalMeta.delete(entityId);
             this.pendingArmyRemovals.delete(entityId);
             this.armyManager.unsuppressArmy(entityId);
+            void this.armyManager.restoreArmyVisualIfVisible(entityId);
             this.requestChunkRefresh(true, "default");
             return;
           }
 
           if (this.currentChunk !== meta.chunkKey) {
-            this.deferArmyRemovalDuringChunkSwitch(entityId, reason, meta.scheduledAt);
+            this.deferArmyRemovalDuringChunkSwitch(entityId, meta);
             return;
           }
 
@@ -4895,7 +4900,7 @@ export default class WorldmapScene extends WarpTravel {
     schedule(initialDelay);
   }
 
-  private deferArmyRemovalDuringChunkSwitch(entityId: ID, reason: "tile" | "zero", scheduledAt: number) {
+  private deferArmyRemovalDuringChunkSwitch(entityId: ID, removal: DeferredWorldmapArmyRemoval) {
     const timeout = this.pendingArmyRemovals.get(entityId);
     if (timeout) {
       clearTimeout(timeout);
@@ -4903,7 +4908,7 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     this.pendingArmyRemovalMeta.delete(entityId);
-    this.deferredChunkRemovals.set(entityId, { reason, scheduledAt });
+    this.deferredChunkRemovals.set(entityId, removal);
   }
 
   private retryDeferredChunkRemovals() {
@@ -4913,10 +4918,10 @@ export default class WorldmapScene extends WarpTravel {
         this.armyManager.unsuppressArmy(entityId);
         void this.armyManager.restoreArmyVisualIfVisible(entityId);
       },
-      onRetryRemoval: (entityId, reason) => {
-        this.scheduleArmyRemoval(entityId, reason);
+      onRetryRemoval: (entityId, reason, context) => {
+        this.scheduleArmyRemoval(entityId, reason, context);
       },
-      resolveLastTileSyncAt: (entityId) => this.resolveLastArmyLiveUpdateAt(entityId),
+      resolveLastTileSyncAt: (entityId) => this.resolveLastArmyTileSyncAt(entityId),
     });
   }
 
@@ -4937,6 +4942,23 @@ export default class WorldmapScene extends WarpTravel {
     return true;
   }
 
+  private shouldRecoverPendingArmyRemovalFromExplorerTroopsUpdate(update: ExplorerTroopsSystemUpdate): boolean {
+    const meta = this.resolvePendingArmyRemovalRecoveryMeta(update.entityId);
+    if (!meta) {
+      return false;
+    }
+
+    return shouldRecoverArmyRemovalFromTroopsPosition({
+      reason: meta.reason,
+      removalPosition: meta.position,
+      troopsPosition: this.resolveNormalizedArmyUpdatePosition(update),
+    });
+  }
+
+  private resolvePendingArmyRemovalRecoveryMeta(entityId: ID): DeferredWorldmapArmyRemoval | undefined {
+    return this.pendingArmyRemovalMeta.get(entityId) ?? this.deferredChunkRemovals.get(entityId);
+  }
+
   private recoverPendingArmyRemovalFromExplorerTroops(update: { entityId: ID }): void {
     const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId, "explorer_troops_live_recovery");
     if (recoveredPendingRemoval) {
@@ -4944,12 +4966,13 @@ export default class WorldmapScene extends WarpTravel {
     }
   }
 
-  private recordAuthoritativeArmyLiveUpdate(entityId: ID): void {
-    this.armyLastLiveUpdateAt.set(entityId, Date.now());
+  private resolveLastArmyTileSyncAt(entityId: ID): number {
+    return this.armyLastTileSyncAt.get(entityId) ?? 0;
   }
 
-  private resolveLastArmyLiveUpdateAt(entityId: ID): number {
-    return Math.max(this.armyLastTileSyncAt.get(entityId) ?? 0, this.armyLastLiveUpdateAt.get(entityId) ?? 0);
+  private resolveNormalizedArmyUpdatePosition(update: { hexCoords: HexPosition }): HexPosition {
+    const normalizedPos = new Position({ x: update.hexCoords.col, y: update.hexCoords.row }).getNormalized();
+    return { col: normalizedPos.x, row: normalizedPos.y };
   }
 
   private recordPendingArmyRemovalCancelled(source: PendingArmyRemovalCancelSource): void {
@@ -10763,7 +10786,6 @@ export default class WorldmapScene extends WarpTravel {
     this.pinnedRenderAreas.clear();
     this.clearCache();
     this.armyLastTileSyncAt.clear();
-    this.armyLastLiveUpdateAt.clear();
     // Also clear the interactive hexes when clearing the entire cache
     this.interactiveHexManager.clearHexes();
   }


### PR DESCRIPTION
This PR gates explorer troop recovery by comparing the live troop position with the original removal position, preserves deferred removal context through chunk-switch retries, and removes the stale live-update timestamp path. It adds tests for tile versus zero-count recovery, deferred retry context, and the explorer troop update ordering. Root cause: deferred chunk removals dropped removal metadata, so a live troop update could not cancel the deferred deletion once pending metadata was cleared. Validated with focused worldmap tests, the Three.js type check, format, and knip.