### PR TITLE
fix(game): use live RECS resources for owned structures in entity detail

### DIFF
--- a/client/apps/game/src/ui/features/world/components/entities/hooks/use-structure-entity-detail.ts
+++ b/client/apps/game/src/ui/features/world/components/entities/hooks/use-structure-entity-detail.ts
@@ -16,6 +16,8 @@ import {
   getStructureRelicEffects,
 } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
+import { useComponentValue } from "@dojoengine/react";
+import { getEntityIdFromKeys } from "@/ui/utils/utils";
 import { getStructureFromToriiClient, type ResourceBalanceRow } from "@bibliothecadao/torii";
 import {
   type ClientComponents,
@@ -233,7 +235,18 @@ export const useStructureEntityDetail = ({ structureEntityId }: UseStructureEnti
   }, [lastRefresh, refetchStructure]);
 
   const structure = structureDetails?.structure;
-  const resources = structureDetails?.resources;
+
+  // For player-owned structures the Resource row is RECS-synced live and
+  // carries optimistic overrides (building costs, automation spends). Prefer
+  // it over the one-shot torii snapshot above so balances agree with the
+  // build menu and resource table. Remote structures aren't in the RECS sync
+  // and keep the torii-fetched snapshot.
+  const recsEntity = getEntityIdFromKeys([BigInt(structureEntityIdNumber || 0)]);
+  const liveStructure = useComponentValue(components.Structure, recsEntity);
+  const liveResources = useComponentValue(components.Resource, recsEntity);
+  const isOwnSyncedStructure =
+    liveStructure?.owner !== undefined && ContractAddress(liveStructure.owner) === userAddress;
+  const resources = isOwnSyncedStructure && liveResources ? liveResources : structureDetails?.resources;
   const playerGuild = structureDetails?.playerGuild;
   const guards = structureDetails?.guards || [];
   const addressName = structureDetails?.addressName;


### PR DESCRIPTION
## Problem

The Empire Cockpit's resource chips disagreed with the build menu and the resource table for the same realm (e.g. cockpit showing 567 labor while the build menu correctly blocked a 59-labor build with only 17 available).

Root cause: `useStructureEntityDetail` sourced `resources` from a one-shot `getStructureFromToriiClient` snapshot (react-query, `staleTime: 5s`, no refetch interval). That snapshot:
- goes stale the moment anything spends/produces on-chain (it's only refetched on remount/manual refresh), and
- is blind to optimistic overrides — building-placement debits (`tile-manager`) and Smart automation's labor spends (`use-automation.tsx` debits `labor_to_resource` cycles before each run).

Every other resource surface (build menu via `getBalance`, resource table via `useEntityQuery`) reads the live RECS store, so they agreed with each other and contradicted the cockpit.

## Fix

For player-owned structures, prefer the RECS-synced `Resource` component (`useComponentValue`) over the torii snapshot — live stream updates plus optimistic overrides, matching every other panel by construction. Ownership is checked against the live RECS `Structure` component, so remote/enemy structures (not in the RECS sync) keep the torii-fetched snapshot unchanged.

## Testing

- Typecheck, eslint, prettier clean
- 90 world-feature tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)