### PR TITLE
perf(game): trim three.js hot-path allocations that scale with entity count (graphics plan phase 3)

### DIFF
--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -374,11 +374,14 @@ export class ArmyManager {
           currentTick: currentArmiesTick,
           previousTick: this.lastKnownArmiesTick,
         });
+        // Phase 3.6: stamina is derived from the armies tick, so only recompute it
+        // over all armies when the tick actually advanced (honouring the existing
+        // tick-gate policy) instead of every second. Battle timers keep the 1s
+        // cadence — they already early-out on armies without a battle cooldown.
         if (tickRefresh.shouldRecompute) {
           this.lastKnownArmiesTick = tickRefresh.nextTrackedTick;
+          this.recomputeStaminaForAllArmies();
         }
-        // Update stamina and battle timers every second
-        this.recomputeStaminaForAllArmies();
         this.recomputeBattleTimersForAllArmies();
       } catch {
         // Swallow errors to keep the tick loop alive
@@ -1291,6 +1294,10 @@ export class ArmyManager {
 
     this.visibleArmies.forEach((army) => {
       const entityId = this.toNumericId(army.entityId);
+      // Phase 3.2: skip non-attachment armies before building the input object.
+      if (!this.activeArmyAttachmentEntities.has(entityId)) {
+        return;
+      }
       const instanceData = this.armyModel.getInstanceData(entityId);
       syncArmyAttachmentTransformState({
         entityId,
@@ -2874,8 +2881,11 @@ export class ArmyManager {
         this.updateArmyCompactLabel(army, instanceData.position);
       }
 
-      // 2. Update attachment transforms
-      if (hasActiveAttachments) {
+      // 2. Update attachment transforms. Phase 3.2: only attachment-bearing armies
+      // need the sync (the callee early-returns for non-members), so hoist the
+      // membership check here to avoid allocating the input object + delegate
+      // closures for every visible army each frame.
+      if (hasActiveAttachments && this.activeArmyAttachmentEntities.has(numericEntityId)) {
         syncArmyAttachmentTransformState({
           entityId: numericEntityId,
           army,

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -22,6 +22,7 @@ import {
 } from "three";
 import { CSS2DObject } from "three/examples/jsm/renderers/CSS2DRenderer.js";
 import { resizeInstancedMorphTexture } from "./morph-texture-resize";
+import { BoundedHexCache } from "../utils/bounded-hex-cache";
 import { env } from "../../../env";
 import {
   ANIMATION_STATE_IDLE,
@@ -141,6 +142,13 @@ export class ArmyModel {
   // Spline-based movement
   private readonly USE_SPLINE_MOVEMENT = true;
   private readonly splineMovingInstances: Map<number, SplineMovementData> = new Map();
+
+  // Phase 3.1: biome is immutable per hex but the resolution (BigInt/simplex noise)
+  // ran twice per frame per moving army. Memoize it by hex; the resolver is a stable
+  // instance field so the per-frame lookups allocate no closures.
+  private readonly biomeHexCache = new BoundedHexCache<BiomeType>();
+  private readonly resolveBiomeForHex = (col: number, row: number): BiomeType =>
+    configManager.getBiome(col + FELT_CENTER(), row + FELT_CENTER());
 
   // agent
   private isAgent: boolean = false;
@@ -1850,7 +1858,7 @@ export class ArmyModel {
 
     // Terrain speed variation — sample biome and lerp multiplier
     const { col, row } = getHexForWorldPosition(instanceData.position);
-    const biome = configManager.getBiome(col + FELT_CENTER(), row + FELT_CENTER());
+    const biome = this.biomeHexCache.get(col, row, this.resolveBiomeForHex);
     const targetMultiplier = resolveTerrainSpeedMultiplier(biome);
     splineData.currentSpeedMultiplier +=
       (targetMultiplier - splineData.currentSpeedMultiplier) *
@@ -2078,7 +2086,7 @@ export class ArmyModel {
 
   private updateModelTypeForPosition(entityId: number, position: Vector3, category: TroopType, tier: TroopTier): void {
     const { col, row } = getHexForWorldPosition(position);
-    const biome = configManager.getBiome(col + FELT_CENTER(), row + FELT_CENTER());
+    const biome = this.biomeHexCache.get(col, row, this.resolveBiomeForHex);
 
     const modelType = this.getModelTypeForEntity(entityId, category, tier, biome);
     if (shouldSwitchModelForPosition({ currentModel: this.entityModelMap.get(entityId), resolvedModel: modelType })) {

--- a/client/apps/game/src/three/managers/compact-entity-label-policy.ts
+++ b/client/apps/game/src/three/managers/compact-entity-label-policy.ts
@@ -1,7 +1,7 @@
 import {
-  buildArmyEntityLabelViewModel,
-  buildStructureEntityLabelViewModel,
+  resolveArmyTitle,
   resolveEntityLabelRelation,
+  resolveStructureTitle,
   type EntityLabelVariant,
 } from "../utils/labels/entity-label-view-model";
 import type { ArmyData, StructureInfo } from "../types";
@@ -14,21 +14,16 @@ interface OwnershipLabelSource {
   isMine: boolean;
 }
 
+// Phase 3.3: the compact label is just the entity title. Resolve it directly instead
+// of building the full view model (detailRows + objects) per moving army per frame.
 export function resolveArmyCompactEntityLabel(army: Pick<ArmyData, "entityId" | "owner">): string {
-  return buildArmyEntityLabelViewModel(army).compactText;
+  return resolveArmyTitle(army);
 }
 
 export function resolveStructureCompactEntityLabel(
   structure: Pick<StructureInfo, "entityId" | "structureName" | "structureType">,
 ): string {
-  return buildStructureEntityLabelViewModel({
-    ...structure,
-    activeProductions: [],
-    guardArmies: [],
-    isAlly: false,
-    isMine: false,
-    owner: { address: 0n, guildName: "", ownerName: "" },
-  }).compactText;
+  return resolveStructureTitle(structure);
 }
 
 export function resolveCompactEntityLabelVariant(input: OwnershipLabelSource): CompactEntityLabelVariant {

--- a/client/apps/game/src/three/managers/structure-hex-lookup.test.ts
+++ b/client/apps/game/src/three/managers/structure-hex-lookup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { findStructureAtHex } from "./structure-hex-lookup";
+
+interface TestStructure {
+  entityId: number;
+  hexCoords: { col: number; row: number };
+}
+
+function makeStore(structures: TestStructure[]) {
+  const byId = new Map(structures.map((s) => [s.entityId, s]));
+  return (id: number) => byId.get(id);
+}
+
+describe("findStructureAtHex", () => {
+  // Phase 3.4: the hover path resolved a structure by hex with an O(all structures)
+  // scan + Array.from per group on every pointermove. Narrowing to the spatial
+  // bucket's candidate ids means only the few structures in that bucket are checked,
+  // but the exact-hex match must still be enforced (a bucket spans many hexes).
+  it("returns the structure whose hex matches exactly", () => {
+    const structures: TestStructure[] = [{ entityId: 1, hexCoords: { col: 5, row: 7 } }];
+    const result = findStructureAtHex({ col: 5, row: 7 }, [1], makeStore(structures));
+    expect(result).toBe(structures[0]);
+  });
+
+  it("ignores candidates in the same bucket that sit on a different hex", () => {
+    const structures: TestStructure[] = [
+      { entityId: 1, hexCoords: { col: 5, row: 7 } },
+      { entityId: 2, hexCoords: { col: 6, row: 7 } }, // same bucket, different hex
+    ];
+    const result = findStructureAtHex({ col: 6, row: 7 }, [1, 2], makeStore(structures));
+    expect(result?.entityId).toBe(2);
+  });
+
+  it("returns undefined when the bucket has no candidates", () => {
+    expect(findStructureAtHex({ col: 0, row: 0 }, undefined, makeStore([]))).toBeUndefined();
+  });
+
+  it("skips candidate ids whose structure record is missing", () => {
+    const structures: TestStructure[] = [{ entityId: 2, hexCoords: { col: 1, row: 1 } }];
+    // id 1 has no record (stale index entry), id 2 matches
+    const result = findStructureAtHex({ col: 1, row: 1 }, [1, 2], makeStore(structures));
+    expect(result?.entityId).toBe(2);
+  });
+
+  it("returns undefined when no candidate sits on the target hex", () => {
+    const structures: TestStructure[] = [{ entityId: 1, hexCoords: { col: 5, row: 7 } }];
+    expect(findStructureAtHex({ col: 9, row: 9 }, [1], makeStore(structures))).toBeUndefined();
+  });
+});

--- a/client/apps/game/src/three/managers/structure-hex-lookup.ts
+++ b/client/apps/game/src/three/managers/structure-hex-lookup.ts
@@ -1,0 +1,32 @@
+interface HexLike {
+  col: number;
+  row: number;
+}
+
+/**
+ * Phase 3.4: resolve the structure sitting exactly on `hexCoords` from a spatial
+ * bucket's candidate ids, instead of scanning every structure on the map.
+ *
+ * The spatial bucket (chunkToStructures) groups structures by a coarse chunk key,
+ * so a bucket can contain several structures on different hexes — the exact-hex
+ * match is still required. Candidate ids whose record is missing (a stale index
+ * entry) are skipped.
+ */
+export function findStructureAtHex<TId, TStructure extends { hexCoords: HexLike }>(
+  hexCoords: HexLike,
+  candidateIds: Iterable<TId> | undefined,
+  getStructureByEntityId: (id: TId) => TStructure | undefined,
+): TStructure | undefined {
+  if (!candidateIds) {
+    return undefined;
+  }
+
+  for (const id of candidateIds) {
+    const structure = getStructureByEntityId(id);
+    if (structure && structure.hexCoords.col === hexCoords.col && structure.hexCoords.row === hexCoords.row) {
+      return structure;
+    }
+  }
+
+  return undefined;
+}

--- a/client/apps/game/src/three/managers/structure-manager.ts
+++ b/client/apps/game/src/three/managers/structure-manager.ts
@@ -69,6 +69,7 @@ import {
   recordVisibleCosmeticStructureModelInstance,
   recordVisibleStructureModelInstance,
 } from "./structure-visible-instance-binding";
+import { findStructureAtHex } from "./structure-hex-lookup";
 import { cleanupVisibleStructurePass } from "./structure-visible-pass-cleanup";
 import { finalizeVisibleStructureModelPass } from "./structure-visible-pass-finalizer";
 import { applyVisibleStructurePresentation } from "./structure-visible-presentation";
@@ -176,6 +177,8 @@ export class StructureManager {
   private structureAttachmentSignatures: Map<number, string> = new Map();
   private activeStructureAttachmentEntities: Set<number> = new Set();
   private chunkToStructures: Map<string, Set<ID>> = new Map();
+  // Phase 3.4: stable resolver so the spatial-index hover lookup allocates no closure.
+  private readonly getStructureByEntityIdBound = (id: ID) => this.structures.getStructureByEntityId(id);
   private readonly tempCosmeticPosition: Vector3 = new Vector3();
   // Scratch vectors for performVisibleStructuresUpdate to avoid allocations
   private readonly scratchPosition: Vector3 = new Vector3();
@@ -1107,17 +1110,14 @@ export class StructureManager {
   }
 
   getStructureByHexCoords(hexCoords: { col: number; row: number }) {
-    const allStructures = this.structures.getStructures();
-
-    for (const structures of allStructures.values()) {
-      const structure = Array.from(structures.values()).find(
-        (structure) => structure.hexCoords.col === hexCoords.col && structure.hexCoords.row === hexCoords.row,
-      );
-      if (structure) {
-        return structure;
-      }
-    }
-    return undefined;
+    // Phase 3.4: resolve via the spatial index (the same chunkToStructures bucket the
+    // visible-structure pass trusts) instead of scanning every structure with an
+    // Array.from+find per group on each pointermove.
+    return findStructureAtHex(
+      hexCoords,
+      this.chunkToStructures.get(this.getSpatialKey(hexCoords.col, hexCoords.row)),
+      this.getStructureByEntityIdBound,
+    );
   }
 
   public getVisibleCount(): number {

--- a/client/apps/game/src/three/renderer-diagnostics.test.ts
+++ b/client/apps/game/src/three/renderer-diagnostics.test.ts
@@ -234,4 +234,23 @@ describe("renderer-diagnostics", () => {
     expect(after).not.toBe(before);
     expect(after.degradations).toEqual([{ feature: "bloom", reason: "disabled-by-quality" }]);
   });
+
+  // Phase 3.6: setRendererDiagnosticSceneName runs every rendered frame, but the
+  // scene name almost never changes. Skip the deep window snapshot when it is
+  // unchanged instead of re-mirroring ~1000 times/second.
+  it("does not re-mirror the window diagnostics when the scene name is unchanged", () => {
+    setRendererDiagnosticSceneName("worldmap");
+    const firstMirror = (window as { __rendererDiagnostics?: unknown }).__rendererDiagnostics;
+    setRendererDiagnosticSceneName("worldmap");
+    expect((window as { __rendererDiagnostics?: unknown }).__rendererDiagnostics).toBe(firstMirror);
+  });
+
+  it("re-mirrors the window diagnostics when the scene name changes", () => {
+    setRendererDiagnosticSceneName("worldmap");
+    const firstMirror = (window as { __rendererDiagnostics?: unknown }).__rendererDiagnostics;
+    setRendererDiagnosticSceneName("hexception");
+    const secondMirror = (window as { __rendererDiagnostics?: { sceneName?: string } }).__rendererDiagnostics;
+    expect(secondMirror).not.toBe(firstMirror);
+    expect(secondMirror?.sceneName).toBe("hexception");
+  });
 });

--- a/client/apps/game/src/three/renderer-diagnostics.ts
+++ b/client/apps/game/src/three/renderer-diagnostics.ts
@@ -170,6 +170,11 @@ export function setRendererDiagnosticPostprocessPolicy(policy: WebgpuPostprocess
 }
 
 export function setRendererDiagnosticSceneName(sceneName: string): void {
+  // Phase 3.6: called every rendered frame; skip the deep window snapshot unless the
+  // scene name actually changed (other diagnostics re-mirror via their own setters).
+  if (rendererDiagnosticsState.sceneName === sceneName) {
+    return;
+  }
   rendererDiagnosticsState.sceneName = sceneName;
   syncRendererDiagnosticsWindow();
 }

--- a/client/apps/game/src/three/utils/bounded-hex-cache.test.ts
+++ b/client/apps/game/src/three/utils/bounded-hex-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BoundedHexCache } from "./bounded-hex-cache";
+
+describe("BoundedHexCache", () => {
+  // Phase 3.1: moving armies resolved their hex biome via BigInt/simplex noise twice
+  // per frame per entity, though biome is immutable per hex. Memoizing by hex keeps
+  // the resolve to once per distinct hex.
+  it("resolves a hex value once and returns the cached value on repeat", () => {
+    const cache = new BoundedHexCache<string>(16);
+    const resolve = vi.fn(() => "grass");
+
+    expect(cache.get(3, 4, resolve)).toBe("grass");
+    expect(cache.get(3, 4, resolve)).toBe("grass");
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves distinct hexes independently", () => {
+    const cache = new BoundedHexCache<string>(16);
+    cache.get(0, 0, () => "a");
+    cache.get(1, 0, () => "b");
+
+    expect(cache.get(0, 0, () => "x")).toBe("a");
+    expect(cache.get(1, 0, () => "x")).toBe("b");
+  });
+
+  it("caches falsy values (e.g. enum value 0) without re-resolving", () => {
+    const cache = new BoundedHexCache<number>(16);
+    const resolve = vi.fn(() => 0);
+
+    cache.get(2, 2, resolve);
+    cache.get(2, 2, resolve);
+
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the oldest entry when the cap is exceeded", () => {
+    const cache = new BoundedHexCache<string>(2);
+    cache.get(0, 0, () => "a");
+    cache.get(1, 1, () => "b");
+    cache.get(2, 2, () => "c"); // exceeds cap → evicts the oldest (0,0)
+
+    expect(cache.size).toBe(2);
+
+    const reResolve = vi.fn(() => "a2");
+    expect(cache.get(0, 0, reResolve)).toBe("a2"); // (0,0) was evicted, so it re-resolves
+    expect(reResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear empties the cache", () => {
+    const cache = new BoundedHexCache<string>(16);
+    cache.get(0, 0, () => "a");
+
+    cache.clear();
+    expect(cache.size).toBe(0);
+
+    const resolve = vi.fn(() => "a");
+    cache.get(0, 0, resolve);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/apps/game/src/three/utils/bounded-hex-cache.ts
+++ b/client/apps/game/src/three/utils/bounded-hex-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Phase 3.1: a small bounded memo keyed by hex (col,row).
+ *
+ * Used to cache values that are immutable per hex but otherwise expensive to
+ * derive every frame — notably the biome at a hex (BigInt/simplex-noise
+ * resolution), which moving armies resolved twice per frame per entity. Because
+ * the cached value is immutable for a hex, eviction only ever costs a re-resolve,
+ * never correctness, so a simple insertion-order (FIFO) eviction is sufficient.
+ */
+export class BoundedHexCache<T> {
+  private readonly cache = new Map<string, T>();
+
+  constructor(private readonly maxSize = 4096) {}
+
+  get(col: number, row: number, resolve: (col: number, row: number) => T): T {
+    const key = `${col},${row}`;
+    const cached = this.cache.get(key);
+    if (cached !== undefined || this.cache.has(key)) {
+      return cached as T;
+    }
+
+    // resolve receives (col,row) so callers can pass a stable, pre-bound resolver
+    // and avoid allocating a closure per lookup on the frame path.
+    const value = resolve(col, row);
+    if (this.cache.size >= this.maxSize) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) {
+        this.cache.delete(oldest);
+      }
+    }
+    this.cache.set(key, value);
+    return value;
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/client/apps/game/src/three/utils/centralized-visibility-manager.ts
+++ b/client/apps/game/src/three/utils/centralized-visibility-manager.ts
@@ -295,16 +295,29 @@ export class CentralizedVisibilityManager {
     }
 
     const visible = this.frustum.intersectsBox(box);
-    this.boxVisibilityCache.set(box, {
-      visibilityVersion: this.currentVisibilityVersion,
-      visible,
-      minX: box.min.x,
-      minY: box.min.y,
-      minZ: box.min.z,
-      maxX: box.max.x,
-      maxY: box.max.y,
-      maxZ: box.max.z,
-    });
+    // Phase 3.6: the key (a reused Box3) usually already has a record from a prior
+    // frame; mutate it in place instead of allocating a fresh record on every miss.
+    if (cached) {
+      cached.visibilityVersion = this.currentVisibilityVersion;
+      cached.visible = visible;
+      cached.minX = box.min.x;
+      cached.minY = box.min.y;
+      cached.minZ = box.min.z;
+      cached.maxX = box.max.x;
+      cached.maxY = box.max.y;
+      cached.maxZ = box.max.z;
+    } else {
+      this.boxVisibilityCache.set(box, {
+        visibilityVersion: this.currentVisibilityVersion,
+        visible,
+        minX: box.min.x,
+        minY: box.min.y,
+        minZ: box.min.z,
+        maxX: box.max.x,
+        maxY: box.max.y,
+        maxZ: box.max.z,
+      });
+    }
     this.cachedBoxChecks++;
     return visible;
   }
@@ -327,14 +340,24 @@ export class CentralizedVisibilityManager {
     }
 
     const visible = this.frustum.intersectsSphere(sphere);
-    this.sphereVisibilityCache.set(sphere, {
-      visibilityVersion: this.currentVisibilityVersion,
-      visible,
-      centerX: sphere.center.x,
-      centerY: sphere.center.y,
-      centerZ: sphere.center.z,
-      radius: sphere.radius,
-    });
+    // Phase 3.6: mutate the existing record in place instead of allocating on miss.
+    if (cached) {
+      cached.visibilityVersion = this.currentVisibilityVersion;
+      cached.visible = visible;
+      cached.centerX = sphere.center.x;
+      cached.centerY = sphere.center.y;
+      cached.centerZ = sphere.center.z;
+      cached.radius = sphere.radius;
+    } else {
+      this.sphereVisibilityCache.set(sphere, {
+        visibilityVersion: this.currentVisibilityVersion,
+        visible,
+        centerX: sphere.center.x,
+        centerY: sphere.center.y,
+        centerZ: sphere.center.z,
+        radius: sphere.radius,
+      });
+    }
     this.cachedSphereChecks++;
     return visible;
   }
@@ -355,13 +378,22 @@ export class CentralizedVisibilityManager {
     }
 
     const visible = this.frustum.containsPoint(point);
-    this.pointVisibilityCache.set(point, {
-      visibilityVersion: this.currentVisibilityVersion,
-      visible,
-      x: point.x,
-      y: point.y,
-      z: point.z,
-    });
+    // Phase 3.6: mutate the existing record in place instead of allocating on miss.
+    if (cached) {
+      cached.visibilityVersion = this.currentVisibilityVersion;
+      cached.visible = visible;
+      cached.x = point.x;
+      cached.y = point.y;
+      cached.z = point.z;
+    } else {
+      this.pointVisibilityCache.set(point, {
+        visibilityVersion: this.currentVisibilityVersion,
+        visible,
+        x: point.x,
+        y: point.y,
+        z: point.z,
+      });
+    }
     this.cachedPointChecks++;
     return visible;
   }

--- a/client/apps/game/src/three/utils/labels/entity-label-view-model.test.ts
+++ b/client/apps/game/src/three/utils/labels/entity-label-view-model.test.ts
@@ -6,6 +6,8 @@ import {
   buildArmyEntityLabelViewModel,
   buildChestEntityLabelViewModel,
   buildStructureEntityLabelViewModel,
+  resolveArmyTitle,
+  resolveStructureTitle,
 } from "./entity-label-view-model";
 
 const army = {
@@ -91,6 +93,24 @@ describe("entity label view model", () => {
       relation: "neutral",
       variant: "neutral",
       iconKey: "chest",
+    });
+  });
+
+  // Phase 3.3: the compact label only needs the title, but the compact resolver built
+  // the entire view model (incl. detailRows) per moving army per frame. These standalone
+  // resolvers are exported so the compact path can produce the title directly.
+  describe("standalone title resolvers", () => {
+    it("resolves the army title (owner name, else entity id fallback) matching compactText", () => {
+      expect(resolveArmyTitle(army)).toBe("Sable Order");
+      expect(resolveArmyTitle({ ...army, owner: { ...army.owner, ownerName: "" } })).toBe("Army #101");
+      expect(resolveArmyTitle(army)).toBe(buildArmyEntityLabelViewModel(army).compactText);
+    });
+
+    it("resolves the structure title (name, else type + id fallback) matching compactText", () => {
+      expect(resolveStructureTitle(structure)).toBe(buildStructureEntityLabelViewModel(structure).compactText);
+      expect(
+        resolveStructureTitle({ ...structure, structureName: "", structureType: StructureType.Realm }),
+      ).toBe("Realm #202");
     });
   });
 });

--- a/client/apps/game/src/three/utils/labels/entity-label-view-model.ts
+++ b/client/apps/game/src/three/utils/labels/entity-label-view-model.ts
@@ -178,12 +178,14 @@ function buildGuardDetailRows(guards: StructureLabelSource["guardArmies"]): Enti
   return rows;
 }
 
-function resolveArmyTitle(army: Pick<ArmyData, "entityId" | "owner">): string {
+export function resolveArmyTitle(army: Pick<ArmyData, "entityId" | "owner">): string {
   const ownerName = resolveOwnerName(army.owner.ownerName);
   return ownerName || `Army #${army.entityId}`;
 }
 
-function resolveStructureTitle(structure: Pick<StructureInfo, "entityId" | "structureName" | "structureType">): string {
+export function resolveStructureTitle(
+  structure: Pick<StructureInfo, "entityId" | "structureName" | "structureType">,
+): string {
   const structureName = structure.structureName.trim();
   if (structureName.length > 0) {
     return structureName;


### PR DESCRIPTION
## Summary

Memory and hot-path performance work for the Three.js game client (`client/apps/game/src/three`), aimed at low-spec hardware. The changes come out of a deep multi-agent review of the graphics layer (328 files / ~72k lines); the full prioritized plan lives in [`GRAPHICS_OPTIMIZATION_PLAN.md`](client/apps/game/src/three/GRAPHICS_OPTIMIZATION_PLAN.md) (added in the Phase 1 commit).

This PR bundles four phases of that plan. Commits are scoped one-per-phase, so it reviews cleanly commit-by-commit.

## What's in here (by commit)

**`9582acc` — Phase 1: scope worldmap terrain cache invalidation**
Stop the cache-invalidation storms that defeat the terrain cache during exploration/panning.
- Structure count changes now invalidate only the affected chunks instead of flushing the whole terrain matrix cache + global pools.
- Army movement no longer invalidates terrain (verified the terrain cache reads only biomes + structures, never armies).
- Per-chunk generation counters replace a single global counter that marked every cached chunk stale on any tile change.
- The terrain fingerprint is now a compact FNV-1a digest instead of a ~60KB sorted-joined string rebuilt on every cache hit.

**`b667108` — Phase 2.1–2.3: GPU leaks + morph-texture crash**
- Arrival-ghost ring geometries are shared instead of leaked two-per-ghost.
- Prepared-terrain pooled attributes are released on every dropped chunk transition (prewarm / rollback / stale-drop) instead of leaked.
- Morph textures are resized on instance-capacity growth — previously `setMorphAt` indexed past a fixed `Float32Array` once >64 animated army slots existed and threw a `RangeError` on the frame path.

**`49422835` — Phase 2.5: manager destroy hygiene**
`ChestManager`/`ArmyModel`/`InstancedModel` dispose paths now free instanced GPU buffers + morph textures (via `InstancedMesh.dispose()`, which leaves shared geometry/materials intact), with an `isDestroyed` guard on the async chest load; removed a dead `Group` hexception leaked on every grid rebuild.

**`586d378` — Phase 5.1: share biome GLTFs across scenes**
The ~23 biome GLBs were parsed and GPU-resident twice (worldmap + hexception). They're now parsed once via a module cache and shared; only per-scene instance buffers + morph textures differ. Includes an idempotent biome draw-order fix so the shared material resolves the same `renderOrder` in both scenes.

**`26b97886` — Phase 3: hot-path allocation diet (scales with entity count)**
- Per-frame biome resolution (BigInt/simplex noise, twice per moving army) is memoized by hex.
- Attachment-transform sync no longer builds an input object + 5 closures for every visible army each frame (hoisted the membership guard → scales with attachment count, not army count).
- Compact labels resolve the title directly instead of building the full view model (+detailRows) per moving army per frame.
- Structure hover resolves via the existing spatial-bucket index instead of an O(all structures) scan + `Array.from` per pointermove.
- Frame-loop micro-churn: diagnostics skip the per-frame window snapshot when unchanged; the 1 Hz stamina recompute is gated behind the existing armies-tick policy; the visibility manager mutates its cache record in place instead of allocating on every miss.

## How it was built

- TDD throughout: new pure logic (fingerprint digest, per-chunk generation, morph-texture resize, prepared-terrain dispose decisions, biome/structure-hex caches, title resolvers, diagnostics gating) lands with unit tests; GPU-lifecycle and allocation refactors are behaviour-preserving and covered by existing tests + careful reading.
- Behaviour-preserving by design: cache-invalidation changes were verified against what the terrain cache actually depends on; the attachment and stamina changes reuse guards/policies that already existed.

## Deferred (intentionally, to focused follow-ups)

- **1.5** compose-once-per-batch terrain presentation (590-line runtime API refactor; needs runtime visual QA).
- **2.4** world-update subscription contract (cross-package: `packages/core/world-update-listener.ts` must return its unsubscribers).
- **3.5** TileOpt hydration spatial index (needs a new ECS-stream index; a bug there means missing terrain/structures → needs runtime QA).
- 2.5 tail (InteractiveHex/HighlightHex cleanup, shared-material ownership) — documented in the plan.

## Reviewer notes / test status

- **CI must run `vitest` + `tsc`.** These were authored in a sandboxed worktree where node is killed, so the red→green cycle was verified by construction, not executed locally. Nothing else gates correctness of the new tests.
- **Runtime QA recommended before merge:**
  - Phase 1: pan + explore while founding/destroying structures — no stale/blank terrain; army movement no longer rebuilds neighbour chunks.
  - Phase 2: spawn **>64 concurrent animated armies** (no `RangeError`); watch `MatrixPool`/attribute-pool stats during fast pans (dropped chunks return their attributes).
  - Phase 5.1: eyeball hexception + worldmap terrain, especially transparent biomes' draw order.
  - Phase 3: structure hover still resolves; stamina labels update on tick advance; no visibility/animation regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
