### PR TITLE
Harden ghost army reconciliation

### DIFF
--- a/client/apps/game/src/dojo/army-authoritative-reconciler.test.ts
+++ b/client/apps/game/src/dojo/army-authoritative-reconciler.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { setEntitiesMock } = vi.hoisted(() => ({
+  setEntitiesMock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@dojoengine/state", () => ({
+  setEntities: setEntitiesMock,
+}));
+
+import { ID } from "@bibliothecadao/types";
+import { Type, createWorld, defineComponent, getComponentValue, setComponent } from "@dojoengine/recs";
+import { ToriiClient } from "@dojoengine/torii-client";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+import {
+  classifyAuthoritativeSweep,
+  isSuspiciousAuthoritativeDeadSet,
+  sweepArmiesAgainstTorii,
+} from "./army-authoritative-reconciler";
+
+const EXPLORER_TROOPS_MODEL = "s1_eternum-ExplorerTroops";
+
+function makeExplorerTroopsWorld() {
+  const world = createWorld();
+  const explorerTroops = defineComponent(world, { explorer_id: Type.Number });
+  return { world, explorerTroops };
+}
+
+function trackArmy(explorerTroops: ReturnType<typeof makeExplorerTroopsWorld>["explorerTroops"], id: number) {
+  setComponent(explorerTroops, getEntityIdFromKeys([BigInt(id)]), { explorer_id: id });
+}
+
+function makeToriiClient(presentIds: number[]): ToriiClient {
+  return {
+    getEntities: vi.fn(async () => ({
+      items: presentIds.map((id) => ({
+        hashed_keys: getEntityIdFromKeys([BigInt(id)]),
+        models: { [EXPLORER_TROOPS_MODEL]: { explorer_id: { type: "primitive", value: id } } },
+      })),
+      next_cursor: undefined,
+    })),
+  } as unknown as ToriiClient;
+}
+
+function makeFailingToriiClient(): ToriiClient {
+  return {
+    getEntities: vi.fn(async () => {
+      throw new Error("torii unavailable");
+    }),
+  } as unknown as ToriiClient;
+}
+
+describe("classifyAuthoritativeSweep", () => {
+  it("records a first absence as missing without confirming death", () => {
+    const result = classifyAuthoritativeSweep({
+      candidateIds: [1, 2] as ID[],
+      presentIds: new Set([1] as ID[]),
+      previousMissing: new Set(),
+    });
+
+    expect(result.confirmedDead).toEqual([]);
+    expect([...result.nextMissing]).toEqual([2]);
+  });
+
+  it("confirms death only on the second consecutive absence", () => {
+    const result = classifyAuthoritativeSweep({
+      candidateIds: [1, 2] as ID[],
+      presentIds: new Set([1] as ID[]),
+      previousMissing: new Set([2] as ID[]),
+    });
+
+    expect(result.confirmedDead).toEqual([2]);
+    expect(result.nextMissing.size).toBe(0);
+  });
+
+  it("drops a reappeared id from the missing set", () => {
+    const result = classifyAuthoritativeSweep({
+      candidateIds: [2] as ID[],
+      presentIds: new Set([2] as ID[]),
+      previousMissing: new Set([2] as ID[]),
+    });
+
+    expect(result.confirmedDead).toEqual([]);
+    expect(result.nextMissing.size).toBe(0);
+  });
+});
+
+describe("isSuspiciousAuthoritativeDeadSet", () => {
+  it("trusts small dead counts even at a high ratio", () => {
+    expect(isSuspiciousAuthoritativeDeadSet(3, 4)).toBe(false);
+  });
+
+  it("distrusts a mass-death result", () => {
+    expect(isSuspiciousAuthoritativeDeadSet(12, 20)).toBe(true);
+  });
+
+  it("trusts large dead counts that are a minority of candidates", () => {
+    expect(isSuspiciousAuthoritativeDeadSet(12, 100)).toBe(false);
+  });
+});
+
+describe("sweepArmiesAgainstTorii", () => {
+  it("skips entirely with no valid candidates", async () => {
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    const result = await sweepArmiesAgainstTorii({
+      toriiClient: makeToriiClient([]),
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [-5, 0] as ID[],
+      previousMissing: new Set(),
+    });
+
+    expect(result.outcome).toBe("skipped_empty");
+  });
+
+  it("keeps two-strike state and RECS untouched when the query fails", async () => {
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    trackArmy(explorerTroops, 42);
+    const previousMissing = new Set([42] as ID[]);
+
+    const result = await sweepArmiesAgainstTorii({
+      toriiClient: makeFailingToriiClient(),
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [42] as ID[],
+      previousMissing,
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.confirmedDead).toEqual([]);
+    expect(result.nextMissing).toBe(previousMissing);
+    expect(getComponentValue(explorerTroops, getEntityIdFromKeys([42n]))).toBeDefined();
+  });
+
+  it("marks a missing army on strike one and removes its component on strike two", async () => {
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    trackArmy(explorerTroops, 42);
+    const toriiClient = makeToriiClient([]);
+
+    const first = await sweepArmiesAgainstTorii({
+      toriiClient,
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [42] as ID[],
+      previousMissing: new Set(),
+    });
+
+    expect(first.outcome).toBe("completed");
+    expect(first.confirmedDead).toEqual([]);
+    expect([...first.nextMissing]).toEqual([42]);
+    expect(getComponentValue(explorerTroops, getEntityIdFromKeys([42n]))).toBeDefined();
+
+    const second = await sweepArmiesAgainstTorii({
+      toriiClient,
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [42] as ID[],
+      previousMissing: first.nextMissing,
+    });
+
+    expect(second.outcome).toBe("completed");
+    expect(second.confirmedDead).toEqual([42]);
+    expect(getComponentValue(explorerTroops, getEntityIdFromKeys([42n]))).toBeUndefined();
+  });
+
+  it("re-applies present armies and keeps them out of the missing set", async () => {
+    setEntitiesMock.mockClear();
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    trackArmy(explorerTroops, 7);
+
+    const result = await sweepArmiesAgainstTorii({
+      toriiClient: makeToriiClient([7]),
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [7] as ID[],
+      previousMissing: new Set([7] as ID[]),
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(result.confirmedDead).toEqual([]);
+    expect(result.nextMissing.size).toBe(0);
+    expect(result.reappliedCount).toBe(1);
+    expect(setEntitiesMock).toHaveBeenCalledTimes(1);
+    expect(getComponentValue(explorerTroops, getEntityIdFromKeys([7n]))).toBeDefined();
+  });
+
+  it("aborts without touching RECS when the dead set looks like a Torii failure", async () => {
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    const candidateIds = Array.from({ length: 12 }, (_, i) => (i + 1) as ID);
+    candidateIds.forEach((id) => trackArmy(explorerTroops, id));
+
+    const result = await sweepArmiesAgainstTorii({
+      toriiClient: makeToriiClient([]),
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds,
+      previousMissing: new Set(candidateIds),
+    });
+
+    expect(result.outcome).toBe("aborted_suspicious");
+    expect(result.confirmedDead).toEqual([]);
+    candidateIds.forEach((id) => {
+      expect(getComponentValue(explorerTroops, getEntityIdFromKeys([BigInt(id)]))).toBeDefined();
+    });
+  });
+});

--- a/client/apps/game/src/dojo/army-authoritative-reconciler.ts
+++ b/client/apps/game/src/dojo/army-authoritative-reconciler.ts
@@ -1,0 +1,219 @@
+import { ID } from "@bibliothecadao/types";
+import { Component, Metadata, Schema, getComponentValue, removeComponent } from "@dojoengine/recs";
+import { setEntities } from "@dojoengine/state";
+import { PatternMatching, ToriiClient } from "@dojoengine/torii-client";
+import { LogicalOperator } from "@dojoengine/torii-wasm";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+
+/**
+ * Loop A of the ghost-army fix: the level-triggered "local RECS == Torii"
+ * invariant enforcer.
+ *
+ * Deletions only ever reach the client as push events (a Torii deletion payload
+ * -> world.deleteEntity -> onDeadArmy). A silent stream drop, a reconnect gap,
+ * or a stale snapshot write can swallow that single event, after which the dead
+ * army emits no further updates and the stale ExplorerTroops component persists
+ * in RECS forever. This sweep re-queries Torii by entity id for every tracked
+ * army and surgically removes the ExplorerTroops component for armies Torii no
+ * longer knows — firing the exact same component-removal edge the real deletion
+ * path produces, so the existing onDeadArmy -> deleteArmy pipeline runs.
+ *
+ * removeComponent (not world.deleteEntity) on purpose: the by-id query only
+ * proves the ExplorerTroops model is gone; sibling models under the same keys
+ * may legitimately still exist, and deleting the whole entity would wipe them.
+ *
+ * Armies that ARE returned get re-applied through setEntities, healing any
+ * coord/count drift via the normal onExplorerTroopsUpdate flow.
+ */
+
+export const ARMY_AUTHORITATIVE_SWEEP_INTERVAL_MS = 30_000;
+// Skip armies tracked less than this: a freshly created army can be visible
+// optimistically before Torii has indexed its create transaction.
+export const ARMY_AUTHORITATIVE_MIN_TRACKED_AGE_MS = 30_000;
+
+const EXPLORER_TROOPS_MODEL = "s1_eternum-ExplorerTroops";
+const SWEEP_QUERY_BATCH_SIZE = 100;
+// Tripwire against a degraded Torii answering with bogus empty pages: if a
+// single sweep would confirm-kill this many armies AND more than half the
+// candidate set, distrust the result and change nothing.
+const SUSPICIOUS_DEAD_MIN_COUNT = 10;
+const SUSPICIOUS_DEAD_MAX_RATIO = 0.5;
+
+export interface ArmyAuthoritativeSweepClassification {
+  /** Missing from Torii for the second consecutive sweep — confirmed dead. */
+  confirmedDead: ID[];
+  /** Two-strike state to feed back into the next sweep. */
+  nextMissing: Set<ID>;
+}
+
+/**
+ * Pure two-strike classifier. An id must be absent from Torii in two
+ * consecutive sweeps before it is confirmed dead; ids that reappear drop out
+ * of the missing set automatically.
+ */
+export function classifyAuthoritativeSweep(input: {
+  candidateIds: readonly ID[];
+  presentIds: ReadonlySet<ID>;
+  previousMissing: ReadonlySet<ID>;
+}): ArmyAuthoritativeSweepClassification {
+  const confirmedDead: ID[] = [];
+  const nextMissing = new Set<ID>();
+
+  for (const id of input.candidateIds) {
+    if (input.presentIds.has(id)) {
+      continue;
+    }
+    if (input.previousMissing.has(id)) {
+      confirmedDead.push(id);
+    } else {
+      nextMissing.add(id);
+    }
+  }
+
+  return { confirmedDead, nextMissing };
+}
+
+export function isSuspiciousAuthoritativeDeadSet(confirmedDeadCount: number, candidateCount: number): boolean {
+  return (
+    confirmedDeadCount >= SUSPICIOUS_DEAD_MIN_COUNT &&
+    candidateCount > 0 &&
+    confirmedDeadCount / candidateCount > SUSPICIOUS_DEAD_MAX_RATIO
+  );
+}
+
+export interface ArmyAuthoritativeSweepResult {
+  outcome: "completed" | "failed" | "aborted_suspicious" | "skipped_empty";
+  confirmedDead: ID[];
+  /** Two-strike state for the next sweep; unchanged when the sweep fails. */
+  nextMissing: ReadonlySet<ID>;
+  reappliedCount: number;
+}
+
+export interface ArmyAuthoritativeSweepInput<S extends Schema> {
+  toriiClient: ToriiClient;
+  /** All contract components, for setEntities re-application. */
+  components: Component<S, Metadata, undefined>[];
+  /** The ExplorerTroops component, for surgical removal. */
+  explorerTroopsComponent: Component<S, Metadata, undefined>;
+  candidateIds: readonly ID[];
+  previousMissing: ReadonlySet<ID>;
+}
+
+const isValidId = (id: unknown): id is ID => typeof id === "number" && Number.isFinite(id) && (id as number) > 0;
+
+const buildByIdClause = (ids: readonly ID[]) => {
+  const keysFor = (id: ID) => ({
+    Keys: {
+      keys: [id.toString()],
+      pattern_matching: "VariableLen" as PatternMatching,
+      models: [],
+    },
+  });
+
+  return ids.length === 1
+    ? keysFor(ids[0])
+    : {
+        Composite: {
+          operator: "Or" as LogicalOperator,
+          clauses: ids.map(keysFor),
+        },
+      };
+};
+
+const hasExplorerTroopsModelData = (models: Record<string, object | undefined> | undefined): boolean => {
+  const model = models?.[EXPLORER_TROOPS_MODEL];
+  return model !== undefined && model !== null && Object.keys(model).length > 0;
+};
+
+/**
+ * Queries Torii authoritatively for the given army ids and reconciles local
+ * RECS: present armies are re-applied (awaited, so RECS writes land before the
+ * promise resolves), armies missing twice in a row get their ExplorerTroops
+ * component removed so the existing dead-army pipeline fires.
+ *
+ * Never throws; a failed query returns outcome "failed" with zero state
+ * changes so a flaky network cannot masquerade as mass death.
+ */
+export async function sweepArmiesAgainstTorii<S extends Schema>(
+  input: ArmyAuthoritativeSweepInput<S>,
+): Promise<ArmyAuthoritativeSweepResult> {
+  const candidateIds = input.candidateIds.filter(isValidId);
+  if (candidateIds.length === 0) {
+    return { outcome: "skipped_empty", confirmedDead: [], nextMissing: new Set(), reappliedCount: 0 };
+  }
+
+  const presentIds = new Set<ID>();
+  const entityKeyToId = new Map<string, ID>();
+  candidateIds.forEach((id) => entityKeyToId.set(getEntityIdFromKeys([BigInt(id)]), id));
+
+  let reappliedCount = 0;
+
+  try {
+    for (let offset = 0; offset < candidateIds.length; offset += SWEEP_QUERY_BATCH_SIZE) {
+      const batch = candidateIds.slice(offset, offset + SWEEP_QUERY_BATCH_SIZE);
+      const clause = buildByIdClause(batch);
+
+      let cursor: string | undefined;
+      for (;;) {
+        const page = await input.toriiClient.getEntities({
+          pagination: { limit: SWEEP_QUERY_BATCH_SIZE, cursor, direction: "Forward", order_by: [] },
+          clause,
+          no_hashed_keys: false,
+          models: [EXPLORER_TROOPS_MODEL],
+          historical: false,
+        });
+
+        const items = Array.isArray(page.items) ? page.items : Object.values(page.items ?? {});
+        const presentItems = items.filter((item) => hasExplorerTroopsModelData(item.models));
+
+        for (const item of presentItems) {
+          const id = entityKeyToId.get(item.hashed_keys);
+          if (id !== undefined) {
+            presentIds.add(id);
+          }
+        }
+
+        if (presentItems.length > 0) {
+          // Awaited per page so RECS state is settled before classification
+          // (the same reason the config fetch awaits its writes).
+          await setEntities(presentItems, input.components, false);
+          reappliedCount += presentItems.length;
+        }
+
+        if (items.length < SWEEP_QUERY_BATCH_SIZE || !page.next_cursor) break;
+        cursor = page.next_cursor;
+      }
+    }
+  } catch (error) {
+    console.warn("[army-reconciler] authoritative sweep query failed; keeping state unchanged", error);
+    return { outcome: "failed", confirmedDead: [], nextMissing: input.previousMissing, reappliedCount };
+  }
+
+  const { confirmedDead, nextMissing } = classifyAuthoritativeSweep({
+    candidateIds,
+    presentIds,
+    previousMissing: input.previousMissing,
+  });
+
+  if (isSuspiciousAuthoritativeDeadSet(confirmedDead.length, candidateIds.length)) {
+    console.warn(
+      `[army-reconciler] sweep would confirm ${confirmedDead.length}/${candidateIds.length} armies dead — distrusting result`,
+    );
+    return { outcome: "aborted_suspicious", confirmedDead: [], nextMissing: input.previousMissing, reappliedCount };
+  }
+
+  for (const id of confirmedDead) {
+    const entity = getEntityIdFromKeys([BigInt(id)]);
+    // Only fire the removal edge if RECS still holds the stale component:
+    // onDeadArmy needs a prevState, and an already-clean RECS means the scene
+    // side (Loop B) owns whatever visual remains.
+    if (getComponentValue(input.explorerTroopsComponent, entity) !== undefined) {
+      if (import.meta.env.DEV) {
+        console.warn(`[army-reconciler] army ${id} missing on Torii twice — removing stale ExplorerTroops`);
+      }
+      removeComponent(input.explorerTroopsComponent, entity);
+    }
+  }
+
+  return { outcome: "completed", confirmedDead, nextMissing, reappliedCount };
+}

--- a/client/apps/game/src/dojo/army-authoritative-reconciler.ts
+++ b/client/apps/game/src/dojo/army-authoritative-reconciler.ts
@@ -39,6 +39,13 @@ const SWEEP_QUERY_BATCH_SIZE = 100;
 const SUSPICIOUS_DEAD_MIN_COUNT = 10;
 const SUSPICIOUS_DEAD_MAX_RATIO = 0.5;
 
+interface ToriiEntityPageItem {
+  hashed_keys: string;
+  models?: Record<string, object | undefined>;
+}
+
+type ToriiEntityPageItems = ToriiEntityPageItem[] | Record<string, ToriiEntityPageItem>;
+
 export interface ArmyAuthoritativeSweepClassification {
   /** Missing from Torii for the second consecutive sweep — confirmed dead. */
   confirmedDead: ID[];
@@ -125,6 +132,13 @@ const hasExplorerTroopsModelData = (models: Record<string, object | undefined> |
   return model !== undefined && model !== null && Object.keys(model).length > 0;
 };
 
+const normalizeToriiPageItems = (items: ToriiEntityPageItems | undefined): ToriiEntityPageItem[] => {
+  if (!items) {
+    return [];
+  }
+  return Array.isArray(items) ? items : Object.values(items);
+};
+
 /**
  * Queries Torii authoritatively for the given army ids and reconciles local
  * RECS: present armies are re-applied (awaited, so RECS writes land before the
@@ -163,7 +177,7 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
           historical: false,
         });
 
-        const items = Array.isArray(page.items) ? page.items : Object.values(page.items ?? {});
+        const items = normalizeToriiPageItems(page.items as ToriiEntityPageItems | undefined);
         const presentItems = items.filter((item) => hasExplorerTroopsModelData(item.models));
 
         for (const item of presentItems) {

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -1632,6 +1632,20 @@ export class ArmyManager {
     return this.isArmyVisible(army, this.getChunkBounds(startRow, startCol));
   }
 
+  // Loop B (worldmap RECS sweep) visibility signal. Reuses the chunk-bounds
+  // predicate rather than visibleArmyIndices membership: an army can be
+  // logically visible yet undrawn (the exact desync the sweep heals), so slot
+  // membership would under-report. Mid-transition the answer is not trusted,
+  // mirroring reconcileArmyRenderIntegrity's settled-chunk gate.
+  public isArmyVisibleInCommittedChunk(entityId: ID): boolean {
+    if (this.isArmyChunkTransitioning || !isCommittedManagerChunk(this.currentChunkKey)) {
+      return false;
+    }
+
+    const army = this.armies.get(entityId);
+    return army !== undefined && this.isArmyVisibleInCurrentChunk(army);
+  }
+
   private drainDeferredArmyQueue(): void {
     if (this.deferredArmyQueue.size === 0) return;
     const deferred = [...this.deferredArmyQueue];
@@ -2725,8 +2739,10 @@ export class ArmyManager {
       if (violation.kind === "orphaned-drawn-slot") {
         this.armyModel.purgeDrawnSlot(violation.slot);
         purgedAny = true;
+        incrementWorldmapRenderCounter("armyRenderIntegrityHealOrphanSlot");
       } else {
         void this.renderArmyIntoCurrentChunkIfVisible(this.toNumericId(violation.entityId));
+        incrementWorldmapRenderCounter("armyRenderIntegrityHealVisibleUndrawn");
       }
 
       if (import.meta.env?.DEV) {
@@ -3614,6 +3630,23 @@ ${
     this.refreshArmyInstance(army, slot, modelType);
     this.refreshVisibleArmyCollection();
     this.updateVisibleArmyBuffers();
+  }
+
+  // DEV-only desync injector for the Loop B sweep test harness: forces the
+  // rendered position away from RECS truth without touching the spatial index
+  // or movement bookkeeping, so the sweep's snap_position heal can be exercised.
+  public debugSetArmyHexCoords(entityId: ID, hexCoords: { col: number; row: number }): void {
+    if (!import.meta.env?.DEV) {
+      return;
+    }
+
+    const army = this.armies.get(entityId);
+    if (!army) {
+      return;
+    }
+
+    army.hexCoords = new Position({ x: hexCoords.col, y: hexCoords.row });
+    this.refreshArmyPositionPresentation(army);
   }
 
   public destroy() {

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.test.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.test.ts
@@ -243,4 +243,28 @@ describe("worldmap-render-diagnostics", () => {
     expect(snapshot.counters).toHaveProperty("pendingArmyRemovalCancelledByExplorerTroopsZero", 1);
     expect(snapshot.counters).toHaveProperty("pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery", 1);
   });
+
+  it("tracks ghost-army convergence sweep and render-integrity heal counters", () => {
+    incrementWorldmapRenderCounter("armyAuthoritativeSweepConfirmedDead");
+    incrementWorldmapRenderCounter("armyAuthoritativeSweepReapplied");
+    incrementWorldmapRenderCounter("armyAuthoritativeSweepFailed");
+    incrementWorldmapRenderCounter("armyRecsSweepRemovedDeadZero");
+    incrementWorldmapRenderCounter("armyRecsSweepRemovedDeadMissing");
+    incrementWorldmapRenderCounter("armyRecsSweepSnappedPosition");
+    incrementWorldmapRenderCounter("armyRecsSweepRestoredAlive");
+    incrementWorldmapRenderCounter("armyRenderIntegrityHealOrphanSlot");
+    incrementWorldmapRenderCounter("armyRenderIntegrityHealVisibleUndrawn");
+
+    const snapshot = snapshotWorldmapRenderDiagnostics();
+
+    expect(snapshot.counters).toHaveProperty("armyAuthoritativeSweepConfirmedDead", 1);
+    expect(snapshot.counters).toHaveProperty("armyAuthoritativeSweepReapplied", 1);
+    expect(snapshot.counters).toHaveProperty("armyAuthoritativeSweepFailed", 1);
+    expect(snapshot.counters).toHaveProperty("armyRecsSweepRemovedDeadZero", 1);
+    expect(snapshot.counters).toHaveProperty("armyRecsSweepRemovedDeadMissing", 1);
+    expect(snapshot.counters).toHaveProperty("armyRecsSweepSnappedPosition", 1);
+    expect(snapshot.counters).toHaveProperty("armyRecsSweepRestoredAlive", 1);
+    expect(snapshot.counters).toHaveProperty("armyRenderIntegrityHealOrphanSlot", 1);
+    expect(snapshot.counters).toHaveProperty("armyRenderIntegrityHealVisibleUndrawn", 1);
+  });
 });

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
@@ -82,7 +82,17 @@ export type WorldmapRenderCounter =
   | "pendingArmyRemovalCancelledByDelete"
   | "pendingArmyRemovalCancelledBySuperseded"
   | "pendingArmyRemovalCancelledByExplorerTroopsZero"
-  | "pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery";
+  | "pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery"
+  | "pendingArmyRemovalCancelledByRecsSweep"
+  | "armyAuthoritativeSweepConfirmedDead"
+  | "armyAuthoritativeSweepReapplied"
+  | "armyAuthoritativeSweepFailed"
+  | "armyRecsSweepRemovedDeadZero"
+  | "armyRecsSweepRemovedDeadMissing"
+  | "armyRecsSweepSnappedPosition"
+  | "armyRecsSweepRestoredAlive"
+  | "armyRenderIntegrityHealOrphanSlot"
+  | "armyRenderIntegrityHealVisibleUndrawn";
 
 export interface WorldmapZoomTelemetrySummary {
   controlsChangeEvents: number;
@@ -219,6 +229,16 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     pendingArmyRemovalCancelledBySuperseded: 0,
     pendingArmyRemovalCancelledByExplorerTroopsZero: 0,
     pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery: 0,
+    pendingArmyRemovalCancelledByRecsSweep: 0,
+    armyAuthoritativeSweepConfirmedDead: 0,
+    armyAuthoritativeSweepReapplied: 0,
+    armyAuthoritativeSweepFailed: 0,
+    armyRecsSweepRemovedDeadZero: 0,
+    armyRecsSweepRemovedDeadMissing: 0,
+    armyRecsSweepSnappedPosition: 0,
+    armyRecsSweepRestoredAlive: 0,
+    armyRenderIntegrityHealOrphanSlot: 0,
+    armyRenderIntegrityHealVisibleUndrawn: 0,
   },
   forceRefreshReasons: {
     default: 0,

--- a/client/apps/game/src/three/scenes/worldmap-army-recs-consistency.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-recs-consistency.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import type { ID } from "@bibliothecadao/types";
+import {
+  ARMY_RECS_MISSING_CONFIRM_MS,
+  ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS,
+  evaluateArmyRecsConsistency,
+  type ArmyRecsConsistencyAction,
+  type ArmyRecsConsistencyCandidate,
+} from "./worldmap-army-recs-consistency";
+
+const NOW_MS = 1_000_000;
+
+function makeCandidate(overrides: Partial<ArmyRecsConsistencyCandidate> = {}): ArmyRecsConsistencyCandidate {
+  return {
+    entityId: 42 as ID,
+    renderedPosition: { col: 10, row: 10 },
+    recs: { troopCount: 100, normalizedCoord: { col: 10, row: 10 } },
+    isVisibleInCurrentChunk: true,
+    hasPendingMovement: false,
+    isMoving: false,
+    hasOptimisticState: false,
+    pendingRemovalScheduledAtMs: null,
+    ...overrides,
+  };
+}
+
+interface ConsistencyCase {
+  name: string;
+  candidate: ArmyRecsConsistencyCandidate;
+  missingSince?: ReadonlyArray<[ID, number]>;
+  expected: ArmyRecsConsistencyAction[];
+}
+
+describe("evaluateArmyRecsConsistency", () => {
+  const cases: ConsistencyCase[] = [
+    {
+      name: "skips synthetic negative pending-create ids entirely",
+      candidate: makeCandidate({ entityId: -7 as ID, recs: { troopCount: 0, normalizedCoord: null } }),
+      expected: [],
+    },
+    {
+      name: "skips zero entity id",
+      candidate: makeCandidate({ entityId: 0 as ID, recs: { troopCount: 0, normalizedCoord: null } }),
+      expected: [],
+    },
+    {
+      name: "skips armies with pending movement",
+      candidate: makeCandidate({ hasPendingMovement: true, recs: { troopCount: 0, normalizedCoord: null } }),
+      expected: [],
+    },
+    {
+      name: "skips armies that are moving",
+      candidate: makeCandidate({ isMoving: true, recs: { troopCount: 0, normalizedCoord: null } }),
+      expected: [],
+    },
+    {
+      name: "skips armies with optimistic state",
+      candidate: makeCandidate({ hasOptimisticState: true, recs: { troopCount: 0, normalizedCoord: null } }),
+      expected: [],
+    },
+    {
+      name: "removes dead army when troop count is zero and no removal is pending",
+      candidate: makeCandidate({ recs: { troopCount: 0, normalizedCoord: { col: 10, row: 10 } } }),
+      expected: [{ kind: "remove_dead", entityId: 42 as ID, cause: "zero_troops" }],
+    },
+    {
+      name: "leaves zero-troop army to its fresh pending removal timeout",
+      candidate: makeCandidate({
+        recs: { troopCount: 0, normalizedCoord: { col: 10, row: 10 } },
+        pendingRemovalScheduledAtMs: NOW_MS - 1_000,
+      }),
+      expected: [],
+    },
+    {
+      name: "removes zero-troop army whose pending removal timer is stuck",
+      candidate: makeCandidate({
+        recs: { troopCount: 0, normalizedCoord: { col: 10, row: 10 } },
+        pendingRemovalScheduledAtMs: NOW_MS - ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS,
+      }),
+      expected: [{ kind: "remove_dead", entityId: 42 as ID, cause: "zero_troops" }],
+    },
+    {
+      name: "missing component outside current chunk only clears tracked missing state",
+      candidate: makeCandidate({
+        recs: { troopCount: null, normalizedCoord: null },
+        isVisibleInCurrentChunk: false,
+      }),
+      missingSince: [[42 as ID, NOW_MS - 1_000]],
+      expected: [{ kind: "clear_missing", entityId: 42 as ID }],
+    },
+    {
+      name: "missing component outside current chunk with no tracking emits nothing",
+      candidate: makeCandidate({
+        recs: { troopCount: null, normalizedCoord: null },
+        isVisibleInCurrentChunk: false,
+      }),
+      expected: [],
+    },
+    {
+      name: "missing component in current chunk marks missing on first strike",
+      candidate: makeCandidate({ recs: { troopCount: null, normalizedCoord: null } }),
+      expected: [{ kind: "mark_missing", entityId: 42 as ID }],
+    },
+    {
+      name: "missing component still within confirm window emits nothing",
+      candidate: makeCandidate({ recs: { troopCount: null, normalizedCoord: null } }),
+      missingSince: [[42 as ID, NOW_MS - (ARMY_RECS_MISSING_CONFIRM_MS - 1)]],
+      expected: [],
+    },
+    {
+      name: "missing component confirmed past window removes dead",
+      candidate: makeCandidate({ recs: { troopCount: null, normalizedCoord: null } }),
+      missingSince: [[42 as ID, NOW_MS - ARMY_RECS_MISSING_CONFIRM_MS]],
+      expected: [{ kind: "remove_dead", entityId: 42 as ID, cause: "missing_component" }],
+    },
+    {
+      name: "reappeared component clears tracked missing state",
+      candidate: makeCandidate({ recs: { troopCount: 100, normalizedCoord: { col: 10, row: 10 } } }),
+      missingSince: [[42 as ID, NOW_MS - 1_000]],
+      expected: [{ kind: "clear_missing", entityId: 42 as ID }],
+    },
+    {
+      name: "snaps rendered position to RECS coord on mismatch",
+      candidate: makeCandidate({
+        renderedPosition: { col: 10, row: 10 },
+        recs: { troopCount: 100, normalizedCoord: { col: 12, row: 9 } },
+      }),
+      expected: [{ kind: "snap_position", entityId: 42 as ID, to: { col: 12, row: 9 } }],
+    },
+    {
+      name: "emits nothing when rendered position matches RECS coord",
+      candidate: makeCandidate({
+        renderedPosition: { col: 10, row: 10 },
+        recs: { troopCount: 100, normalizedCoord: { col: 10, row: 10 } },
+      }),
+      expected: [],
+    },
+    {
+      name: "emits nothing for coord check when rendered position is unknown",
+      candidate: makeCandidate({
+        renderedPosition: undefined,
+        recs: { troopCount: 100, normalizedCoord: { col: 12, row: 9 } },
+      }),
+      expected: [],
+    },
+    {
+      name: "restores alive army hidden by a stale pending removal",
+      candidate: makeCandidate({
+        recs: { troopCount: 100, normalizedCoord: { col: 10, row: 10 } },
+        pendingRemovalScheduledAtMs: NOW_MS - ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS,
+      }),
+      expected: [{ kind: "restore_alive", entityId: 42 as ID }],
+    },
+    {
+      name: "does not restore alive army while pending removal is still fresh",
+      candidate: makeCandidate({
+        recs: { troopCount: 100, normalizedCoord: { col: 10, row: 10 } },
+        pendingRemovalScheduledAtMs: NOW_MS - (ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS - 1),
+      }),
+      expected: [],
+    },
+  ];
+
+  cases.forEach(({ name, candidate, missingSince, expected }) => {
+    it(name, () => {
+      const actions = evaluateArmyRecsConsistency({
+        candidates: [candidate],
+        missingSince: new Map(missingSince ?? []),
+        nowMs: NOW_MS,
+      });
+
+      expect(actions).toEqual(expected);
+    });
+  });
+
+  it("evaluates each candidate independently within a single sweep", () => {
+    const actions = evaluateArmyRecsConsistency({
+      candidates: [
+        makeCandidate({ entityId: 1 as ID, recs: { troopCount: 0, normalizedCoord: null } }),
+        makeCandidate({ entityId: 2 as ID, recs: { troopCount: null, normalizedCoord: null } }),
+        makeCandidate({ entityId: 3 as ID, isMoving: true, recs: { troopCount: 0, normalizedCoord: null } }),
+        makeCandidate({
+          entityId: 4 as ID,
+          renderedPosition: { col: 1, row: 1 },
+          recs: { troopCount: 50, normalizedCoord: { col: 2, row: 2 } },
+        }),
+      ],
+      missingSince: new Map(),
+      nowMs: NOW_MS,
+    });
+
+    expect(actions).toEqual([
+      { kind: "remove_dead", entityId: 1 as ID, cause: "zero_troops" },
+      { kind: "mark_missing", entityId: 2 as ID },
+      { kind: "snap_position", entityId: 4 as ID, to: { col: 2, row: 2 } },
+    ]);
+  });
+
+  it("emits clear_missing alongside remove_dead when a tracked component reappears already dead", () => {
+    const actions = evaluateArmyRecsConsistency({
+      candidates: [makeCandidate({ recs: { troopCount: 0, normalizedCoord: { col: 10, row: 10 } } })],
+      missingSince: new Map([[42 as ID, NOW_MS - 1_000]]),
+      nowMs: NOW_MS,
+    });
+
+    expect(actions).toEqual([
+      { kind: "clear_missing", entityId: 42 as ID },
+      { kind: "remove_dead", entityId: 42 as ID, cause: "zero_troops" },
+    ]);
+  });
+});

--- a/client/apps/game/src/three/scenes/worldmap-army-recs-consistency.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-recs-consistency.ts
@@ -1,0 +1,136 @@
+import type { ID } from "@bibliothecadao/types";
+
+/**
+ * Loop B of the ghost-army fix: the level-triggered "scene == RECS" invariant
+ * enforcer.
+ *
+ * Event-driven updates (Torii subscriptions, optimistic actions) handle
+ * latency, but a dropped or out-of-order event can leave the rendered worldmap
+ * out of sync with local RECS state indefinitely. This module periodically
+ * compares each rendered army against its RECS snapshot and emits corrective
+ * actions so the scene converges back to RECS truth, no matter which event was
+ * missed.
+ *
+ * This is a PURE policy module: no three.js, no scene access, no side effects.
+ * Callers gather candidates, invoke {@link evaluateArmyRecsConsistency}, and
+ * apply the returned actions (including maintaining the `missingSince`
+ * two-strike map from `mark_missing` / `clear_missing` actions).
+ */
+
+export const ARMY_RECS_SWEEP_INTERVAL_MS = 5_000;
+export const ARMY_RECS_MISSING_CONFIRM_MS = 8_000; // two-strike window for component absence
+export const ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS = 30_000;
+
+export interface ArmyRecsSnapshot {
+  troopCount: number | null; // null = component absent from local RECS
+  normalizedCoord: { col: number; row: number } | null;
+}
+
+export interface ArmyRecsConsistencyCandidate {
+  entityId: ID;
+  renderedPosition: { col: number; row: number } | undefined; // normalized coords
+  recs: ArmyRecsSnapshot;
+  isVisibleInCurrentChunk: boolean;
+  hasPendingMovement: boolean;
+  isMoving: boolean;
+  hasOptimisticState: boolean;
+  pendingRemovalScheduledAtMs: number | null; // null = no pending/deferred removal
+}
+
+export type ArmyRecsConsistencyAction =
+  | { kind: "remove_dead"; entityId: ID; cause: "zero_troops" | "missing_component" }
+  | { kind: "snap_position"; entityId: ID; to: { col: number; row: number } }
+  | { kind: "restore_alive"; entityId: ID }
+  | { kind: "mark_missing"; entityId: ID }
+  | { kind: "clear_missing"; entityId: ID };
+
+export function evaluateArmyRecsConsistency(input: {
+  candidates: readonly ArmyRecsConsistencyCandidate[];
+  missingSince: ReadonlyMap<ID, number>;
+  nowMs: number;
+}): ArmyRecsConsistencyAction[] {
+  const { candidates, missingSince, nowMs } = input;
+  const actions: ArmyRecsConsistencyAction[] = [];
+
+  for (const candidate of candidates) {
+    const { entityId, recs } = candidate;
+
+    // Synthetic pending-create ghost ids are negative; never sweep them.
+    if (entityId <= 0) {
+      continue;
+    }
+
+    // In-flight movement or optimistic state owns the entity; defer judgement.
+    if (candidate.hasPendingMovement || candidate.isMoving || candidate.hasOptimisticState) {
+      continue;
+    }
+
+    if (recs.troopCount !== null) {
+      // Component reappeared in local RECS; drop the two-strike tracker.
+      if (missingSince.has(entityId)) {
+        actions.push({ kind: "clear_missing", entityId });
+      }
+
+      if (recs.troopCount === 0) {
+        // A fresh pending removal already covers this army; leave it to its
+        // timeout. But scheduling delays max out around ~10s, so a removal
+        // still pending past the stuck threshold means its timer was lost
+        // (cleared without meta cleanup, stranded deferral) — without this
+        // branch the dead army would render forever.
+        const pendingRemovalIsStuck =
+          candidate.pendingRemovalScheduledAtMs !== null &&
+          nowMs - candidate.pendingRemovalScheduledAtMs >= ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS;
+        if (candidate.pendingRemovalScheduledAtMs === null || pendingRemovalIsStuck) {
+          actions.push({ kind: "remove_dead", entityId, cause: "zero_troops" });
+        }
+        continue;
+      }
+
+      // Alive in RECS.
+      if (
+        candidate.pendingRemovalScheduledAtMs !== null &&
+        nowMs - candidate.pendingRemovalScheduledAtMs >= ARMY_RECS_STUCK_REMOVAL_MAX_AGE_MS
+      ) {
+        // A stale pending removal is hiding a live army.
+        actions.push({ kind: "restore_alive", entityId });
+        continue;
+      }
+
+      if (
+        recs.normalizedCoord !== null &&
+        candidate.renderedPosition !== undefined &&
+        (recs.normalizedCoord.col !== candidate.renderedPosition.col ||
+          recs.normalizedCoord.row !== candidate.renderedPosition.row)
+      ) {
+        actions.push({
+          kind: "snap_position",
+          entityId,
+          to: { col: recs.normalizedCoord.col, row: recs.normalizedCoord.row },
+        });
+      }
+      continue;
+    }
+
+    // Component absent from local RECS. Absence outside the subscribed/rendered
+    // area is not evidence of death — only treat it as meaningful when the army
+    // is visible in the current chunk.
+    if (!candidate.isVisibleInCurrentChunk) {
+      if (missingSince.has(entityId)) {
+        actions.push({ kind: "clear_missing", entityId });
+      }
+      continue;
+    }
+
+    const missingSinceMs = missingSince.get(entityId);
+    if (missingSinceMs === undefined) {
+      actions.push({ kind: "mark_missing", entityId });
+      continue;
+    }
+
+    if (nowMs - missingSinceMs >= ARMY_RECS_MISSING_CONFIRM_MS) {
+      actions.push({ kind: "remove_dead", entityId, cause: "missing_component" });
+    }
+  }
+
+  return actions;
+}

--- a/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-suppression.test.ts
@@ -62,7 +62,9 @@ describe("worldmap army suppression integration", () => {
     const listenerStart = src.indexOf("this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {");
     expect(listenerStart).toBeGreaterThan(-1);
 
-    const listenerBody = src.slice(listenerStart, listenerStart + 1200);
+    // Window spans the listener plus the shared applyExplorerTroopsSystemUpdate
+    // helper it delegates to (factored out for the Loop B RECS sweep).
+    const listenerBody = src.slice(listenerStart, listenerStart + 1800);
     expect(listenerBody).not.toContain("this.cancelPendingArmyRemoval(update.entityId)");
     expect(listenerBody).not.toContain("restoreArmyVisualIfVisible(update.entityId)");
     expect(listenerBody).toContain("this.armyManager.updateArmyFromExplorerTroopsUpdate(update)");

--- a/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-tile-sync-recovery.test.ts
@@ -22,7 +22,7 @@ describe("worldmap army tile-sync recovery", () => {
     );
     expect(listenerStart).toBeGreaterThan(-1);
 
-    const listenerBody = src.slice(listenerStart, listenerStart + 3400);
+    const listenerBody = src.slice(listenerStart, listenerStart + 4400);
     const applyPos = listenerBody.indexOf("await this.armyManager.onTileUpdate(update)");
     const syncPos = listenerBody.indexOf("this.armyLastTileSyncAt.set(update.entityId, Date.now())");
 

--- a/client/apps/game/src/three/scenes/worldmap-chunk-trace.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-trace.ts
@@ -39,7 +39,9 @@ export type WorldmapChunkTraceEvent =
   | "reconnect_refresh_drained"
   | "torii_resubscribe_requested"
   | "torii_resubscribe_completed"
-  | "torii_resubscribe_failed";
+  | "torii_resubscribe_failed"
+  | "army_authoritative_sweep"
+  | "army_recs_sweep_heal";
 
 export interface WorldmapChunkTraceEntry {
   id: number;

--- a/client/apps/game/src/three/scenes/worldmap-debug-hooks.ts
+++ b/client/apps/game/src/three/scenes/worldmap-debug-hooks.ts
@@ -12,11 +12,25 @@ export interface WorldmapDebugWindow {
   getArmyMovementLatencyTrace?: () => ArmyMovementLatencyTraceEntry[];
   getArmyMovementLatencySummary?: () => ArmyMovementLatencySummary;
   clearArmyMovementLatencyTrace?: () => void;
+  simulateArmyGhostDesync?: (entityId: number) => boolean;
+  simulateArmyPositionDesync?: (entityId: number, col: number, row: number) => boolean;
+  getArmyGhostHardeningStats?: () => unknown;
+}
+
+// DEV-only desync injectors for the ghost-army reconcile loops: they reproduce
+// the production failure modes (missed deletion event, rendered/RECS position
+// drift) so the self-healing sweeps can be exercised without waiting for a
+// real desync.
+export interface WorldmapArmyDesyncHarnessHooks {
+  simulateArmyGhostDesync: (entityId: number) => boolean;
+  simulateArmyPositionDesync: (entityId: number, col: number, row: number) => boolean;
+  getArmyGhostHardeningStats: () => unknown;
 }
 
 interface WorldmapDebugHooks {
   testMaterialSharing: () => void;
   testTroopDiffFx: (diff?: number) => void;
+  armyDesyncHarness?: WorldmapArmyDesyncHarnessHooks;
 }
 
 export function installWorldmapDebugHooks<T extends object>(
@@ -28,6 +42,11 @@ export function installWorldmapDebugHooks<T extends object>(
   debugWindow.getArmyMovementLatencyTrace = () => snapshotArmyMovementLatencyTrace();
   debugWindow.getArmyMovementLatencySummary = () => summarizeArmyMovementLatency();
   debugWindow.clearArmyMovementLatencyTrace = () => clearArmyMovementLatencyTrace();
+  if (hooks.armyDesyncHarness) {
+    debugWindow.simulateArmyGhostDesync = hooks.armyDesyncHarness.simulateArmyGhostDesync;
+    debugWindow.simulateArmyPositionDesync = hooks.armyDesyncHarness.simulateArmyPositionDesync;
+    debugWindow.getArmyGhostHardeningStats = hooks.armyDesyncHarness.getArmyGhostHardeningStats;
+  }
 }
 
 export function uninstallWorldmapDebugHooks<T extends object>(debugWindow: T & WorldmapDebugWindow): void {
@@ -36,4 +55,7 @@ export function uninstallWorldmapDebugHooks<T extends object>(debugWindow: T & W
   delete debugWindow.getArmyMovementLatencyTrace;
   delete debugWindow.getArmyMovementLatencySummary;
   delete debugWindow.clearArmyMovementLatencyTrace;
+  delete debugWindow.simulateArmyGhostDesync;
+  delete debugWindow.simulateArmyPositionDesync;
+  delete debugWindow.getArmyGhostHardeningStats;
 }

--- a/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
+++ b/client/apps/game/src/three/scenes/worldmap-update-helpers.ts
@@ -6,7 +6,8 @@ export type PendingArmyRemovalCancelSource =
   | "delete"
   | "superseded"
   | "explorer_troops_zero"
-  | "explorer_troops_live_recovery";
+  | "explorer_troops_live_recovery"
+  | "recs_sweep";
 
 type ExplorerTroopsUpdateHandlers = {
   cancelPendingArmyRemoval: (entityId: ID, source: PendingArmyRemovalCancelSource) => void;

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -1,6 +1,11 @@
 import { playUnitCommandSound, playUnitCommandSoundForWorldmapAction } from "@/audio/unit-command-audio";
 import { toast } from "sonner";
 
+import {
+  ARMY_AUTHORITATIVE_MIN_TRACKED_AGE_MS,
+  ARMY_AUTHORITATIVE_SWEEP_INTERVAL_MS,
+  sweepArmiesAgainstTorii,
+} from "@/dojo/army-authoritative-reconciler";
 import { ensureStructureSynced } from "@/dojo/queries";
 import { initializeSyncSimulator } from "@/dojo/sync-simulator";
 import { BOUNDED_SPATIAL_MAP_MODELS, GLOBAL_SPATIAL_MAP_MODELS } from "@/dojo/torii-spatial-models";
@@ -69,6 +74,7 @@ import {
   BattleEventSystemUpdate,
   ChestSystemUpdate,
   DEFAULT_COORD_ALT,
+  divideByPrecision,
   ExplorerRewardSystemUpdate,
   ExplorerTroopsSystemUpdate,
   ExplorerTroopsTileSystemUpdate,
@@ -105,7 +111,14 @@ import {
   TroopTier,
   TroopType,
 } from "@bibliothecadao/types";
-import { getComponentEntities, getComponentValue } from "@dojoengine/recs";
+import {
+  getComponentEntities,
+  getComponentValue,
+  removeComponent,
+  type Component,
+  type Metadata,
+  type Schema,
+} from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
 import throttle from "lodash/throttle";
 import { Account, AccountInterface } from "starknet";
@@ -246,6 +259,12 @@ import {
   isStaleTrackedArmyTileRemoval,
   shouldRecoverPendingArmyRemovalFromExplorerTroops as shouldRecoverArmyRemovalFromTroopsPosition,
 } from "./worldmap-army-removal";
+import {
+  ARMY_RECS_SWEEP_INTERVAL_MS,
+  evaluateArmyRecsConsistency,
+  type ArmyRecsConsistencyAction,
+  type ArmyRecsConsistencyCandidate,
+} from "./worldmap-army-recs-consistency";
 import { resolveAttachedArmyOwnerFromStructure } from "./worldmap-attached-army-owner-sync";
 import { resolveArmyActionPathOrigin } from "./worldmap-action-path-origin";
 import { resolveArmyOwnerCacheAction } from "./worldmap-army-owner-resolution";
@@ -1092,6 +1111,20 @@ export default class WorldmapScene extends WarpTravel {
     }
   > = new Map();
   private deferredChunkRemovals: Map<ID, DeferredWorldmapArmyRemoval> = new Map();
+  // Loop B sweep state: two-strike tracker for ExplorerTroops components that
+  // vanished from local RECS while the army is still rendered on-chunk.
+  private armyRecsMissingSince: Map<ID, number> = new Map();
+  private lastArmyRecsSweepAtMs = 0;
+  // Loop A sweep state: two-strike tracker for armies missing from Torii, the
+  // first-seen stamps that guard freshly created armies from the create-tx
+  // indexing race, and single-flight/throttle bookkeeping.
+  private armyAuthoritativeMissing: ReadonlySet<ID> = new Set();
+  private armyAuthoritativeFirstSeenAtMs: Map<ID, number> = new Map();
+  private armyAuthoritativeSweepInFlight = false;
+  private lastArmyAuthoritativeSweepAtMs = 0;
+  // DEV desync harness: one-shot suppression of the next onDeadArmy event per
+  // entity, so the production "missed deletion" failure mode can be injected.
+  private devSuppressedDeadArmies: Set<ID> = new Set();
 
   private fxManager!: FXManager;
   private arrivalGhostManager!: ArrivalGhostManager;
@@ -1512,6 +1545,14 @@ export default class WorldmapScene extends WarpTravel {
         console.log(`[TestTroopDiffFx] Spawning FX at camera target with diff: ${testDiff}`);
         this.fxManager.playTroopDiffFx(testDiff, worldPos.x, worldPos.y + 3, worldPos.z);
       },
+      armyDesyncHarness: import.meta.env.DEV
+        ? {
+            simulateArmyGhostDesync: (entityId: number) => this.simulateArmyGhostDesync(entityId as ID),
+            simulateArmyPositionDesync: (entityId: number, col: number, row: number) =>
+              this.simulateArmyPositionDesync(entityId as ID, col, row),
+            getArmyGhostHardeningStats: () => this.getArmyGhostHardeningStats(),
+          }
+        : undefined,
     });
     this.installChunkDiagnosticsDebugHooks();
 
@@ -1626,10 +1667,12 @@ export default class WorldmapScene extends WarpTravel {
             row: update.hexCoords.row,
           },
         });
-        const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId, "tile_recovery");
         const normalizedPos = new Position({ x: update.hexCoords.col, y: update.hexCoords.row }).getNormalized();
 
         if (update.removed) {
+          // A fresh removal supersedes any deferred entry (scheduleArmyRemoval
+          // already clears a pending timer and rewrites the meta itself).
+          this.deferredChunkRemovals.delete(update.entityId);
           this.scheduleArmyRemoval(update.entityId, "tile", {
             ownerAddress: update.ownerAddress,
             ownerStructureId: update.ownerStructureId,
@@ -1637,6 +1680,12 @@ export default class WorldmapScene extends WarpTravel {
           });
           return;
         }
+
+        // Only a live (non-removed) tile update is evidence the army still
+        // exists. Cancelling before the removed-check let a stale TileOpt
+        // replay permanently cancel a scheduled removal — the deletion edge
+        // was already consumed, so nothing ever re-fired it (ghost army).
+        const recoveredPendingRemoval = this.cancelPendingArmyRemoval(update.entityId, "tile_recovery");
 
         this.resolveSupersededPendingArmyRemoval(update.entityId, update.ownerAddress, update.ownerStructureId, {
           col: normalizedPos.x,
@@ -1711,30 +1760,42 @@ export default class WorldmapScene extends WarpTravel {
 
     this.addWorldUpdateSubscription(
       this.worldUpdateListener.Army.onExplorerTroopsUpdate((update) => {
-        processExplorerTroopsUpdate(update, {
-          cancelPendingArmyRemoval: (entityId, source) => this.cancelPendingArmyRemoval(entityId, source),
-          scheduleArmyRemoval: (entityId, reason) => this.scheduleArmyRemoval(entityId, reason),
-          updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
-          updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
-          onManagerUpdateApplied: () => this.reconcileHoverLabels(),
-          onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
-          shouldRecoverPendingArmyRemovalFromExplorerTroops: (update) =>
-            this.shouldRecoverPendingArmyRemovalFromExplorerTroopsUpdate(update),
-          recoverPendingArmyRemovalFromExplorerTroops: (update) =>
-            this.recoverPendingArmyRemovalFromExplorerTroops(update),
-          shouldSkipStalePositionUpdate: (entityId, normalized) =>
-            this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
-        });
+        this.applyExplorerTroopsSystemUpdate(update);
       }),
     );
 
     this.addWorldUpdateSubscription(
       this.worldUpdateListener.Army.onDeadArmy((entityId) => {
+        // DEV desync harness: swallow the event once to reproduce a missed
+        // deletion; the reconcile sweeps must clean the ghost up instead.
+        if (import.meta.env.DEV && this.devSuppressedDeadArmies.delete(entityId)) {
+          return;
+        }
         this.deleteArmy(entityId);
         this.removeEntityFromTracking(entityId);
         this.requestChunkRefresh(false, "army_dead");
       }),
     );
+  }
+
+  // Single apply path for authoritative ExplorerTroops state, shared by the
+  // live subscription above and the Loop B RECS sweep so snap_position heals
+  // flow through the same ordered helper as real Torii deliveries.
+  private applyExplorerTroopsSystemUpdate(update: ExplorerTroopsSystemUpdate): void {
+    processExplorerTroopsUpdate(update, {
+      cancelPendingArmyRemoval: (entityId, source) => this.cancelPendingArmyRemoval(entityId, source),
+      scheduleArmyRemoval: (entityId, reason) => this.scheduleArmyRemoval(entityId, reason),
+      updateArmyHexes: (troopsUpdate) => this.updateArmyHexes(troopsUpdate),
+      updateArmyFromExplorerTroopsUpdate: (update) => this.armyManager.updateArmyFromExplorerTroopsUpdate(update),
+      onManagerUpdateApplied: () => this.reconcileHoverLabels(),
+      onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
+      shouldRecoverPendingArmyRemovalFromExplorerTroops: (update) =>
+        this.shouldRecoverPendingArmyRemovalFromExplorerTroopsUpdate(update),
+      recoverPendingArmyRemovalFromExplorerTroops: (update) =>
+        this.recoverPendingArmyRemovalFromExplorerTroops(update),
+      shouldSkipStalePositionUpdate: (entityId, normalized) =>
+        this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
+    });
   }
 
   private registerBattleWorldUpdateSubscriptions(): void {
@@ -4833,6 +4894,11 @@ export default class WorldmapScene extends WarpTravel {
     this.toriiLoadingCounter = runtimeState.toriiLoadingCounter;
     this.lastControlsCameraDistance = runtimeState.lastControlsCameraDistance;
     this.currentChunk = runtimeState.currentChunk;
+    this.armyRecsMissingSince.clear();
+    this.armyAuthoritativeFirstSeenAtMs.clear();
+    this.armyAuthoritativeMissing = new Set();
+    this.lastArmyAuthoritativeSweepAtMs = 0;
+    this.devSuppressedDeadArmies.clear();
 
     // Clear follow camera timeout to prevent callback firing on destroyed UI store state
     if (this.followCameraTimeout) {
@@ -4871,6 +4937,8 @@ export default class WorldmapScene extends WarpTravel {
     this.armiesPositions.delete(entityId);
     this.armyLastTileSyncAt.delete(entityId);
     this.pendingArmyRemovalMeta.delete(entityId);
+    this.armyRecsMissingSince.delete(entityId);
+    this.armyAuthoritativeFirstSeenAtMs.delete(entityId);
     this.armyStructureOwners.delete(entityId);
     this.clearArmyMovementTxEntriesForEntity(entityId);
     this.clearPendingArmyMovement(entityId);
@@ -5112,7 +5180,321 @@ export default class WorldmapScene extends WarpTravel {
       case "explorer_troops_live_recovery":
         incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByExplorerTroopsLiveRecovery");
         return;
+      case "recs_sweep":
+        incrementWorldmapRenderCounter("pendingArmyRemovalCancelledByRecsSweep");
+        return;
     }
+  }
+
+  // Loop B of the ghost-army fix: level-triggered "scene == RECS" enforcement.
+  // The event listeners above handle the fast path; this throttled sweep
+  // compares every tracked army against its local RECS snapshot and heals any
+  // divergence a dropped or out-of-order event left behind. Policy lives in
+  // worldmap-army-recs-consistency.ts; this driver only gathers candidates and
+  // applies the returned actions.
+  private sweepArmyRecsConsistency(): void {
+    const nowMs = Date.now();
+    if (nowMs - this.lastArmyRecsSweepAtMs < ARMY_RECS_SWEEP_INTERVAL_MS) {
+      return;
+    }
+
+    if (
+      this.isSwitchedOff ||
+      this.sceneManager.getCurrentScene() !== SceneName.WorldMap ||
+      this.currentChunk === "null" ||
+      this.isChunkTransitioning
+    ) {
+      return;
+    }
+
+    this.lastArmyRecsSweepAtMs = nowMs;
+
+    const candidates: ArmyRecsConsistencyCandidate[] = [];
+    for (const army of this.armyManager.getArmies()) {
+      const entityId = army.entityId;
+      // Synthetic pending-create ghost ids are negative; never sweep them.
+      if (entityId <= 0) {
+        continue;
+      }
+
+      const explorer = getComponentValue(this.dojo.components.ExplorerTroops, getEntityIdFromKeys([BigInt(entityId)]));
+      // explorer.coord is contract (felt-offset); the policy compares against
+      // armiesPositions, which stores normalized col/row.
+      const normalizedCoord = explorer
+        ? new Position({ x: explorer.coord.x, y: explorer.coord.y }).getNormalized()
+        : null;
+
+      candidates.push({
+        entityId,
+        renderedPosition: this.armiesPositions.get(entityId),
+        recs: {
+          troopCount: explorer ? divideByPrecision(Number(explorer.troops.count)) : null,
+          normalizedCoord: normalizedCoord ? { col: normalizedCoord.x, row: normalizedCoord.y } : null,
+        },
+        isVisibleInCurrentChunk: this.armyManager.isArmyVisibleInCommittedChunk(entityId),
+        hasPendingMovement: this.pendingArmyMovements.has(entityId),
+        isMoving: this.armyManager.isArmyMoving(entityId),
+        hasOptimisticState: this.armyManager.hasUnresolvedOptimisticMovement(entityId),
+        pendingRemovalScheduledAtMs:
+          this.pendingArmyRemovalMeta.get(entityId)?.scheduledAt ??
+          this.deferredChunkRemovals.get(entityId)?.scheduledAt ??
+          null,
+      });
+    }
+
+    const actions = evaluateArmyRecsConsistency({
+      candidates,
+      missingSince: this.armyRecsMissingSince,
+      nowMs,
+    });
+
+    for (const action of actions) {
+      this.applyArmyRecsConsistencyAction(action, nowMs);
+    }
+  }
+
+  private applyArmyRecsConsistencyAction(action: ArmyRecsConsistencyAction, nowMs: number): void {
+    switch (action.kind) {
+      case "mark_missing":
+        this.armyRecsMissingSince.set(action.entityId, nowMs);
+        return;
+      case "clear_missing":
+        this.armyRecsMissingSince.delete(action.entityId);
+        return;
+      case "remove_dead":
+        incrementWorldmapRenderCounter(
+          action.cause === "zero_troops" ? "armyRecsSweepRemovedDeadZero" : "armyRecsSweepRemovedDeadMissing",
+        );
+        this.traceChunk("army_recs_sweep_heal", {
+          action: action.kind,
+          entityId: action.entityId,
+          cause: action.cause,
+        });
+        this.armyRecsMissingSince.delete(action.entityId);
+        // Same triple as the onDeadArmy subscription, minus the defeat FX —
+        // by the time the sweep fires the death is stale, not a live event.
+        this.deleteArmy(action.entityId, { playDefeatFx: false });
+        this.removeEntityFromTracking(action.entityId);
+        this.requestChunkRefresh(false, "army_dead");
+        return;
+      case "snap_position":
+        incrementWorldmapRenderCounter("armyRecsSweepSnappedPosition");
+        this.traceChunk("army_recs_sweep_heal", {
+          action: action.kind,
+          entityId: action.entityId,
+          to: action.to,
+        });
+        this.snapArmyToRecsPosition(action.entityId);
+        return;
+      case "restore_alive":
+        incrementWorldmapRenderCounter("armyRecsSweepRestoredAlive");
+        this.traceChunk("army_recs_sweep_heal", {
+          action: action.kind,
+          entityId: action.entityId,
+        });
+        // Cancel already unsuppresses the visual.
+        this.cancelPendingArmyRemoval(action.entityId, "recs_sweep");
+        void this.armyManager.restoreArmyVisualIfVisible(action.entityId);
+        return;
+    }
+  }
+
+  // Re-applies authoritative RECS state through the same ordered helper the
+  // live onExplorerTroopsUpdate listener uses, so a sweep heal is
+  // indistinguishable from a real Torii delivery downstream. Owner fields come
+  // from the tracked army because the RECS component only carries the owning
+  // structure id.
+  private snapArmyToRecsPosition(entityId: ID): void {
+    const explorer = getComponentValue(this.dojo.components.ExplorerTroops, getEntityIdFromKeys([BigInt(entityId)]));
+    if (!explorer) {
+      return;
+    }
+
+    const army = this.armyManager.getArmy(entityId);
+    const update: ExplorerTroopsSystemUpdate = {
+      entityId,
+      troopCount: divideByPrecision(Number(explorer.troops.count)),
+      onChainStamina: {
+        amount: BigInt(explorer.troops.stamina.amount),
+        updatedTick: Number(explorer.troops.stamina.updated_tick),
+      },
+      ownerStructureId: explorer.owner && explorer.owner !== 0 ? explorer.owner : null,
+      hexCoords: { col: explorer.coord.x, row: explorer.coord.y },
+      ownerAddress: army?.owner.address ?? 0n,
+      ownerName: army?.owner.ownerName ?? "",
+      battleCooldownEnd: explorer.troops.battle_cooldown_end,
+    };
+
+    this.applyExplorerTroopsSystemUpdate(update);
+  }
+
+  // Loop A of the ghost-army fix: level-triggered "local RECS == Torii"
+  // enforcement. Deletions reach the client as single push events; a reconnect
+  // gap or a stale snapshot write can swallow one, after which the dead army
+  // never emits again and Loop B sees a perfectly "alive" RECS component. This
+  // throttled sweep re-queries Torii by id for every settled tracked army and
+  // lets army-authoritative-reconciler.ts remove stale ExplorerTroops
+  // components — firing the same removal edge as a real deletion, so the
+  // existing onDeadArmy pipeline does the cleanup.
+  private maybeRunArmyAuthoritativeSweep(): void {
+    const nowMs = Date.now();
+    if (nowMs - this.lastArmyAuthoritativeSweepAtMs < ARMY_AUTHORITATIVE_SWEEP_INTERVAL_MS) {
+      return;
+    }
+
+    this.lastArmyAuthoritativeSweepAtMs = nowMs;
+    void this.runArmyAuthoritativeSweep("interval");
+  }
+
+  private async runArmyAuthoritativeSweep(reason: "interval" | "reconnect"): Promise<void> {
+    if (
+      this.armyAuthoritativeSweepInFlight ||
+      this.isSwitchedOff ||
+      this.sceneManager.getCurrentScene() !== SceneName.WorldMap ||
+      this.currentChunk === "null" ||
+      this.isChunkTransitioning
+    ) {
+      return;
+    }
+
+    // A hidden tab throttles timers and animation frames; sweeping there would
+    // race the backlog of stream updates that replays on visibility. A
+    // non-connected stream means absence from Torii proves nothing.
+    if (typeof document !== "undefined" && document.hidden) {
+      return;
+    }
+    if (useConnectionStore.getState().status !== "connected") {
+      return;
+    }
+
+    const toriiClient = this.dojo.network?.toriiClient;
+    const contractComponents = this.dojo.network?.contractComponents as unknown as
+      | Component<Schema, Metadata, undefined>[]
+      | undefined;
+    if (!toriiClient || !contractComponents) {
+      return;
+    }
+
+    const nowMs = Date.now();
+    const candidateIds: ID[] = [];
+    for (const army of this.armyManager.getArmies()) {
+      const entityId = army.entityId;
+      // Synthetic pending-create ghost ids are negative; never sweep them.
+      if (entityId <= 0) {
+        continue;
+      }
+
+      // Stamp first sight and let freshly seen armies settle: a just-created
+      // army can render optimistically before Torii has indexed its create tx.
+      const firstSeenAtMs = this.armyAuthoritativeFirstSeenAtMs.get(entityId);
+      if (firstSeenAtMs === undefined) {
+        this.armyAuthoritativeFirstSeenAtMs.set(entityId, nowMs);
+        continue;
+      }
+      if (nowMs - firstSeenAtMs < ARMY_AUTHORITATIVE_MIN_TRACKED_AGE_MS) {
+        continue;
+      }
+
+      // In-flight movement or optimistic state owns the entity; defer judgement.
+      if (
+        this.pendingArmyMovements.has(entityId) ||
+        this.armyManager.isArmyMoving(entityId) ||
+        this.armyManager.hasUnresolvedOptimisticMovement(entityId)
+      ) {
+        continue;
+      }
+
+      candidateIds.push(entityId);
+    }
+
+    if (candidateIds.length === 0) {
+      return;
+    }
+
+    this.armyAuthoritativeSweepInFlight = true;
+    try {
+      const result = await sweepArmiesAgainstTorii({
+        toriiClient,
+        components: contractComponents,
+        explorerTroopsComponent: this.dojo.components.ExplorerTroops as unknown as Component<
+          Schema,
+          Metadata,
+          undefined
+        >,
+        candidateIds,
+        previousMissing: this.armyAuthoritativeMissing,
+      });
+
+      this.armyAuthoritativeMissing = result.nextMissing;
+      if (result.reappliedCount > 0) {
+        incrementWorldmapRenderCounter("armyAuthoritativeSweepReapplied", result.reappliedCount);
+      }
+      if (result.outcome === "failed" || result.outcome === "aborted_suspicious") {
+        incrementWorldmapRenderCounter("armyAuthoritativeSweepFailed");
+      }
+      if (result.confirmedDead.length > 0) {
+        incrementWorldmapRenderCounter("armyAuthoritativeSweepConfirmedDead", result.confirmedDead.length);
+        result.confirmedDead.forEach((entityId) => this.armyAuthoritativeFirstSeenAtMs.delete(entityId));
+      }
+      // Quiet sweeps (everything present) stay out of the trace ring buffer.
+      if (result.confirmedDead.length > 0 || result.outcome !== "completed") {
+        this.traceChunk("army_authoritative_sweep", {
+          reason,
+          outcome: result.outcome,
+          candidateCount: candidateIds.length,
+          confirmedDead: result.confirmedDead,
+          reappliedCount: result.reappliedCount,
+        });
+      }
+    } finally {
+      this.armyAuthoritativeSweepInFlight = false;
+    }
+  }
+
+  // DEV desync harness: reproduces the production "missed deletion" desync by
+  // swallowing the next onDeadArmy event and removing the ExplorerTroops
+  // component from local RECS. Loop B must clear the ghost within its confirm
+  // window. Note: if the army is still alive on Torii, Loop A will legitimately
+  // resurrect it on its next sweep — that is Loop A working, not a bug.
+  private simulateArmyGhostDesync(entityId: ID): boolean {
+    if (!import.meta.env.DEV) {
+      return false;
+    }
+    const entity = getEntityIdFromKeys([BigInt(entityId)]);
+    if (getComponentValue(this.dojo.components.ExplorerTroops, entity) === undefined) {
+      console.warn(`[desync-harness] army ${entityId} has no ExplorerTroops component in RECS`);
+      return false;
+    }
+    this.devSuppressedDeadArmies.add(entityId);
+    removeComponent(this.dojo.components.ExplorerTroops, entity);
+    console.warn(`[desync-harness] injected ghost desync for army ${entityId} — Loop B should heal it`);
+    return true;
+  }
+
+  // DEV desync harness: diverges both the rendered visual and the scene's
+  // tracked position from RECS. Loop B must snap them back.
+  private simulateArmyPositionDesync(entityId: ID, col: number, row: number): boolean {
+    if (!import.meta.env.DEV) {
+      return false;
+    }
+    if (!this.armyManager.getArmy(entityId)) {
+      console.warn(`[desync-harness] army ${entityId} is not tracked by the army manager`);
+      return false;
+    }
+    this.armyManager.debugSetArmyHexCoords(entityId, { col, row });
+    this.armiesPositions.set(entityId, { col, row });
+    console.warn(`[desync-harness] injected position desync for army ${entityId} — Loop B should snap it back`);
+    return true;
+  }
+
+  private getArmyGhostHardeningStats() {
+    return {
+      counters: snapshotWorldmapRenderDiagnostics().counters,
+      recsMissingSince: Array.from(this.armyRecsMissingSince.entries()),
+      authoritativeMissing: Array.from(this.armyAuthoritativeMissing),
+      authoritativeFirstSeenCount: this.armyAuthoritativeFirstSeenAtMs.size,
+      suppressedDeadArmies: Array.from(this.devSuppressedDeadArmies),
+    };
   }
 
   public deleteChest(entityId: ID) {
@@ -8370,6 +8752,10 @@ export default class WorldmapScene extends WarpTravel {
           chunkKey: this.currentChunk,
         });
         this.requestChunkRefresh(true, "reconnect");
+        // Deletions that happened during the gap were never delivered and the
+        // recreated subscription will not replay them — sweep Torii now.
+        this.lastArmyAuthoritativeSweepAtMs = Date.now();
+        void this.runArmyAuthoritativeSweep("reconnect");
       },
     });
 
@@ -8395,6 +8781,9 @@ export default class WorldmapScene extends WarpTravel {
           chunkKey: this.currentChunk,
         });
         this.requestChunkRefresh(true, "reconnect");
+        // Same gap-fill as the immediate reconnect path.
+        this.lastArmyAuthoritativeSweepAtMs = Date.now();
+        void this.runArmyAuthoritativeSweep("reconnect");
       },
     });
   }
@@ -8515,6 +8904,12 @@ export default class WorldmapScene extends WarpTravel {
       force: true,
       transitionToken: this.chunkTransitionToken,
     });
+
+    // Removals parked by deferArmyRemovalDuringChunkSwitch are normally drained
+    // at the healthy chunk-settle points. A stalled transition skips all of
+    // them; without this drain the deferred removals sit forever and the dead
+    // armies keep rendering (ghost army).
+    this.retryDeferredChunkRemovals();
   }
 
   private handleChunkPresentationTimeout(info: WorldmapChunkPresentationTimeoutInfo): void {
@@ -10771,6 +11166,8 @@ export default class WorldmapScene extends WarpTravel {
     this.updateCameraTargetHexThrottled?.();
     setWorldmapRenderGauge("activeLabels", this.hoverLabelManager.getActiveLabelCount());
     this.runPendingHoverLabelRecoveryFrame();
+    this.sweepArmyRecsConsistency();
+    this.maybeRunArmyAuthoritativeSweep();
     if (WORLDMAP_ZOOM_HARDENING.terrainSelfHeal) {
       this.monitorTerrainVisibilityHealth();
     } else {

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -1791,8 +1791,7 @@ export default class WorldmapScene extends WarpTravel {
       onAuthoritativePositionApplied: (update) => this.clearPendingArmyMovementFromAuthoritativePosition(update),
       shouldRecoverPendingArmyRemovalFromExplorerTroops: (update) =>
         this.shouldRecoverPendingArmyRemovalFromExplorerTroopsUpdate(update),
-      recoverPendingArmyRemovalFromExplorerTroops: (update) =>
-        this.recoverPendingArmyRemovalFromExplorerTroops(update),
+      recoverPendingArmyRemovalFromExplorerTroops: (update) => this.recoverPendingArmyRemovalFromExplorerTroops(update),
       shouldSkipStalePositionUpdate: (entityId, normalized) =>
         this.armyManager.shouldSkipStalePositionUpdate(entityId, normalized),
     });


### PR DESCRIPTION
Adds level-triggered reconciliation for ghost armies by comparing tracked armies against Torii and local RECS, removing stale ExplorerTroops components only after two strikes and snapping rendered position drift back to authoritative state.
Wires the sweeps into worldmap update/reconnect flow, adds diagnostics counters/chunk traces, and exposes DEV-only desync harness hooks for reproducing missed deletions and position drift.
This fixes ghost units caused by swallowed deletion events, stale snapshot writes, stranded pending removals, or out-of-order render state.
Validation: `git diff --check`; `pnpm run format`/`pnpm run knip` were attempted, but the local pnpm runner exited silently in this workspace and could not provide meaningful output.
