### PR TITLE
Classify Torii disconnects as local vs remote with debug instrumentation

### DIFF
--- a/client/apps/game/env.ts
+++ b/client/apps/game/env.ts
@@ -248,6 +248,53 @@ const envSchema = z.object({
     .default("8000")
     .transform((v) => Number(v))
     .refine((value) => Number.isFinite(value) && value >= 0, "VITE_PUBLIC_TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS"),
+  // How long without a Torii indexer heartbeat before a stream is treated as
+  // stale. Lower = faster detection of a silently-dropped stream.
+  VITE_PUBLIC_TORII_STALE_THRESHOLD_MS: z
+    .string()
+    .optional()
+    .default("8000")
+    .transform((v) => Number(v))
+    .refine((value) => Number.isFinite(value) && value > 0, "VITE_PUBLIC_TORII_STALE_THRESHOLD_MS"),
+  // Cadence of the lightweight heartbeat watchdog (decoupled from the heavier
+  // HTTP health probe) so staleness is caught in seconds, not a probe interval.
+  // 0 disables the watchdog (falls back to probe-driven detection only).
+  VITE_PUBLIC_TORII_HEARTBEAT_WATCHDOG_INTERVAL_MS: z
+    .string()
+    .optional()
+    .default("3000")
+    .transform((v) => Number(v))
+    .refine((value) => Number.isFinite(value) && value >= 0, "VITE_PUBLIC_TORII_HEARTBEAT_WATCHDOG_INTERVAL_MS"),
+  // Adaptive reconnect backoff: first retry waits min, then doubles up to max.
+  // Replaces the flat 60s cooldown so a transient drop recovers in ~1s while a
+  // genuinely-down server still backs off. min<=0 disables adaptive backoff.
+  VITE_PUBLIC_TORII_RECONNECT_MIN_COOLDOWN_MS: z
+    .string()
+    .optional()
+    .default("1000")
+    .transform((v) => Number(v))
+    .refine((value) => Number.isFinite(value) && value >= 0, "VITE_PUBLIC_TORII_RECONNECT_MIN_COOLDOWN_MS"),
+  VITE_PUBLIC_TORII_RECONNECT_MAX_COOLDOWN_MS: z
+    .string()
+    .optional()
+    .default("30000")
+    .transform((v) => Number(v))
+    .refine((value) => Number.isFinite(value) && value >= 0, "VITE_PUBLIC_TORII_RECONNECT_MAX_COOLDOWN_MS"),
+  // Proactively re-subscribe streams after this long with no activity, to dodge
+  // proxy idle / MAX_CONNECTION_AGE reaps in quiet worlds. 0 disables.
+  VITE_PUBLIC_TORII_QUIET_STREAM_REFRESH_MS: z
+    .string()
+    .optional()
+    .default("120000")
+    .transform((v) => Number(v))
+    .refine((value) => Number.isFinite(value) && value >= 0, "VITE_PUBLIC_TORII_QUIET_STREAM_REFRESH_MS"),
+  // Reconnect by re-opening only the global stream (cheap) instead of a full
+  // initialSync re-bootstrap. Falls back to full re-bootstrap when false.
+  VITE_PUBLIC_TORII_LIGHTWEIGHT_RECONNECT: z
+    .string()
+    .transform((v) => v === "true")
+    .optional()
+    .default("true"),
   VITE_PUBLIC_TORII_SPATIAL_SUBSCRIPTION_UPDATE_ENABLED: z
     .string()
     .transform((v) => v === "true")

--- a/client/apps/game/src/dojo/army-authoritative-reconciler.test.ts
+++ b/client/apps/game/src/dojo/army-authoritative-reconciler.test.ts
@@ -203,4 +203,44 @@ describe("sweepArmiesAgainstTorii", () => {
       expect(getComponentValue(explorerTroops, getEntityIdFromKeys([BigInt(id)]))).toBeDefined();
     });
   });
+
+  it("reports timing for a completed sweep", async () => {
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    trackArmy(explorerTroops, 7);
+
+    const result = await sweepArmiesAgainstTorii({
+      toriiClient: makeToriiClient([7]),
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [7] as ID[],
+      previousMissing: new Set(),
+    });
+
+    expect(result.timing.pageCount).toBeGreaterThanOrEqual(1);
+    expect(typeof result.timing.totalMs).toBe("number");
+    expect(typeof result.timing.maxQueryMs).toBe("number");
+    expect(typeof result.timing.maxApplyMs).toBe("number");
+  });
+
+  it("treats a query past the per-op timeout as a failure with state unchanged", async () => {
+    const { explorerTroops } = makeExplorerTroopsWorld();
+    trackArmy(explorerTroops, 99);
+    const previousMissing = new Set([99] as ID[]);
+    const hangingClient = {
+      getEntities: vi.fn(() => new Promise(() => {})),
+    } as unknown as ToriiClient;
+
+    const result = await sweepArmiesAgainstTorii({
+      toriiClient: hangingClient,
+      components: [explorerTroops] as never,
+      explorerTroopsComponent: explorerTroops as never,
+      candidateIds: [99] as ID[],
+      previousMissing,
+      queryTimeoutMs: 5,
+    });
+
+    expect(result.outcome).toBe("failed");
+    expect(result.nextMissing).toBe(previousMissing);
+    expect(getComponentValue(explorerTroops, getEntityIdFromKeys([99n]))).toBeDefined();
+  });
 });

--- a/client/apps/game/src/dojo/army-authoritative-reconciler.ts
+++ b/client/apps/game/src/dojo/army-authoritative-reconciler.ts
@@ -30,6 +30,11 @@ export const ARMY_AUTHORITATIVE_SWEEP_INTERVAL_MS = 30_000;
 // Skip armies tracked less than this: a freshly created army can be visible
 // optimistically before Torii has indexed its create transaction.
 export const ARMY_AUTHORITATIVE_MIN_TRACKED_AGE_MS = 30_000;
+// Per-page Torii query deadline. A timed-out page rejects the await, which the
+// existing catch treats exactly like a failed query: state unchanged, never a
+// mass-death. This bounds how long a slow/degraded Torii can hold the loop —
+// the LOCAL-freeze failure mode Phase 3 instruments.
+export const ARMY_SWEEP_QUERY_TIMEOUT_MS = 15_000;
 
 const EXPLORER_TROOPS_MODEL = "s1_eternum-ExplorerTroops";
 const SWEEP_QUERY_BATCH_SIZE = 100;
@@ -88,12 +93,26 @@ export function isSuspiciousAuthoritativeDeadSet(confirmedDeadCount: number, can
   );
 }
 
