### PR TITLE
feat(factory): auto-prune settled game runs from the run store

### DIFF
--- a/.github/workflows/factory-run-store-prune.yml
+++ b/.github/workflows/factory-run-store-prune.yml
@@ -1,0 +1,92 @@
+name: Factory Run Store Prune
+run-name: >-
+  Factory Run Store Prune / max-age ${{ inputs.max_age_days || '7' }}d / dry-run ${{ inputs.dry_run || 'false' }}
+
+# GET /api/factory/runs makes one GitHub subrequest per indexed run, and the
+# Cloudflare Workers free plan caps a single invocation at 50 subrequests, so
+# the launch dashboard breaks once an environment passes ~47 indexed runs.
+# This prunes settled game runs (complete, idle, untouched for max_age_days)
+# from the factory-runs branch; records stay recoverable from branch history.
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: "Prune completed runs untouched for more than this many days"
+        required: false
+        default: "7"
+      dry_run:
+        description: "Only report what would be pruned"
+        required: false
+        default: "false"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: factory-run-store-prune
+  cancel-in-progress: false
+
+env:
+  CI: "true"
+
+jobs:
+  prune:
+    name: Prune settled runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout factory-runs store
+        uses: actions/checkout@v4
+        with:
+          ref: factory-runs
+          path: factory-runs-store
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Prune settled runs
+        env:
+          MAX_AGE_DAYS: ${{ inputs.max_age_days || '7' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          git -C factory-runs-store config user.name "github-actions[bot]"
+          git -C factory-runs-store config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # The factory worker commits to factory-runs on live game operations,
+          # so re-resolve the branch tip and retry on push races.
+          for attempt in 1 2 3; do
+            git -C factory-runs-store fetch origin factory-runs
+            git -C factory-runs-store reset --hard origin/factory-runs
+
+            bun config/deployer/clean/cli/prune-run-store.ts \
+              --root factory-runs-store \
+              --max-age-days "$MAX_AGE_DAYS" \
+              --dry-run "$DRY_RUN"
+
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "Dry run requested; not committing."
+              exit 0
+            fi
+
+            if git -C factory-runs-store diff --quiet; then
+              echo "Nothing to prune."
+              exit 0
+            fi
+
+            git -C factory-runs-store add -A
+            git -C factory-runs-store commit -m "factory-runs: auto-prune settled game runs older than ${MAX_AGE_DAYS} days"
+            if git -C factory-runs-store push origin HEAD:factory-runs; then
+              exit 0
+            fi
+            echo "Push rejected (concurrent run-store write); retrying ($attempt/3)."
+          done
+
+          echo "Failed to push prune after 3 attempts." >&2
+          exit 1

--- a/config/deployer/clean/cli/prune-run-store.ts
+++ b/config/deployer/clean/cli/prune-run-store.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+import { parseArgs } from "./args";
+import { pruneFactoryRunStoreDirectory } from "../run-store/prune";
+
+const DEFAULT_MAX_AGE_DAYS = 7;
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+
+  const storeRoot = args.root;
+  if (!storeRoot) {
+    throw new Error("--root <factory-runs checkout> is required");
+  }
+
+  const maxAgeDays = args["max-age-days"] ? Number.parseFloat(args["max-age-days"]) : DEFAULT_MAX_AGE_DAYS;
+  if (!Number.isFinite(maxAgeDays) || maxAgeDays <= 0) {
+    throw new Error(`Invalid --max-age-days: ${args["max-age-days"]}`);
+  }
+
+  const dryRun = args["dry-run"] === "true";
+  const results = pruneFactoryRunStoreDirectory(storeRoot, { now: new Date(), maxAgeDays, dryRun });
+
+  let totalPruned = 0;
+  for (const result of results) {
+    totalPruned += result.prunedGameNames.length;
+    const action = dryRun ? "would prune" : "pruned";
+    console.log(
+      `[prune-run-store] ${result.environment}: ${action} ${result.prunedGameNames.length} run(s), ` +
+        `${result.remainingEntryCount} entr(ies) remain`,
+    );
+    for (const gameName of result.prunedGameNames) {
+      console.log(`[prune-run-store]   - ${gameName}`);
+    }
+  }
+
+  console.log(`[prune-run-store] total: ${dryRun ? "would prune" : "pruned"} ${totalPruned} run(s)`);
+}
+
+main();

--- a/config/deployer/clean/run-store/prune.ts
+++ b/config/deployer/clean/run-store/prune.ts
@@ -1,0 +1,128 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { FactoryGameRunMaintenanceIndexEntry, FactoryRunMaintenanceIndexRecord } from "./types";
+
+export interface FactoryRunPruneOptions {
+  now: Date;
+  maxAgeDays: number;
+}
+
+export interface FactoryRunStorePruneEnvironmentResult {
+  environment: string;
+  indexPath: string;
+  prunedGameNames: string[];
+  remainingEntryCount: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * A game run entry is prunable when the game is definitively over and no
+ * automation could still act on it: status complete, no running step, no
+ * unexpired launch lease, no pending indexer-tier change, and the record has
+ * been untouched for longer than `maxAgeDays`.
+ *
+ * GET /api/factory/runs makes one GitHub subrequest per indexed run, and the
+ * Cloudflare Workers free plan caps a single invocation at 50 subrequests, so
+ * environments must stay well below ~47 indexed runs for the launch dashboard
+ * to load. Pruning settled runs keeps each environment under that budget.
+ */
+export function isPrunableFactoryGameRunEntry(
+  entry: FactoryGameRunMaintenanceIndexEntry,
+  options: FactoryRunPruneOptions,
+): boolean {
+  if (entry.kind !== "game" || entry.status !== "complete" || entry.hasRunningStep) {
+    return false;
+  }
+
+  if (entry.activeLeaseExpiresAt) {
+    const leaseExpiry = Date.parse(entry.activeLeaseExpiresAt);
+    if (!Number.isFinite(leaseExpiry) || leaseExpiry > options.now.getTime()) {
+      return false;
+    }
+  }
+
+  const artifacts = entry.artifacts || {};
+  if (artifacts.pendingIndexerTierTarget || artifacts.pendingIndexerTierRequestedAt) {
+    return false;
+  }
+
+  const updatedAt = Date.parse(entry.updatedAt || "");
+  if (!Number.isFinite(updatedAt)) {
+    return false;
+  }
+
+  return options.now.getTime() - updatedAt > options.maxAgeDays * MS_PER_DAY;
+}
+
+export function resolvePrunableFactoryGameRunKeys(
+  index: FactoryRunMaintenanceIndexRecord,
+  options: FactoryRunPruneOptions,
+): string[] {
+  return Object.keys(index.entries || {})
+    .filter((key) => {
+      const entry = index.entries[key];
+      return entry.kind === "game" && isPrunableFactoryGameRunEntry(entry, options);
+    })
+    .sort();
+}
+
+function listGameMaintenanceIndexPaths(storeRoot: string): string[] {
+  const indexesRoot = path.join(storeRoot, "indexes");
+  if (!fs.existsSync(indexesRoot)) {
+    return [];
+  }
+
+  const indexPaths: string[] = [];
+  for (const chain of fs.readdirSync(indexesRoot)) {
+    const chainDir = path.join(indexesRoot, chain);
+    if (!fs.statSync(chainDir).isDirectory()) continue;
+    for (const gameType of fs.readdirSync(chainDir)) {
+      const candidate = path.join(chainDir, gameType, "games.json");
+      if (fs.existsSync(candidate)) {
+        indexPaths.push(candidate);
+      }
+    }
+  }
+  return indexPaths.sort();
+}
+
+/**
+ * Prune settled game runs from a checked-out factory-runs working tree:
+ * delete each prunable run record file and drop its games.json index entry.
+ * Run records stay recoverable from the branch history. With `dryRun`, only
+ * report what would be pruned.
+ */
+export function pruneFactoryRunStoreDirectory(
+  storeRoot: string,
+  options: FactoryRunPruneOptions & { dryRun?: boolean },
+): FactoryRunStorePruneEnvironmentResult[] {
+  const results: FactoryRunStorePruneEnvironmentResult[] = [];
+
+  for (const indexPath of listGameMaintenanceIndexPaths(storeRoot)) {
+    const index = JSON.parse(fs.readFileSync(indexPath, "utf8")) as FactoryRunMaintenanceIndexRecord;
+    const prunedGameNames = resolvePrunableFactoryGameRunKeys(index, options);
+
+    if (prunedGameNames.length > 0 && !options.dryRun) {
+      for (const gameName of prunedGameNames) {
+        const recordPath = index.entries[gameName].path;
+        // Only ever delete run records; refuse paths escaping the runs tree.
+        if (recordPath && recordPath.startsWith("runs/") && !recordPath.includes("..")) {
+          fs.rmSync(path.join(storeRoot, recordPath), { force: true });
+        }
+        delete index.entries[gameName];
+      }
+      index.updatedAt = options.now.toISOString();
+      fs.writeFileSync(indexPath, `${JSON.stringify(index, null, 2)}\n`);
+    }
+
+    results.push({
+      environment: index.environment,
+      indexPath,
+      prunedGameNames,
+      remainingEntryCount: Object.keys(index.entries).length - (options.dryRun ? prunedGameNames.length : 0),
+    });
+  }
+
+  return results;
+}

--- a/config/deployer/clean/tests/run-store-prune.test.ts
+++ b/config/deployer/clean/tests/run-store-prune.test.ts
@@ -1,0 +1,160 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  isPrunableFactoryGameRunEntry,
+  pruneFactoryRunStoreDirectory,
+  resolvePrunableFactoryGameRunKeys,
+} from "../run-store/prune";
+import type { FactoryGameRunMaintenanceIndexEntry, FactoryRunMaintenanceIndexRecord } from "../run-store/types";
+
+const NOW = new Date("2026-06-10T12:00:00.000Z");
+const TEN_DAYS_AGO = "2026-05-31T12:00:00.000Z";
+const TWO_DAYS_AGO = "2026-06-08T12:00:00.000Z";
+
+function buildGameEntry(
+  gameName: string,
+  overrides: Partial<FactoryGameRunMaintenanceIndexEntry> = {},
+): FactoryGameRunMaintenanceIndexEntry {
+  return {
+    kind: "game",
+    environment: "slot.blitz",
+    gameName,
+    path: `runs/slot/blitz/${gameName}.json`,
+    status: "complete",
+    updatedAt: TEN_DAYS_AGO,
+    currentStepId: null,
+    hasRunningStep: false,
+    artifacts: {},
+    ...overrides,
+  } as FactoryGameRunMaintenanceIndexEntry;
+}
+
+function buildIndex(entries: Record<string, FactoryGameRunMaintenanceIndexEntry>): FactoryRunMaintenanceIndexRecord {
+  return {
+    version: 1,
+    environment: "slot.blitz",
+    kind: "game",
+    updatedAt: TEN_DAYS_AGO,
+    entries,
+  } as FactoryRunMaintenanceIndexRecord;
+}
+
+describe("isPrunableFactoryGameRunEntry", () => {
+  const options = { now: NOW, maxAgeDays: 7 };
+
+  test("prunes a complete run untouched for longer than the age threshold", () => {
+    expect(isPrunableFactoryGameRunEntry(buildGameEntry("old-complete"), options)).toBe(true);
+  });
+
+  test("keeps recent, non-complete, running, leased, and pending-tier runs", () => {
+    expect(isPrunableFactoryGameRunEntry(buildGameEntry("recent", { updatedAt: TWO_DAYS_AGO }), options)).toBe(false);
+    expect(isPrunableFactoryGameRunEntry(buildGameEntry("attention", { status: "attention" }), options)).toBe(false);
+    expect(isPrunableFactoryGameRunEntry(buildGameEntry("running", { hasRunningStep: true }), options)).toBe(false);
+    expect(
+      isPrunableFactoryGameRunEntry(
+        buildGameEntry("leased", { activeLeaseExpiresAt: "2026-06-11T00:00:00.000Z" }),
+        options,
+      ),
+    ).toBe(false);
+    expect(
+      isPrunableFactoryGameRunEntry(
+        buildGameEntry("pending-tier", { artifacts: { pendingIndexerTierTarget: "pro" } }),
+        options,
+      ),
+    ).toBe(false);
+  });
+
+  test("keeps runs with an unparseable updatedAt", () => {
+    expect(isPrunableFactoryGameRunEntry(buildGameEntry("bad-date", { updatedAt: "not-a-date" }), options)).toBe(false);
+  });
+
+  test("prunes once an expired lease has lapsed", () => {
+    expect(
+      isPrunableFactoryGameRunEntry(buildGameEntry("lease-lapsed", { activeLeaseExpiresAt: TEN_DAYS_AGO }), options),
+    ).toBe(true);
+  });
+});
+
+describe("resolvePrunableFactoryGameRunKeys", () => {
+  test("returns only prunable keys, sorted", () => {
+    const index = buildIndex({
+      "z-old": buildGameEntry("z-old"),
+      "a-old": buildGameEntry("a-old"),
+      recent: buildGameEntry("recent", { updatedAt: TWO_DAYS_AGO }),
+    });
+
+    expect(resolvePrunableFactoryGameRunKeys(index, { now: NOW, maxAgeDays: 7 })).toEqual(["a-old", "z-old"]);
+  });
+});
+
+describe("pruneFactoryRunStoreDirectory", () => {
+  let storeRoot: string;
+
+  afterEach(() => {
+    if (storeRoot) {
+      fs.rmSync(storeRoot, { recursive: true, force: true });
+    }
+  });
+
+  function writeStore(index: FactoryRunMaintenanceIndexRecord): string {
+    storeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "factory-runs-prune-"));
+    fs.mkdirSync(path.join(storeRoot, "indexes/slot/blitz"), { recursive: true });
+    fs.mkdirSync(path.join(storeRoot, "runs/slot/blitz"), { recursive: true });
+    fs.writeFileSync(path.join(storeRoot, "indexes/slot/blitz/games.json"), `${JSON.stringify(index, null, 2)}\n`);
+    for (const entry of Object.values(index.entries)) {
+      if (entry.path.startsWith("runs/")) {
+        fs.writeFileSync(path.join(storeRoot, entry.path), `${JSON.stringify({ gameName: entry }, null, 2)}\n`);
+      }
+    }
+    return storeRoot;
+  }
+
+  test("deletes prunable run records and rewrites the index", () => {
+    const root = writeStore(
+      buildIndex({
+        "old-complete": buildGameEntry("old-complete"),
+        recent: buildGameEntry("recent", { updatedAt: TWO_DAYS_AGO }),
+      }),
+    );
+
+    const results = pruneFactoryRunStoreDirectory(root, { now: NOW, maxAgeDays: 7 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].prunedGameNames).toEqual(["old-complete"]);
+    expect(results[0].remainingEntryCount).toBe(1);
+    expect(fs.existsSync(path.join(root, "runs/slot/blitz/old-complete.json"))).toBe(false);
+    expect(fs.existsSync(path.join(root, "runs/slot/blitz/recent.json"))).toBe(true);
+
+    const rewritten = JSON.parse(fs.readFileSync(path.join(root, "indexes/slot/blitz/games.json"), "utf8"));
+    expect(Object.keys(rewritten.entries)).toEqual(["recent"]);
+    expect(rewritten.updatedAt).toBe(NOW.toISOString());
+  });
+
+  test("dry run reports without touching files", () => {
+    const root = writeStore(buildIndex({ "old-complete": buildGameEntry("old-complete") }));
+
+    const results = pruneFactoryRunStoreDirectory(root, { now: NOW, maxAgeDays: 7, dryRun: true });
+
+    expect(results[0].prunedGameNames).toEqual(["old-complete"]);
+    expect(results[0].remainingEntryCount).toBe(0);
+    expect(fs.existsSync(path.join(root, "runs/slot/blitz/old-complete.json"))).toBe(true);
+    const untouched = JSON.parse(fs.readFileSync(path.join(root, "indexes/slot/blitz/games.json"), "utf8"));
+    expect(Object.keys(untouched.entries)).toEqual(["old-complete"]);
+  });
+
+  test("never deletes record paths outside the runs tree", () => {
+    const escape = buildGameEntry("escape", { path: "sentinel.txt" });
+    const root = writeStore(buildIndex({ escape }));
+    fs.writeFileSync(path.join(root, "sentinel.txt"), "do not delete\n");
+
+    const results = pruneFactoryRunStoreDirectory(root, { now: NOW, maxAgeDays: 7 });
+
+    expect(results[0].prunedGameNames).toEqual(["escape"]);
+    // The entry is dropped from the index, but the non-runs path is not deleted.
+    expect(fs.existsSync(path.join(root, "sentinel.txt"))).toBe(true);
+    const rewritten = JSON.parse(fs.readFileSync(path.join(root, "indexes/slot/blitz/games.json"), "utf8"));
+    expect(Object.keys(rewritten.entries)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

`GET /api/factory/runs` makes one GitHub subrequest per indexed run (default limit 50) plus three index reads, and the Cloudflare Workers free plan caps a single invocation at **50 subrequests**. Once an environment passes ~47 indexed runs, the endpoint returns `Too many subrequests by single Worker invocation` and the game-launch dashboard breaks. This hit `mainnet.blitz` and `slot.blitz` this week and was fixed manually (factory-runs commits `5fac9439ec`, `bd48a5b15a`).

## What

- **`.github/workflows/factory-run-store-prune.yml`** — daily cron (05:30 UTC) + `workflow_dispatch` (with `max_age_days` and `dry_run` inputs). Checks out the `factory-runs` branch alongside the code, runs the prune CLI, commits and pushes, with a fetch/reset retry loop in case the factory worker writes concurrently.
- **`config/deployer/clean/run-store/prune.ts`** — prune logic: a game run is pruned only when it is `complete`, has no running step, no unexpired launch lease, no pending indexer-tier change, and has been untouched for more than `max_age_days` (default 7). Walks every `indexes/*/*/games.json`, deletes the run record files (path-guarded to the `runs/` tree) and drops the index entries. Pruned records remain recoverable from branch history.
- **`config/deployer/clean/cli/prune-run-store.ts`** — thin CLI wrapper (`--root`, `--max-age-days`, `--dry-run`); runs with bare `bun`, no install needed.
- **`config/deployer/clean/tests/run-store-prune.test.ts`** — bun tests for the criteria, sorting, end-to-end directory prune, dry-run, and the path-escape guard (8 tests).

## Validation

- `bun test config/deployer/clean/tests/run-store-prune.test.ts` — 8/8 pass.
- Dry run against the live `factory-runs` branch: correctly reports 0 prunable in the just-cleaned `mainnet.blitz`/`slot.blitz`, finds 4 settled runs in `slot.eternum`, and leaves the working tree untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)