### PR TITLE
Add websocket transaction confirmation

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -26,10 +26,12 @@
     "@scure/starknet": "^1.1.0",
     "chalk": "^5.4.1",
     "eventemitter3": "^5.0.1",
-    "starknet": "catalog:"
+    "starknet": "catalog:",
+    "ws": "^8.19.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.10",
+    "@types/ws": "^8.18.1",
     "tsup": "^8.0.2",
     "typedoc": "^0.26.11",
     "typedoc-plugin-markdown": "^4.2.10",

--- a/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
+++ b/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
@@ -11,6 +11,32 @@ const makeResourceBounds = (l2GasMaxAmount: bigint): ResourceBoundsBN => ({
   l2_gas: { max_amount: l2GasMaxAmount, max_price_per_unit: 1n },
 });
 
+const makeManifest = () =>
+  ({
+    world: {
+      address: "0x1",
+      abi: [
+        {
+          type: "interface",
+          name: "IWorld",
+          items: [
+            {
+              type: "function",
+              name: "dummy",
+              inputs: [],
+              outputs: [],
+              state_mutability: "view",
+            },
+          ],
+        },
+      ],
+      metadata: {
+        rpc_url: "http://localhost:5050",
+      },
+    },
+    contracts: [],
+  }) as any;
+
 const makeProvider = () => {
   const provider = Object.create(EternumProvider.prototype) as any;
   provider.emit = vi.fn();
@@ -47,6 +73,43 @@ const findTransactionFailedPayload = (
 describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("preserves the legacy fourth-argument retry config", () => {
+    const retryConfig = {
+      maxRetries: 1,
+      baseDelayMs: 0,
+      maxDelayMs: 0,
+      jitterFactor: 0,
+    };
+
+    const provider = new EternumProvider(makeManifest(), "http://localhost:5050", undefined, retryConfig);
+
+    expect((provider as any).retryConfig).toBe(retryConfig);
+    expect((provider as any).transactionReceiptWaiter.constructor.name).toBe("PollingTransactionReceiptWaiter");
+  });
+
+  it("accepts retry and websocket confirmation in the options object", () => {
+    const retryConfig = {
+      maxRetries: 1,
+      baseDelayMs: 0,
+      maxDelayMs: 0,
+      jitterFactor: 0,
+    };
+    const websocketFactory = vi.fn();
+
+    const provider = new EternumProvider(makeManifest(), "http://localhost:5050", undefined, {
+      retryConfig,
+      transactionConfirmation: {
+        mode: "websocket",
+        wsUrl: "wss://rpc.example",
+        websocketFactory,
+      },
+    });
+
+    expect((provider as any).retryConfig).toBe(retryConfig);
+    expect((provider as any).transactionReceiptWaiter.constructor.name).toBe("WebSocketTransactionReceiptWaiter");
+    expect(websocketFactory).not.toHaveBeenCalled();
   });
 
   it("caps l2 gas max_amount at the current v3 mainnet limit", async () => {

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -19,7 +19,6 @@ import {
   CallData,
   GetTransactionReceiptResponse,
   ResourceBoundsBN,
-  TransactionFinalityStatus,
   uint256,
   UniversalDetails,
 } from "starknet";
@@ -27,6 +26,14 @@ import { PromiseQueue, QueueableTransaction } from "./promise-queue";
 import { ExecutionOptions } from "./transaction-executor";
 import { withRetry } from "./retry";
 import type { RetryConfig } from "./retry";
+import {
+  createTransactionReceiptWaiter,
+  TX_WAIT_RETRY_INTERVAL_MS,
+  TX_WAIT_SUCCESS_STATES,
+  type EternumProviderOptions,
+  type TransactionConfirmationConfig,
+  type TransactionReceiptWaiter,
+} from "./transaction-confirmation";
 import {
   BatchedTransactionDetail,
   TransactionFailedPayload,
@@ -55,6 +62,7 @@ export type { TransactionExecutor, ExecutionOptions } from "./transaction-execut
 export { withRetry, isRetryableError, calculateBackoffDelay, DEFAULT_RETRY_CONFIG } from "./retry";
 export type { RetryConfig } from "./retry";
 export { TransactionType } from "./types";
+export { createTransactionReceiptWaiter } from "./transaction-confirmation";
 export type {
   BatchedTransactionDetail,
   TransactionFailedPayload,
@@ -66,6 +74,12 @@ export type {
   TransactionSubmitGuard,
   TransactionSubmitGuardContext,
 } from "./types";
+export type {
+  EternumProviderOptions,
+  TransactionConfirmationConfig,
+  TransactionConfirmationMode,
+  WebSocketFactory,
+} from "./transaction-confirmation";
 export type { VrfSource } from "./vrf";
 
 // Mainnet currently rejects V3 invokes above this l2_gas max_amount ceiling.
@@ -75,17 +89,11 @@ const HUNDRED_PERCENT = 100n;
 const DEFAULT_FEE_ESTIMATE_TIMEOUT_MS = 5_000;
 const DEFAULT_TRANSACTION_SUBMIT_TIMEOUT_MS = 20_000;
 const EXPLORE_RESOURCE_BOUNDS_CACHE_TTL_MS = 15_000;
-const TX_WAIT_RETRY_INTERVAL_MS = 500;
 // Resolve confirmation at PRE_CONFIRMED: the sequencer pre-confirms within
 // ~a second and the receipt already carries execution_status, so reverts are
 // detected immediately while the receipt poll loop drops from dozens of RPC
 // requests per tx (waiting for ACCEPTED_ON_L2 block inclusion) to one or two.
 // Game state itself arrives via torii sync, not this receipt.
-const TX_WAIT_SUCCESS_STATES = [
-  TransactionFinalityStatus.PRE_CONFIRMED,
-  TransactionFinalityStatus.ACCEPTED_ON_L2,
-  TransactionFinalityStatus.ACCEPTED_ON_L1,
-];
 export const SUBMISSION_TIMEOUT_UNCERTAIN_MESSAGE =
   "Submission timed out before a tx hash was returned. Check wallet/activity before retrying.";
 const NON_MEANINGFUL_ERROR_MESSAGES = new Set(["", "[object Object]", "undefined", "null"]);
@@ -487,6 +495,34 @@ const resolveTransactionFailureStage = (error: unknown, fallback: TransactionFai
   return fallback;
 };
 
+const isEternumProviderOptions = (
+  value: RetryConfig | EternumProviderOptions | undefined,
+): value is EternumProviderOptions => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  return "retryConfig" in value || "transactionConfirmation" in value;
+};
+
+const resolveEternumProviderOptions = (
+  retryConfigOrOptions: RetryConfig | EternumProviderOptions | undefined,
+): {
+  retryConfig?: RetryConfig;
+  transactionConfirmation?: TransactionConfirmationConfig;
+} => {
+  if (isEternumProviderOptions(retryConfigOrOptions)) {
+    return {
+      retryConfig: retryConfigOrOptions.retryConfig,
+      transactionConfirmation: retryConfigOrOptions.transactionConfirmation,
+    };
+  }
+
+  return {
+    retryConfig: retryConfigOrOptions,
+  };
+};
+
 /**
  * Gets a contract address from the manifest by name
  *
@@ -589,6 +625,7 @@ export class EternumProvider extends EnhancedDojoProvider {
   private pendingVrfExecutionLocks = new Map<string, VrfExecutionLock>();
   private cachedExploreExecutionDetails = new Map<string, CachedExploreExecutionDetails>();
   private readonly retryConfig?: RetryConfig;
+  private readonly transactionReceiptWaiter?: TransactionReceiptWaiter;
   private transactionSubmitGuard?: TransactionSubmitGuard;
   /**
    * Create a new EternumProvider instance
@@ -600,11 +637,16 @@ export class EternumProvider extends EnhancedDojoProvider {
     katana: Manifest,
     url?: string,
     private VRF_PROVIDER_ADDRESS?: string,
-    retryConfig?: RetryConfig,
+    retryConfigOrOptions?: RetryConfig | EternumProviderOptions,
   ) {
     super(katana, url);
+    const providerOptions = resolveEternumProviderOptions(retryConfigOrOptions);
     this.manifest = katana;
-    this.retryConfig = retryConfig;
+    this.retryConfig = providerOptions.retryConfig;
+    this.transactionReceiptWaiter = createTransactionReceiptWaiter(
+      this.provider,
+      providerOptions.transactionConfirmation,
+    );
 
     this.getWorldAddress = function () {
       const worldAddress = this.manifest.world.address;
@@ -1702,10 +1744,9 @@ export class EternumProvider extends EnhancedDojoProvider {
       transactionType: transactionMeta?.type,
     });
     try {
-      receipt = await this.provider.waitForTransaction(transactionHash, {
-        retryInterval: TX_WAIT_RETRY_INTERVAL_MS,
-        successStates: TX_WAIT_SUCCESS_STATES,
-      });
+      const transactionReceiptWaiter =
+        this.transactionReceiptWaiter ?? createTransactionReceiptWaiter(this.provider, { mode: "polling" });
+      receipt = await transactionReceiptWaiter.waitForTransactionReceipt(transactionHash);
     } catch (error) {
       console.error(`Error waiting for transaction ${transactionHash}`, {
         nodeUrl,

--- a/packages/provider/src/transaction-confirmation.test.ts
+++ b/packages/provider/src/transaction-confirmation.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTransactionReceiptWaiter } from "./transaction-confirmation";
+
+type FakeWebSocketMessage = { data: string };
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: FakeWebSocketMessage) => void) | null = null;
+  onerror: ((error: unknown) => void) | null = null;
+  onclose: (() => void) | null = null;
+  sent: string[] = [];
+  closed = false;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.onclose?.();
+  }
+
+  open(): void {
+    this.onopen?.();
+  }
+
+  fail(error: Error): void {
+    this.onerror?.(error);
+  }
+
+  respond(id: string | number, result: unknown): void {
+    this.onmessage?.({ data: JSON.stringify({ jsonrpc: "2.0", id, result }) });
+  }
+
+  notify(params: unknown): void {
+    this.onmessage?.({
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "starknet_subscriptionTransactionStatus",
+        params,
+      }),
+    });
+  }
+}
+
+const buildFakeWebSocketFactory = () => {
+  FakeWebSocket.instances = [];
+  return (url: string) => new FakeWebSocket(url) as any;
+};
+
+const parseSentMessage = (socket: FakeWebSocket, index: number) => JSON.parse(socket.sent[index]);
+
+const makeReceipt = () => ({ isReverted: () => false });
+
+const flushConnectionSetup = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const waitForSocketInstance = async (): Promise<FakeWebSocket> => {
+  await vi.waitFor(() => {
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+  return FakeWebSocket.instances[0];
+};
+
+const openSocketAfterHandlersAttach = async (socket: FakeWebSocket) => {
+  await vi.waitFor(() => {
+    expect(socket.onopen).toEqual(expect.any(Function));
+  });
+  socket.open();
+  await vi.waitFor(() => {
+    expect(socket.sent).toHaveLength(1);
+  });
+};
+
+describe("transaction confirmation waiters", () => {
+  it("confirms through a transaction-status websocket subscription and fetches the receipt once", async () => {
+    const receipt = makeReceipt();
+    const provider = {
+      getTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+      waitForTransaction: vi.fn(),
+    };
+    const waiter = createTransactionReceiptWaiter(provider, {
+      mode: "websocket",
+      wsUrl: "wss://rpc.example",
+      websocketFactory: buildFakeWebSocketFactory(),
+    });
+
+    const confirmed = waiter.waitForTransactionReceipt("0xabc");
+    await flushConnectionSetup();
+    const socket = await waitForSocketInstance();
+    await openSocketAfterHandlersAttach(socket);
+
+    const subscribe = parseSentMessage(socket, 0);
+    expect(subscribe).toMatchObject({
+      jsonrpc: "2.0",
+      method: "starknet_subscribeTransactionStatus",
+      params: ["0xabc"],
+    });
+
+    socket.respond(subscribe.id, "subscription-1");
+    await Promise.resolve();
+    socket.notify({
+      subscription_id: "subscription-1",
+      result: {
+        transaction_hash: "0xabc",
+        status: {
+          finality_status: "PRE_CONFIRMED",
+          execution_status: "SUCCEEDED",
+        },
+      },
+    });
+
+    await expect(confirmed).resolves.toBe(receipt);
+    expect(provider.getTransactionReceipt).toHaveBeenCalledWith("0xabc");
+    expect(provider.waitForTransaction).not.toHaveBeenCalled();
+
+    const unsubscribe = parseSentMessage(socket, 1);
+    expect(unsubscribe).toMatchObject({
+      jsonrpc: "2.0",
+      method: "starknet_unsubscribe",
+      params: ["subscription-1"],
+    });
+  });
+
+  it("accepts array-style transaction-status websocket notifications", async () => {
+    const receipt = makeReceipt();
+    const provider = {
+      getTransactionReceipt: vi.fn().mockResolvedValue(receipt),
+      waitForTransaction: vi.fn(),
+    };
+    const waiter = createTransactionReceiptWaiter(provider, {
+      mode: "websocket",
+      wsUrl: "wss://rpc.example",
+      websocketFactory: buildFakeWebSocketFactory(),
+    });
+
+    const confirmed = waiter.waitForTransactionReceipt("0xabc");
+    await flushConnectionSetup();
+    const socket = await waitForSocketInstance();
+    await openSocketAfterHandlersAttach(socket);
+    const subscribe = parseSentMessage(socket, 0);
+    socket.respond(subscribe.id, "subscription-1");
+    await Promise.resolve();
+    socket.notify([
+      "subscription-1",
+      {
+        transaction_hash: "0xabc",
+        status: {
+          finality_status: "ACCEPTED_ON_L2",
+          execution_status: "SUCCEEDED",
+        },
+      },
+    ]);
+
+    await expect(confirmed).resolves.toBe(receipt);
+    expect(provider.getTransactionReceipt).toHaveBeenCalledWith("0xabc");
+  });
+
+  it("uses polling when no websocket url is configured", async () => {
+    const receipt = makeReceipt();
+    const provider = {
+      getTransactionReceipt: vi.fn(),
+      waitForTransaction: vi.fn().mockResolvedValue(receipt),
+    };
+    const waiter = createTransactionReceiptWaiter(provider, { mode: "auto" });
+
+    await expect(waiter.waitForTransactionReceipt("0xabc")).resolves.toBe(receipt);
+
+    expect(provider.waitForTransaction).toHaveBeenCalledWith("0xabc", {
+      retryInterval: 500,
+      successStates: ["PRE_CONFIRMED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+    });
+    expect(provider.getTransactionReceipt).not.toHaveBeenCalled();
+  });
+
+  it("uses polling when polling mode is selected even with a websocket url", async () => {
+    const receipt = makeReceipt();
+    const provider = {
+      getTransactionReceipt: vi.fn(),
+      waitForTransaction: vi.fn().mockResolvedValue(receipt),
+    };
+    const waiter = createTransactionReceiptWaiter(provider, {
+      mode: "polling",
+      wsUrl: "wss://rpc.example",
+      websocketFactory: buildFakeWebSocketFactory(),
+    });
+
+    await expect(waiter.waitForTransactionReceipt("0xabc")).resolves.toBe(receipt);
+
+    expect(FakeWebSocket.instances).toHaveLength(0);
+    expect(provider.waitForTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to polling in auto mode when websocket connection fails", async () => {
+    const receipt = makeReceipt();
+    const provider = {
+      getTransactionReceipt: vi.fn(),
+      waitForTransaction: vi.fn().mockResolvedValue(receipt),
+    };
+    const waiter = createTransactionReceiptWaiter(provider, {
+      mode: "auto",
+      wsUrl: "wss://rpc.example",
+      websocketFactory: buildFakeWebSocketFactory(),
+    });
+
+    const confirmed = waiter.waitForTransactionReceipt("0xabc");
+    await flushConnectionSetup();
+    const socket = await waitForSocketInstance();
+    socket.fail(new Error("socket failed"));
+
+    await expect(confirmed).resolves.toBe(receipt);
+    expect(provider.waitForTransaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/provider/src/transaction-confirmation.ts
+++ b/packages/provider/src/transaction-confirmation.ts
@@ -1,0 +1,422 @@
+import type { GetTransactionReceiptResponse, TransactionFinalityStatus } from "starknet";
+import type { RetryConfig } from "./retry";
+
+export const TX_WAIT_RETRY_INTERVAL_MS = 500;
+export const TX_WAIT_SUCCESS_STATES: TransactionFinalityStatus[] = [
+  "PRE_CONFIRMED" as TransactionFinalityStatus,
+  "ACCEPTED_ON_L2" as TransactionFinalityStatus,
+  "ACCEPTED_ON_L1" as TransactionFinalityStatus,
+];
+
+export type TransactionConfirmationMode = "auto" | "polling" | "websocket";
+
+export type WebSocketLike = {
+  readyState?: number;
+  onopen?: (() => void) | null;
+  onmessage?: ((event: { data: unknown }) => void) | null;
+  onerror?: ((error: unknown) => void) | null;
+  onclose?: (() => void) | null;
+  addEventListener?: (event: string, listener: (...args: any[]) => void) => void;
+  on?: (event: string, listener: (...args: any[]) => void) => void;
+  send: (payload: string) => void;
+  close: () => void;
+};
+
+export type WebSocketFactory = (url: string) => WebSocketLike | Promise<WebSocketLike>;
+
+export interface TransactionConfirmationConfig {
+  mode?: TransactionConfirmationMode;
+  wsUrl?: string;
+  websocketFactory?: WebSocketFactory;
+}
+
+export interface EternumProviderOptions {
+  retryConfig?: RetryConfig;
+  transactionConfirmation?: TransactionConfirmationConfig;
+}
+
+export interface TransactionReceiptProvider {
+  waitForTransaction(
+    transactionHash: string,
+    options: {
+      retryInterval: number;
+      successStates: TransactionFinalityStatus[];
+    },
+  ): Promise<GetTransactionReceiptResponse>;
+  getTransactionReceipt(transactionHash: string): Promise<GetTransactionReceiptResponse>;
+}
+
+export interface TransactionReceiptWaiter {
+  waitForTransactionReceipt(transactionHash: string): Promise<GetTransactionReceiptResponse>;
+}
+
+type JsonRpcMessage = {
+  id?: number | string;
+  method?: string;
+  result?: unknown;
+  error?: unknown;
+  params?: unknown;
+};
+
+type PendingRequest = {
+  resolve: (result: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+type PendingSubscription = {
+  transactionHash: string;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+type TransactionStatusNotification = {
+  subscriptionId?: string;
+  transactionHash?: string;
+  finalityStatus?: string;
+};
+
+export const createTransactionReceiptWaiter = (
+  provider: TransactionReceiptProvider,
+  config: TransactionConfirmationConfig = {},
+): TransactionReceiptWaiter => {
+  const pollingWaiter = new PollingTransactionReceiptWaiter(provider);
+  const mode = config.mode ?? "auto";
+
+  if (mode === "polling" || !config.wsUrl) {
+    return pollingWaiter;
+  }
+
+  const websocketWaiter = new WebSocketTransactionReceiptWaiter(provider, config.wsUrl, config.websocketFactory);
+  if (mode === "websocket") {
+    return websocketWaiter;
+  }
+
+  return new FallbackTransactionReceiptWaiter(websocketWaiter, pollingWaiter);
+};
+
+class PollingTransactionReceiptWaiter implements TransactionReceiptWaiter {
+  constructor(private readonly provider: TransactionReceiptProvider) {}
+
+  async waitForTransactionReceipt(transactionHash: string): Promise<GetTransactionReceiptResponse> {
+    return await this.provider.waitForTransaction(transactionHash, {
+      retryInterval: TX_WAIT_RETRY_INTERVAL_MS,
+      successStates: TX_WAIT_SUCCESS_STATES,
+    });
+  }
+}
+
+class FallbackTransactionReceiptWaiter implements TransactionReceiptWaiter {
+  constructor(
+    private readonly preferredWaiter: TransactionReceiptWaiter,
+    private readonly fallbackWaiter: TransactionReceiptWaiter,
+  ) {}
+
+  async waitForTransactionReceipt(transactionHash: string): Promise<GetTransactionReceiptResponse> {
+    try {
+      return await this.preferredWaiter.waitForTransactionReceipt(transactionHash);
+    } catch {
+      return await this.fallbackWaiter.waitForTransactionReceipt(transactionHash);
+    }
+  }
+}
+
+class WebSocketTransactionReceiptWaiter implements TransactionReceiptWaiter {
+  private connection?: Promise<WebSocketJsonRpcConnection>;
+
+  constructor(
+    private readonly provider: TransactionReceiptProvider,
+    private readonly wsUrl: string,
+    private readonly websocketFactory?: WebSocketFactory,
+  ) {}
+
+  async waitForTransactionReceipt(transactionHash: string): Promise<GetTransactionReceiptResponse> {
+    const connection = await this.getConnection();
+    const subscriptionId = await connection.subscribeTransactionStatus(transactionHash);
+
+    try {
+      await connection.waitForTransactionStatus(subscriptionId, transactionHash);
+      return await this.provider.getTransactionReceipt(transactionHash);
+    } finally {
+      connection.unsubscribe(subscriptionId);
+    }
+  }
+
+  private async getConnection(): Promise<WebSocketJsonRpcConnection> {
+    if (!this.connection) {
+      this.connection = WebSocketJsonRpcConnection.open(this.wsUrl, this.websocketFactory).catch((error) => {
+        this.connection = undefined;
+        throw error;
+      });
+    }
+
+    return await this.connection;
+  }
+}
+
+class WebSocketJsonRpcConnection {
+  private nextRequestId = 1;
+  private pendingRequests = new Map<number, PendingRequest>();
+  private pendingSubscriptions = new Map<string, PendingSubscription>();
+  private completedSubscriptions = new Map<string, string | undefined>();
+
+  private constructor(private readonly socket: WebSocketLike) {}
+
+  static async open(wsUrl: string, websocketFactory?: WebSocketFactory): Promise<WebSocketJsonRpcConnection> {
+    const socket = await createWebSocket(wsUrl, websocketFactory);
+    const connection = new WebSocketJsonRpcConnection(socket);
+    await connection.waitUntilOpen();
+    connection.attachMessageHandlers();
+    return connection;
+  }
+
+  async subscribeTransactionStatus(transactionHash: string): Promise<string> {
+    const result = await this.sendRequest("starknet_subscribeTransactionStatus", [transactionHash]);
+    if (typeof result !== "string" || result.length === 0) {
+      throw new Error("Starknet websocket subscription did not return a subscription id");
+    }
+
+    return result;
+  }
+
+  waitForTransactionStatus(subscriptionId: string, transactionHash: string): Promise<void> {
+    if (this.matchesCompletedSubscription(subscriptionId, transactionHash)) {
+      this.completedSubscriptions.delete(subscriptionId);
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      this.pendingSubscriptions.set(subscriptionId, {
+        transactionHash,
+        resolve,
+        reject,
+      });
+    });
+  }
+
+  unsubscribe(subscriptionId: string): void {
+    this.pendingSubscriptions.delete(subscriptionId);
+    void this.sendRequest("starknet_unsubscribe", [subscriptionId]).catch(() => {
+      // Nothing actionable remains once local subscription state has been cleared.
+    });
+  }
+
+  private waitUntilOpen(): Promise<void> {
+    if (this.socket.readyState === 1) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      const handleOpen = () => resolve();
+      const handleFailure = (error: unknown) => {
+        reject(error instanceof Error ? error : new Error("Websocket failed"));
+      };
+
+      attachWebSocketHandler(this.socket, "open", handleOpen);
+      attachWebSocketHandler(this.socket, "error", handleFailure);
+      attachWebSocketHandler(this.socket, "close", () => handleFailure(new Error("Websocket closed before opening")));
+    });
+  }
+
+  private attachMessageHandlers(): void {
+    attachWebSocketHandler(this.socket, "message", (event: { data: unknown }) => {
+      this.handleMessage(event.data);
+    });
+    attachWebSocketHandler(this.socket, "error", (error: unknown) => {
+      this.rejectActiveWork(error);
+    });
+    attachWebSocketHandler(this.socket, "close", () => {
+      this.rejectActiveWork(new Error("Websocket connection closed"));
+    });
+  }
+
+  private sendRequest(method: string, params: unknown[]): Promise<unknown> {
+    const id = this.nextRequestId++;
+    const payload = JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method,
+      params,
+    });
+
+    return new Promise<unknown>((resolve, reject) => {
+      this.pendingRequests.set(id, { resolve, reject });
+      try {
+        this.socket.send(payload);
+      } catch (error) {
+        this.pendingRequests.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  private handleMessage(data: unknown): void {
+    const message = parseJsonRpcMessage(data);
+    if (!message) {
+      return;
+    }
+
+    if (message.id !== undefined) {
+      this.resolveRequest(message);
+      return;
+    }
+
+    if (message.method === "starknet_subscriptionTransactionStatus") {
+      this.resolveTransactionStatus(message.params);
+    }
+  }
+
+  private resolveRequest(message: JsonRpcMessage): void {
+    const id = Number(message.id);
+    const pendingRequest = this.pendingRequests.get(id);
+    if (!pendingRequest) {
+      return;
+    }
+
+    this.pendingRequests.delete(id);
+    if (message.error !== undefined) {
+      pendingRequest.reject(message.error);
+      return;
+    }
+
+    pendingRequest.resolve(message.result);
+  }
+
+  private resolveTransactionStatus(params: unknown): void {
+    const notification = parseTransactionStatusNotification(params);
+    if (!notification.subscriptionId || !notification.finalityStatus) {
+      return;
+    }
+
+    const pendingSubscription = this.pendingSubscriptions.get(notification.subscriptionId);
+    if (TX_WAIT_SUCCESS_STATES.includes(notification.finalityStatus as TransactionFinalityStatus)) {
+      if (!pendingSubscription) {
+        this.completedSubscriptions.set(notification.subscriptionId, notification.transactionHash);
+        return;
+      }
+
+      if (notification.transactionHash && notification.transactionHash !== pendingSubscription.transactionHash) {
+        return;
+      }
+
+      pendingSubscription.resolve();
+    }
+  }
+
+  private matchesCompletedSubscription(subscriptionId: string, transactionHash: string): boolean {
+    if (!this.completedSubscriptions.has(subscriptionId)) {
+      return false;
+    }
+
+    const completedTransactionHash = this.completedSubscriptions.get(subscriptionId);
+    return !completedTransactionHash || completedTransactionHash === transactionHash;
+  }
+
+  private rejectActiveWork(error: unknown): void {
+    for (const pendingRequest of this.pendingRequests.values()) {
+      pendingRequest.reject(error);
+    }
+    this.pendingRequests.clear();
+
+    for (const pendingSubscription of this.pendingSubscriptions.values()) {
+      pendingSubscription.reject(error);
+    }
+    this.pendingSubscriptions.clear();
+  }
+}
+
+const createWebSocket = async (wsUrl: string, websocketFactory?: WebSocketFactory): Promise<WebSocketLike> => {
+  if (websocketFactory) {
+    return await websocketFactory(wsUrl);
+  }
+
+  if (typeof globalThis.WebSocket === "function") {
+    return new globalThis.WebSocket(wsUrl) as WebSocketLike;
+  }
+
+  const wsModule = (await import("ws")) as {
+    WebSocket?: new (url: string) => WebSocketLike;
+    default?: new (url: string) => WebSocketLike;
+  };
+  const WebSocketConstructor = wsModule.WebSocket ?? wsModule.default;
+  if (!WebSocketConstructor) {
+    throw new Error("No websocket implementation is available");
+  }
+
+  return new WebSocketConstructor(wsUrl);
+};
+
+const attachWebSocketHandler = (socket: WebSocketLike, event: string, listener: (...args: any[]) => void): void => {
+  if (typeof socket.addEventListener === "function") {
+    socket.addEventListener(event, listener);
+    return;
+  }
+
+  if (typeof socket.on === "function") {
+    socket.on(event, listener);
+    return;
+  }
+
+  if (event === "open") {
+    socket.onopen = () => listener();
+  }
+  if (event === "message") {
+    socket.onmessage = (message) => listener(message);
+  }
+  if (event === "error") {
+    socket.onerror = (error) => listener(error);
+  }
+  if (event === "close") {
+    socket.onclose = () => listener();
+  }
+};
+
+const parseJsonRpcMessage = (data: unknown): JsonRpcMessage | null => {
+  try {
+    const raw =
+      typeof data === "string"
+        ? data
+        : typeof Buffer !== "undefined" && data instanceof Buffer
+          ? data.toString("utf8")
+          : String(data);
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as JsonRpcMessage) : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseTransactionStatusNotification = (params: unknown): TransactionStatusNotification => {
+  if (Array.isArray(params)) {
+    return buildTransactionStatusNotification(params[0], params[1]);
+  }
+
+  if (!params || typeof params !== "object") {
+    return {};
+  }
+
+  const record = params as Record<string, unknown>;
+  return buildTransactionStatusNotification(record.subscription_id ?? record.subscriptionId, record.result);
+};
+
+const buildTransactionStatusNotification = (
+  subscriptionId: unknown,
+  result: unknown,
+): TransactionStatusNotification => {
+  if (!result || typeof result !== "object") {
+    return {
+      subscriptionId: typeof subscriptionId === "string" ? subscriptionId : undefined,
+    };
+  }
+
+  const record = result as Record<string, unknown>;
+  const status = record.status && typeof record.status === "object" ? (record.status as Record<string, unknown>) : {};
+  const finalityStatus =
+    status.finality_status ?? status.finalityStatus ?? record.finality_status ?? record.finalityStatus;
+  const transactionHash = record.transaction_hash ?? record.transactionHash;
+
+  return {
+    subscriptionId: typeof subscriptionId === "string" ? subscriptionId : undefined,
+    transactionHash: typeof transactionHash === "string" ? transactionHash : undefined,
+    finalityStatus: typeof finalityStatus === "string" ? finalityStatus : undefined,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,10 +1131,16 @@ importers:
       starknet:
         specifier: 'catalog:'
         version: 8.9.2
+      ws:
+        specifier: ^8.19.0
+        version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     devDependencies:
       '@types/node':
         specifier: ^20.11.10
         version: 20.19.33
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       tsup:
         specifier: ^8.0.2
         version: 8.5.1(@swc/core@1.15.11(@swc/helpers@0.5.18))(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -19103,7 +19109,6 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.11
-    optional: true
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
Adds an internal transaction confirmation strategy for `packages/provider` that can use Starknet websocket transaction-status subscriptions when a `wsUrl` is configured, while preserving polling as the default and auto fallback path.

The provider constructor now accepts either the legacy retry config or an options object with retry and transaction confirmation settings.

The websocket waiter subscribes to transaction status, treats `PRE_CONFIRMED`, `ACCEPTED_ON_L2`, and `ACCEPTED_ON_L1` as success states, fetches the receipt once, and leaves existing revert/background confirmation handling intact.

Validation: `CI=1 pnpm --filter @bibliothecadao/provider test`, `pnpm --filter @bibliothecadao/provider build`, `pnpm run format`, and `pnpm run knip`.