### PR TITLE
fix(game): eliminate RPC polling that was causing 429 rate limits

### DIFF
--- a/client/apps/game/src/hooks/summary-to-world-config-meta.test.ts
+++ b/client/apps/game/src/hooks/summary-to-world-config-meta.test.ts
@@ -57,9 +57,12 @@ describe("summaryToWorldConfigMeta", () => {
     expect(meta.devModeOn).toBe(false);
   });
 
-  it("leaves winnerJackpotAmount at 0n — jackpot is resolved via useWorldJackpot", () => {
+  it("maps the server-resolved winnerJackpotAmount through, null when absent", () => {
     const meta = summaryToWorldConfigMeta(baseSummary, null);
-    expect(meta.winnerJackpotAmount).toBe(0n);
+    expect(meta.winnerJackpotAmount).toBe(999n);
+
+    const withoutJackpot = summaryToWorldConfigMeta({ ...baseSummary, winnerJackpotAmount: null }, null);
+    expect(withoutJackpot.winnerJackpotAmount).toBeNull();
   });
 
   it("resolves eternum mode for eternum summaries", () => {
@@ -131,7 +134,7 @@ describe("summaryToWorldConfigMeta", () => {
     expect(meta.feeAmount).toBe(0n);
     expect(meta.registrationStartAt).toBeNull();
     expect(meta.registrationEndAt).toBeNull();
-    expect(meta.winnerJackpotAmount).toBe(0n);
+    expect(meta.winnerJackpotAmount).toBeNull();
   });
 
   it("threads eternum settlement counts from the summary", () => {

--- a/client/apps/game/src/hooks/summary-to-world-config-meta.ts
+++ b/client/apps/game/src/hooks/summary-to-world-config-meta.ts
@@ -8,9 +8,10 @@
  * fields (`isPlayerRegistered`, `hasPlayerSettledRealm`) are not part of the
  * bulk payload — callers layer those in via a separate, gated query.
  *
- * The jackpot balance is fetched on-demand via `useWorldJackpot`, so this
- * adapter leaves `winnerJackpotAmount` at 0n and exposes
- * `prizeDistributionAddress` (already resolved server-side) for that lookup.
+ * The jackpot balance is resolved server-side (one RPC call per world per
+ * poll cycle) and carried on the summary as `winnerJackpotAmount`. When the
+ * server hasn't provided it (null), callers fall back to the on-demand
+ * `useWorldJackpot` RPC lookup via `prizeDistributionAddress`.
  */
 import type { WorldSummary } from "@bibliothecadao/types";
 import type { ResolvedGameMode } from "@/config/game-modes/resolved-mode";
@@ -36,12 +37,22 @@ const parseSummaryBigInt = (value: string | null): bigint => {
   }
 };
 
+const parseNullableSummaryBigInt = (value: string | null): bigint | null => {
+  if (value == null) return null;
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+};
+
 /**
  * Map a `WorldSummary` payload into the legacy `WorldConfigMeta` shape.
  *
  * Player-specific fields must be passed explicitly; this function does not
- * fetch anything. Jackpot is intentionally left at 0n — callers should
- * resolve it via `useWorldJackpot` when needed (e.g. on card render).
+ * fetch anything. Jackpot is mapped from the server-resolved summary value;
+ * null means the server didn't provide one and callers may fall back to
+ * `useWorldJackpot`.
  */
 export const summaryToWorldConfigMeta = (
   summary: WorldSummary,
@@ -86,8 +97,6 @@ export const summaryToWorldConfigMeta = (
     settledRealmsCount: summary.settledRealmsCount ?? null,
     settledVillagesCount: summary.settledVillagesCount ?? null,
     prizeDistributionAddress: summary.prizeDistributionAddress ?? null,
-    // Jackpot is resolved on-demand via `useWorldJackpot` — callers should
-    // read it from the hook's data, not from this field.
-    winnerJackpotAmount: 0n,
+    winnerJackpotAmount: parseNullableSummaryBigInt(summary.winnerJackpotAmount),
   };
 };

--- a/client/apps/game/src/hooks/use-resource-balance.tsx
+++ b/client/apps/game/src/hooks/use-resource-balance.tsx
@@ -11,17 +11,18 @@ export const useResourceBalance = ({
 }) => {
   const { account } = useAccount();
 
-  const { data } = useCall({
+  // Fetched once per account/token; callers refetch on demand (e.g. after a
+  // swap) instead of interval polling to avoid RPC rate limits.
+  const { data, refetch } = useCall({
     abi: LordsAbi as Abi, // Using LordsAbi as the interface is the same for all ERC20 tokens
     functionName: "balance_of",
     address: resourceAddress as `0x${string}`,
     args: [(account?.address as `0x${string}`) ?? "0"],
-    watch: true,
-    refetchInterval: 5000, // Reduced from 1000ms to prevent excessive RPC calls
     enabled: !!account?.address && !!resourceAddress && !disabled,
   });
 
   return {
     balance: (data as bigint) || BigInt(0),
+    refetch,
   };
 };

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -3,20 +3,16 @@
  * This eliminates N+1 request patterns when checking multiple worlds
  * by caching results and sharing them across components.
  */
-import { getFactorySqlBaseUrl } from "@/runtime/world";
 import { BULK_WORLD_AVAILABILITY_QUERY_KEY, WORLD_AVAILABILITY_QUERY_KEY } from "@/hooks/world-list-queries";
-import { fetchBulkAvailability, isToriiAvailable, resolveWorldContracts } from "@/runtime/world/factory-resolver";
-import { normalizeSelector } from "@/runtime/world/normalize";
+import { fetchBulkAvailability, isToriiAvailable } from "@/runtime/world/factory-resolver";
 import {
   parseMaybeBooleanFlag,
   resolveGameModeFromBlitzFlag,
   type ResolvedGameMode,
 } from "@/config/game-modes/resolved-mode";
 import { buildPlayerBlitzSettlementStatusQuery } from "@/services/blitz/blitz-settlement-sql";
-import { getRpcUrlForChain } from "@/ui/features/admin/constants";
 import type { Chain } from "@contracts";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { RpcProvider } from "starknet";
 import { env } from "../../env";
 
 const WORLD_CONFIG_TABLE = "s1_eternum-WorldConfig";
@@ -63,10 +59,6 @@ const WORLD_CONFIG_ETERNUM_QUERY = `
   LIMIT 1;
 `;
 
-const PRIZE_DISTRIBUTION_SYSTEMS_SELECTOR = "0x42230b5f7ccc6ce02a4ecb99c31d92ddd0f24ab472896afd617a2a763cf4179";
-const prizeDistributionSelector = normalizeSelector(PRIZE_DISTRIBUTION_SYSTEMS_SELECTOR);
-const rpcProviderCache = new Map<string, RpcProvider>();
-
 const buildToriiBaseUrl = (worldName: string) => `https://api.cartridge.gg/x/${worldName}/torii`;
 
 const parseMaybeHexToNumber = (v: unknown): number | null => {
@@ -103,35 +95,6 @@ const parseMaybeHexToAddress = (v: unknown): string | null => {
   const bigIntVal = parseMaybeHexToBigInt(v);
   if (bigIntVal == null || bigIntVal === 0n) return null;
   return `0x${bigIntVal.toString(16)}`;
-};
-
-const getCachedRpcProvider = (rpcUrl: string): RpcProvider => {
-  const existingProvider = rpcProviderCache.get(rpcUrl);
-  if (existingProvider) return existingProvider;
-  const provider = new RpcProvider({ nodeUrl: rpcUrl });
-  rpcProviderCache.set(rpcUrl, provider);
-  return provider;
-};
-
-const fetchTokenBalance = async (
-  provider: RpcProvider,
-  tokenAddress: string,
-  accountAddress: string,
-): Promise<bigint> => {
-  try {
-    const result = await provider.callContract({
-      contractAddress: tokenAddress,
-      entrypoint: "balance_of",
-      calldata: [accountAddress],
-    });
-
-    if (result.length < 2) return 0n;
-    const low = BigInt(result[0] ?? 0);
-    const high = BigInt(result[1] ?? 0);
-    return low + (high << 128n);
-  } catch {
-    return 0n;
-  }
 };
 
 export interface WorldConfigMeta {
@@ -174,8 +137,9 @@ export interface WorldConfigMeta {
   settledVillagesCount: number | null;
   // Reward distribution contract for this world
   prizeDistributionAddress: string | null;
-  // Current fee-token balance held by the reward distribution contract
-  winnerJackpotAmount: bigint;
+  // Current fee-token balance held by the reward distribution contract.
+  // Resolved server-side via the worlds summary; null when not provided.
+  winnerJackpotAmount: bigint | null;
 }
 
 interface WorldRef {
@@ -230,35 +194,6 @@ const fetchPlayerHasSettledRealm = async (toriiBaseUrl: string, playerAddress: s
   return null;
 };
 
-const fetchPrizeDistributionAddress = async (worldName: string, chain: Chain): Promise<string | null> => {
-  try {
-    const factorySqlBaseUrl = getFactorySqlBaseUrl(chain);
-    if (!factorySqlBaseUrl) return null;
-
-    const contracts = await resolveWorldContracts(factorySqlBaseUrl, worldName);
-    return contracts[prizeDistributionSelector] ?? null;
-  } catch {
-    return null;
-  }
-};
-
-const fetchWinnerJackpotAmount = async (
-  worldName: string,
-  chain: Chain,
-  feeTokenAddress: string,
-): Promise<{ prizeDistributionAddress: string | null; winnerJackpotAmount: bigint }> => {
-  const prizeDistributionAddress = await fetchPrizeDistributionAddress(worldName, chain);
-  if (!prizeDistributionAddress) {
-    return { prizeDistributionAddress: null, winnerJackpotAmount: 0n };
-  }
-
-  const rpcUrl = getRpcUrlForChain(chain);
-  const provider = getCachedRpcProvider(rpcUrl);
-  const winnerJackpotAmount = await fetchTokenBalance(provider, feeTokenAddress, prizeDistributionAddress);
-
-  return { prizeDistributionAddress, winnerJackpotAmount };
-};
-
 /**
  * Fetch world config metadata from Torii SQL endpoint.
  * Optionally fetches player registration status if playerAddress is provided.
@@ -266,8 +201,6 @@ const fetchWinnerJackpotAmount = async (
  */
 const fetchWorldConfigMeta = async (
   toriiBaseUrl: string,
-  worldName: string,
-  chain?: Chain,
   playerAddress?: string | null,
 ): Promise<WorldConfigMeta> => {
   const meta: WorldConfigMeta = {
@@ -302,7 +235,7 @@ const fetchWorldConfigMeta = async (
     settledRealmsCount: null,
     settledVillagesCount: null,
     prizeDistributionAddress: null,
-    winnerJackpotAmount: 0n,
+    winnerJackpotAmount: null,
   };
 
   try {
@@ -408,16 +341,6 @@ const fetchWorldConfigMeta = async (
         }),
       );
     }
-    if (chain && meta.feeTokenAddress) {
-      sideFetches.push(
-        fetchWinnerJackpotAmount(worldName, chain, meta.feeTokenAddress).then(
-          ({ prizeDistributionAddress, winnerJackpotAmount }) => {
-            meta.prizeDistributionAddress = prizeDistributionAddress;
-            meta.winnerJackpotAmount = winnerJackpotAmount;
-          },
-        ),
-      );
-    }
 
     if (sideFetches.length > 0) {
       await Promise.all(sideFetches);
@@ -435,7 +358,6 @@ const fetchWorldConfigMeta = async (
  */
 const checkWorldAvailability = async (
   worldName: string,
-  chain?: Chain,
   playerAddress?: string | null,
   bulkAvailability?: Record<string, boolean>,
 ): Promise<{ isAvailable: boolean; meta: WorldConfigMeta | null }> => {
@@ -451,7 +373,7 @@ const checkWorldAvailability = async (
     return { isAvailable: false, meta: null };
   }
 
-  const meta = await fetchWorldConfigMeta(toriiBaseUrl, worldName, chain, playerAddress);
+  const meta = await fetchWorldConfigMeta(toriiBaseUrl, playerAddress);
   return { isAvailable: true, meta };
 };
 
@@ -482,7 +404,7 @@ export const useWorldsAvailability = (worlds: WorldRef[], enabled = true, player
     queries: worlds.map((world) => ({
       // Include playerAddress in query key so it refetches when user connects
       queryKey: [...WORLD_AVAILABILITY_QUERY_KEY, getWorldKey(world), playerAddress ?? "anonymous"],
-      queryFn: () => checkWorldAvailability(world.name, world.chain, playerAddress, bulkAvailability),
+      queryFn: () => checkWorldAvailability(world.name, playerAddress, bulkAvailability),
       enabled: enabled && !!world.name && !isBulkAvailabilityPending,
       staleTime: 30 * 1000, // 30 seconds - data is fresh for 30s
       gcTime: 10 * 60 * 1000, // 10 minutes

--- a/client/apps/game/src/hooks/use-world-availability.ts
+++ b/client/apps/game/src/hooks/use-world-availability.ts
@@ -199,10 +199,7 @@ const fetchPlayerHasSettledRealm = async (toriiBaseUrl: string, playerAddress: s
  * Optionally fetches player registration status if playerAddress is provided.
  * Cached by React Query.
  */
-const fetchWorldConfigMeta = async (
-  toriiBaseUrl: string,
-  playerAddress?: string | null,
-): Promise<WorldConfigMeta> => {
+const fetchWorldConfigMeta = async (toriiBaseUrl: string, playerAddress?: string | null): Promise<WorldConfigMeta> => {
   const meta: WorldConfigMeta = {
     mode: "unknown",
     startSettlingAt: null,

--- a/client/apps/game/src/hooks/use-world-jackpot.ts
+++ b/client/apps/game/src/hooks/use-world-jackpot.ts
@@ -56,6 +56,9 @@ interface UseWorldJackpotInput {
  * On-demand jackpot balance query. The prize distribution address is assumed already resolved
  * (e.g. via the worlds summary endpoint), so this hook only does the RPC `balance_of` call.
  *
+ * The worlds summary now carries a server-resolved `winnerJackpotAmount`; prefer that and use
+ * this hook only as a fallback when the summary value is null.
+ *
  * Cached for 60s; not refetched on a timer — callers can call `refetch` if needed.
  */
 export const useWorldJackpot = ({

--- a/client/apps/game/src/pm/hooks/dojo/user.tsx
+++ b/client/apps/game/src/pm/hooks/dojo/user.tsx
@@ -53,22 +53,22 @@ export function UserProvider({ children, chain, ...props }: UserProviderProps) {
   const { account } = useAccount();
   const collateralToken = getPredictionMarketConfig(chain).collateralToken;
 
-  // LORDS balance from RPC
+  // LORDS balance from RPC. Fetched once per account; consumers refetch on demand
+  // (trade panel open, post-trade) instead of interval polling to avoid RPC rate limits.
   const lordsBalanceCall = useCall({
     abi: LordsAbi as Abi,
     functionName: "balance_of",
     address: collateralToken as `0x${string}`,
     args: [(account?.address as `0x${string}`) ?? "0x0"],
-    watch: true,
-    refetchInterval: 5_000,
     enabled: Boolean(account?.address),
   });
 
   const lordsBalance = useMemo(() => normalizeUint256(lordsBalanceCall.data), [lordsBalanceCall.data]);
 
+  const refetchBalance = lordsBalanceCall.refetch;
   const refetchLordsBalance = useCallback(() => {
-    lordsBalanceCall.refetch?.();
-  }, [lordsBalanceCall]);
+    refetchBalance?.();
+  }, [refetchBalance]);
 
   return (
     <UserProviderContext.Provider

--- a/client/apps/game/src/ui/features/amm/amm-swap.tsx
+++ b/client/apps/game/src/ui/features/amm/amm-swap.tsx
@@ -66,10 +66,10 @@ export const AmmSwap = () => {
   const [showSlippage, setShowSlippage] = useState(false);
   const [isSwapping, setIsSwapping] = useState(false);
 
-  const { balance: payTokenBalance } = useResourceBalance({
+  const { balance: payTokenBalance, refetch: refetchPayTokenBalance } = useResourceBalance({
     resourceAddress: payToken || null,
   });
-  const { balance: receiveTokenBalance } = useResourceBalance({
+  const { balance: receiveTokenBalance, refetch: refetchReceiveTokenBalance } = useResourceBalance({
     resourceAddress: receiveToken || null,
   });
 
@@ -210,13 +210,26 @@ export const AmmSwap = () => {
 
       await executeSwap(calls);
       await invalidateAmmReadQueries(queryClient);
+      // Wallet balances are not polled — refresh them after the swap settles.
+      void refetchPayTokenBalance?.();
+      void refetchReceiveTokenBalance?.();
       setShowConfirmation(false);
       setPayAmount(0);
       setReceiveAmount(0);
     } finally {
       setIsSwapping(false);
     }
-  }, [account?.address, client, executeSwap, payAmount, queryClient, route, swapQuote]);
+  }, [
+    account?.address,
+    client,
+    executeSwap,
+    payAmount,
+    queryClient,
+    refetchPayTokenBalance,
+    refetchReceiveTokenBalance,
+    route,
+    swapQuote,
+  ]);
 
   const activePoolForFees = route?.kind === "direct" ? route.pool : route?.outputPool;
   const payAmountBigint = payAmount > 0 ? parseTokenAmount(payAmount.toString()) : 0n;

--- a/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
+++ b/client/apps/game/src/ui/features/landing/components/game-selector/game-card-grid.tsx
@@ -341,16 +341,17 @@ const GameCard = ({
   const lordsFeeAmount = game.config?.feeAmount ?? 0n;
   const hasLordsFee = lordsFeeAmount > 0n;
   const isMainnetGame = game.chain === "mainnet";
-  // Jackpot is resolved on-demand via useWorldJackpot now — the bulk summary
-  // does not carry per-world balances. Gate the RPC call on mainnet cards
-  // where we actually render the prize pool.
+  // The jackpot is resolved server-side and carried on the bulk summary.
+  // Only fall back to the on-demand RPC lookup when the summary didn't
+  // provide one (e.g. realtime server not yet updated).
+  const summaryJackpotAmount = game.config?.winnerJackpotAmount ?? null;
   const { data: jackpotBalance } = useWorldJackpot({
     chain: game.chain,
     feeTokenAddress: game.config?.feeTokenAddress ?? null,
     prizeDistributionAddress: game.config?.prizeDistributionAddress ?? null,
-    enabled: isMainnetGame && Boolean(game.config?.prizeDistributionAddress),
+    enabled: isMainnetGame && Boolean(game.config?.prizeDistributionAddress) && summaryJackpotAmount == null,
   });
-  const winnerJackpotAmount = jackpotBalance ?? 0n;
+  const winnerJackpotAmount = summaryJackpotAmount ?? jackpotBalance ?? 0n;
   const marketSnapshot = marketState?.data ?? null;
   const hasPrizeAddress = Boolean(game.config?.prizeDistributionAddress);
   const showPredictionMarket = hasPrizeAddress && !devModeOn;

--- a/client/apps/game/src/ui/features/market/hooks/use-quick-market-create.ts
+++ b/client/apps/game/src/ui/features/market/hooks/use-quick-market-create.ts
@@ -377,18 +377,18 @@ export const useQuickMarketCreate = (
     return parsed ?? 0n;
   }, [fundingAmount]);
 
-  // Fetch user's LORDS balance
+  // Fetch user's LORDS balance. Fetched once per account/token and refreshed
+  // after market creation instead of interval polling to avoid RPC rate limits.
   const balanceCall = useCall({
     abi: LordsAbi as Abi,
     functionName: "balance_of",
     address: (collateralToken ?? "0x0") as `0x${string}`,
     args: [(account?.address as `0x${string}`) ?? "0x0"],
-    watch: true,
-    refetchInterval: 10_000,
     enabled: Boolean(account?.address && collateralToken),
   });
 
   const balance = useMemo(() => normalizeUint256(balanceCall.data), [balanceCall.data]);
+  const refetchBalance = balanceCall.refetch;
   const isBalanceLoading = balanceCall.isLoading && Boolean(collateralToken);
   const hasSufficientBalance = balance >= requiredAmount;
 
@@ -645,6 +645,8 @@ export const useQuickMarketCreate = (
       });
 
       toast.success(`Prediction market created for ${worldName}!`);
+      // Balance is not polled — refresh it after the creation spend.
+      void refetchBalance?.();
     } catch (e) {
       console.error("[useQuickMarketCreate] Error:", e);
       const message = e instanceof Error ? e.message : "Failed to create market";
@@ -664,6 +666,7 @@ export const useQuickMarketCreate = (
     gameEndTime,
     playerWeights,
     noneWeight,
+    refetchBalance,
   ]);
 
   return useMemo(

--- a/client/apps/game/src/ui/features/market/landing-markets/details/market-trade.tsx
+++ b/client/apps/game/src/ui/features/market/landing-markets/details/market-trade.tsx
@@ -1,7 +1,7 @@
 import AlertTriangle from "lucide-react/dist/esm/icons/alert-triangle";
 import Loader2 from "lucide-react/dist/esm/icons/loader-2";
 import TrendingUp from "lucide-react/dist/esm/icons/trending-up";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { toast } from "sonner";
 import { BigNumberish, Call, uint256 } from "starknet";
@@ -310,6 +310,12 @@ export function MarketTrade({
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const account = useAccountStore((state) => state.account);
+  const { refetchLordsBalance } = useUser();
+
+  // The provider no longer polls the balance; refresh it when the trade panel opens.
+  useEffect(() => {
+    if (account?.address) refetchLordsBalance();
+  }, [account?.address, refetchLordsBalance]);
 
   const marketContractAddress = getContractByName(manifest, "pm", "Markets")?.address;
   const nowSec = Math.floor(Date.now() / 1_000);
@@ -473,6 +479,7 @@ export function MarketTrade({
       });
 
       toast.success("Trade submitted successfully!");
+      refetchLordsBalance();
       if (onTradeSuccess) {
         void Promise.resolve(onTradeSuccess()).catch((callbackError) => {
           console.error("[MarketTrade] post-trade sync callback failed:", callbackError);

--- a/client/apps/realtime-server/src/services/__tests__/torii-availability.test.ts
+++ b/client/apps/realtime-server/src/services/__tests__/torii-availability.test.ts
@@ -242,10 +242,14 @@ describe("ToriiAvailabilityService", () => {
 
     it("preserves the last good summary when a later summary fetch fails", async () => {
       mockFetch
-        .mockResolvedValueOnce(new Response(null, { status: 200 }))
-        .mockResolvedValueOnce(new Response(JSON.stringify([blitzSummaryRow]), { status: 200 }))
-        .mockResolvedValueOnce(new Response(null, { status: 200 }))
-        .mockResolvedValueOnce(new Response(null, { status: 500 }));
+        .mockResolvedValueOnce(new Response(null, { status: 200 })) // probe 1: HEAD
+        .mockResolvedValueOnce(new Response(JSON.stringify([blitzSummaryRow]), { status: 200 })) // probe 1: summary
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: ["0x64", "0x0"] }), { status: 200 }),
+        ) // probe 1: jackpot
+        .mockResolvedValueOnce(new Response(null, { status: 200 })) // probe 2: HEAD
+        .mockResolvedValueOnce(new Response(null, { status: 500 })) // probe 2: summary fails
+        .mockResolvedValueOnce(new Response(null, { status: 500 })); // probe 2: jackpot fails
 
       const service = new ToriiAvailabilityService({ factoryChains: [] });
       await service.probeWorld("alpha", "mainnet", "0xprize", "0xabc");
@@ -259,7 +263,45 @@ describe("ToriiAvailabilityService", () => {
         startMainAt: 0x65b1ffe0,
         prizeDistributionAddress: "0xprize",
         worldAddress: "0xabc",
+        // Jackpot from probe 1 is preserved when probe 2's RPC call fails.
+        winnerJackpotAmount: "100",
       });
+    });
+
+    it("folds the mainnet jackpot balance into the summary via one RPC call", async () => {
+      mockFetch
+        .mockResolvedValueOnce(new Response(null, { status: 200 })) // HEAD
+        .mockResolvedValueOnce(new Response(JSON.stringify([blitzSummaryRow]), { status: 200 })) // summary
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: ["0xff", "0x0"] }), { status: 200 }),
+        ); // jackpot
+
+      const service = new ToriiAvailabilityService({ factoryChains: [] });
+      await service.probeWorld("alpha", "mainnet", "0xprize", "0xabc");
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const [rpcUrl, rpcOpts] = mockFetch.mock.calls[2]!;
+      expect(rpcUrl).toBe("https://api.cartridge.gg/x/starknet/mainnet");
+      const body = JSON.parse((rpcOpts as RequestInit).body as string);
+      expect(body.method).toBe("starknet_call");
+      expect(body.params.request.contract_address).toBe("0xabcd");
+      expect(body.params.request.calldata).toEqual(["0xprize"]);
+
+      const [summary] = service.getSummaries();
+      expect(summary?.winnerJackpotAmount).toBe("255");
+    });
+
+    it("does not fetch the jackpot for non-mainnet worlds", async () => {
+      mockFetch
+        .mockResolvedValueOnce(new Response(null, { status: 200 })) // HEAD
+        .mockResolvedValueOnce(new Response(JSON.stringify([blitzSummaryRow]), { status: 200 })); // summary
+
+      const service = new ToriiAvailabilityService({ factoryChains: [] });
+      await service.probeWorld("alpha", "slot", "0xprize", "0xabc");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [summary] = service.getSummaries();
+      expect(summary?.winnerJackpotAmount).toBeNull();
     });
 
     it("does not fetch summary for dead worlds", async () => {

--- a/client/apps/realtime-server/src/services/jackpot-balance.ts
+++ b/client/apps/realtime-server/src/services/jackpot-balance.ts
@@ -1,0 +1,56 @@
+/**
+ * Fetch the prize-pool ("winner jackpot") balance for a world: the fee-token
+ * balance held by its prize distribution contract.
+ *
+ * Centralized here so the jackpot costs one RPC call per world per poll cycle
+ * server-wide, instead of every connected client polling `balance_of` itself
+ * (which was rate-limiting the public RPC endpoint).
+ */
+
+// starknet_keccak("balance_of") — precomputed so we don't need a starknet dependency.
+const BALANCE_OF_SELECTOR = "0x35a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33";
+
+const MAINNET_RPC_URL = process.env.STARKNET_MAINNET_RPC_URL || "https://api.cartridge.gg/x/starknet/mainnet";
+
+/**
+ * Call `balance_of(prizeDistributionAddress)` on the fee-token contract via
+ * raw JSON-RPC. Returns the uint256 balance as a decimal string, or null on
+ * any failure so callers can keep the last known value.
+ */
+export async function fetchJackpotBalance(
+  feeTokenAddress: string,
+  prizeDistributionAddress: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  try {
+    const response = await fetch(MAINNET_RPC_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "starknet_call",
+        params: {
+          request: {
+            contract_address: feeTokenAddress,
+            entry_point_selector: BALANCE_OF_SELECTOR,
+            calldata: [prizeDistributionAddress],
+          },
+          block_id: "latest",
+        },
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return null;
+
+    const payload = (await response.json()) as { result?: unknown };
+    const result = payload?.result;
+    if (!Array.isArray(result) || result.length < 1) return null;
+
+    const low = BigInt(result[0] as string);
+    const high = result.length > 1 ? BigInt(result[1] as string) : 0n;
+    return (low + (high << 128n)).toString();
+  } catch {
+    return null;
+  }
+}

--- a/client/apps/realtime-server/src/services/torii-availability.ts
+++ b/client/apps/realtime-server/src/services/torii-availability.ts
@@ -1,6 +1,7 @@
 import type { WorldSummary, WorldSummaryChain } from "@bibliothecadao/types";
 import { fetchFactoryPrizeAddresses } from "./factory-prize-addresses";
 import { fetchFactoryWorldDeployments, type FactoryWorldDeployment } from "./factory-worlds";
+import { fetchJackpotBalance } from "./jackpot-balance";
 import { fetchWorldSummaryResult } from "./world-summary";
 
 const CARTRIDGE_API_BASE = "https://api.cartridge.gg";
@@ -136,13 +137,29 @@ export class ToriiAvailabilityService {
     const summaryFields = summaryResult.ok
       ? summaryResult.fields
       : extractSummaryFields(previousSummary, fallbackFields);
+
+    // Resolve the jackpot server-side (one RPC call per world per cycle) so
+    // clients can read it from the summary instead of polling RPC themselves.
+    // Only mainnet worlds render a prize pool; keep the last good value on failure.
+    const resolvedPrizeAddress = prizeDistributionAddress ?? summaryFields.prizeDistributionAddress;
+    let winnerJackpotAmount = previousSummary?.winnerJackpotAmount ?? null;
+    if (chain === "mainnet" && summaryFields.feeTokenAddress && resolvedPrizeAddress) {
+      const fetched = await fetchJackpotBalance(
+        summaryFields.feeTokenAddress,
+        resolvedPrizeAddress,
+        this.probeTimeoutMs,
+      );
+      if (fetched != null) winnerJackpotAmount = fetched;
+    }
+
     this.cache.set(cacheKey, {
       name: worldName,
       chain,
       alive: true,
       lastCheckedAt: now,
       ...summaryFields,
-      prizeDistributionAddress: prizeDistributionAddress ?? summaryFields.prizeDistributionAddress,
+      winnerJackpotAmount,
+      prizeDistributionAddress: resolvedPrizeAddress,
       worldAddress: worldAddress ?? summaryFields.worldAddress,
     });
     return true;

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -19,6 +19,7 @@ import {
   CallData,
   GetTransactionReceiptResponse,
   ResourceBoundsBN,
+  TransactionFinalityStatus,
   uint256,
   UniversalDetails,
 } from "starknet";
@@ -74,6 +75,17 @@ const HUNDRED_PERCENT = 100n;
 const DEFAULT_FEE_ESTIMATE_TIMEOUT_MS = 5_000;
 const DEFAULT_TRANSACTION_SUBMIT_TIMEOUT_MS = 20_000;
 const EXPLORE_RESOURCE_BOUNDS_CACHE_TTL_MS = 15_000;
+const TX_WAIT_RETRY_INTERVAL_MS = 500;
+// Resolve confirmation at PRE_CONFIRMED: the sequencer pre-confirms within
+// ~a second and the receipt already carries execution_status, so reverts are
+// detected immediately while the receipt poll loop drops from dozens of RPC
+// requests per tx (waiting for ACCEPTED_ON_L2 block inclusion) to one or two.
+// Game state itself arrives via torii sync, not this receipt.
+const TX_WAIT_SUCCESS_STATES = [
+  TransactionFinalityStatus.PRE_CONFIRMED,
+  TransactionFinalityStatus.ACCEPTED_ON_L2,
+  TransactionFinalityStatus.ACCEPTED_ON_L1,
+];
 export const SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE =
   "Submission timed out before a tx hash was returned. Check wallet/activity before retrying.";
 const NON_MEANINGFUL_ERROR_MESSAGES = new Set(["", "[object Object]", "undefined", "null"]);
@@ -1682,7 +1694,8 @@ export class EternumProvider extends EnhancedDojoProvider {
     const manifestRpcUrl = (this.manifest as any)?.world?.metadata?.rpc_url;
     console.info("[provider] waitForTransaction start", {
       transactionHash,
-      retryInterval: 500,
+      retryInterval: TX_WAIT_RETRY_INTERVAL_MS,
+      successStates: TX_WAIT_SUCCESS_STATES,
       nodeUrl,
       manifestRpcUrl,
       worldAddress: this.manifest?.world?.address,
@@ -1690,7 +1703,8 @@ export class EternumProvider extends EnhancedDojoProvider {
     });
     try {
       receipt = await this.provider.waitForTransaction(transactionHash, {
-        retryInterval: 500,
+        retryInterval: TX_WAIT_RETRY_INTERVAL_MS,
+        successStates: TX_WAIT_SUCCESS_STATES,
       });
     } catch (error) {
       console.error(`Error waiting for transaction ${transactionHash}`, {

--- a/packages/provider/src/retry.test.ts
+++ b/packages/provider/src/retry.test.ts
@@ -83,7 +83,7 @@ describe("retry utilities", () => {
       expect(fn).toHaveBeenCalledTimes(3);
     });
 
-    it("retries on HTTP 429 with exponential backoff", async () => {
+    it("retries on HTTP 429 with a rate-limit backoff floor", async () => {
       vi.useFakeTimers();
 
       const rateLimitError = new Error("Too Many Requests");
@@ -101,9 +101,13 @@ describe("retry utilities", () => {
         maxDelayMs: 5000,
       });
 
-      // Advance through the backoff delays
-      await vi.advanceTimersByTimeAsync(100); // first retry delay
-      await vi.advanceTimersByTimeAsync(500); // second retry delay (exponential)
+      // Rate-limited retries wait at least 2s, scaling with the attempt —
+      // the regular 100ms backoff would just keep the gateway saturated.
+      await vi.advanceTimersByTimeAsync(1_900);
+      expect(fn).toHaveBeenCalledTimes(1); // floor not yet elapsed
+      await vi.advanceTimersByTimeAsync(100); // first retry fires at 2s
+      expect(fn).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(4_000); // second retry floor (2s * 2)
 
       const result = await retryPromise;
       expect(result).toBe("ok");

--- a/packages/provider/src/retry.ts
+++ b/packages/provider/src/retry.ts
@@ -25,6 +25,21 @@ const RETRYABLE_MESSAGE_PATTERNS = ["nonce is too low", "nonce too old"];
 // Error patterns that should NOT be retried (business logic failures)
 const NON_RETRYABLE_MESSAGE_PATTERNS = ["execution reverted", "revert", "insufficient"];
 
+// Minimum wait before retrying a rate-limited request. Retrying 429s on the
+// regular 100ms-base backoff just adds pressure to an already-limited gateway.
+const RATE_LIMIT_MIN_DELAY_MS = 2_000;
+
+/**
+ * Whether the error is an HTTP 429 / rate-limit rejection.
+ */
+export function isRateLimitError(error: unknown): boolean {
+  if (!(error instanceof Error) && typeof error !== "object") return false;
+  const err = error as any;
+  if (err?.status === 429) return true;
+  const message = (err?.message ?? "").toLowerCase();
+  return message.includes("429") || message.includes("too many requests");
+}
+
 /**
  * Determine whether an error is transient and safe to retry.
  */
@@ -94,8 +109,12 @@ export async function withRetry<T>(
         retryCallback(error, attempt + 1);
       }
 
-      // Wait before retrying
-      const delay = calculateBackoffDelay(attempt, fullConfig);
+      // Wait before retrying. Rate-limited requests get a longer floor so the
+      // retry itself doesn't keep the gateway saturated.
+      let delay = calculateBackoffDelay(attempt, fullConfig);
+      if (isRateLimitError(error)) {
+        delay = Math.max(delay, RATE_LIMIT_MIN_DELAY_MS * (attempt + 1));
+      }
       await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }


### PR DESCRIPTION
## Problem

We're getting rate limited (429) on the public RPC gateway (`api.cartridge.gg/x/starknet/mainnet`). An audit of the client found two classes of offenders, both multiplied across every connected client:

**1. Interval-based ERC20 `balance_of` polling on UI surfaces:**

| Source | Poll rate | When |
|---|---|---|
| `pm/hooks/dojo/user.tsx` LORDS balance | every 5s | whole time the landing play tab is mounted |
| `use-quick-market-create.ts` LORDS balance | every 10s | in-game prediction market modal open |
| `amm-swap.tsx` pair balances (×2) | every 5s | AMM view open |
| `use-world-availability.ts` jackpot per world | every 30s | entry modal open |
| `game-card-grid.tsx` jackpot via `useWorldJackpot` | per mainnet card | landing world list |

**2. Transaction confirmation polling** — every system call polled `getTransactionReceipt` every 500ms until `ACCEPTED_ON_L2` (full block inclusion): 10–60 RPC requests per tx. The receipt is only used for revert detection — game state arrives via torii sync. With Smart automation submitting production plans continuously across realms, this was the dominant steady in-game source. On top of that, the retry layer treated 429 as retryable with a 100ms-base backoff, adding pressure to an already-saturated gateway.

## Changes

**Tx confirmation — resolve at PRE_CONFIRMED (`packages/provider`):**
- `waitForTransaction` now accepts `PRE_CONFIRMED` as a success state (same pattern as death-mountain, same `starknet@8.5.2`). The sequencer pre-confirms within ~a second and the receipt already carries `execution_status`, so the poll loop drops to **1–2 requests per tx** and revert feedback gets *faster*, not slower. Optimistic-override cleanup that hangs off this wait also resolves sooner.
- Rate-limited (429) retries get a 2s-per-attempt backoff floor instead of the 100ms-base exponential. Other transient errors keep the fast path.

**Balance polls → on-demand fetches** (fetch once per account/panel, refetch after the tx that changes the value):
- LORDS balance in the pm `UserProvider`: refetched when the trade panel opens and after a trade. Torii token subscriptions weren't an option — the global torii doesn't index ERC20 balances (verified live), and the blanket subscription was deliberately removed in `cd31dd5a28` with a guard test.
- Market-creation LORDS balance: refetched after a market is created.
- AMM swap pair balances: refetched after a swap settles.

**Jackpot — moved server-side:**
- The realtime server's `WorldSummary.winnerJackpotAmount` field existed but was hardcoded `null`. It's now resolved in the existing 30s availability poll via a raw `starknet_call` (no new dependency) — one RPC read per world per cycle **fleet-wide**, instead of one per client per card. Request shape verified against the live mainnet endpoint.
- The card grid reads the summary value and only falls back to the on-demand RPC lookup while the realtime server hasn't been redeployed yet (graceful rollout).
- Deleted the dead 30s jackpot RPC side-fetch in `use-world-availability.ts` — its only consumer (the entry modal) never read those fields.

## Result

Steady-state RPC calls (idle on landing or in a blitz game) drop to **zero**; per-transaction confirmation traffic drops ~10–30×. Remaining RPC usage is user-action scoped: tx submission + 1–2 confirmation polls, settle-time fee checks, login probe, and batched-cached MMR reads.

## Testing

- Provider package: 55 tests pass (incl. updated 429-backoff test asserting the 2s floor), typecheck clean
- Game app: typecheck clean, 439 tests pass (pm/market/landing/hooks suites)
- Realtime server: typecheck clean, 59 tests pass incl. 3 new/updated jackpot cases (mainnet folding, failure fallback, non-mainnet gating)
- Live-verified: torii `token_balances` empty on global + world toriis (subscription not viable), `starknet_call` jackpot request returns correct balance for `bltz-riff-795`

## Deploy note

The realtime server (Railway) needs a redeploy for summaries to carry jackpots; until then clients transparently use the existing RPC fallback (60s cached, per mainnet card).

## Known tradeoff

A pre-confirmed tx can in rare cases still be dropped before block inclusion — the UI would show success while torii never delivers the update. Same tradeoff death-mountain accepts; the build-slot fallback timeout already covers the optimistic-override side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)