+/**
+ * Wall-clock timing for one sweep, so the caller can detect a sweep that blocks
+ * the event loop (a perceived "freeze"/disconnect that is actually LOCAL).
+ */
+export interface ArmyAuthoritativeSweepTiming {
+  totalMs: number;
+  /** Longest single awaited Torii getEntities() call. */
+  maxQueryMs: number;
+  /** Longest single awaited setEntities() RECS write. */
+  maxApplyMs: number;
+  pageCount: number;
+}
+
 export interface ArmyAuthoritativeSweepResult {
   outcome: "completed" | "failed" | "aborted_suspicious" | "skipped_empty";
   confirmedDead: ID[];
   /** Two-strike state for the next sweep; unchanged when the sweep fails. */
   nextMissing: ReadonlySet<ID>;
   reappliedCount: number;
+  timing: ArmyAuthoritativeSweepTiming;
 }
 
 export interface ArmyAuthoritativeSweepInput<S extends Schema> {
@@ -104,6 +123,27 @@ export interface ArmyAuthoritativeSweepInput<S extends Schema> {
   explorerTroopsComponent: Component<S, Metadata, undefined>;
   candidateIds: readonly ID[];
   previousMissing: ReadonlySet<ID>;
+  /** Per-page Torii query deadline (ms). Defaults to ARMY_SWEEP_QUERY_TIMEOUT_MS. */
+  queryTimeoutMs?: number;
+}
+
+function withOperationTimeout<T>(operation: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return operation;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timeoutId = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    operation.then(
+      (value) => {
+        clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
 }
 
 const isValidId = (id: unknown): id is ID => typeof id === "number" && Number.isFinite(id) && (id as number) > 0;
@@ -151,11 +191,23 @@ const normalizeToriiPageItems = (items: ToriiEntityPageItems | undefined): Torii
 export async function sweepArmiesAgainstTorii<S extends Schema>(
   input: ArmyAuthoritativeSweepInput<S>,
 ): Promise<ArmyAuthoritativeSweepResult> {
+  const startedAtMs = performance.now();
+  let maxQueryMs = 0;
+  let maxApplyMs = 0;
+  let pageCount = 0;
+  const buildTiming = (): ArmyAuthoritativeSweepTiming => ({
+    totalMs: performance.now() - startedAtMs,
+    maxQueryMs,
+    maxApplyMs,
+    pageCount,
+  });
+
   const candidateIds = input.candidateIds.filter(isValidId);
   if (candidateIds.length === 0) {
-    return { outcome: "skipped_empty", confirmedDead: [], nextMissing: new Set(), reappliedCount: 0 };
+    return { outcome: "skipped_empty", confirmedDead: [], nextMissing: new Set(), reappliedCount: 0, timing: buildTiming() };
   }
 
+  const queryTimeoutMs = input.queryTimeoutMs ?? ARMY_SWEEP_QUERY_TIMEOUT_MS;
   const presentIds = new Set<ID>();
   const entityKeyToId = new Map<string, ID>();
   candidateIds.forEach((id) => entityKeyToId.set(getEntityIdFromKeys([BigInt(id)]), id));
@@ -169,13 +221,20 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
 
       let cursor: string | undefined;
       for (;;) {
-        const page = await input.toriiClient.getEntities({
-          pagination: { limit: SWEEP_QUERY_BATCH_SIZE, cursor, direction: "Forward", order_by: [] },
-          clause,
-          no_hashed_keys: false,
-          models: [EXPLORER_TROOPS_MODEL],
-          historical: false,
-        });
+        const queryStartedAtMs = performance.now();
+        const page = await withOperationTimeout(
+          input.toriiClient.getEntities({
+            pagination: { limit: SWEEP_QUERY_BATCH_SIZE, cursor, direction: "Forward", order_by: [] },
+            clause,
+            no_hashed_keys: false,
+            models: [EXPLORER_TROOPS_MODEL],
+            historical: false,
+          }),
+          queryTimeoutMs,
+          "army authoritative sweep query",
+        );
+        maxQueryMs = Math.max(maxQueryMs, performance.now() - queryStartedAtMs);
+        pageCount += 1;
 
         const items = normalizeToriiPageItems(page.items as ToriiEntityPageItems | undefined);
         const presentItems = items.filter((item) => hasExplorerTroopsModelData(item.models));
@@ -190,7 +249,9 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
         if (presentItems.length > 0) {
           // Awaited per page so RECS state is settled before classification
           // (the same reason the config fetch awaits its writes).
+          const applyStartedAtMs = performance.now();
           await setEntities(presentItems, input.components, false);
+          maxApplyMs = Math.max(maxApplyMs, performance.now() - applyStartedAtMs);
           reappliedCount += presentItems.length;
         }
 
@@ -200,7 +261,13 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
     }
   } catch (error) {
     console.warn("[army-reconciler] authoritative sweep query failed; keeping state unchanged", error);
-    return { outcome: "failed", confirmedDead: [], nextMissing: input.previousMissing, reappliedCount };
+    return {
+      outcome: "failed",
+      confirmedDead: [],
+      nextMissing: input.previousMissing,
+      reappliedCount,
+      timing: buildTiming(),
+    };
   }
 
   const { confirmedDead, nextMissing } = classifyAuthoritativeSweep({
@@ -213,7 +280,13 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
     console.warn(
       `[army-reconciler] sweep would confirm ${confirmedDead.length}/${candidateIds.length} armies dead — distrusting result`,
     );
-    return { outcome: "aborted_suspicious", confirmedDead: [], nextMissing: input.previousMissing, reappliedCount };
+    return {
+      outcome: "aborted_suspicious",
+      confirmedDead: [],
+      nextMissing: input.previousMissing,
+      reappliedCount,
+      timing: buildTiming(),
+    };
   }
 
   for (const id of confirmedDead) {
@@ -229,5 +302,5 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
     }
   }
 
-  return { outcome: "completed", confirmedDead, nextMissing, reappliedCount };
+  return { outcome: "completed", confirmedDead, nextMissing, reappliedCount, timing: buildTiming() };
 }

--- a/client/apps/game/src/dojo/army-authoritative-reconciler.ts
+++ b/client/apps/game/src/dojo/army-authoritative-reconciler.ts
@@ -34,7 +34,7 @@ export const ARMY_AUTHORITATIVE_MIN_TRACKED_AGE_MS = 30_000;
 // existing catch treats exactly like a failed query: state unchanged, never a
 // mass-death. This bounds how long a slow/degraded Torii can hold the loop —
 // the LOCAL-freeze failure mode Phase 3 instruments.
-export const ARMY_SWEEP_QUERY_TIMEOUT_MS = 15_000;
+const ARMY_SWEEP_QUERY_TIMEOUT_MS = 15_000;
 
 const EXPLORER_TROOPS_MODEL = "s1_eternum-ExplorerTroops";
 const SWEEP_QUERY_BATCH_SIZE = 100;
@@ -204,7 +204,13 @@ export async function sweepArmiesAgainstTorii<S extends Schema>(
 
   const candidateIds = input.candidateIds.filter(isValidId);
   if (candidateIds.length === 0) {
-    return { outcome: "skipped_empty", confirmedDead: [], nextMissing: new Set(), reappliedCount: 0, timing: buildTiming() };
+    return {
+      outcome: "skipped_empty",
+      confirmedDead: [],
+      nextMissing: new Set(),
+      reappliedCount: 0,
+      timing: buildTiming(),
+    };
   }
 
   const queryTimeoutMs = input.queryTimeoutMs ?? ARMY_SWEEP_QUERY_TIMEOUT_MS;

--- a/client/apps/game/src/dojo/connection-disconnect-classification.test.ts
+++ b/client/apps/game/src/dojo/connection-disconnect-classification.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyDisconnect,
+  OFFLINE_RECENCY_MS,
+  type DisconnectSignalSnapshot,
+} from "./connection-disconnect-classification";
+
+const baseSignal = (overrides: Partial<DisconnectSignalSnapshot> = {}): DisconnectSignalSnapshot => ({
+  onLine: true,
+  msSinceOffline: null,
+  visibilityState: "visible",
+  healthProbeReason: "reachable",
+  heartbeatAvailable: true,
+  msSinceHeartbeat: 20_000,
+  streamCloseObserved: false,
+  serverAvailability: "unknown",
+  ...overrides,
+});
+
+describe("classifyDisconnect", () => {
+  it("flags LOCAL with high confidence when the browser is offline", () => {
+    const result = classifyDisconnect(baseSignal({ onLine: false }));
+    expect(result).toEqual({ source: "local", confidence: "high", reason: "browser_offline" });
+  });
+
+  it("flags LOCAL when a recent offline event occurred even if onLine flipped back", () => {
+    const result = classifyDisconnect(baseSignal({ onLine: true, msSinceOffline: OFFLINE_RECENCY_MS - 1 }));
+    expect(result.source).toBe("local");
+    expect(result.reason).toBe("browser_offline");
+  });
+
+  it("does not treat a stale offline event as a current local cause", () => {
+    const result = classifyDisconnect(
+      baseSignal({ onLine: true, msSinceOffline: OFFLINE_RECENCY_MS + 1, healthProbeReason: "reachable" }),
+    );
+    expect(result.reason).not.toBe("browser_offline");
+  });
+
+  it("flags REMOTE high when the server-side probe says the world is dead", () => {
+    const result = classifyDisconnect(baseSignal({ serverAvailability: "dead", healthProbeReason: "timeout" }));
+    expect(result).toEqual({ source: "remote", confidence: "high", reason: "server_unreachable" });
+  });
+
+  it("flags REMOTE high on endpoint_not_found", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "endpoint_not_found" }));
+    expect(result).toEqual({ source: "remote", confidence: "high", reason: "endpoint_not_found" });
+  });
+
+  it("flags REMOTE high on server_error", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "server_error" }));
+    expect(result.source).toBe("remote");
+    expect(result.reason).toBe("server_error");
+  });
+
+  it("flags REMOTE high when a real stream close was observed", () => {
+    const result = classifyDisconnect(baseSignal({ streamCloseObserved: true, healthProbeReason: "reachable" }));
+    expect(result).toEqual({ source: "remote", confidence: "high", reason: "stream_closed" });
+  });
+
+  it("flags LOCAL when probe fails but the server is independently alive", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "timeout", serverAvailability: "alive" }));
+    expect(result).toEqual({ source: "local", confidence: "medium", reason: "probe_failed_server_alive" });
+  });
+
+  it("flags REMOTE (medium) when probe fails and server status is unknown", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "network_error", serverAvailability: "unknown" }));
+    expect(result).toEqual({ source: "remote", confidence: "medium", reason: "probe_network_error" });
+  });
+
+  it("flags LOCAL when the stream went stale while the tab was hidden", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "reachable", visibilityState: "hidden" }));
+    expect(result).toEqual({ source: "local", confidence: "medium", reason: "stale_while_hidden" });
+  });
+
+  it("is INDETERMINATE when HTTP is reachable but there is no heartbeat channel", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "reachable", heartbeatAvailable: false }));
+    expect(result).toEqual({ source: "indeterminate", confidence: "low", reason: "heartbeat_unsupported_http_ok" });
+  });
+
+  it("flags REMOTE (medium) when HTTP is up but the heartbeat stream went silent", () => {
+    const result = classifyDisconnect(
+      baseSignal({ healthProbeReason: "reachable", heartbeatAvailable: true, visibilityState: "visible" }),
+    );
+    expect(result).toEqual({ source: "remote", confidence: "medium", reason: "stream_stale_http_ok" });
+  });
+
+  it("prioritises browser-offline over every remote signal", () => {
+    const result = classifyDisconnect(
+      baseSignal({ onLine: false, serverAvailability: "dead", healthProbeReason: "server_error" }),
+    );
+    expect(result.reason).toBe("browser_offline");
+  });
+
+  it("falls back to INDETERMINATE when the probe reason is unknown", () => {
+    const result = classifyDisconnect(baseSignal({ healthProbeReason: "unknown" }));
+    expect(result).toEqual({ source: "indeterminate", confidence: "low", reason: "unknown" });
+  });
+});

