### PR TITLE
[codex] Prefer configured node RPC URLs

### DIFF
--- a/client/apps/eternum-mobile/src/app/dojo/context/dojo-context.tsx
+++ b/client/apps/eternum-mobile/src/app/dojo/context/dojo-context.tsx
@@ -44,7 +44,7 @@ const useRpcProvider = () => {
   return useMemo(
     () =>
       new RpcProvider({
-        nodeUrl: env.VITE_PUBLIC_NODE_URL || "http://localhost:5050",
+        nodeUrl: env.VITE_PUBLIC_NODE_URL,
       }),
     [],
   );

--- a/client/apps/eternum-mobile/src/app/dojo/context/starknet-provider.tsx
+++ b/client/apps/eternum-mobile/src/app/dojo/context/starknet-provider.tsx
@@ -17,16 +17,13 @@ const namespace: string = "s1_eternum";
 const KATANA_CHAIN_ID = shortString.encodeShortString("KATANA");
 const KATANA_CHAIN_NETWORK = "Katana Local";
 const KATANA_CHAIN_NAME = "katana";
-const KATANA_RPC_URL = "http://localhost:5050";
 const isLocal = env.VITE_PUBLIC_CHAIN === "local";
 
 // ==============================================
 
 const SLOT_CHAIN_ID = "0x57505f455445524e554d5f424c49545a5f534c4f545f34";
-const SLOT_RPC_URL = "https://api.cartridge.gg/x/eternum-blitz-slot-4/katana";
 
 const SLOT_CHAIN_ID_TEST = "0x57505f455445524e554d5f424c49545a5f534c4f545f54455354";
-const SLOT_RPC_URL_TEST = "https://api.cartridge.gg/x/eternum-blitz-slot-test/katana";
 
 const isSlot = env.VITE_PUBLIC_CHAIN === "slot";
 const isSlottest = env.VITE_PUBLIC_CHAIN === "slottest";
@@ -46,15 +43,7 @@ const chain_id = isLocal
 const controller = new ControllerConnector({
   chains: [
     {
-      rpcUrl: isLocal
-        ? KATANA_RPC_URL
-        : isSlot
-          ? SLOT_RPC_URL
-          : isSlottest
-            ? SLOT_RPC_URL_TEST
-            : env.VITE_PUBLIC_NODE_URL !== "http://localhost:5050"
-              ? env.VITE_PUBLIC_NODE_URL
-              : "https://api.cartridge.gg/x/starknet/sepolia",
+      rpcUrl: env.VITE_PUBLIC_NODE_URL,
     },
   ],
   defaultChainId: isLocal
@@ -84,10 +73,10 @@ const katanaLocalChain = {
   },
   rpcUrls: {
     default: {
-      http: [KATANA_RPC_URL],
+      http: [env.VITE_PUBLIC_NODE_URL],
     },
     public: {
-      http: [KATANA_RPC_URL],
+      http: [env.VITE_PUBLIC_NODE_URL],
     },
   },
   paymasterRpcUrls: {

--- a/client/apps/game/env.ts
+++ b/client/apps/game/env.ts
@@ -31,11 +31,7 @@ const envSchema = z.object({
   // API endpoints
   VITE_PUBLIC_TORII: z.string().url().optional().default("https://api.cartridge.gg/x/eternum-blitz-slot-4/torii"),
   VITE_PUBLIC_GLOBAL_TORII: z.string().url().optional().default("https://api.cartridge.gg/x/blitz-slot-global-1/torii"),
-  VITE_PUBLIC_NODE_URL: z
-    .string()
-    .url()
-    .optional()
-    .default("https://api.cartridge.gg/x/eternum-blitz-slot-4/katana/rpc/v0_9"),
+  VITE_PUBLIC_NODE_URL: z.string().url(),
   VITE_PUBLIC_TORII_RELAY: z
     .string()
     .optional()
@@ -326,4 +322,3 @@ try {
 }
 
 export { env };
-export const hasPublicNodeUrl = Boolean(env.VITE_PUBLIC_NODE_URL);

--- a/client/apps/game/src/hooks/context/starknet-chain-config.test.ts
+++ b/client/apps/game/src/hooks/context/starknet-chain-config.test.ts
@@ -6,11 +6,26 @@ import { describe, expect, it } from "vitest";
 import { resolveStarknetRuntimeConfig } from "./starknet-chain-config";
 
 describe("resolveStarknetRuntimeConfig", () => {
+  it("uses the configured node url for local runtime rpc", () => {
+    const config = resolveStarknetRuntimeConfig({
+      fallbackChain: "local",
+      selectedChain: "local",
+      baseRpcUrl: "http://127.0.0.1:5050/rpc/v0_9",
+      configuredRpcUrl: "http://127.0.0.1:5050/rpc/v0_9",
+      cartridgeApiBase: "https://api.cartridge.gg",
+    });
+
+    expect(config.chainKind).toBe("local");
+    expect(config.rpcUrl).toBe("http://127.0.0.1:5050/rpc/v0_9");
+    expect(config.controllerSupportedRpcUrls[0]).toBe("http://127.0.0.1:5050/rpc/v0_9");
+  });
+
   it("falls back to the slot runtime rpc when the selected chain changes away from an incompatible startup rpc", () => {
     const config = resolveStarknetRuntimeConfig({
       fallbackChain: "mainnet",
       selectedChain: "slot",
       baseRpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
+      configuredRpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
       cartridgeApiBase: "https://api.cartridge.gg",
     });
 
@@ -24,6 +39,7 @@ describe("resolveStarknetRuntimeConfig", () => {
       fallbackChain: "mainnet",
       selectedChain: "mainnet",
       baseRpcUrl: "https://mainnet.example-rpc.invalid/rpc",
+      configuredRpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
       cartridgeApiBase: "https://api.cartridge.gg",
     });
 
@@ -32,11 +48,26 @@ describe("resolveStarknetRuntimeConfig", () => {
     expect(config.rpcUrl).toBe("https://mainnet.example-rpc.invalid/rpc");
   });
 
-  it("uses the selected mainnet chain instead of the startup slot configuration", () => {
+  it("uses the configured mainnet node url instead of the cartridge fallback when startup rpc is incompatible", () => {
     const config = resolveStarknetRuntimeConfig({
       fallbackChain: "slot",
       selectedChain: "mainnet",
       baseRpcUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/katana/rpc/v0_9",
+      configuredRpcUrl: "https://mainnet.env-rpc.invalid/rpc",
+      cartridgeApiBase: "https://api.cartridge.gg",
+    });
+
+    expect(config.chainKind).toBe("mainnet");
+    expect(config.defaultChainId).toBe(constants.StarknetChainId.SN_MAIN);
+    expect(config.rpcUrl).toBe("https://mainnet.env-rpc.invalid/rpc");
+  });
+
+  it("uses the cartridge mainnet fallback only when the startup and configured rpc urls are incompatible", () => {
+    const config = resolveStarknetRuntimeConfig({
+      fallbackChain: "slot",
+      selectedChain: "mainnet",
+      baseRpcUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/katana/rpc/v0_9",
+      configuredRpcUrl: "https://api.cartridge.gg/x/starknet/sepolia/rpc/v0_9",
       cartridgeApiBase: "https://api.cartridge.gg",
     });
 
@@ -50,6 +81,7 @@ describe("resolveStarknetRuntimeConfig", () => {
       fallbackChain: "mainnet",
       selectedChain: "slot",
       baseRpcUrl: "https://api.cartridge.gg/x/eternum-blitz-slot-4/katana/rpc/v0_9",
+      configuredRpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
       cartridgeApiBase: "https://api.cartridge.gg",
     });
 
@@ -63,6 +95,7 @@ describe("resolveStarknetRuntimeConfig", () => {
       fallbackChain: "slot",
       selectedChain: "slot",
       baseRpcUrl: "https://api.cartridge.gg/x/s0-game-5/katana/rpc/v0_9",
+      configuredRpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
       cartridgeApiBase: "https://api.cartridge.gg",
     });
 

--- a/client/apps/game/src/hooks/context/starknet-chain-config.ts
+++ b/client/apps/game/src/hooks/context/starknet-chain-config.ts
@@ -4,7 +4,6 @@ import { buildSharedSlotRpcUrl, isRpcUrlCompatibleForChain, normalizeRpcUrl } fr
 import { constants, shortString } from "starknet";
 
 const KATANA_CHAIN_ID = shortString.encodeShortString("KATANA");
-const KATANA_RPC_URL = "http://localhost:5050";
 const SLOT_CHAIN_ID = "0x57505f455445524e554d5f424c49545a5f534c4f545f34";
 const SLOT_CHAIN_ID_TEST = "0x57505f455445524e554d5f424c49545a5f534c4f545f54455354";
 
@@ -58,14 +57,24 @@ const buildSupportedRpcUrls = (preferredRpcUrl: string, ...additionalRpcUrls: st
 
 const resolveChainCompatibleRuntimeRpcUrl = ({
   chain,
+  configuredRpcUrl,
   fallbackRpcUrl,
   requestedRpcUrl,
 }: {
   chain: Chain;
+  configuredRpcUrl: string;
   fallbackRpcUrl: string;
   requestedRpcUrl: string;
 }): string => {
-  return isRpcUrlCompatibleForChain(chain, requestedRpcUrl) ? requestedRpcUrl : fallbackRpcUrl;
+  if (isRpcUrlCompatibleForChain(chain, requestedRpcUrl)) {
+    return requestedRpcUrl;
+  }
+
+  if (isRpcUrlCompatibleForChain(chain, configuredRpcUrl)) {
+    return configuredRpcUrl;
+  }
+
+  return fallbackRpcUrl;
 };
 
 const resolveSlotRuntimeChainId = (selectedChain: Chain, baseRpcUrl: string): string => {
@@ -85,14 +94,17 @@ export const resolveStarknetRuntimeConfig = ({
   fallbackChain,
   selectedChain,
   baseRpcUrl,
+  configuredRpcUrl,
   cartridgeApiBase,
 }: {
   fallbackChain: Chain;
   selectedChain: Chain | null;
   baseRpcUrl: string;
+  configuredRpcUrl: string;
   cartridgeApiBase: string;
 }): StarknetRuntimeConfig => {
   const normalizedBaseRpcUrl = normalizeRpcUrl(baseRpcUrl);
+  const normalizedConfiguredRpcUrl = normalizeRpcUrl(configuredRpcUrl);
   const effectiveChain = selectedChain ?? fallbackChain;
   const mainnetRpcUrl = buildCartridgeRpcUrl(cartridgeApiBase, "/x/starknet/mainnet/rpc/v0_9");
   const sepoliaRpcUrl = buildCartridgeRpcUrl(cartridgeApiBase, "/x/starknet/sepolia/rpc/v0_9");
@@ -102,14 +114,15 @@ export const resolveStarknetRuntimeConfig = ({
     return {
       chainKind: "local",
       defaultChainId: KATANA_CHAIN_ID,
-      rpcUrl: KATANA_RPC_URL,
-      controllerSupportedRpcUrls: [KATANA_RPC_URL, slotRpcUrl, sepoliaRpcUrl, mainnetRpcUrl],
+      rpcUrl: normalizedBaseRpcUrl,
+      controllerSupportedRpcUrls: buildSupportedRpcUrls(normalizedBaseRpcUrl, slotRpcUrl, sepoliaRpcUrl, mainnetRpcUrl),
     };
   }
 
   if (effectiveChain === "mainnet") {
     const runtimeRpcUrl = resolveChainCompatibleRuntimeRpcUrl({
       chain: effectiveChain,
+      configuredRpcUrl: normalizedConfiguredRpcUrl,
       fallbackRpcUrl: mainnetRpcUrl,
       requestedRpcUrl: normalizedBaseRpcUrl,
     });
@@ -125,6 +138,7 @@ export const resolveStarknetRuntimeConfig = ({
   if (effectiveChain === "sepolia") {
     const runtimeRpcUrl = resolveChainCompatibleRuntimeRpcUrl({
       chain: effectiveChain,
+      configuredRpcUrl: normalizedConfiguredRpcUrl,
       fallbackRpcUrl: sepoliaRpcUrl,
       requestedRpcUrl: normalizedBaseRpcUrl,
     });

--- a/client/apps/game/src/hooks/context/starknet-provider.tsx
+++ b/client/apps/game/src/hooks/context/starknet-provider.tsx
@@ -21,37 +21,37 @@ const namespace: string = "s1_eternum";
 const KATANA_CHAIN_ID = shortString.encodeShortString("KATANA");
 const KATANA_CHAIN_NETWORK = "Katana Local";
 const KATANA_CHAIN_NAME = "katana";
-const KATANA_RPC_URL = "http://localhost:5050";
 const fallbackChain = env.VITE_PUBLIC_CHAIN as RuntimeChain;
 const cartridgeApiBase = env.VITE_PUBLIC_CARTRIDGE_API_BASE || "https://api.cartridge.gg";
 
-const katanaLocalChain = {
-  id: BigInt(KATANA_CHAIN_ID),
-  network: KATANA_CHAIN_NETWORK,
-  name: KATANA_CHAIN_NAME,
-  nativeCurrency: {
-    address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-    name: "Ether",
-    symbol: "ETH",
-    decimals: 18,
-  },
-  rpcUrls: {
-    default: {
-      http: [KATANA_RPC_URL],
+const createKatanaLocalChain = (rpcUrl: string): Chain =>
+  ({
+    id: BigInt(KATANA_CHAIN_ID),
+    network: KATANA_CHAIN_NETWORK,
+    name: KATANA_CHAIN_NAME,
+    nativeCurrency: {
+      address: "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      name: "Ether",
+      symbol: "ETH",
+      decimals: 18,
     },
-    public: {
-      http: [KATANA_RPC_URL],
+    rpcUrls: {
+      default: {
+        http: [rpcUrl],
+      },
+      public: {
+        http: [rpcUrl],
+      },
     },
-  },
-  paymasterRpcUrls: {
-    default: {
-      http: [],
+    paymasterRpcUrls: {
+      default: {
+        http: [],
+      },
+      public: {
+        http: [],
+      },
     },
-    public: {
-      http: [],
-    },
-  },
-} as const satisfies Chain;
+  }) as const satisfies Chain;
 
 // Custom QueryClient with game-appropriate defaults
 // - Disable refetchOnWindowFocus to prevent surprise refetch storms when alt-tabbing
@@ -85,6 +85,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
         fallbackChain,
         selectedChain: runtimeChain,
         baseRpcUrl,
+        configuredRpcUrl: env.VITE_PUBLIC_NODE_URL,
         cartridgeApiBase,
       }),
     [baseRpcUrl, runtimeChain],
@@ -125,7 +126,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
 
   const resolvedChains = useMemo(() => {
     if (runtimeConfig.chainKind === "local") {
-      return [katanaLocalChain];
+      return [createKatanaLocalChain(runtimeConfig.rpcUrl)];
     }
 
     if (runtimeConfig.chainKind === "slot") {
@@ -137,7 +138,7 @@ export function StarknetProvider({ children }: { children: React.ReactNode }) {
     }
 
     return [sepolia];
-  }, [runtimeConfig.chainKind, runtimeConfig.defaultChainId]);
+  }, [runtimeConfig.chainKind, runtimeConfig.defaultChainId, runtimeConfig.rpcUrl]);
 
   return (
     <StarknetConfig
@@ -165,7 +166,7 @@ const resolveWalletProviderBaseRpcUrl = ({
   defaultRpcUrl: string;
 }): string => {
   if (runtimeChain === "local") {
-    return KATANA_RPC_URL;
+    return defaultRpcUrl;
   }
 
   return profileRpcUrl ?? defaultRpcUrl;

--- a/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.concurrency.test.ts
@@ -44,7 +44,6 @@ vi.mock("../../../env", () => ({
     VITE_PUBLIC_CARTRIDGE_API_BASE: "https://api.cartridge.gg",
     VITE_PUBLIC_NODE_URL: "https://fallback-rpc.example",
   },
-  hasPublicNodeUrl: true,
 }));
 
 vi.mock("./factory-endpoints", () => ({

--- a/client/apps/game/src/runtime/world/profile-builder.ts
+++ b/client/apps/game/src/runtime/world/profile-builder.ts
@@ -2,7 +2,7 @@ import { SqlApi } from "@bibliothecadao/torii";
 import type { Chain } from "@contracts";
 import { recordGameEntryDuration } from "@/ui/layouts/game-entry-timeline";
 
-import { env, hasPublicNodeUrl } from "../../../env";
+import { env } from "../../../env";
 import { getFactorySqlBaseUrl } from "./factory-endpoints";
 import { resolveWorldContracts, resolveWorldDeploymentFromFactory } from "./factory-resolver";
 import { buildSharedSlotRpcUrl, isRpcUrlCompatibleForChain, isSlotWorldChain, normalizeRpcUrl } from "./normalize";
@@ -153,8 +153,7 @@ export const buildWorldProfile = async (chain: Chain, name: string): Promise<Wor
       : chain === "mainnet" || chain === "sepolia"
         ? `${cartridgeApiBase}/x/starknet/${chain}`
         : env.VITE_PUBLIC_NODE_URL;
-  const canUseEnvRpc =
-    !isSlotWorldChain(chain) && hasPublicNodeUrl && isRpcUrlCompatibleForChain(chain, env.VITE_PUBLIC_NODE_URL);
+  const canUseEnvRpc = !isSlotWorldChain(chain) && isRpcUrlCompatibleForChain(chain, env.VITE_PUBLIC_NODE_URL);
   const fallbackRpcUrl = canUseEnvRpc ? env.VITE_PUBLIC_NODE_URL : chainDefaultRpcUrl;
   const rpcUrl = normalizeRpcUrl(
     resolveWorldProfileRpcUrl({


### PR DESCRIPTION
Makes VITE_PUBLIC_NODE_URL required for the game client and removes runtime fallback paths that silently selected hard-coded local or slot RPCs. Updates game and mobile providers so their node URL comes from env/configured runtime state, and changes mainnet/sepolia runtime resolution to prefer a compatible VITE_PUBLIC_NODE_URL before Cartridge defaults. Adds resolver coverage for local RPC selection and env-preferred mainnet fallback. Validated with focused vitest, pnpm run format, pnpm run knip, and git diff --check.