--- a/client/apps/game/src/dojo/connection-disconnect-classification.ts
+++ b/client/apps/game/src/dojo/connection-disconnect-classification.ts
@@ -1,0 +1,114 @@
+import type { ToriiHealthUnreachableReason } from "./torii-health-probe";
+
+/**
+ * Buckets a Torii disconnect into LOCAL (the player's browser / network / CPU)
+ * vs REMOTE (Torii websocket-stream or server outage) vs INDETERMINATE.
+ *
+ * Why this exists: the client never observes a real websocket close event
+ * (torii-wasm subscriptions expose only `cancel()`), so a disconnect is always
+ * detected *indirectly* — heartbeat staleness + an HTTP health probe. That makes
+ * a local network drop and a remote stream death look identical in telemetry.
+ * This classifier combines the few signals that *can* disambiguate the two so
+ * every "Disconnected from the realm" banner event is tagged at the source.
+ *
+ * Pure and synchronous on purpose — all I/O (server-availability fetch) happens
+ * before the snapshot is built, so this is trivially unit-testable.
+ */
+
+export type DisconnectSource = "local" | "remote" | "indeterminate";
+export type DisconnectConfidence = "high" | "medium" | "low";
+export type ServerAvailabilityVerdict = "alive" | "dead" | "unknown";
+
+/** The most recent Torii HTTP health-probe outcome, flattened for the snapshot. */
+export type HealthProbeSignal = ToriiHealthUnreachableReason | "reachable" | "unknown";
+
+export interface DisconnectSignalSnapshot {
+  /** `navigator.onLine` at the moment the outage was detected. */
+  onLine: boolean;
+  /** ms since the last browser `offline` event, or null if none observed. */
+  msSinceOffline: number | null;
+  /** `document.visibilityState` at detection time. */
+  visibilityState: "visible" | "hidden";
+  /** Most recent Torii HTTP health-probe outcome. */
+  healthProbeReason: HealthProbeSignal;
+  /** Whether the Torii indexer heartbeat (`onIndexerUpdated`) was ever available. */
+  heartbeatAvailable: boolean;
+  /** ms since the last heartbeat tick, or null if never received. */
+  msSinceHeartbeat: number | null;
+  /**
+   * True only if the SDK surfaced a real stream close/error. torii-wasm
+   * 1.7.0-preview.3 does not expose one, so this is best-effort and usually
+   * false — but when present it is the single strongest REMOTE signal.
+   */
+  streamCloseObserved: boolean;
+  /** Independent server-side reachability verdict (realtime-server probe). */
+  serverAvailability: ServerAvailabilityVerdict;
+}
+
+export interface DisconnectClassification {
+  source: DisconnectSource;
+  confidence: DisconnectConfidence;
+  /** Stable machine-readable key for telemetry grouping. */
+  reason: string;
+}
+
+/** A browser `offline` event this recent counts as a live local-network cause. */
+export const OFFLINE_RECENCY_MS = 30_000;
+
+/**
+ * Ordered, first-match-wins. Definitive signals (browser offline, server probe,
+ * real HTTP error, real stream close) come first; inference-only buckets last.
+ */
+export function classifyDisconnect(signal: DisconnectSignalSnapshot): DisconnectClassification {
+  const recentlyOffline = signal.msSinceOffline !== null && signal.msSinceOffline <= OFFLINE_RECENCY_MS;
+
+  // 1. Definitive LOCAL: the browser itself reports no network.
+  if (!signal.onLine || recentlyOffline) {
+    return { source: "local", confidence: "high", reason: "browser_offline" };
+  }
+
+  // 2. Definitive REMOTE: an independent server-side probe says the world is down.
+  if (signal.serverAvailability === "dead") {
+    return { source: "remote", confidence: "high", reason: "server_unreachable" };
+  }
+
+  // 3. Definitive REMOTE: the HTTP probe got a real error response from Torii.
+  if (signal.healthProbeReason === "endpoint_not_found") {
+    return { source: "remote", confidence: "high", reason: "endpoint_not_found" };
+  }
+  if (signal.healthProbeReason === "server_error") {
+    return { source: "remote", confidence: "high", reason: "server_error" };
+  }
+
+  // 4. Definitive REMOTE: the SDK surfaced an actual stream close/error.
+  if (signal.streamCloseObserved) {
+    return { source: "remote", confidence: "high", reason: "stream_closed" };
+  }
+
+  // 5. HTTP probe could not reach Torii (timeout / fetch error) while the browser
+  //    still believes it is online.
+  if (signal.healthProbeReason === "timeout" || signal.healthProbeReason === "network_error") {
+    // Infra can reach the server but this client cannot => client network path.
+    if (signal.serverAvailability === "alive") {
+      return { source: "local", confidence: "medium", reason: "probe_failed_server_alive" };
+    }
+    return { source: "remote", confidence: "medium", reason: `probe_${signal.healthProbeReason}` };
+  }
+
+  // 6. HTTP is reachable but the live stream went quiet (heartbeat stale).
+  if (signal.healthProbeReason === "reachable") {
+    if (signal.visibilityState === "hidden") {
+      // Tab was backgrounded; the health loop is paused and the indexer push may
+      // have been throttled by the browser — a likely false positive.
+      return { source: "local", confidence: "medium", reason: "stale_while_hidden" };
+    }
+    if (!signal.heartbeatAvailable) {
+      // No heartbeat channel at all, so "stale" is meaningless; HTTP says alive.
+      return { source: "indeterminate", confidence: "low", reason: "heartbeat_unsupported_http_ok" };
+    }
+    // Server HTTP is up but the stream stopped ticking -> stream/proxy drop.
+    return { source: "remote", confidence: "medium", reason: "stream_stale_http_ok" };
+  }
+
+  return { source: "indeterminate", confidence: "low", reason: "unknown" };
+}

--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -284,6 +284,84 @@ describe("ConnectionHealthMonitor", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
+  it("records a browser offline event so a later outage can be classified LOCAL", () => {
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn: vi.fn(() => Promise.resolve(reachableHealth())),
+      onReconnectGlobal: vi.fn(() => Promise.resolve()),
+      onReconnectSpatial: vi.fn(() => Promise.resolve()),
+    });
+    monitor.start();
+
+    const win = (globalThis as { window: FakeEventTarget }).window;
+    const offlineHandler = win.addEventListener.mock.calls.find(([event]: [string]) => event === "offline")?.[1];
+    expect(offlineHandler).toBeTypeOf("function");
+
+    offlineHandler();
+
+    expect(useConnectionStore.getState().isOnline).toBe(false);
+    expect(useConnectionStore.getState().lastOfflineAt).toBe(Date.now());
+
+    monitor.dispose();
+  });
+
+  it("classifies an outage with server availability when status leaves connected", async () => {
+    useConnectionStore.setState({
+      status: "connected",
+      isOnline: true,
+      lastOfflineAt: null,
+      lastStreamCloseAt: null,
+    } as any);
+    const onDisconnectClassified = vi.fn();
+    const getServerAvailability = vi.fn(() => Promise.resolve("alive" as const));
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn: vi.fn(() => Promise.resolve(reachableHealth())),
+      onReconnectGlobal: vi.fn(() => Promise.resolve()),
+      onReconnectSpatial: vi.fn(() => Promise.resolve()),
+      getServerAvailability,
+      onDisconnectClassified,
+    });
+    monitor.start();
+
+    useConnectionStore.getState().setStatus("disconnected");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(getServerAvailability).toHaveBeenCalledTimes(1);
+    expect(onDisconnectClassified).toHaveBeenCalledTimes(1);
+    const [, snapshot] = onDisconnectClassified.mock.calls[0];
+    expect(snapshot.serverAvailability).toBe("alive");
+
+    monitor.dispose();
+  });
+
+  it("drops classification if the outage recovers before the server probe resolves", async () => {
+    useConnectionStore.setState({ status: "connected", isOnline: true, lastOfflineAt: null } as any);
+    const onDisconnectClassified = vi.fn();
+    let resolveAvailability!: (value: "alive" | "dead" | "unknown") => void;
+    const getServerAvailability = vi.fn(
+      () =>
+        new Promise<"alive" | "dead" | "unknown">((resolve) => {
+          resolveAvailability = resolve;
+        }),
+    );
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn: vi.fn(() => Promise.resolve(reachableHealth())),
+      onReconnectGlobal: vi.fn(() => Promise.resolve()),
+      onReconnectSpatial: vi.fn(() => Promise.resolve()),
+      getServerAvailability,
+      onDisconnectClassified,
+    });
+    monitor.start();
+
+    useConnectionStore.getState().setStatus("disconnected"); // starts classification, awaits probe
+    useConnectionStore.getState().setStatus("connected"); // recovery invalidates the generation
+    resolveAvailability("dead");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(onDisconnectClassified).not.toHaveBeenCalled();
+
+    monitor.dispose();
+  });
+
   it("does not reconnect twice within a single staleThresholdMs window (cooldown)", async () => {
     const onReconnectSpatial = vi.fn(() => Promise.resolve());
     const onReconnectGlobal = vi.fn(() => Promise.resolve());

--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -362,6 +362,112 @@ describe("ConnectionHealthMonitor", () => {
     monitor.dispose();
   });
 
+  it("catches heartbeat staleness via the watchdog without waiting for a health probe", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn: vi.fn(() => Promise.resolve(reachableHealth())),
+      healthCheckIntervalMs: 60_000, // probe effectively never fires in-window
+      heartbeatWatchdogIntervalMs: 1_000,
+      staleThresholdMs: 5_000,
+      minReconnectCooldownMs: 1_000,
+      maxReconnectCooldownMs: 30_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now(),
+      lastGlobalUpdate: Date.now(),
+      lastToriiHeartbeat: Date.now() - 10_000,
+      toriiHeartbeatAvailable: true,
+    } as any);
+
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    expect(onReconnectSpatial).toHaveBeenCalled();
+    expect(onReconnectGlobal).toHaveBeenCalled();
+
+    monitor.dispose();
+  });
+
+  it("recovers fast-first with adaptive backoff instead of a flat cooldown", async () => {
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn: vi.fn(() => Promise.resolve(reachableHealth())),
+      healthCheckIntervalMs: 60_000,
+      heartbeatWatchdogIntervalMs: 500,
+      staleThresholdMs: 5_000,
+      minReconnectCooldownMs: 1_000,
+      maxReconnectCooldownMs: 30_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+
+    // Heartbeat stays stale (never refreshed), so each cooldown window yields one
+    // more reconnect. With min=1s a flat 60s cooldown would allow only one.
+    useConnectionStore.setState({
+      lastSpatialUpdate: Date.now(),
+      lastGlobalUpdate: Date.now(),
+      lastToriiHeartbeat: Date.now() - 10_000,
+      toriiHeartbeatAvailable: true,
+    } as any);
+
+    await vi.advanceTimersByTimeAsync(2_600);
+
+    expect(onReconnectGlobal.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    monitor.dispose();
+  });
+
+  it("proactively refreshes quiet streams without flipping status or classifying", async () => {
+    useConnectionStore.setState({
+      status: "connected",
+      spatialStatus: "connected",
+      globalStatus: "connected",
+      toriiHeartbeatAvailable: true,
+      lastToriiHeartbeat: Date.now(),
+      lastGlobalDataUpdate: Date.now() - 60_000,
+      lastSpatialDataUpdate: Date.now() - 60_000,
+      lastGlobalHandshake: Date.now() - 60_000,
+      lastSpatialHandshake: Date.now() - 60_000,
+    } as any);
+
+    const onReconnectSpatial = vi.fn(() => Promise.resolve());
+    const onReconnectGlobal = vi.fn(() => Promise.resolve());
+    const onDisconnectClassified = vi.fn();
+    const monitor = new ConnectionHealthMonitor({
+      healthCheckFn: vi.fn(() => Promise.resolve(reachableHealth())),
+      healthCheckIntervalMs: 60_000,
+      heartbeatWatchdogIntervalMs: 1_000,
+      staleThresholdMs: 5_000,
+      quietStreamRefreshMs: 30_000,
+      minReconnectCooldownMs: 1_000,
+      maxReconnectCooldownMs: 30_000,
+      onReconnectGlobal,
+      onReconnectSpatial,
+      onDisconnectClassified,
+    });
+
+    monitor.start();
+    monitor.exitBootGraceForTests();
+
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    expect(onReconnectGlobal).toHaveBeenCalled();
+    expect(useConnectionStore.getState().status).toBe("connected");
+    expect(onDisconnectClassified).not.toHaveBeenCalled();
+
+    monitor.dispose();
+  });
+
   it("does not reconnect twice within a single staleThresholdMs window (cooldown)", async () => {
     const onReconnectSpatial = vi.fn(() => Promise.resolve());
     const onReconnectGlobal = vi.fn(() => Promise.resolve());

--- a/client/apps/game/src/dojo/connection-health-monitor.test.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.test.ts
@@ -292,11 +292,12 @@ describe("ConnectionHealthMonitor", () => {
     });
     monitor.start();
 
-    const win = (globalThis as { window: FakeEventTarget }).window;
-    const offlineHandler = win.addEventListener.mock.calls.find(([event]: [string]) => event === "offline")?.[1];
+    const win = (globalThis as unknown as { window: FakeEventTarget }).window;
+    const offlineCall = win.addEventListener.mock.calls.find((call) => call[0] === "offline");
+    const offlineHandler = offlineCall?.[1] as (() => void) | undefined;
     expect(offlineHandler).toBeTypeOf("function");
 
-    offlineHandler();
+    offlineHandler?.();
 
     expect(useConnectionStore.getState().isOnline).toBe(false);
     expect(useConnectionStore.getState().lastOfflineAt).toBe(Date.now());

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -34,6 +34,22 @@ interface ConnectionHealthMonitorConfig {
   recoveryToastThresholdMs?: number;
   deadEndAttempts?: number;
   transientHealthFailureThreshold?: number;
+  /**
+   * Cadence of a lightweight heartbeat watchdog that catches staleness between
+   * the slower HTTP probes. Omit/0 to disable (probe-driven detection only).
+   */
+  heartbeatWatchdogIntervalMs?: number;
+  /**
+   * Adaptive reconnect backoff: first retry waits min, then doubles up to max.
+   * When either is omitted, the flat `reconnectCooldownMs` is used (legacy).
+   */
+  minReconnectCooldownMs?: number;
+  maxReconnectCooldownMs?: number;
+  /**
+   * Proactively re-subscribe streams after this long with no activity, to dodge
+   * proxy idle / MAX_CONNECTION_AGE reaps in quiet worlds. Omit/0 to disable.
+   */
+  quietStreamRefreshMs?: number;
 }
 
 interface ConnectionHealthToriiInput {
@@ -89,8 +105,14 @@ export class ConnectionHealthMonitor {
   private readonly staleThresholdMs: number;
   private readonly reconnectCooldownMs: number;
   private readonly recoveryToastThresholdMs: number;
+  private readonly heartbeatWatchdogIntervalMs: number | null;
+  private readonly minReconnectCooldownMs: number | null;
+  private readonly maxReconnectCooldownMs: number | null;
+  private readonly quietStreamRefreshMs: number;
 
   private healthCheckTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+  private lastProactiveRefreshAtMs = 0;
   private reconnecting = false;
   private disposed = false;
   private lastStreamReconnectAtMs = 0;
@@ -119,6 +141,10 @@ export class ConnectionHealthMonitor {
     this.deadEndAttempts = config.deadEndAttempts ?? DEFAULT_DEAD_END_ATTEMPTS;
     this.transientHealthFailureThreshold =
       config.transientHealthFailureThreshold ?? DEFAULT_TRANSIENT_HEALTH_FAILURE_THRESHOLD;
+    this.heartbeatWatchdogIntervalMs = config.heartbeatWatchdogIntervalMs ?? null;
+    this.minReconnectCooldownMs = config.minReconnectCooldownMs ?? null;
+    this.maxReconnectCooldownMs = config.maxReconnectCooldownMs ?? null;
+    this.quietStreamRefreshMs = config.quietStreamRefreshMs ?? 0;
   }
 
   start(): void {
@@ -137,6 +163,7 @@ export class ConnectionHealthMonitor {
       this.handleStatusTransition(state.status, previous.status);
     });
     this.startHealthCheckLoop();
+    this.startHeartbeatWatchdog();
   }
 
   stop(): void {
@@ -147,6 +174,7 @@ export class ConnectionHealthMonitor {
     this.unsubscribeStore?.();
     this.unsubscribeStore = null;
     this.stopHealthCheckLoop();
+    this.stopHeartbeatWatchdog();
     if (activeMonitor === this) activeMonitor = null;
   }
 
@@ -216,6 +244,75 @@ export class ConnectionHealthMonitor {
     if (this.healthCheckTimer !== null) {
       clearInterval(this.healthCheckTimer);
       this.healthCheckTimer = null;
+    }
+  }
+
+  // --- Heartbeat watchdog (fast detection) + proactive quiet-stream refresh ---
+
+  private startHeartbeatWatchdog(): void {
+    if (this.heartbeatWatchdogIntervalMs === null || this.heartbeatWatchdogIntervalMs <= 0) return;
+    this.heartbeatWatchdogTimer = setInterval(() => {
+      this.runHeartbeatWatchdog();
+    }, this.heartbeatWatchdogIntervalMs);
+  }
+
+  private stopHeartbeatWatchdog(): void {
+    if (this.heartbeatWatchdogTimer !== null) {
+      clearInterval(this.heartbeatWatchdogTimer);
+      this.heartbeatWatchdogTimer = null;
+    }
+  }
+
+  private runHeartbeatWatchdog(): void {
+    if (this.disposed) return;
+    if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
+    if (!this.hasObservedHealthyStreams) return;
+
+    const store = useConnectionStore.getState();
+    // Catch a silently-dropped stream within a watchdog tick rather than waiting
+    // for the next (slower) HTTP probe. Reuses the cooldown-gated reconnect path.
+    this.reconnectSilentStreamsAfterCooldown(store);
+    // Keep quiet streams under proxy idle / max-age limits.
+    void this.maybeProactivelyRefreshQuietStreams();
+  }
+
+  private async maybeProactivelyRefreshQuietStreams(): Promise<void> {
+    if (this.quietStreamRefreshMs <= 0 || this.reconnecting) return;
+
+    const store = useConnectionStore.getState();
+    // Only refresh a healthy, quiet connection; a real outage uses the normal path.
+    if (store.status !== "connected") return;
+
+    const now = Date.now();
+    const lastActivity = Math.max(
+      store.lastGlobalDataUpdate,
+      store.lastSpatialDataUpdate,
+      store.lastGlobalHandshake,
+      store.lastSpatialHandshake,
+    );
+    if (now - lastActivity < this.quietStreamRefreshMs) return;
+    if (now - this.lastProactiveRefreshAtMs < this.quietStreamRefreshMs) return;
+
+    this.lastProactiveRefreshAtMs = now;
+    this.lastStreamReconnectAtMs = now;
+    await this.silentRefreshStreams();
+  }
+
+  // Re-open the streams WITHOUT flipping connection status: a proactive refresh
+  // is maintenance, not an outage, so it must not show the banner or emit a
+  // disconnect classification. A failure is swallowed — the heartbeat/health
+  // path will detect and surface a genuine problem.
+  private async silentRefreshStreams(): Promise<void> {
+    if (this.reconnecting || this.disposed) return;
+    this.reconnecting = true;
+    try {
+      await Promise.all([this.config.onReconnectSpatial(), this.config.onReconnectGlobal()]);
+      this.config.onReconnectComplete?.();
+      useConnectionStore.getState().recordStreamReconnect();
+    } catch (error) {
+      console.warn("[ConnectionHealthMonitor] Proactive stream refresh failed", error);
+    } finally {
+      this.reconnecting = false;
     }
   }
 
@@ -303,9 +400,22 @@ export class ConnectionHealthMonitor {
     return lastSpatialActivity > this.startedAtMs && lastGlobalActivity > this.startedAtMs;
   }
 
+  // Time to wait before the next reconnect attempt. With min/max configured this
+  // is fast-first exponential backoff (min, 2x, 4x… capped at max) keyed on the
+  // consecutive-failure count, so a transient drop recovers in ~min while a
+  // genuinely-down server still backs off. Falls back to the flat cooldown.
+  private currentReconnectCooldownMs(): number {
+    if (this.minReconnectCooldownMs === null || this.maxReconnectCooldownMs === null) {
+      return this.reconnectCooldownMs;
+    }
+    const attempts = useConnectionStore.getState().reconnectAttempts;
+    const scaled = this.minReconnectCooldownMs * 2 ** Math.max(0, attempts);
+    return Math.min(this.maxReconnectCooldownMs, Math.max(this.minReconnectCooldownMs, scaled));
+  }
+
   private reconnectSilentStreamsAfterCooldown(store: ReturnType<typeof useConnectionStore.getState>): void {
     const now = Date.now();
-    if (now - this.lastStreamReconnectAtMs < this.reconnectCooldownMs) return;
+    if (now - this.lastStreamReconnectAtMs < this.currentReconnectCooldownMs()) return;
 
     if (!this.isHeartbeatStale(store)) return;
 
@@ -321,7 +431,7 @@ export class ConnectionHealthMonitor {
 
   private reconnectAfterFailedHealthCheck(reason: ToriiHealthUnreachableReason): void {
     const now = Date.now();
-    if (now - this.lastStreamReconnectAtMs < this.reconnectCooldownMs) return;
+    if (now - this.lastStreamReconnectAtMs < this.currentReconnectCooldownMs()) return;
 
     const store = useConnectionStore.getState();
     store.setStatus("disconnected");

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -1,5 +1,13 @@
-import { useConnectionStore } from "@/hooks/store/use-connection-store";
+import { useConnectionStore, type ConnectionStatus } from "@/hooks/store/use-connection-store";
 import { addToriiStreamBreadcrumb, reportToriiSubscriptionLifecycle } from "@/observability/network-health-reporting";
+import {
+  classifyDisconnect,
+  type DisconnectClassification,
+  type DisconnectSignalSnapshot,
+  type HealthProbeSignal,
+  type ServerAvailabilityVerdict,
+} from "./connection-disconnect-classification";
+import { observeToriiStreamLifecycle } from "./torii-stream-lifecycle-observer";
 import type { ToriiHealthProbeResult, ToriiHealthUnreachableReason } from "./torii-health-probe";
 
 const DEFAULT_HEALTH_CHECK_INTERVAL_MS = 10_000;
@@ -16,6 +24,10 @@ interface ConnectionHealthMonitorConfig {
   healthCheckFn: () => Promise<ToriiHealthProbeResult>;
   onRecovery?: (outageMs: number, attempts: number) => void;
   onDeadEnd?: (outageMs: number, attempts: number, reason?: ToriiHealthUnreachableReason) => void;
+  /** Phase 2: independent server-side reachability for the active world. */
+  getServerAvailability?: () => Promise<ServerAvailabilityVerdict>;
+  /** Fired once per outage (connected -> not-connected) with the LOCAL/REMOTE verdict. */
+  onDisconnectClassified?: (classification: DisconnectClassification, snapshot: DisconnectSignalSnapshot) => void;
   healthCheckIntervalMs?: number;
   staleThresholdMs?: number;
   reconnectCooldownMs?: number;
@@ -54,7 +66,17 @@ export async function subscribeToToriiHeartbeat(
       });
     });
     useConnectionStore.getState().markToriiHeartbeatAvailable();
-    return subscription;
+    // Best-effort: if the SDK ever surfaces a real close/error on the heartbeat
+    // stream, record it so the next outage is classified REMOTE. No-op today.
+    const detachLifecycle = observeToriiStreamLifecycle(subscription, () => {
+      useConnectionStore.getState().recordStreamClose();
+    });
+    return {
+      cancel: () => {
+        detachLifecycle();
+        subscription.cancel();
+      },
+    };
   } catch (error) {
     console.warn("[ConnectionHealthMonitor] Failed to subscribe to Torii heartbeat", error);
     return null;
@@ -79,6 +101,11 @@ export class ConnectionHealthMonitor {
   private readonly deadEndAttempts: number;
   private readonly transientHealthFailureThreshold: number;
   private consecutiveTransientHealthFailures = 0;
+  private lastHealthProbeResult: ToriiHealthProbeResult | null = null;
+  private unsubscribeStore: (() => void) | null = null;
+  // Monotonic token: bumped on every connected<->outage edge so an in-flight
+  // async classification can detect that its outage already recovered.
+  private classifyGeneration = 0;
 
   constructor(config: ConnectionHealthMonitorConfig) {
     this.config = config;
@@ -102,14 +129,23 @@ export class ConnectionHealthMonitor {
     this.hasObservedHealthyStreams = this.haveObservedStreamHandshakes(useConnectionStore.getState());
     document.addEventListener("visibilitychange", this.handleVisibilityChange);
     window.addEventListener("online", this.handleOnline);
+    window.addEventListener("offline", this.handleOffline);
     window.addEventListener("pageshow", this.handlePageShow);
+    // Classify every outage at the exact moment overall status leaves "connected"
+    // — the same edge that drives the "Disconnected from the realm" banner.
+    this.unsubscribeStore = useConnectionStore.subscribe((state, previous) => {
+      this.handleStatusTransition(state.status, previous.status);
+    });
     this.startHealthCheckLoop();
   }
 
   stop(): void {
     document.removeEventListener("visibilitychange", this.handleVisibilityChange);
     window.removeEventListener("online", this.handleOnline);
+    window.removeEventListener("offline", this.handleOffline);
     window.removeEventListener("pageshow", this.handlePageShow);
+    this.unsubscribeStore?.();
+    this.unsubscribeStore = null;
     this.stopHealthCheckLoop();
     if (activeMonitor === this) activeMonitor = null;
   }
@@ -149,9 +185,18 @@ export class ConnectionHealthMonitor {
 
   private handleOnline = (): void => {
     if (this.disposed) return;
+    useConnectionStore.getState().recordOnline();
     if (!this.hasObservedHealthyStreams) return;
 
     void this.reconnectStaleStreams(true, true);
+  };
+
+  // A local network drop: record it so a subsequent outage is classified LOCAL.
+  // No reconnect attempt here — the OS is offline, so the `online` event drives
+  // recovery. This is the LOCAL signal the monitor previously could not see.
+  private handleOffline = (): void => {
+    if (this.disposed) return;
+    useConnectionStore.getState().recordOffline();
   };
 
   private handlePageShow = (): void => {
@@ -190,6 +235,8 @@ export class ConnectionHealthMonitor {
   // --- Shared reconnect logic ---
 
   private applyHealthProbeResult(result: ToriiHealthProbeResult): void {
+    // Remembered so disconnect classification can read the latest probe verdict.
+    this.lastHealthProbeResult = result;
     if (result.status === "reachable") {
       this.markHealthCheckPassed();
       return;
@@ -392,6 +439,64 @@ export class ConnectionHealthMonitor {
         this.config.onRecovery?.(outageMs, attemptsBeforeReset);
       }
     }
+  }
+
+  // --- Disconnect classification (LOCAL vs REMOTE) ---
+
+  private handleStatusTransition(next: ConnectionStatus, previous: ConnectionStatus): void {
+    if (this.disposed) return;
+    if (previous === "connected" && next !== "connected") {
+      const generation = ++this.classifyGeneration;
+      void this.classifyOutage(generation);
+    } else if (next === "connected" && previous !== "connected") {
+      // Recovery invalidates any in-flight classification for the prior outage.
+      this.classifyGeneration += 1;
+    }
+  }
+
+  private async classifyOutage(generation: number): Promise<void> {
+    const serverAvailability = await this.resolveServerAvailability();
+    // The outage recovered (or the monitor was disposed) while we awaited the
+    // server probe — drop the now-irrelevant classification.
+    if (this.disposed || generation !== this.classifyGeneration) return;
+
+    const snapshot = this.buildDisconnectSnapshot(serverAvailability);
+    this.config.onDisconnectClassified?.(classifyDisconnect(snapshot), snapshot);
+  }
+
+  private async resolveServerAvailability(): Promise<ServerAvailabilityVerdict> {
+    if (!this.config.getServerAvailability) return "unknown";
+    try {
+      return await this.config.getServerAvailability();
+    } catch {
+      return "unknown";
+    }
+  }
+
+  private buildDisconnectSnapshot(serverAvailability: ServerAvailabilityVerdict): DisconnectSignalSnapshot {
+    const store = useConnectionStore.getState();
+    const now = Date.now();
+    // Only trust navigator.onLine when it is a real boolean; otherwise fall back
+    // to the store snapshot so non-browser/edge runtimes never read as "offline".
+    const navigatorOnLine =
+      typeof navigator !== "undefined" && typeof navigator.onLine === "boolean" ? navigator.onLine : store.isOnline;
+    return {
+      onLine: navigatorOnLine,
+      msSinceOffline: store.lastOfflineAt !== null ? now - store.lastOfflineAt : null,
+      visibilityState:
+        typeof document !== "undefined" && document.visibilityState === "hidden" ? "hidden" : "visible",
+      healthProbeReason: this.resolveHealthProbeReason(),
+      heartbeatAvailable: store.toriiHeartbeatAvailable,
+      msSinceHeartbeat: store.toriiHeartbeatAvailable ? now - store.lastToriiHeartbeat : null,
+      streamCloseObserved: store.lastStreamCloseAt !== null && now - store.lastStreamCloseAt <= this.staleThresholdMs,
+      serverAvailability,
+    };
+  }
+
+  private resolveHealthProbeReason(): HealthProbeSignal {
+    const result = this.lastHealthProbeResult;
+    if (!result) return "unknown";
+    return result.status === "reachable" ? "reachable" : result.reason;
   }
 }
 

--- a/client/apps/game/src/dojo/fetch-server-world-availability.test.ts
+++ b/client/apps/game/src/dojo/fetch-server-world-availability.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchServerWorldAvailability } from "./fetch-server-world-availability";
+
+const jsonResponse = (body: unknown, ok = true): Response =>
+  ({ ok, json: async () => body }) as unknown as Response;
+
+describe("fetchServerWorldAvailability", () => {
+  it("returns 'unknown' without a base url or world name", async () => {
+    const fetchFn = vi.fn();
+    await expect(fetchServerWorldAvailability("", "world", { fetchFn })).resolves.toBe("unknown");
+    await expect(fetchServerWorldAvailability("https://rt", "", { fetchFn })).resolves.toBe("unknown");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("returns 'alive' when the matching world is alive", async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse([
+        { name: "other", alive: false },
+        { name: "eternum-1", alive: true },
+      ]),
+    );
+    await expect(fetchServerWorldAvailability("https://rt/", "eternum-1", { fetchFn })).resolves.toBe("alive");
+    expect(fetchFn).toHaveBeenCalledWith("https://rt/api/worlds/summary", expect.objectContaining({ method: "GET" }));
+  });
+
+  it("returns 'dead' when the matching world is not alive", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse([{ name: "eternum-1", alive: false }]));
+    await expect(fetchServerWorldAvailability("https://rt", "eternum-1", { fetchFn })).resolves.toBe("dead");
+  });
+
+  it("returns 'unknown' when the world is not in the summary", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse([{ name: "other", alive: true }]));
+    await expect(fetchServerWorldAvailability("https://rt", "eternum-1", { fetchFn })).resolves.toBe("unknown");
+  });
+
+  it("returns 'unknown' on non-ok response, non-array payload, or fetch throw", async () => {
+    await expect(
+      fetchServerWorldAvailability("https://rt", "w", { fetchFn: vi.fn(async () => jsonResponse([], false)) }),
+    ).resolves.toBe("unknown");
+    await expect(
+      fetchServerWorldAvailability("https://rt", "w", { fetchFn: vi.fn(async () => jsonResponse({ nope: true })) }),
+    ).resolves.toBe("unknown");
+    await expect(
+      fetchServerWorldAvailability("https://rt", "w", {
+        fetchFn: vi.fn(async () => {
+          throw new Error("network down");
+        }),
+      }),
+    ).resolves.toBe("unknown");
+  });
+});

--- a/client/apps/game/src/dojo/fetch-server-world-availability.ts
+++ b/client/apps/game/src/dojo/fetch-server-world-availability.ts
@@ -1,0 +1,65 @@
+import type { ServerAvailabilityVerdict } from "./connection-disconnect-classification";
+
+/**
+ * Phase 2 correlation: ask the realtime-server whether THIS world's Torii is
+ * reachable from server-side infrastructure, independent of the client's own
+ * network path.
+ *
+ * - `alive`  => server can reach the world's Torii => a client outage is most
+ *               likely LOCAL or stream-specific, not a world-wide outage.
+ * - `dead`   => server also cannot reach it => REMOTE.
+ * - `unknown` => could not determine (network error, world not listed, timeout);
+ *               classification falls back to client-only signals.
+ *
+ * Reuses the existing `/api/worlds/summary` endpoint (see use-worlds-summary.ts)
+ * but with a short timeout because it runs inside disconnect classification.
+ */
+
+const DEFAULT_TIMEOUT_MS = 4_000;
+
+interface ServerWorldAvailabilityOptions {
+  timeoutMs?: number;
+  fetchFn?: typeof fetch;
+}
+
+interface WorldSummaryAvailabilityRow {
+  name?: unknown;
+  alive?: unknown;
+}
+
+export async function fetchServerWorldAvailability(
+  realtimeBaseUrl: string | null | undefined,
+  worldName: string | null | undefined,
+  { timeoutMs = DEFAULT_TIMEOUT_MS, fetchFn = fetch }: ServerWorldAvailabilityOptions = {},
+): Promise<ServerAvailabilityVerdict> {
+  const baseUrl = realtimeBaseUrl?.trim();
+  const name = worldName?.trim();
+  if (!baseUrl || !name) {
+    return "unknown";
+  }
+
+  try {
+    const url = `${baseUrl.replace(/\/+$/, "")}/api/worlds/summary`;
+    const response = await fetchFn(url, {
+      method: "GET",
+      signal: timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
+    });
+    if (!response.ok) {
+      return "unknown";
+    }
+
+    const data = (await response.json()) as unknown;
+    if (!Array.isArray(data)) {
+      return "unknown";
+    }
+
+    const match = (data as WorldSummaryAvailabilityRow[]).find((row) => row?.name === name);
+    if (!match || typeof match.alive !== "boolean") {
+      return "unknown";
+    }
+
+    return match.alive ? "alive" : "dead";
+  } catch {
+    return "unknown";
+  }
+}

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -30,6 +30,7 @@ import {
   GLOBAL_SPATIAL_MAP_BOOTSTRAP_MODEL_NAMES,
   GLOBAL_SPATIAL_MAP_BOOTSTRAP_SNAPSHOT_MODELS,
 } from "./torii-spatial-models";
+import { observeToriiStreamLifecycle } from "./torii-stream-lifecycle-observer";
 import { buildModelKeysClause, type GlobalModelStreamConfig } from "./torii-stream-manager";
 import {
   setupToriiSubscriptions,
@@ -618,6 +619,15 @@ export const syncEntitiesDebounced = async (
 
     readiness.markSubscriptionsReady();
 
+    // Best-effort runtime close/error detection. torii-wasm exposes none today,
+    // so these are no-ops; if a future SDK adds one, a silent stream drop records
+    // a close timestamp that classifies the next outage as REMOTE.
+    const recordStreamClose = () => useConnectionStore.getState().recordStreamClose();
+    const detachLifecycle = [
+      observeToriiStreamLifecycle(subscriptions.entitySubscription, recordStreamClose),
+      observeToriiStreamLifecycle(subscriptions.eventSubscription, recordStreamClose),
+    ];
+
     const canUpdateSubscriptionClause =
       typeof client.updateEntitySubscription === "function" &&
       typeof client.updateEventMessageSubscription === "function";
@@ -627,6 +637,7 @@ export const syncEntitiesDebounced = async (
         return readiness.ready;
       },
       cancel: () => {
+        detachLifecycle.forEach((detach) => detach());
         subscriptions.cancel();
         queueProcessor.dispose();
         readiness.cancel();

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -962,3 +962,55 @@ const resubscribeEntityStream = async (
     reportProgress: false,
   });
 };
+
+/**
+ * Lightweight reconnect: re-open ONLY the global entity + event stream.
+ *
+ * A silently-dropped stream needs its subscription re-created, but the one-time
+ * hydration that {@link initialSync} also performs (config, guilds, address
+ * names, owned structures, spatial bootstrap snapshot) is already in RECS and
+ * does not change across a brief drop — re-running it turns a transient blip
+ * into a full re-bootstrap. This re-subscribes the global stream only; spatial
+ * recovery is owned by the worldmap recovery handle (onReconnectComplete).
+ */
+export const resubscribeGlobalEntityStream = async (
+  setup: SetupResult,
+  options: {
+    logging?: boolean;
+    subscriptionSetupTimeoutMs?: number;
+    onSubscriptionSetupTimeout?: (info: ToriiSubscriptionSetupTimeoutInfo) => void;
+  } = {},
+): Promise<void> => {
+  const logging = options.logging ?? false;
+  const subscriptionSetupTimeoutMs =
+    options.subscriptionSetupTimeoutMs ?? env.VITE_PUBLIC_TORII_SUBSCRIPTION_SETUP_TIMEOUT_MS;
+
+  cancelGlobalEntityStreamSubscriptions();
+  // Guard the exported cancelEntityStreamSubscription() against tearing down the
+  // half-built subscription while we re-handshake.
+  isInitialSyncInFlight = true;
+  try {
+    const initialGlobalEntityClause = getInitialGlobalEntityStreamClause();
+    entityStreamSubscription = await syncEntitiesDebounced(
+      setup.network.toriiClient,
+      setup,
+      {
+        entityClause: initialGlobalEntityClause,
+        eventClause: GLOBAL_EVENT_STREAM_CLAUSE,
+      },
+      logging,
+      () => useConnectionStore.getState().recordGlobalUpdate(),
+      {
+        streamType: "global",
+        subscriptionSetupTimeoutMs,
+        onSubscriptionSetupTimeout: options.onSubscriptionSetupTimeout,
+      },
+    );
+    useConnectionStore.getState().recordGlobalHandshake();
+  } catch (error) {
+    cancelGlobalEntityStreamSubscriptions();
+    throw error;
+  } finally {
+    isInitialSyncInFlight = false;
+  }
+};

--- a/client/apps/game/src/dojo/torii-stream-lifecycle-observer.test.ts
+++ b/client/apps/game/src/dojo/torii-stream-lifecycle-observer.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { observeToriiStreamLifecycle } from "./torii-stream-lifecycle-observer";
+
+describe("observeToriiStreamLifecycle", () => {
+  it("is a no-op for a cancel-only subscription (current torii-wasm shape)", () => {
+    const onClose = vi.fn();
+    const detach = observeToriiStreamLifecycle({ cancel: () => {} }, onClose);
+    detach();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for non-object subscriptions", () => {
+    const onClose = vi.fn();
+    expect(() => observeToriiStreamLifecycle(null, onClose)()).not.toThrow();
+    expect(() => observeToriiStreamLifecycle(undefined, onClose)()).not.toThrow();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("wires Node-style emitter error/close events when present", () => {
+    const handlers: Record<string, (arg?: unknown) => void> = {};
+    const sub = {
+      cancel: () => {},
+      on: (event: string, cb: (arg?: unknown) => void) => {
+        handlers[event] = cb;
+      },
+      off: vi.fn(),
+    };
+    const onClose = vi.fn();
+
+    observeToriiStreamLifecycle(sub, onClose);
+    handlers.error?.(new Error("boom"));
+    expect(onClose).toHaveBeenCalledWith({ reason: "boom" });
+
+    handlers.close?.();
+    expect(onClose).toHaveBeenCalledWith({ reason: "close" });
+  });
+
+  it("detaches emitter listeners via off", () => {
+    const off = vi.fn();
+    const sub = { cancel: () => {}, on: () => {}, off };
+    const detach = observeToriiStreamLifecycle(sub, vi.fn());
+    detach();
+    expect(off).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(off).toHaveBeenCalledWith("close", expect.any(Function));
+  });
+
+  it("wires assignable onerror/onclose handler slots when present", () => {
+    const sub: { cancel: () => void; onerror: ((e: unknown) => void) | null; onclose: (() => void) | null } = {
+      cancel: () => {},
+      onerror: null,
+      onclose: null,
+    };
+    const onClose = vi.fn();
+
+    const detach = observeToriiStreamLifecycle(sub, onClose);
+    sub.onerror?.(new Error("kaboom"));
+    expect(onClose).toHaveBeenCalledWith({ reason: "kaboom" });
+
+    detach();
+    expect(sub.onerror).toBeNull();
+    expect(sub.onclose).toBeNull();
+  });
+});

--- a/client/apps/game/src/dojo/torii-stream-lifecycle-observer.ts
+++ b/client/apps/game/src/dojo/torii-stream-lifecycle-observer.ts
@@ -14,7 +14,7 @@
  * testable and documents the gap in one place.
  */
 
-export interface ToriiStreamCloseInfo {
+interface ToriiStreamCloseInfo {
   reason: string;
 }
 

--- a/client/apps/game/src/dojo/torii-stream-lifecycle-observer.ts
+++ b/client/apps/game/src/dojo/torii-stream-lifecycle-observer.ts
@@ -1,0 +1,75 @@
+/**
+ * Best-effort observer for a Torii subscription's runtime close/error.
+ *
+ * FINDING (torii-wasm@1.7.0-preview.3): the subscription objects returned by
+ * `onEntityUpdated` / `onEventMessageUpdated` / `onIndexerUpdated` expose ONLY a
+ * `cancel()` method — there is no runtime error or close event. A silently
+ * dropped gRPC/websocket stream therefore produces no callback today; the client
+ * can only *infer* it via heartbeat staleness + the HTTP health probe.
+ *
+ * This helper feature-detects the common emitter shapes so that the moment a
+ * future SDK surfaces a close/error, stream death becomes a first-class REMOTE
+ * signal with no further wiring. It is intentionally a no-op against the current
+ * SDK. Keeping it here (rather than inline) makes the feature-detection unit
+ * testable and documents the gap in one place.
+ */
+
+export interface ToriiStreamCloseInfo {
+  reason: string;
+}
+
+export type ToriiStreamCloseHandler = (info: ToriiStreamCloseInfo) => void;
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : typeof error === "string" ? error : "stream_error";
+
+type EmitterLike = {
+  on: (event: string, cb: (...args: unknown[]) => void) => void;
+  off?: (event: string, cb: (...args: unknown[]) => void) => void;
+  removeListener?: (event: string, cb: (...args: unknown[]) => void) => void;
+};
+
+const isEmitterLike = (value: Record<string, unknown>): value is Record<string, unknown> & EmitterLike =>
+  typeof value.on === "function";
+
+/**
+ * Attaches close/error listeners if the subscription supports them. Returns a
+ * detach function (always safe to call, even when nothing was attached).
+ */
+export function observeToriiStreamLifecycle(subscription: unknown, onClose: ToriiStreamCloseHandler): () => void {
+  if (!subscription || typeof subscription !== "object") {
+    return () => {};
+  }
+
+  const sub = subscription as Record<string, unknown>;
+
+  // Shape A: Node-style event emitter — sub.on("error" | "close", cb).
+  if (isEmitterLike(sub)) {
+    const errorCb = (error: unknown) => onClose({ reason: errorMessage(error) });
+    const closeCb = () => onClose({ reason: "close" });
+    sub.on("error", errorCb);
+    sub.on("close", closeCb);
+
+    const detach = sub.off ?? sub.removeListener;
+    return () => {
+      if (typeof detach === "function") {
+        detach.call(sub, "error", errorCb);
+        detach.call(sub, "close", closeCb);
+      }
+    };
+  }
+
+  // Shape B: assignable handler slots — sub.onerror / sub.onclose.
+  if ("onerror" in sub || "onclose" in sub) {
+    const previousError = sub.onerror;
+    const previousClose = sub.onclose;
+    sub.onerror = (error: unknown) => onClose({ reason: errorMessage(error) });
+    sub.onclose = () => onClose({ reason: "close" });
+    return () => {
+      sub.onerror = previousError;
+      sub.onclose = previousClose;
+    };
+  }
+
+  return () => {};
+}

--- a/client/apps/game/src/hooks/store/use-connection-store.ts
+++ b/client/apps/game/src/hooks/store/use-connection-store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-type ConnectionStatus = "connected" | "degraded" | "disconnected";
+export type ConnectionStatus = "connected" | "degraded" | "disconnected";
 export type StreamStatus = "connected" | "stale" | "reconnecting" | "failed";
 
 interface ConnectionState {
@@ -15,11 +15,20 @@ interface ConnectionState {
   lastGlobalHandshake: number;
   lastToriiHeartbeat: number;
   toriiHeartbeatAvailable: boolean;
+  /** Interval (ms) between the two most recent heartbeats; null until the second tick. */
+  lastHeartbeatIntervalMs: number | null;
   lastHealthCheck: number;
   lastConnectedAt: number;
   lastDisconnectedAt: number | null;
   reconnectAttempts: number;
   streamReconnectVersion: number;
+  // --- Disconnect-source signals (used by classifyDisconnect) ---
+  /** Snapshot of navigator.onLine, kept fresh via the browser online/offline events. */
+  isOnline: boolean;
+  /** Timestamp of the last browser `offline` event, or null if none observed. */
+  lastOfflineAt: number | null;
+  /** Timestamp of the last observed real stream close/error (best-effort; usually null). */
+  lastStreamCloseAt: number | null;
   setStatus: (status: ConnectionStatus) => void;
   setSpatialStatus: (status: StreamStatus) => void;
   setGlobalStatus: (status: StreamStatus) => void;
@@ -31,9 +40,14 @@ interface ConnectionState {
   markToriiHeartbeatAvailable: () => void;
   recordHealthCheck: () => void;
   recordStreamReconnect: () => void;
+  recordOnline: () => void;
+  recordOffline: () => void;
+  recordStreamClose: () => void;
   incrementReconnectAttempts: () => void;
   resetReconnectAttempts: () => void;
 }
+
+const readInitialOnline = (): boolean => (typeof navigator !== "undefined" ? navigator.onLine : true);
 
 const deriveOverallStatus = (spatial: StreamStatus, global: StreamStatus): ConnectionStatus => {
   if (spatial === "failed" || global === "failed") return "disconnected";
@@ -53,11 +67,15 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
   lastGlobalHandshake: 0,
   lastToriiHeartbeat: Date.now(),
   toriiHeartbeatAvailable: false,
+  lastHeartbeatIntervalMs: null,
   lastHealthCheck: Date.now(),
   lastConnectedAt: Date.now(),
   lastDisconnectedAt: null,
   reconnectAttempts: 0,
   streamReconnectVersion: 0,
+  isOnline: readInitialOnline(),
+  lastOfflineAt: null,
+  lastStreamCloseAt: null,
   setStatus: (status: ConnectionStatus) =>
     set((state) => {
       const now = Date.now();
@@ -120,10 +138,20 @@ export const useConnectionStore = create<ConnectionState>((set) => ({
     const now = Date.now();
     set({ lastGlobalUpdate: now, lastGlobalHandshake: now });
   },
-  recordToriiHeartbeat: () => set({ lastToriiHeartbeat: Date.now(), toriiHeartbeatAvailable: true }),
+  recordToriiHeartbeat: () =>
+    set((state) => {
+      const now = Date.now();
+      // Only treat the gap as a real heartbeat interval once a heartbeat has
+      // actually been received before (avoids reporting the time since store init).
+      const intervalMs = state.toriiHeartbeatAvailable ? now - state.lastToriiHeartbeat : null;
+      return { lastToriiHeartbeat: now, toriiHeartbeatAvailable: true, lastHeartbeatIntervalMs: intervalMs };
+    }),
   markToriiHeartbeatAvailable: () => set({ lastToriiHeartbeat: Date.now(), toriiHeartbeatAvailable: true }),
   recordHealthCheck: () => set({ lastHealthCheck: Date.now() }),
   recordStreamReconnect: () => set((state) => ({ streamReconnectVersion: state.streamReconnectVersion + 1 })),
+  recordOnline: () => set({ isOnline: true }),
+  recordOffline: () => set({ isOnline: false, lastOfflineAt: Date.now() }),
+  recordStreamClose: () => set({ lastStreamCloseAt: Date.now() }),
   incrementReconnectAttempts: () => set((state) => ({ reconnectAttempts: state.reconnectAttempts + 1 })),
   resetReconnectAttempts: () => set({ reconnectAttempts: 0 }),
 }));

--- a/client/apps/game/src/observability/network-health-reporting.ts
+++ b/client/apps/game/src/observability/network-health-reporting.ts
@@ -2,6 +2,11 @@ import * as Sentry from "@sentry/react";
 
 import { env } from "../../env";
 import { getActiveWorld } from "@/runtime/world";
+import { captureClientEvent } from "@/posthog";
+import type {
+  DisconnectClassification,
+  DisconnectSignalSnapshot,
+} from "@/dojo/connection-disconnect-classification";
 import { resolveUserIdentity } from "./wallet-identity";
 
 export type NetworkStreamType = "spatial" | "global" | "player" | "both";
@@ -288,6 +293,68 @@ const reportOutage = (report: OutageReport, recovered: boolean): void => {
 export const reportNetworkOutageResolved = (report: OutageReport): void => reportOutage(report, true);
 
 export const reportNetworkOutageDeadEnd = (report: OutageReport): void => reportOutage(report, false);
+
+/**
+ * Emits the single "is this disconnect LOCAL or REMOTE" verdict at outage start.
+ * Mirrored to PostHog (independent of Sentry network-health enablement) so the
+ * split is queryable even where Sentry network-health is off; PostHog has no
+ * other Torii instrumentation today.
+ */
+export const reportDisconnectClassification = (
+  classification: DisconnectClassification,
+  snapshot: DisconnectSignalSnapshot,
+): void => {
+  const eventProps = {
+    source: classification.source,
+    confidence: classification.confidence,
+    reason: classification.reason,
+    on_line: snapshot.onLine,
+    ms_since_offline: snapshot.msSinceOffline,
+    visibility_state: snapshot.visibilityState,
+    health_probe_reason: snapshot.healthProbeReason,
+    heartbeat_available: snapshot.heartbeatAvailable,
+    ms_since_heartbeat: snapshot.msSinceHeartbeat,
+    stream_close_observed: snapshot.streamCloseObserved,
+    server_availability: snapshot.serverAvailability,
+    world: getActiveWorldName(),
+  };
+
+  // PostHog mirror — guarded internally by the PostHog key.
+  captureClientEvent("torii_disconnect_classification", eventProps);
+
+  if (!isEnabled()) return;
+  if (!canEmitMore()) return;
+
+  const dedupeKey = `disconnect-classification:${classification.source}:${classification.reason}`;
+  if (shouldSkipDuplicate(dedupeKey)) return;
+
+  eventsThisSession += 1;
+
+  Sentry.captureMessage(`Torii disconnect classified: ${classification.source} (${classification.reason})`, {
+    level: classification.source === "remote" ? "error" : "warning",
+    tags: {
+      feature: "network-health",
+      "network.kind": "disconnect_classification",
+      "network.disconnect_source": classification.source,
+      "network.disconnect_reason": classification.reason,
+      "network.disconnect_confidence": classification.confidence,
+      "network.server_availability": snapshot.serverAvailability,
+    },
+    contexts: {
+      network: {
+        on_line: snapshot.onLine,
+        ...(snapshot.msSinceOffline !== null ? { ms_since_offline: snapshot.msSinceOffline } : {}),
+        visibility_state: snapshot.visibilityState,
+        health_probe_reason: snapshot.healthProbeReason,
+        heartbeat_available: snapshot.heartbeatAvailable,
+        ...(snapshot.msSinceHeartbeat !== null ? { ms_since_heartbeat: snapshot.msSinceHeartbeat } : {}),
+        stream_close_observed: snapshot.streamCloseObserved,
+        server_availability: snapshot.serverAvailability,
+      },
+    },
+    fingerprint: ["network-health", "disconnect-classification", classification.source, classification.reason],
+  });
+};
 
 export const reportSubscriptionSetupTimeout = ({
   label,

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
@@ -87,6 +87,8 @@ export type WorldmapRenderCounter =
   | "armyAuthoritativeSweepConfirmedDead"
   | "armyAuthoritativeSweepReapplied"
   | "armyAuthoritativeSweepFailed"
+  | "armyAuthoritativeSweepSlowOp"
+  | "armyRecsSweepSlowPass"
   | "armyRecsSweepRemovedDeadZero"
   | "armyRecsSweepRemovedDeadMissing"
   | "armyRecsSweepSnappedPosition"
@@ -233,6 +235,8 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     armyAuthoritativeSweepConfirmedDead: 0,
     armyAuthoritativeSweepReapplied: 0,
     armyAuthoritativeSweepFailed: 0,
+    armyAuthoritativeSweepSlowOp: 0,
+    armyRecsSweepSlowPass: 0,
     armyRecsSweepRemovedDeadZero: 0,
     armyRecsSweepRemovedDeadMissing: 0,
     armyRecsSweepSnappedPosition: 0,

--- a/client/apps/game/src/three/scenes/worldmap-chunk-trace.ts
+++ b/client/apps/game/src/three/scenes/worldmap-chunk-trace.ts
@@ -41,7 +41,9 @@ export type WorldmapChunkTraceEvent =
   | "torii_resubscribe_completed"
   | "torii_resubscribe_failed"
   | "army_authoritative_sweep"
-  | "army_recs_sweep_heal";
+  | "army_authoritative_sweep_slow"
+  | "army_recs_sweep_heal"
+  | "army_recs_sweep_slow_pass";
 
 export interface WorldmapChunkTraceEntry {
   id: number;

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -5208,6 +5208,11 @@ export default class WorldmapScene extends WarpTravel {
 
     this.lastArmyRecsSweepAtMs = nowMs;
 
+    // Loop B runs synchronously inside update(); a pass over N armies that
+    // exceeds a frame budget drops frames and reads to players as a freeze. Time
+    // the whole pass so a perceived "disconnect" can be attributed to it (LOCAL).
+    const passStartedAtMs = performance.now();
+
     const candidates: ArmyRecsConsistencyCandidate[] = [];
     for (const army of this.armyManager.getArmies()) {
       const entityId = army.entityId;
@@ -5249,6 +5254,17 @@ export default class WorldmapScene extends WarpTravel {
 
     for (const action of actions) {
       this.applyArmyRecsConsistencyAction(action, nowMs);
+    }
+
+    const SWEEP_SLOW_PASS_WARN_MS = 16; // one 60fps frame budget
+    const passMs = performance.now() - passStartedAtMs;
+    if (passMs >= SWEEP_SLOW_PASS_WARN_MS) {
+      incrementWorldmapRenderCounter("armyRecsSweepSlowPass");
+      this.traceChunk("army_recs_sweep_slow_pass", {
+        candidateCount: candidates.length,
+        actionCount: actions.length,
+        passMs: Math.round(passMs),
+      });
     }
   }
 
@@ -5443,6 +5459,26 @@ export default class WorldmapScene extends WarpTravel {
           candidateCount: candidateIds.length,
           confirmedDead: result.confirmedDead,
           reappliedCount: result.reappliedCount,
+        });
+      }
+
+      // Loop A blocks the event loop while it awaits Torii/RECS. A single op this
+      // slow is the LOCAL-freeze signal Phase 3 is hunting — record it alongside
+      // heartbeat age so a "disconnect" can be traced back to a self-inflicted stall.
+      const SWEEP_SLOW_OP_WARN_MS = 100;
+      if (result.timing.maxQueryMs >= SWEEP_SLOW_OP_WARN_MS || result.timing.maxApplyMs >= SWEEP_SLOW_OP_WARN_MS) {
+        incrementWorldmapRenderCounter("armyAuthoritativeSweepSlowOp");
+        const connection = useConnectionStore.getState();
+        this.traceChunk("army_authoritative_sweep_slow", {
+          reason,
+          candidateCount: candidateIds.length,
+          maxQueryMs: Math.round(result.timing.maxQueryMs),
+          maxApplyMs: Math.round(result.timing.maxApplyMs),
+          totalMs: Math.round(result.timing.totalMs),
+          pageCount: result.timing.pageCount,
+          msSinceHeartbeat: connection.toriiHeartbeatAvailable
+            ? Math.round(Date.now() - connection.lastToriiHeartbeat)
+            : null,
         });
       }
     } finally {

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -7,10 +7,12 @@ import { createConnectionDeadEndRecoveryGate } from "@/dojo/connection-dead-end-
 import { createToriiHeartbeatLifecycle } from "@/dojo/torii-heartbeat-lifecycle";
 import { cancelEntityStreamSubscription, initialSync } from "@/dojo/sync";
 import { probeToriiHealth } from "@/dojo/torii-health-probe";
+import { fetchServerWorldAvailability } from "@/dojo/fetch-server-world-availability";
 import { requestGameRebootstrap } from "@/game-entry/bootstrap-controller";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import {
   addNetworkBreadcrumb,
+  reportDisconnectClassification,
   reportNetworkOutageDeadEnd,
   reportNetworkOutageResolved,
   setNetworkHealthScopeTags,
@@ -236,6 +238,17 @@ const ConnectionMonitor = () => {
         }
       },
       healthCheckFn: () => probeToriiHealth(toriiBaseUrl),
+      // Phase 2: independent server-side ground truth for the active world, so a
+      // disconnect can be split into LOCAL vs REMOTE rather than inferred.
+      getServerAvailability: () => fetchServerWorldAvailability(env.VITE_PUBLIC_REALTIME_URL, activeWorld?.name),
+      onDisconnectClassified: (classification, snapshot) => {
+        addNetworkBreadcrumb({
+          event: "outage_start",
+          streamType: "both",
+          status: `${classification.source}:${classification.reason}`,
+        });
+        reportDisconnectClassification(classification, snapshot);
+      },
       onRecovery: (outageMs, attempts) => {
         toast.success("Back online", {
           description: `Reconnected after ${Math.max(1, Math.round(outageMs / 1000))}s offline.`,

--- a/client/apps/game/src/ui/layouts/world.tsx
+++ b/client/apps/game/src/ui/layouts/world.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/dojo/connection-health-monitor";
 import { createConnectionDeadEndRecoveryGate } from "@/dojo/connection-dead-end-recovery-gate";
 import { createToriiHeartbeatLifecycle } from "@/dojo/torii-heartbeat-lifecycle";
-import { cancelEntityStreamSubscription, initialSync } from "@/dojo/sync";
+import { cancelEntityStreamSubscription, initialSync, resubscribeGlobalEntityStream } from "@/dojo/sync";
 import { probeToriiHealth } from "@/dojo/torii-health-probe";
 import { fetchServerWorldAvailability } from "@/dojo/fetch-server-world-availability";
 import { requestGameRebootstrap } from "@/game-entry/bootstrap-controller";
@@ -216,8 +216,14 @@ const ConnectionMonitor = () => {
       onReconnectGlobal: async () => {
         addNetworkBreadcrumb({ event: "reconnect_start", streamType: "global" });
         try {
-          cancelEntityStreamSubscription();
-          await initialSync(setup, state, () => {}, { logging: false, reportProgress: false });
+          if (env.VITE_PUBLIC_TORII_LIGHTWEIGHT_RECONNECT) {
+            // Re-open just the global stream; config/guilds/structures already
+            // live in RECS and a full initialSync would turn a blip into a reboot.
+            await resubscribeGlobalEntityStream(setup, { logging: false });
+          } else {
+            cancelEntityStreamSubscription();
+            await initialSync(setup, state, () => {}, { logging: false, reportProgress: false });
+          }
           addNetworkBreadcrumb({ event: "reconnect_success", streamType: "global" });
         } catch (error) {
           addNetworkBreadcrumb({
@@ -238,6 +244,15 @@ const ConnectionMonitor = () => {
         }
       },
       healthCheckFn: () => probeToriiHealth(toriiBaseUrl),
+      // Faster detect + recover (env-tunable per deploy): a lightweight heartbeat
+      // watchdog catches staleness in seconds, and adaptive backoff recovers a
+      // transient drop in ~1s instead of waiting out a flat 60s cooldown. Quiet
+      // streams are proactively refreshed to dodge proxy idle / max-age reaps.
+      staleThresholdMs: env.VITE_PUBLIC_TORII_STALE_THRESHOLD_MS,
+      heartbeatWatchdogIntervalMs: env.VITE_PUBLIC_TORII_HEARTBEAT_WATCHDOG_INTERVAL_MS,
+      minReconnectCooldownMs: env.VITE_PUBLIC_TORII_RECONNECT_MIN_COOLDOWN_MS,
+      maxReconnectCooldownMs: env.VITE_PUBLIC_TORII_RECONNECT_MAX_COOLDOWN_MS,
+      quietStreamRefreshMs: env.VITE_PUBLIC_TORII_QUIET_STREAM_REFRESH_MS,
       // Phase 2: independent server-side ground truth for the active world, so a
       // disconnect can be split into LOCAL vs REMOTE rather than inferred.
       getServerAvailability: () => fetchServerWorldAvailability(env.VITE_PUBLIC_REALTIME_URL, activeWorld?.name),


### PR DESCRIPTION
During games, players intermittently hit the 'Disconnected from the realm' banner, but the client never observes a real websocket close (torii-wasm exposes only cancel()), so local drops and remote stream/server failures were indistinguishable in telemetry. This adds a disconnect-source classifier that tags every outage local/remote/indeterminate at the moment overall status leaves connected, fed by newly-captured signals: browser offline/navigator.onLine, indexer-heartbeat intervals, the HTTP health-probe reason, tab visibility, a best-effort SDK stream-close observer, and an independent realtime-server world-availability check. It also times both army reconciliation loops (new render counters and chunk-trace events) and gives the authoritative sweep a fail-safe per-op query timeout, to rule out a self-inflicted local freeze masquerading as a disconnect. Verdicts are reported to Sentry and PostHog (torii_disconnect_classification), and the new pure modules ship with unit tests; the only recovery-behavior change is the additive sweep timeout.