### PR TITLE
Reduce explore transaction gas

### DIFF
--- a/client/apps/eternum-mobile/src/app/dojo/context/policies.ts
+++ b/client/apps/eternum-mobile/src/app/dojo/context/policies.ts
@@ -545,6 +545,10 @@ export const policies = toSessionPolicies({
           entrypoint: "explorer_move",
         },
         {
+          name: "explorer_explore_and_extract",
+          entrypoint: "explorer_explore_and_extract",
+        },
+        {
           name: "explorer_extract_reward",
           entrypoint: "explorer_extract_reward",
         },

--- a/client/apps/game/src/dojo/connection-disconnect-classification.test.ts
+++ b/client/apps/game/src/dojo/connection-disconnect-classification.test.ts
@@ -63,7 +63,9 @@ describe("classifyDisconnect", () => {
   });
 
   it("flags REMOTE (medium) when probe fails and server status is unknown", () => {
-    const result = classifyDisconnect(baseSignal({ healthProbeReason: "network_error", serverAvailability: "unknown" }));
+    const result = classifyDisconnect(
+      baseSignal({ healthProbeReason: "network_error", serverAvailability: "unknown" }),
+    );
     expect(result).toEqual({ source: "remote", confidence: "medium", reason: "probe_network_error" });
   });
 

--- a/client/apps/game/src/dojo/connection-health-monitor.ts
+++ b/client/apps/game/src/dojo/connection-health-monitor.ts
@@ -593,8 +593,7 @@ export class ConnectionHealthMonitor {
     return {
       onLine: navigatorOnLine,
       msSinceOffline: store.lastOfflineAt !== null ? now - store.lastOfflineAt : null,
-      visibilityState:
-        typeof document !== "undefined" && document.visibilityState === "hidden" ? "hidden" : "visible",
+      visibilityState: typeof document !== "undefined" && document.visibilityState === "hidden" ? "hidden" : "visible",
       healthProbeReason: this.resolveHealthProbeReason(),
       heartbeatAvailable: store.toriiHeartbeatAvailable,
       msSinceHeartbeat: store.toriiHeartbeatAvailable ? now - store.lastToriiHeartbeat : null,

--- a/client/apps/game/src/dojo/fetch-server-world-availability.test.ts
+++ b/client/apps/game/src/dojo/fetch-server-world-availability.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { fetchServerWorldAvailability } from "./fetch-server-world-availability";
 
-const jsonResponse = (body: unknown, ok = true): Response =>
-  ({ ok, json: async () => body }) as unknown as Response;
+const jsonResponse = (body: unknown, ok = true): Response => ({ ok, json: async () => body }) as unknown as Response;
 
 describe("fetchServerWorldAvailability", () => {
   it("returns 'unknown' without a base url or world name", async () => {

--- a/client/apps/game/src/hooks/context/policies.ts
+++ b/client/apps/game/src/hooks/context/policies.ts
@@ -756,6 +756,10 @@ export const buildPolicies = (manifest: any) => {
             entrypoint: "explorer_move",
           },
           {
+            name: "explorer_explore_and_extract",
+            entrypoint: "explorer_explore_and_extract",
+          },
+          {
             name: "explorer_extract_reward",
             entrypoint: "explorer_extract_reward",
           },

--- a/client/apps/game/src/observability/network-health-reporting.ts
+++ b/client/apps/game/src/observability/network-health-reporting.ts
@@ -3,10 +3,7 @@ import * as Sentry from "@sentry/react";
 import { env } from "../../env";
 import { getActiveWorld } from "@/runtime/world";
 import { captureClientEvent } from "@/posthog";
-import type {
-  DisconnectClassification,
-  DisconnectSignalSnapshot,
-} from "@/dojo/connection-disconnect-classification";
+import type { DisconnectClassification, DisconnectSignalSnapshot } from "@/dojo/connection-disconnect-classification";
 import { resolveUserIdentity } from "./wallet-identity";
 
 export type NetworkStreamType = "spatial" | "global" | "player" | "both";

--- a/contracts/game/dojo_dev.toml
+++ b/contracts/game/dojo_dev.toml
@@ -43,6 +43,7 @@ website = "https://alpha-eternum.realms.world/"
 	"s1_eternum-troop_raid_systems",
     "s1_eternum-troop_movement_systems",
     "s1_eternum-troop_movement_util_systems",
+    "s1_eternum-troop_movement_reward_systems",
     "s1_eternum-agent_discovery_systems",
     "s1_eternum-hyperstructure_discovery_systems",
     "s1_eternum-relic_chest_discovery_systems",

--- a/contracts/game/dojo_local.toml
+++ b/contracts/game/dojo_local.toml
@@ -43,6 +43,7 @@ website = "https://alpha-eternum.realms.world/"
 	"s1_eternum-troop_raid_systems",
     "s1_eternum-troop_movement_systems",
     "s1_eternum-troop_movement_util_systems",
+    "s1_eternum-troop_movement_reward_systems",
     "s1_eternum-agent_discovery_systems",
     "s1_eternum-hyperstructure_discovery_systems",
     "s1_eternum-relic_chest_discovery_systems",

--- a/contracts/game/dojo_sepolia.toml
+++ b/contracts/game/dojo_sepolia.toml
@@ -43,6 +43,7 @@ website = "https://eternum.realms.world/"
 	"s1_eternum-troop_raid_systems",
     "s1_eternum-troop_movement_systems",
     "s1_eternum-troop_movement_util_systems",
+    "s1_eternum-troop_movement_reward_systems",
     "s1_eternum-agent_discovery_systems",
     "s1_eternum-hyperstructure_discovery_systems",
     "s1_eternum-relic_chest_discovery_systems",

--- a/contracts/game/dojo_slot.toml
+++ b/contracts/game/dojo_slot.toml
@@ -44,6 +44,7 @@ website = "https://alpha-eternum.realms.world/"
 	"s1_eternum-troop_raid_systems",
     "s1_eternum-troop_movement_systems",
     "s1_eternum-troop_movement_util_systems",
+    "s1_eternum-troop_movement_reward_systems",
     "s1_eternum-agent_discovery_systems",
     "s1_eternum-hyperstructure_discovery_systems",
     "s1_eternum-relic_chest_discovery_systems",

--- a/contracts/game/dojo_slottest.toml
+++ b/contracts/game/dojo_slottest.toml
@@ -44,6 +44,7 @@ website = "https://alpha-eternum.realms.world/"
 	"s1_eternum-troop_raid_systems",
     "s1_eternum-troop_movement_systems",
     "s1_eternum-troop_movement_util_systems",
+    "s1_eternum-troop_movement_reward_systems",
     "s1_eternum-agent_discovery_systems",
     "s1_eternum-hyperstructure_discovery_systems",
     "s1_eternum-relic_chest_discovery_systems",

--- a/contracts/game/src/models/hyperstructure.cairo
+++ b/contracts/game/src/models/hyperstructure.cairo
@@ -210,6 +210,7 @@ pub struct PlayerRegisteredPoints {
 
 #[generate_trait]
 pub impl PlayerRegisteredPointsImpl of PlayerRegisteredPointsTrait {
+    #[inline(always)]
     fn register_points(ref world: WorldStorage, address: ContractAddress, points: u128) {
         if points.is_non_zero() {
             let mut player_registered_points: PlayerRegisteredPoints = world.read_model(address);

--- a/contracts/game/src/models/map2.cairo
+++ b/contracts/game/src/models/map2.cairo
@@ -59,6 +59,7 @@ const ALT_MASK: u128 = 0x1; // 1 bit
 
 #[generate_trait]
 pub impl TileOptDataWriteImpl of TileOptDataWriteTrait {
+    #[inline(always)]
     fn with_alt(data: u128, alt: bool) -> u128 {
         let value: u128 = if alt {
             1
@@ -68,26 +69,32 @@ pub impl TileOptDataWriteImpl of TileOptDataWriteTrait {
         Self::_set_field(data, value, ALT_SHIFT, ALT_MASK)
     }
 
+    #[inline(always)]
     fn with_col(data: u128, col: u32) -> u128 {
         Self::_set_field(data, col.into(), COL_SHIFT, COL_MASK)
     }
 
+    #[inline(always)]
     fn with_row(data: u128, row: u32) -> u128 {
         Self::_set_field(data, row.into(), ROW_SHIFT, ROW_MASK)
     }
 
+    #[inline(always)]
     fn with_biome(data: u128, biome: u8) -> u128 {
         Self::_set_field(data, biome.into(), BIOME_SHIFT, BIOME_MASK)
     }
 
+    #[inline(always)]
     fn with_occupier_id(data: u128, occupier_id: ID) -> u128 {
         Self::_set_field(data, occupier_id.into(), OCCUPIER_ID_SHIFT, OCCUPIER_ID_MASK)
     }
 
+    #[inline(always)]
     fn with_occupier_type(data: u128, occupier_type: u8) -> u128 {
         Self::_set_field(data, occupier_type.into(), OCCUPIER_TYPE_SHIFT, OCCUPIER_TYPE_MASK)
     }
 
+    #[inline(always)]
     fn with_occupier_is_structure(data: u128, occupier_is_structure: bool) -> u128 {
         let value: u128 = if occupier_is_structure {
             1
@@ -97,6 +104,7 @@ pub impl TileOptDataWriteImpl of TileOptDataWriteTrait {
         Self::_set_field(data, value, OCCUPIER_IS_STRUCTURE_SHIFT, OCCUPIER_IS_STRUCTURE_MASK)
     }
 
+    #[inline(always)]
     fn with_reward_extracted(data: u128, reward_extracted: bool) -> u128 {
         let value: u128 = if reward_extracted {
             1
@@ -106,6 +114,25 @@ pub impl TileOptDataWriteImpl of TileOptDataWriteTrait {
         Self::_set_field(data, value, REWARD_EXTRACTED_SHIFT, REWARD_EXTRACTED_MASK)
     }
 
+    #[inline(always)]
+    fn without_occupier(data: u128) -> u128 {
+        let data = Self::with_occupier_is_structure(data, false);
+        let data = Self::with_occupier_type(data, 0);
+        Self::with_occupier_id(data, 0)
+    }
+
+    #[inline(always)]
+    fn with_tile_state(
+        data: u128, biome: u8, occupier_type: u8, occupier_is_structure: bool, occupier_id: ID, reward_extracted: bool,
+    ) -> u128 {
+        let data = Self::with_biome(data, biome);
+        let data = Self::with_occupier_type(data, occupier_type);
+        let data = Self::with_occupier_is_structure(data, occupier_is_structure);
+        let data = Self::with_occupier_id(data, occupier_id);
+        Self::with_reward_extracted(data, reward_extracted)
+    }
+
+    #[inline(always)]
     fn _set_field(data: u128, value: u128, shift: u8, mask: u128) -> u128 {
         let shifted_mask = BitShift::shl(mask, shift.into());
         let cleared = data & ~shifted_mask;
@@ -116,41 +143,50 @@ pub impl TileOptDataWriteImpl of TileOptDataWriteTrait {
 
 #[generate_trait]
 pub impl TileOptDataReadImpl of TileOptDataReadTrait {
+    #[inline(always)]
     fn alt(data: u128) -> bool {
         let value = Self::_get_field(data, ALT_SHIFT, ALT_MASK);
         value != 0
     }
 
+    #[inline(always)]
     fn col(data: u128) -> u32 {
         Self::_get_field(data, COL_SHIFT, COL_MASK).try_into().unwrap()
     }
 
+    #[inline(always)]
     fn row(data: u128) -> u32 {
         Self::_get_field(data, ROW_SHIFT, ROW_MASK).try_into().unwrap()
     }
 
+    #[inline(always)]
     fn biome(data: u128) -> u8 {
         Self::_get_field(data, BIOME_SHIFT, BIOME_MASK).try_into().unwrap()
     }
 
+    #[inline(always)]
     fn occupier_id(data: u128) -> ID {
         Self::_get_field(data, OCCUPIER_ID_SHIFT, OCCUPIER_ID_MASK).try_into().unwrap()
     }
 
+    #[inline(always)]
     fn occupier_type(data: u128) -> u8 {
         Self::_get_field(data, OCCUPIER_TYPE_SHIFT, OCCUPIER_TYPE_MASK).try_into().unwrap()
     }
 
+    #[inline(always)]
     fn occupier_is_structure(data: u128) -> bool {
         let value = Self::_get_field(data, OCCUPIER_IS_STRUCTURE_SHIFT, OCCUPIER_IS_STRUCTURE_MASK);
         value != 0
     }
 
+    #[inline(always)]
     fn reward_extracted(data: u128) -> bool {
         let value = Self::_get_field(data, REWARD_EXTRACTED_SHIFT, REWARD_EXTRACTED_MASK);
         value != 0
     }
 
+    #[inline(always)]
     fn _get_field(data: u128, shift: u8, mask: u128) -> u128 {
         BitShift::shr(data, shift.into()) & mask
     }
@@ -158,6 +194,7 @@ pub impl TileOptDataReadImpl of TileOptDataReadTrait {
 
 #[generate_trait]
 pub impl TileOptDataPackImpl of TileOptDataPackTrait {
+    #[inline(always)]
     fn pack(
         alt: bool,
         col: u32,
@@ -182,6 +219,7 @@ pub impl TileOptDataPackImpl of TileOptDataPackTrait {
 }
 
 pub impl TileIntoTileOpt of Into<Tile, TileOpt> {
+    #[inline(always)]
     fn into(self: Tile) -> TileOpt {
         let data = TileOptDataPackTrait::pack(
             self.alt,
@@ -198,6 +236,7 @@ pub impl TileIntoTileOpt of Into<Tile, TileOpt> {
 }
 
 pub impl TileOptIntoTile of Into<TileOpt, Tile> {
+    #[inline(always)]
     fn into(self: TileOpt) -> Tile {
         let alt = self.alt;
         let col = self.col;

--- a/contracts/game/src/models/resource/resource.cairo
+++ b/contracts/game/src/models/resource/resource.cairo
@@ -34,11 +34,13 @@ impl SingleResourceDisplay of Display<SingleResource> {
 
 #[generate_trait]
 pub impl WeightStoreImpl of WeightStoreTrait {
+    #[inline(always)]
     fn retrieve(ref world: WorldStorage, entity_id: ID) -> Weight {
         assert!(entity_id.is_non_zero(), "entity id not found");
         ResourceImpl::read_weight(ref world, entity_id)
     }
 
+    #[inline(always)]
     fn store(ref self: Weight, ref world: WorldStorage, entity_id: ID) {
         ResourceImpl::write_weight(ref world, entity_id, self);
     }
@@ -46,6 +48,7 @@ pub impl WeightStoreImpl of WeightStoreTrait {
 
 #[generate_trait]
 pub impl ResourceWeightImpl of ResourceWeightTrait {
+    #[inline(always)]
     fn grams(ref world: WorldStorage, resource_type: u8) -> u128 {
         let unit_weight_config: WeightConfig = world.read_model(resource_type);
         unit_weight_config.weight_gram
@@ -55,6 +58,7 @@ pub impl ResourceWeightImpl of ResourceWeightTrait {
 
 #[generate_trait]
 pub impl SingleResourceStoreImpl of SingleResourceStoreTrait {
+    #[inline(always)]
     fn retrieve(
         ref world: WorldStorage,
         entity_id: ID,
@@ -93,6 +97,7 @@ pub impl SingleResourceStoreImpl of SingleResourceStoreTrait {
         return resource;
     }
 
+    #[inline(always)]
     fn store(ref self: SingleResource, ref world: WorldStorage) {
         ResourceImpl::write_balance(ref world, self.entity_id, self.resource_type, self.balance);
         if self.produces {
@@ -149,6 +154,7 @@ pub impl TroopResourceImpl of TroopResourceTrait {
 
 #[generate_trait]
 pub impl SingleResourceImpl of SingleResourceTrait {
+    #[inline(always)]
     fn ensure_correct_precision(ref self: SingleResource) {
         if RelicResourceImpl::is_relic(self.resource_type) {
             assert!(
@@ -158,6 +164,7 @@ pub impl SingleResourceImpl of SingleResourceTrait {
         }
     }
 
+    #[inline(always)]
     fn spend(ref self: SingleResource, amount: u128, ref entity_weight: Weight, unit_weight: u128) {
         assert!(self.balance >= amount, "Insufficient Balance: {} < {}", self, amount);
         self.balance -= amount;
@@ -167,6 +174,7 @@ pub impl SingleResourceImpl of SingleResourceTrait {
     }
 
 
+    #[inline(always)]
     fn add(ref self: SingleResource, amount: u128, ref entity_weight: Weight, unit_weight: u128) -> u128 {
         // todo: increase capacity with storehouse buildings
 
@@ -180,6 +188,7 @@ pub impl SingleResourceImpl of SingleResourceTrait {
         max_storable
     }
 
+    #[inline(always)]
     fn storable_amount(amount: u128, storage_left: u128, unit_weight: u128) -> (u128, u128) {
         let mut max_storable: u128 = amount;
         let mut total_weight: u128 = unit_weight * amount;
@@ -313,17 +322,20 @@ pub struct Resource {
 
 #[generate_trait]
 pub impl ResourceImpl of ResourceTrait {
+    #[inline(always)]
     fn initialize(ref world: WorldStorage, entity_id: ID) {
         let mut resource: Resource = Default::default();
         resource.entity_id = entity_id;
         world.write_model(@resource);
     }
 
+    #[inline(always)]
     fn read_balance(ref world: WorldStorage, entity_id: ID, resource_type: u8) -> u128 {
         return world
             .read_member(Model::<Resource>::ptr_from_keys(entity_id), Self::balance_selector(resource_type.into()));
     }
 
+    #[inline(always)]
     fn read_production(ref world: WorldStorage, entity_id: ID, resource_type: u8) -> Production {
         // Skip production for resources that don't have production mechanics
         if RelicResourceImpl::is_relic(resource_type) || resource_type == ResourceTypes::LORDS {
@@ -334,6 +346,7 @@ pub impl ResourceImpl of ResourceTrait {
     }
 
 
+    #[inline(always)]
     fn write_balance(ref world: WorldStorage, entity_id: ID, resource_type: u8, balance: u128) {
         world
             .write_member(
@@ -341,6 +354,7 @@ pub impl ResourceImpl of ResourceTrait {
             );
     }
 
+    #[inline(always)]
     fn write_production(ref world: WorldStorage, entity_id: ID, resource_type: u8, production: Production) {
         // Skip production for resources that don't have production mechanics
         if RelicResourceImpl::is_relic(resource_type) || resource_type == ResourceTypes::LORDS {
@@ -354,14 +368,17 @@ pub impl ResourceImpl of ResourceTrait {
             );
     }
 
+    #[inline(always)]
     fn read_weight(ref world: WorldStorage, entity_id: ID) -> Weight {
         return world.read_member(Model::<Resource>::ptr_from_keys(entity_id), selector!("weight"));
     }
 
+    #[inline(always)]
     fn write_weight(ref world: WorldStorage, entity_id: ID, weight: Weight) {
         world.write_member(Model::<Resource>::ptr_from_keys(entity_id), selector!("weight"), weight);
     }
 
+    #[inline(always)]
     fn balance_selector(resource_type: felt252) -> felt252 {
         match resource_type {
             0 => panic!("Invalid resource type"),

--- a/contracts/game/src/models/rng.cairo
+++ b/contracts/game/src/models/rng.cairo
@@ -1,6 +1,8 @@
 use dojo::model::ModelStorage;
 use dojo::world::WorldStorage;
 
+pub const RNG_TX_SEED_INCREMENT: u256 = 1432;
+
 #[derive(Introspect, Copy, Drop, Serde)]
 #[dojo::model]
 pub struct RNG {
@@ -15,7 +17,7 @@ pub impl RNGImpl of RNGTrait {
     // We get random numbers this way to make sure that during multicalls,
     // the same calls to the rng function returns different values.
     fn ensure_unique_tx_seed(ref world: WorldStorage, ref rng: RNG) -> RNG {
-        rng.seed += 1432; // random number
+        rng.seed += RNG_TX_SEED_INCREMENT;
         world.write_model(@rng);
         rng
     }

--- a/contracts/game/src/models/stamina.cairo
+++ b/contracts/game/src/models/stamina.cairo
@@ -11,16 +11,19 @@ pub struct Stamina {
 
 #[generate_trait]
 pub impl StaminaImpl of StaminaTrait {
+    #[inline(always)]
     fn reset(ref self: Stamina) {
         self.amount = 0;
         self.updated_tick = 0;
     }
 
+    #[inline(always)]
     fn grant_initial_amount(ref self: Stamina, troop_stamina_config: TroopStaminaConfig, current_tick: u64) {
         self.amount = troop_stamina_config.stamina_initial.into();
         self.updated_tick = current_tick;
     }
 
+    #[inline(always)]
     fn revert_initial_amount(ref self: Stamina, troop_stamina_config: TroopStaminaConfig, current_tick: u64) {
         if self.amount > troop_stamina_config.stamina_initial.into() {
             self.grant_initial_amount(troop_stamina_config, current_tick);
@@ -28,6 +31,7 @@ pub impl StaminaImpl of StaminaTrait {
     }
 
 
+    #[inline(always)]
     fn refill(
         ref self: Stamina,
         ref troop_boosts: TroopBoosts,
@@ -72,6 +76,7 @@ pub impl StaminaImpl of StaminaTrait {
         }
     }
 
+    #[inline(always)]
     fn spend(
         ref self: Stamina,
         ref troop_boosts: TroopBoosts,
@@ -95,6 +100,7 @@ pub impl StaminaImpl of StaminaTrait {
         }
     }
 
+    #[inline(always)]
     fn add(
         ref self: Stamina,
         ref troop_boosts: TroopBoosts,
@@ -110,6 +116,7 @@ pub impl StaminaImpl of StaminaTrait {
     }
 
 
+    #[inline(always)]
     fn max(troop_type: TroopType, troop_tier: TroopTier, troop_stamina_config: TroopStaminaConfig) -> u64 {
         let initial_max = match troop_type {
             TroopType::Knight => troop_stamina_config.stamina_knight_max.into(),

--- a/contracts/game/src/models/weight.cairo
+++ b/contracts/game/src/models/weight.cairo
@@ -23,6 +23,7 @@ pub impl WeightZeroableImpl of Zero<Weight> {
 
 #[generate_trait]
 pub impl WeightImpl of WeightTrait {
+    #[inline(always)]
     fn deduct_capacity(ref self: Weight, amount: u128, is_troop: bool) {
         if self.capacity != Bounded::MAX {
             self.capacity -= amount;
@@ -37,12 +38,14 @@ pub impl WeightImpl of WeightTrait {
     }
 
 
+    #[inline(always)]
     fn add_capacity(ref self: Weight, amount: u128) {
         if self.capacity != Bounded::MAX {
             self.capacity += amount;
         }
     }
 
+    #[inline(always)]
     fn deduct(ref self: Weight, amount: u128) {
         if self.capacity != Bounded::MAX {
             // this should never happen. check is a contract sanity check
@@ -51,6 +54,7 @@ pub impl WeightImpl of WeightTrait {
         }
     }
 
+    #[inline(always)]
     fn add(ref self: Weight, amount: u128) {
         // the amount > 0 check fixes the case where there is an error
         // if entity weight > capacity and you try to add a weightless resource
@@ -60,6 +64,7 @@ pub impl WeightImpl of WeightTrait {
         }
     }
 
+    #[inline(always)]
     fn unused(ref self: Weight) -> u128 {
         if self.capacity != Bounded::MAX {
             if self.weight > self.capacity {

--- a/contracts/game/src/systems.cairo
+++ b/contracts/game/src/systems.cairo
@@ -70,6 +70,7 @@ pub mod combat {
         mod test_troop_battle;
         mod test_troop_management;
         mod test_troop_movement;
+        mod test_troop_movement_active;
     }
     pub mod contracts {
         pub mod troop_battle;

--- a/contracts/game/src/systems/combat/contracts/troop_movement.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_movement.cairo
@@ -6,6 +6,9 @@ pub trait ITroopMovementSystems<TContractState> {
     fn explorer_move(
         ref self: TContractState, explorer_id: ID, directions: Span<Direction>, explore: bool,
     ) -> Span<Tile>;
+    fn explorer_explore_and_extract(
+        ref self: TContractState, explorer_id: ID, directions: Span<Direction>,
+    ) -> Span<Tile>;
     fn explorer_extract_reward(ref self: TContractState, explorer_id: ID);
 }
 
@@ -13,11 +16,12 @@ pub trait ITroopMovementSystems<TContractState> {
 pub mod troop_movement_systems {
     use core::num::traits::zero::Zero;
     use dojo::event::EventStorage;
-    use dojo::model::ModelStorage;
-    use dojo::world::{IWorldDispatcherTrait, WorldStorageTrait};
+    use dojo::model::{Model, ModelStorage};
+    use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
     use starknet::ContractAddress;
     use crate::alias::ID;
-    use crate::constants::DEFAULT_NS;
+    use crate::constants::{DAYDREAMS_AGENT_ID, DEFAULT_NS, RESOURCE_PRECISION, ResourceTypes};
+    use crate::models::agent::AgentOwner;
     use crate::models::config::{
         BlitzExplorationConfig, CombatConfigImpl, MapConfig, SeasonConfigImpl, TickImpl, TickTrait, TroopLimitConfig,
         TroopStaminaConfig, VictoryPointsGrantConfig, WorldConfigUtilImpl,
@@ -28,15 +32,18 @@ pub mod troop_movement_systems {
     };
     use crate::models::hyperstructure::PlayerRegisteredPointsImpl;
     use crate::models::map::{BiomeDiscovered, Tile, TileImpl, TileOccupier};
-    use crate::models::map2::TileOpt;
+    use crate::models::map2::{TileOpt, TileOptDataReadTrait, TileOptDataWriteTrait};
+    use crate::models::owner::OwnerAddressTrait;
     use crate::models::position::{Coord, CoordTrait, Direction};
+    use crate::models::resource::production::production::Production;
     use crate::models::resource::resource::{
-        ResourceWeightImpl, SingleResourceImpl, SingleResourceStoreImpl, WeightStoreImpl,
+        Resource, ResourceImpl, ResourceWeightImpl, SingleResourceImpl, SingleResourceStoreImpl, WeightStoreImpl,
     };
+    use crate::models::rng::{RNG, RNG_TX_SEED_INCREMENT};
+    use crate::models::stamina::StaminaTrait;
     use crate::models::structure::{StructureBaseStoreImpl, StructureOwnerStoreImpl};
-    use crate::models::troop::{ExplorerTroops, GuardImpl};
-    use crate::models::weight::Weight;
-    use crate::system_libraries::biome_library::{IBiomeLibraryDispatcherTrait, biome_library};
+    use crate::models::troop::{ExplorerTroops, GuardImpl, TroopsTrait};
+    use crate::models::weight::{Weight, WeightImpl};
     use crate::system_libraries::rng_library::{IRNGlibraryDispatcherTrait, rng_library};
     use crate::systems::utils::blitz_profile::iBlitzProfileImpl;
     use crate::systems::utils::hyperstructure::iHyperstructureDiscoveryImpl;
@@ -45,9 +52,13 @@ pub mod troop_movement_systems {
     use crate::systems::utils::troop::{iAgentDiscoveryImpl, iExplorerImpl, iTroopImpl};
     use crate::utils::achievements::index::{AchievementTrait, Tasks};
     use crate::utils::cartridge::vrf::Source;
-    use crate::utils::map::biomes::Biome;
-    use crate::utils::random::VRFImpl;
-    use super::{ITroopMovementSystems, ITroopMovementUtilSystemsDispatcher, ITroopMovementUtilSystemsDispatcherTrait};
+    use crate::utils::map::biomes::{Biome, get_biome_from_world};
+    use crate::utils::math::PercentageValueImpl;
+    use crate::utils::random::{VRFImpl, random};
+    use super::{
+        ITroopMovementSystems, ITroopMovementUtilSystemsDispatcher, ITroopMovementUtilSystemsDispatcherTrait,
+        movement_discovery,
+    };
 
     // to be removed
     #[derive(Copy, Drop, Serde)]
@@ -73,6 +84,9 @@ pub mod troop_movement_systems {
         pub coord: Coord,
         pub timestamp: u64,
     }
+
+    const NON_BLITZ_EXPLORATION_REWARD_WEIGHT_TOTAL: u128 = 10_022_132;
+
     #[abi(embed_v0)]
     impl TroopMovementSystemsImpl of ITroopMovementSystems<ContractState> {
         fn explorer_move(
@@ -130,8 +144,7 @@ pub mod troop_movement_systems {
                 assert!(tile.not_occupied(), "one of the tiles in path is occupied");
 
                 // add biome to biomes
-                let biome_library = biome_library::get_dispatcher(@world);
-                let biome = biome_library.get_biome(world, next.alt, next.x.into(), next.y.into());
+                let biome = get_biome_from_world(world, next.alt, next.x.into(), next.y.into());
                 biomes.append(biome);
 
                 let mut occupy_destination: bool = true;
@@ -160,8 +173,8 @@ pub mod troop_movement_systems {
                     // ensure target tile is not explored
                     assert!(!tile.discovered(), "tile is already explored");
 
-                    // set tile as explored
-                    IMapImpl::explore(ref world, ref tile, biome);
+                    // set tile as explored in memory; the final occupancy write stores the packed tile once.
+                    IMapImpl::explore_memory(ref tile, biome);
 
                     // register points for player
                     PlayerRegisteredPointsImpl::register_points(
@@ -280,9 +293,6 @@ pub mod troop_movement_systems {
                         let from_tile_opt: TileOpt = world.read_model((from.alt, from.x, from.y));
                         let mut from_tile: Tile = from_tile_opt.into();
                         IMapImpl::occupy(ref world, ref from_tile, tile_occupier, explorer_id);
-
-                        let from_tile_opt: TileOpt = from_tile.into();
-                        world.write_model(@from_tile_opt);
                     }
                     tiles_to_return.append(tile);
                     break;
@@ -358,6 +368,136 @@ pub mod troop_movement_systems {
 
             // update explorer
             world.write_model(@explorer);
+
+            tiles_to_return.span()
+        }
+
+        fn explorer_explore_and_extract(
+            ref self: ContractState, explorer_id: ID, mut directions: Span<Direction>,
+        ) -> Span<Tile> {
+            let mut tiles_to_return: Array<Tile> = array![];
+
+            assert!(directions.len().is_non_zero(), "directions must be more than 0");
+            let original_directions = directions;
+
+            let mut world = self.world(DEFAULT_NS());
+            SeasonConfigImpl::get(world).assert_started_and_not_over();
+
+            let mut explorer: ExplorerTroops = world.read_model(explorer_id);
+            let caller = starknet::get_caller_address();
+            let explorer_owner = assert_explorer_caller_and_resolve_event_owner(ref world, explorer, caller);
+
+            let start_coord = explorer.coord;
+            assert!(explorer.troops.count.is_non_zero(), "explorer is dead");
+
+            let from = explorer.coord;
+            let mut source_tile_opt: TileOpt = world.read_model((from.alt, from.x, from.y));
+            assert!(
+                explorer_id == TileOptDataReadTrait::occupier_id(source_tile_opt.data),
+                "tile occupier should be explorer",
+            );
+
+            let block_timestamp = starknet::get_block_timestamp();
+            let current_tick: u64 = TickImpl::get_tick_interval(ref world).current();
+            let troop_stamina_config: TroopStaminaConfig = CombatConfigImpl::troop_stamina_config(ref world);
+            let victory_points_grant_config: VictoryPointsGrantConfig = WorldConfigUtilImpl::get_member(
+                world, selector!("victory_points_grant_config"),
+            );
+            let map_config: MapConfig = WorldConfigUtilImpl::get_member(world, selector!("map_config"));
+            let blitz_mode_on: bool = WorldConfigUtilImpl::get_member(world, selector!("blitz_mode_on"));
+            let season_mode_on = !blitz_mode_on;
+
+            let next = explorer.coord.neighbor(*directions.pop_front().unwrap());
+            let mut target_tile_opt: TileOpt = world.read_model((next.alt, next.x, next.y));
+            let mut target_tile: Tile = target_tile_opt.into();
+            assert!(target_tile.not_occupied(), "one of the tiles in path is occupied");
+            assert!(directions.len().is_zero(), "explorer can only move one direction when exploring");
+
+            let biome = get_biome_from_world(world, next.alt, next.x.into(), next.y.into());
+
+            let (explore, explore_find, occupy_destination, movement_vrf_seed) = discover_target_if_needed(
+                ref world,
+                ref target_tile,
+                caller,
+                next,
+                biome,
+                map_config,
+                troop_stamina_config,
+                victory_points_grant_config,
+                current_tick,
+                block_timestamp,
+                season_mode_on,
+            );
+
+            explorer.coord = next;
+            let explorer_occupier_type = TileOptDataReadTrait::occupier_type(source_tile_opt.data);
+            let explorer_occupier_is_structure = TileOptDataReadTrait::occupier_is_structure(source_tile_opt.data);
+
+            let mut reward_tile: Tile = target_tile;
+            if occupy_destination {
+                occupy_tile_with_existing_occupier_memory(
+                    ref target_tile, explorer_occupier_type, explorer_occupier_is_structure, explorer_id,
+                );
+                reward_tile = target_tile;
+            } else {
+                explorer.coord = from;
+                let source_tile: Tile = source_tile_opt.into();
+                reward_tile = source_tile;
+            }
+
+            let tile_to_return = target_tile;
+            tiles_to_return.append(tile_to_return);
+
+            assert!(explorer.coord.alt == false, "Eternum: explorer must be on surface to extract reward");
+            assert!(explorer_id == reward_tile.occupier_id, "tile occupier should be explorer");
+            assert!(reward_tile.biome != Biome::None.into(), "tile must be explored");
+
+            let reward_vrf_seed: u256 = movement_vrf_seed + RNG_TX_SEED_INCREMENT;
+            let should_grant_reward = !reward_tile.reward_extracted;
+            if should_grant_reward {
+                IMapImpl::mark_reward_extracted_memory(ref reward_tile);
+            }
+
+            store_combined_explore_tiles(
+                ref world, ref source_tile_opt, ref target_tile_opt, reward_tile, occupy_destination,
+            );
+
+            burn_single_step_stamina_cost(ref explorer, troop_stamina_config, explore, biome, current_tick);
+            burn_explorer_food_cost_with_deferred_weight_store(ref world, explorer, troop_stamina_config, explore);
+
+            let tx_hash = starknet::get_tx_info().unbox().transaction_hash;
+            emit_explorer_move_stories(
+                ref world,
+                explorer,
+                explorer_owner,
+                caller,
+                explorer_id,
+                start_coord,
+                original_directions,
+                explore,
+                explore_find,
+                victory_points_grant_config,
+                tx_hash,
+                block_timestamp,
+            );
+
+            world.write_model(@explorer);
+
+            if should_grant_reward {
+                grant_explorer_reward_and_emit(
+                    ref world,
+                    explorer,
+                    explorer_owner,
+                    caller,
+                    reward_tile,
+                    reward_vrf_seed,
+                    current_tick,
+                    map_config,
+                    blitz_mode_on,
+                    tx_hash,
+                    block_timestamp,
+                );
+            }
 
             tiles_to_return.span()
         }
@@ -471,6 +611,603 @@ pub mod troop_movement_systems {
                 );
         }
     }
+
+    #[inline(always)]
+    fn discover_target_if_needed(
+        ref world: WorldStorage,
+        ref target_tile: Tile,
+        caller: ContractAddress,
+        target_coord: Coord,
+        biome: Biome,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        victory_points_grant_config: VictoryPointsGrantConfig,
+        current_tick: u64,
+        block_timestamp: u64,
+        season_mode_on: bool,
+    ) -> (bool, ExploreFind, bool, u256) {
+        if target_tile.discovered() {
+            let movement_vrf_seed = derive_initial_tx_random_seed(ref world, Source::Salt(target_tile.to_seed()));
+            return (false, ExploreFind::None, true, movement_vrf_seed);
+        }
+
+        IMapImpl::explore_memory(ref target_tile, biome);
+
+        PlayerRegisteredPointsImpl::register_points(
+            ref world, caller, victory_points_grant_config.explore_tiles_points.into(),
+        );
+
+        let vrf_seed: u256 = derive_initial_tx_random_seed(ref world, Source::Salt(target_tile.to_seed()));
+        let (found_treasure, explore_find) = movement_discovery::find_treasure(
+            ref world, vrf_seed, target_tile, caller, map_config, troop_stamina_config, current_tick, season_mode_on,
+        );
+
+        let mut occupy_destination = true;
+        if found_treasure {
+            occupy_destination = false;
+            let target_tile_opt: TileOpt = world.read_model((target_coord.alt, target_coord.x, target_coord.y));
+            target_tile = target_tile_opt.into();
+        }
+
+        AchievementTrait::progress(world, caller.into(), Tasks::EXPLORE, 1, block_timestamp);
+        progress_discovery_achievement(world, caller, explore_find, block_timestamp);
+        mark_biome_discovered_if_needed(ref world, caller, biome, block_timestamp);
+
+        (true, explore_find, occupy_destination, vrf_seed)
+    }
+
+    #[inline(always)]
+    fn store_combined_explore_tiles(
+        ref world: WorldStorage,
+        ref source_tile_opt: TileOpt,
+        ref target_tile_opt: TileOpt,
+        reward_tile: Tile,
+        occupy_destination: bool,
+    ) {
+        if occupy_destination {
+            source_tile_opt.data = TileOptDataWriteTrait::without_occupier(source_tile_opt.data);
+            target_tile_opt
+                .data =
+                    TileOptDataWriteTrait::with_tile_state(
+                        target_tile_opt.data,
+                        reward_tile.biome,
+                        reward_tile.occupier_type,
+                        reward_tile.occupier_is_structure,
+                        reward_tile.occupier_id,
+                        reward_tile.reward_extracted,
+                    );
+            world.write_model(@source_tile_opt);
+            world.write_model(@target_tile_opt);
+        } else {
+            source_tile_opt
+                .data =
+                    TileOptDataWriteTrait::with_reward_extracted(source_tile_opt.data, reward_tile.reward_extracted);
+            world.write_model(@source_tile_opt);
+        }
+    }
+
+    #[inline(always)]
+    fn progress_discovery_achievement(
+        world: WorldStorage, caller: ContractAddress, explore_find: ExploreFind, block_timestamp: u64,
+    ) {
+        match explore_find {
+            ExploreFind::None => {},
+            ExploreFind::Hyperstructure => {
+                AchievementTrait::progress(world, caller.into(), Tasks::HYPERSTRUCTURE_DISCOVER, 1, block_timestamp);
+            },
+            ExploreFind::Mine => {
+                AchievementTrait::progress(world, caller.into(), Tasks::MINE_DISCOVER, 1, block_timestamp);
+            },
+            ExploreFind::Agent => {
+                AchievementTrait::progress(world, caller.into(), Tasks::AGENT_DISCOVER, 1, block_timestamp);
+            },
+            ExploreFind::Quest => {
+                AchievementTrait::progress(world, caller.into(), Tasks::QUEST_DISCOVER, 1, block_timestamp);
+            },
+            ExploreFind::Village => {},
+            ExploreFind::HolySite => {
+                AchievementTrait::progress(world, caller.into(), Tasks::HOLYSITE_DISCOVER, 1, block_timestamp);
+            },
+            ExploreFind::Camp => {
+                AchievementTrait::progress(world, caller.into(), Tasks::CAMP_DISCOVER, 1, block_timestamp);
+            },
+            ExploreFind::BitcoinMine => {},
+        }
+    }
+
+    #[inline(always)]
+    fn mark_biome_discovered_if_needed(
+        ref world: WorldStorage, caller: ContractAddress, biome: Biome, block_timestamp: u64,
+    ) {
+        let biome_u8: u8 = biome.into();
+        let mut biome_discovered: BiomeDiscovered = world.read_model((caller, biome_u8));
+        if !biome_discovered.discovered {
+            biome_discovered.discovered = true;
+            world.write_model(@biome_discovered);
+
+            AchievementTrait::progress(world, caller.into(), Tasks::BIOME_DISCOVER, 1, block_timestamp);
+        }
+    }
+
+    #[inline(always)]
+    fn assert_explorer_caller_and_resolve_event_owner(
+        ref world: WorldStorage, explorer: ExplorerTroops, caller: ContractAddress,
+    ) -> ContractAddress {
+        if explorer.owner == DAYDREAMS_AGENT_ID {
+            let agent_owner: AgentOwner = world.read_model(explorer.explorer_id);
+            assert!(agent_owner.address == caller, "caller is not the agent owner");
+            return StructureOwnerStoreImpl::retrieve(ref world, explorer.owner);
+        }
+
+        let explorer_owner = StructureOwnerStoreImpl::retrieve(ref world, explorer.owner);
+        explorer_owner.assert_caller_owner();
+        explorer_owner
+    }
+
+    #[inline(always)]
+    fn derive_initial_tx_random_seed(ref world: WorldStorage, source: Source) -> u256 {
+        let tx_hash = starknet::get_tx_info().unbox().transaction_hash;
+        let rng: RNG = world.read_model(tx_hash);
+        let mut seed = rng.seed;
+        if seed.is_zero() {
+            let vrf_provider: ContractAddress = WorldConfigUtilImpl::get_member(
+                world, selector!("vrf_provider_address"),
+            );
+            seed = VRFImpl::seed(source, vrf_provider);
+        }
+        seed + RNG_TX_SEED_INCREMENT
+    }
+
+    #[inline(always)]
+    fn occupy_tile_with_existing_occupier_memory(
+        ref tile: Tile, occupier_type: u8, occupier_is_structure: bool, occupier_id: ID,
+    ) {
+        tile.occupier_type = occupier_type;
+        tile.occupier_id = occupier_id;
+        tile.occupier_is_structure = occupier_is_structure;
+    }
+
+    #[inline(always)]
+    fn emit_explorer_move_stories(
+        ref world: WorldStorage,
+        explorer: ExplorerTroops,
+        explorer_owner: ContractAddress,
+        caller: ContractAddress,
+        explorer_id: ID,
+        start_coord: Coord,
+        original_directions: Span<Direction>,
+        explore: bool,
+        explore_find: ExploreFind,
+        victory_points_grant_config: VictoryPointsGrantConfig,
+        tx_hash: felt252,
+        block_timestamp: u64,
+    ) {
+        world
+            .emit_event(
+                @StoryEvent {
+                    id: world.dispatcher.uuid(),
+                    owner: Option::Some(explorer_owner),
+                    entity_id: Option::Some(explorer_id),
+                    tx_hash,
+                    story: Story::ExplorerMoveStory(
+                        ExplorerMoveStory {
+                            explorer_owner,
+                            explorer_id,
+                            explorer_structure_id: explorer.owner,
+                            start_coord,
+                            end_coord: explorer.coord,
+                            directions: original_directions,
+                            explore,
+                            explore_find,
+                        },
+                    ),
+                    timestamp: block_timestamp,
+                },
+            );
+
+        if explore {
+            let points_registered_story = PointsRegisteredStory {
+                owner_address: explorer_owner,
+                activity: PointsActivity::Exploration,
+                points: victory_points_grant_config.explore_tiles_points.into(),
+            };
+            world
+                .emit_event(
+                    @StoryEvent {
+                        id: world.dispatcher.uuid(),
+                        owner: Option::Some(explorer_owner),
+                        entity_id: Option::Some(explorer_id),
+                        tx_hash,
+                        story: Story::PointsRegisteredStory(points_registered_story),
+                        timestamp: block_timestamp,
+                    },
+                );
+        }
+
+        world
+            .emit_event(
+                @ExplorerMoveEvent {
+                    explorer_id,
+                    explorer_structure_id: explorer.owner,
+                    explorer_owner_address: caller,
+                    explore_find: explore_find,
+                    timestamp: block_timestamp,
+                },
+            );
+    }
+
+    #[inline(always)]
+    fn grant_explorer_reward_and_emit(
+        ref world: WorldStorage,
+        explorer: ExplorerTroops,
+        explorer_owner: ContractAddress,
+        caller: ContractAddress,
+        reward_tile: Tile,
+        vrf_seed: u256,
+        current_tick: u64,
+        map_config: MapConfig,
+        blitz_mode_on: bool,
+        tx_hash: felt252,
+        block_timestamp: u64,
+    ) {
+        let blitz_exploration_reward_profile_id = if blitz_mode_on {
+            let blitz_exploration_config: BlitzExplorationConfig = WorldConfigUtilImpl::get_member(
+                world, selector!("blitz_exploration_config"),
+            );
+            iBlitzProfileImpl::resolve_blitz_profile_id(blitz_exploration_config.reward_profile_id)
+        } else {
+            0
+        };
+
+        let (explore_reward_type, explore_reward_amount) = if blitz_mode_on {
+            iExplorerImpl::exploration_reward(
+                ref world,
+                Option::Some(explorer),
+                current_tick,
+                map_config,
+                vrf_seed,
+                blitz_mode_on,
+                blitz_exploration_reward_profile_id,
+            )
+        } else {
+            non_blitz_exploration_reward(explorer, current_tick, map_config, vrf_seed, block_timestamp)
+        };
+
+        if blitz_mode_on {
+            let exploration_reward_receiver = iExplorerImpl::exploration_reward_receiver(
+                ref world, blitz_mode_on, explorer, explore_reward_type,
+            );
+            grant_resource_reward_to_producing_receiver(
+                ref world, exploration_reward_receiver, explore_reward_type, explore_reward_amount,
+            );
+        } else {
+            grant_resource_reward_to_non_producing_receiver(
+                ref world, explorer.explorer_id, explore_reward_type, explore_reward_amount,
+            );
+        }
+
+        world
+            .emit_event(
+                @StoryEvent {
+                    id: world.dispatcher.uuid(),
+                    owner: Option::Some(explorer_owner),
+                    entity_id: Option::Some(explorer.explorer_id),
+                    tx_hash,
+                    story: Story::ExplorerExtractRewardStory(
+                        ExplorerExtractRewardStory {
+                            explorer_owner,
+                            explorer_id: explorer.explorer_id,
+                            explorer_structure_id: explorer.owner,
+                            coord: reward_tile.into(),
+                            reward_resource_type: explore_reward_type,
+                            reward_resource_amount: explore_reward_amount,
+                        },
+                    ),
+                    timestamp: block_timestamp,
+                },
+            );
+
+        world
+            .emit_event(
+                @ExplorerRewardEvent {
+                    explorer_id: explorer.explorer_id,
+                    explorer_structure_id: explorer.owner,
+                    explorer_owner_address: caller,
+                    reward_resource_id: explore_reward_type,
+                    reward_resource_amount: explore_reward_amount,
+                    coord: explorer.coord,
+                    timestamp: block_timestamp,
+                },
+            );
+    }
+
+    #[inline(always)]
+    fn grant_resource_reward_to_producing_receiver(
+        ref world: WorldStorage, entity_id: ID, resource_type: u8, amount: u128,
+    ) {
+        assert!(entity_id.is_non_zero(), "entity id not found");
+        assert!(resource_type.is_non_zero(), "invalid resource specified");
+
+        let resource_weight_grams: u128 = ResourceWeightImpl::grams(ref world, resource_type);
+        let mut entity_weight: Weight = WeightStoreImpl::retrieve(ref world, entity_id);
+        let mut resource = SingleResourceStoreImpl::retrieve(
+            ref world, entity_id, resource_type, ref entity_weight, resource_weight_grams, true,
+        );
+        resource.add(amount, ref entity_weight, resource_weight_grams);
+        resource.store(ref world);
+        entity_weight.store(ref world, entity_id);
+    }
+
+    #[inline(always)]
+    fn grant_resource_reward_to_non_producing_receiver(
+        ref world: WorldStorage, entity_id: ID, resource_type: u8, amount: u128,
+    ) {
+        assert!(entity_id.is_non_zero(), "entity id not found");
+        assert!(resource_type.is_non_zero(), "invalid resource specified");
+
+        let resource_weight_grams: u128 = ResourceWeightImpl::grams(ref world, resource_type);
+        let mut entity_weight: Weight = WeightStoreImpl::retrieve(ref world, entity_id);
+        let balance: u128 = ResourceImpl::read_balance(ref world, entity_id, resource_type);
+        let (storable_amount, total_weight) = storable_resource_amount(
+            amount, entity_weight.unused(), resource_weight_grams,
+        );
+        ResourceImpl::write_balance(ref world, entity_id, resource_type, balance + storable_amount);
+        entity_weight.add(total_weight);
+        entity_weight.store(ref world, entity_id);
+    }
+
+    #[inline(always)]
+    fn storable_resource_amount(amount: u128, storage_left: u128, unit_weight: u128) -> (u128, u128) {
+        let mut max_storable: u128 = amount;
+        let mut total_weight: u128 = unit_weight * amount;
+
+        if storage_left < total_weight {
+            max_storable = storage_left / unit_weight;
+            total_weight = max_storable * unit_weight;
+        }
+
+        (max_storable, total_weight)
+    }
+
+    #[inline(always)]
+    fn non_blitz_exploration_reward(
+        explorer: ExplorerTroops, current_tick: u64, map_config: MapConfig, vrf_seed: u256, block_timestamp: u64,
+    ) -> (u8, u128) {
+        let reward_resource_type = non_blitz_exploration_reward_resource(vrf_seed, block_timestamp);
+        let reward_resource_amount = non_blitz_exploration_reward_amount(explorer, current_tick, map_config);
+        (reward_resource_type, reward_resource_amount)
+    }
+
+    #[inline(always)]
+    fn non_blitz_exploration_reward_amount(explorer: ExplorerTroops, current_tick: u64, map_config: MapConfig) -> u128 {
+        let mut reward_resource_amount: u128 = map_config.reward_resource_amount.into();
+        let mut reward_boost_percent: u128 = explorer.troops.boosts.incr_explore_reward_percent_num.into();
+        if reward_boost_percent.is_zero() {
+            return reward_resource_amount * RESOURCE_PRECISION;
+        }
+        if current_tick > explorer.troops.boosts.incr_explore_reward_end_tick.into() {
+            return reward_resource_amount * RESOURCE_PRECISION;
+        }
+
+        reward_resource_amount += (reward_resource_amount * reward_boost_percent) / PercentageValueImpl::_100().into();
+        reward_resource_amount * RESOURCE_PRECISION
+    }
+
+    #[inline(always)]
+    fn non_blitz_exploration_reward_resource(vrf_seed: u256, block_timestamp: u64) -> u8 {
+        let reward_salt: u128 = block_timestamp.into() + 18;
+        let reward_roll = random(vrf_seed, reward_salt, NON_BLITZ_EXPLORATION_REWARD_WEIGHT_TOTAL);
+        non_blitz_exploration_reward_resource_from_roll(reward_roll)
+    }
+
+    #[inline(always)]
+    fn non_blitz_exploration_reward_resource_from_roll(reward_roll: u128) -> u8 {
+        if reward_roll < 2_018_108 {
+            return ResourceTypes::WOOD;
+        }
+        if reward_roll < 3_604_023 {
+            return ResourceTypes::STONE;
+        }
+        if reward_roll < 5_146_478 {
+            return ResourceTypes::COAL;
+        }
+        if reward_roll < 6_210_059 {
+            return ResourceTypes::COPPER;
+        }
+        if reward_roll < 7_101_809 {
+            return ResourceTypes::OBSIDIAN;
+        }
+        if reward_roll < 7_802_413 {
+            return ResourceTypes::SILVER;
+        }
+        if reward_roll < 8_276_860 {
+            return ResourceTypes::IRONWOOD;
+        }
+        if reward_roll < 8_661_971 {
+            return ResourceTypes::COLD_IRON;
+        }
+        if reward_roll < 9_029_778 {
+            return ResourceTypes::GOLD;
+        }
+        if reward_roll < 9_268_812 {
+            return ResourceTypes::HARTWOOD;
+        }
+        if reward_roll < 9_389_536 {
+            return ResourceTypes::DIAMONDS;
+        }
+        if reward_roll < 9_488_932 {
+            return ResourceTypes::SAPPHIRE;
+        }
+        if reward_roll < 9_585_109 {
+            return ResourceTypes::RUBY;
+        }
+        if reward_roll < 9_681_286 {
+            return ResourceTypes::DEEP_CRYSTAL;
+        }
+        if reward_roll < 9_750_501 {
+            return ResourceTypes::IGNIUM;
+        }
+        if reward_roll < 9_815_692 {
+            return ResourceTypes::ETHEREAL_SILICA;
+        }
+        if reward_roll < 9_871_628 {
+            return ResourceTypes::TRUE_ICE;
+        }
+        if reward_roll < 9_916_296 {
+            return ResourceTypes::TWILIGHT_QUARTZ;
+        }
+        if reward_roll < 9_953_721 {
+            return ResourceTypes::ALCHEMICAL_SILVER;
+        }
+        if reward_roll < 9_975_854 {
+            return ResourceTypes::ADAMANTINE;
+        }
+        if reward_roll < 9_990_743 {
+            return ResourceTypes::MITHRAL;
+        }
+        if reward_roll < 9_999_999 {
+            return ResourceTypes::DRAGONHIDE;
+        }
+        ResourceTypes::EARTHEN_SHARD
+    }
+
+    #[inline(always)]
+    fn burn_explorer_food_cost_with_deferred_weight_store(
+        ref world: WorldStorage, explorer: ExplorerTroops, troop_stamina_config: TroopStaminaConfig, explore: bool,
+    ) {
+        if explorer.owner == DAYDREAMS_AGENT_ID {
+            return;
+        }
+
+        let (wheat_cost, fish_cost) = food_costs_for_movement(troop_stamina_config, explore);
+        let troop_count = explorer.troops.count.into() / RESOURCE_PRECISION;
+        let wheat_burn_amount: u128 = wheat_cost * troop_count;
+        let fish_burn_amount: u128 = fish_cost * troop_count;
+        let wheat_weight_grams: u128 = ResourceWeightImpl::grams(ref world, ResourceTypes::WHEAT);
+        let fish_weight_grams: u128 = ResourceWeightImpl::grams(ref world, ResourceTypes::FISH);
+
+        let mut explorer_weight: Weight = WeightStoreImpl::retrieve(ref world, explorer.owner);
+        burn_structure_food_resource(
+            ref world,
+            explorer.owner,
+            selector!("WHEAT_BALANCE"),
+            selector!("WHEAT_PRODUCTION"),
+            wheat_burn_amount,
+            wheat_weight_grams,
+            ref explorer_weight,
+        );
+        burn_structure_food_resource(
+            ref world,
+            explorer.owner,
+            selector!("FISH_BALANCE"),
+            selector!("FISH_PRODUCTION"),
+            fish_burn_amount,
+            fish_weight_grams,
+            ref explorer_weight,
+        );
+        explorer_weight.store(ref world, explorer.owner);
+    }
+
+    #[inline(always)]
+    fn food_costs_for_movement(troop_stamina_config: TroopStaminaConfig, explore: bool) -> (u128, u128) {
+        if explore {
+            return (
+                troop_stamina_config.stamina_explore_wheat_cost.into(),
+                troop_stamina_config.stamina_explore_fish_cost.into(),
+            );
+        }
+
+        (troop_stamina_config.stamina_travel_wheat_cost.into(), troop_stamina_config.stamina_travel_fish_cost.into())
+    }
+
+    #[inline(always)]
+    fn burn_single_step_stamina_cost(
+        ref explorer: ExplorerTroops,
+        troop_stamina_config: TroopStaminaConfig,
+        explore: bool,
+        biome: Biome,
+        current_tick: u64,
+    ) {
+        let stamina_cost = single_step_stamina_cost(ref explorer, troop_stamina_config, explore, biome);
+        explorer
+            .troops
+            .stamina
+            .spend(
+                ref explorer.troops.boosts,
+                explorer.troops.category,
+                explorer.troops.tier,
+                troop_stamina_config,
+                stamina_cost,
+                current_tick,
+                true,
+            );
+    }
+
+    #[inline(always)]
+    fn single_step_stamina_cost(
+        ref explorer: ExplorerTroops, troop_stamina_config: TroopStaminaConfig, explore: bool, biome: Biome,
+    ) -> u64 {
+        if explore {
+            return troop_stamina_config.stamina_explore_stamina_cost.into();
+        }
+
+        let mut stamina_cost: u64 = troop_stamina_config.stamina_travel_stamina_cost.into();
+        let (add, stamina_bonus) = explorer.troops.stamina_travel_bonus(biome, troop_stamina_config);
+        if add {
+            stamina_cost += stamina_bonus.into();
+        } else {
+            stamina_cost -= stamina_bonus.into();
+        }
+        stamina_cost
+    }
+
+    #[inline(always)]
+    fn burn_structure_food_resource(
+        ref world: WorldStorage,
+        structure_id: ID,
+        balance_selector: felt252,
+        production_selector: felt252,
+        burn_amount: u128,
+        resource_weight_grams: u128,
+        ref structure_weight: Weight,
+    ) {
+        let resource_ptr = Model::<Resource>::ptr_from_keys(structure_id);
+        let mut balance: u128 = world.read_member(resource_ptr, balance_selector);
+        let mut production: Production = world.read_member(resource_ptr, production_selector);
+        let produces = production.building_count.is_non_zero();
+        if produces {
+            harvest_active_food_production(ref production, ref balance, ref structure_weight, resource_weight_grams);
+        }
+
+        assert!(balance >= burn_amount, "insufficient food balance");
+        world.write_member(resource_ptr, balance_selector, balance - burn_amount);
+        if produces {
+            world.write_member(resource_ptr, production_selector, production);
+        }
+
+        structure_weight.deduct(burn_amount * resource_weight_grams);
+    }
+
+    #[inline(always)]
+    fn harvest_active_food_production(
+        ref production: Production, ref balance: u128, ref structure_weight: Weight, resource_weight_grams: u128,
+    ) {
+        let now: u32 = starknet::get_block_timestamp().try_into().unwrap();
+        if production.last_updated_at == now {
+            return;
+        }
+
+        let start_at = production.last_updated_at;
+        production.last_updated_at = now;
+        let harvest_amount: u128 = ((now - start_at).into()) * production.production_rate.into();
+        if harvest_amount.is_non_zero() {
+            let (storable_amount, total_weight) = storable_resource_amount(
+                harvest_amount, structure_weight.unused(), resource_weight_grams,
+            );
+            balance += storable_amount;
+            structure_weight.add(total_weight);
+        }
+    }
 }
 use crate::models::config::{MapConfig, TroopLimitConfig, TroopStaminaConfig};
 use crate::models::events::ExploreFind;
@@ -491,37 +1228,271 @@ pub trait ITroopMovementUtilSystems<T> {
     ) -> (bool, ExploreFind);
 }
 
-#[dojo::contract]
-pub mod troop_movement_util_systems {
+pub mod movement_discovery {
     use dojo::model::ModelStorage;
-    use dojo::world::WorldStorageTrait;
-    use crate::constants::DEFAULT_NS;
-    use crate::models::config::{
-        CombatConfigImpl, MapConfig, SeasonConfigImpl, TickImpl, TroopLimitConfig, TroopStaminaConfig,
-        WorldConfigUtilImpl,
-    };
+    use dojo::world::WorldStorage;
+    use starknet::ContractAddress;
+    use crate::models::agent::AgentCountImpl;
+    use crate::models::config::{CombatConfigImpl, MapConfig, TroopLimitConfig, TroopStaminaConfig};
     use crate::models::events::ExploreFind;
     use crate::models::map::Tile;
     use crate::models::position::Coord;
-    // use crate::models::config::{QuestConfig};
-    // use crate::models::quest::{QuestFeatureFlag, QuestGameRegistry};
+    use crate::models::record::{RelicRecord, WorldRecordImpl};
     use crate::models::structure::StructureReservation;
-    // use crate::systems::quest::constants::VERSION;
-    // use crate::systems::quest::contracts::{IQuestSystemsDispatcher, IQuestSystemsDispatcherTrait,
-    // iQuestDiscoveryImpl};
+    use crate::systems::utils::bitcoin_mine::iBitcoinMineDiscoveryImpl;
+    use crate::systems::utils::camp::iCampDiscoveryImpl;
+    use crate::systems::utils::holysite::iHolySiteDiscoveryImpl;
     use crate::systems::utils::hyperstructure::iHyperstructureDiscoveryImpl;
     use crate::systems::utils::mine::iMineDiscoveryImpl;
-    use crate::systems::utils::troop::{iAgentDiscoveryImpl, iExplorerImpl, iTroopImpl};
-    use super::{
-        ITroopMovementUtilSystems, ITroopMovementUtilSystemsDispatcher, ITroopMovementUtilSystemsDispatcherTrait,
-    };
+    use crate::systems::utils::relic::iRelicChestDiscoveryImpl;
+    use crate::systems::utils::troop::iAgentDiscoveryImpl;
+
+    pub fn find_treasure(
+        ref world: WorldStorage,
+        vrf_seed: u256,
+        tile: Tile,
+        caller: ContractAddress,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        current_tick: u64,
+        season_mode_on: bool,
+    ) -> (bool, ExploreFind) {
+        if !season_mode_on {
+            discover_relic_chest_if_due(ref world, tile, map_config, vrf_seed);
+        }
+
+        if !has_enabled_personal_discovery_chance(tile, map_config, season_mode_on) {
+            return (false, ExploreFind::None);
+        }
+
+        if is_structure_reserved(world, tile) {
+            return (false, ExploreFind::None);
+        }
+
+        if season_mode_on && find_hyperstructure(ref world, tile, caller, map_config, troop_stamina_config, vrf_seed) {
+            return (true, ExploreFind::Hyperstructure);
+        }
+
+        if find_mine(ref world, tile, season_mode_on, map_config, troop_stamina_config, vrf_seed) {
+            return (true, ExploreFind::Mine);
+        }
+
+        if season_mode_on && find_holysite(ref world, tile, map_config, troop_stamina_config, vrf_seed) {
+            return (true, ExploreFind::HolySite);
+        }
+
+        if tile.alt && find_bitcoin_mine(ref world, tile, map_config, troop_stamina_config, vrf_seed) {
+            return (true, ExploreFind::BitcoinMine);
+        }
+
+        if !season_mode_on && find_camp(ref world, tile, map_config, troop_stamina_config, vrf_seed) {
+            return (true, ExploreFind::Camp);
+        }
+
+        if find_agent(ref world, tile, map_config, troop_stamina_config, current_tick, vrf_seed) {
+            return (true, ExploreFind::Agent);
+        }
+
+        return (false, ExploreFind::None);
+    }
+
+    fn has_enabled_personal_discovery_chance(tile: Tile, map_config: MapConfig, season_mode_on: bool) -> bool {
+        if season_mode_on && map_config.hyps_win_prob != 0 {
+            return true;
+        }
+
+        if map_config.shards_mines_win_probability != 0 {
+            return true;
+        }
+
+        if season_mode_on && map_config.holysite_win_probability != 0 {
+            return true;
+        }
+
+        if tile.alt && map_config.bitcoin_mine_win_probability != 0 {
+            return true;
+        }
+
+        if !season_mode_on && map_config.camp_win_probability != 0 {
+            return true;
+        }
+
+        map_config.agent_discovery_prob != 0
+    }
+
+    fn discover_relic_chest_if_due(ref world: WorldStorage, tile: Tile, map_config: MapConfig, vrf_seed: u256) {
+        let mut relic_record: RelicRecord = WorldRecordImpl::get_member(world, selector!("relic_record"));
+        if iRelicChestDiscoveryImpl::should_discover(world, relic_record, map_config) {
+            iRelicChestDiscoveryImpl::discover(ref world, tile.into(), map_config, vrf_seed);
+            relic_record.last_discovered_at = starknet::get_block_timestamp();
+            WorldRecordImpl::set_member(ref world, selector!("relic_record"), relic_record);
+        }
+    }
+
+    fn is_structure_reserved(world: WorldStorage, tile: Tile) -> bool {
+        let coord: Coord = tile.into();
+        let structure_reservation: StructureReservation = world.read_model(coord);
+        structure_reservation.reserved
+    }
+
+    fn find_hyperstructure(
+        ref world: WorldStorage,
+        tile: Tile,
+        caller: ContractAddress,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        vrf_seed: u256,
+    ) -> bool {
+        if map_config.hyps_win_prob == 0 {
+            return false;
+        }
+
+        let hyps_lottery_won = iHyperstructureDiscoveryImpl::lottery(world, tile.into(), map_config, vrf_seed);
+        if hyps_lottery_won {
+            let troop_limit_config: TroopLimitConfig = CombatConfigImpl::troop_limit_config(ref world);
+            iHyperstructureDiscoveryImpl::create(
+                ref world,
+                tile.into(),
+                caller,
+                map_config,
+                troop_limit_config,
+                troop_stamina_config,
+                vrf_seed,
+                false,
+                false,
+            );
+            return true;
+        }
+        return false;
+    }
+
+    fn find_mine(
+        ref world: WorldStorage,
+        tile: Tile,
+        season_mode_on: bool,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        vrf_seed: u256,
+    ) -> bool {
+        if map_config.shards_mines_win_probability == 0 {
+            return false;
+        }
+
+        let mine_lottery_won = iMineDiscoveryImpl::lottery(map_config, vrf_seed, world);
+        if mine_lottery_won {
+            let troop_limit_config: TroopLimitConfig = CombatConfigImpl::troop_limit_config(ref world);
+            iMineDiscoveryImpl::create(
+                ref world, tile.into(), season_mode_on, map_config, troop_limit_config, troop_stamina_config, vrf_seed,
+            );
+            return true;
+        }
+        return false;
+    }
+
+    fn find_holysite(
+        ref world: WorldStorage,
+        tile: Tile,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        vrf_seed: u256,
+    ) -> bool {
+        if map_config.holysite_win_probability == 0 {
+            return false;
+        }
+
+        let holysite_lottery_won = iHolySiteDiscoveryImpl::lottery(map_config, vrf_seed, world);
+        if holysite_lottery_won {
+            let troop_limit_config: TroopLimitConfig = CombatConfigImpl::troop_limit_config(ref world);
+            iHolySiteDiscoveryImpl::create(ref world, tile.into(), troop_limit_config, troop_stamina_config, vrf_seed);
+            return true;
+        }
+        return false;
+    }
+
+    fn find_bitcoin_mine(
+        ref world: WorldStorage,
+        tile: Tile,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        vrf_seed: u256,
+    ) -> bool {
+        if map_config.bitcoin_mine_win_probability == 0 {
+            return false;
+        }
+
+        let bitcoin_mine_lottery_won = iBitcoinMineDiscoveryImpl::lottery(map_config, vrf_seed, world);
+        if bitcoin_mine_lottery_won {
+            let troop_limit_config: TroopLimitConfig = CombatConfigImpl::troop_limit_config(ref world);
+            iBitcoinMineDiscoveryImpl::create(
+                ref world, tile.into(), troop_limit_config, troop_stamina_config, vrf_seed,
+            );
+            return true;
+        }
+        return false;
+    }
+
+    fn find_camp(
+        ref world: WorldStorage,
+        tile: Tile,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        vrf_seed: u256,
+    ) -> bool {
+        if map_config.camp_win_probability == 0 {
+            return false;
+        }
+
+        let camp_lottery_won = iCampDiscoveryImpl::lottery(map_config, vrf_seed, world);
+        if camp_lottery_won {
+            let troop_limit_config: TroopLimitConfig = CombatConfigImpl::troop_limit_config(ref world);
+            iCampDiscoveryImpl::create(ref world, tile.into(), troop_limit_config, troop_stamina_config, vrf_seed);
+            return true;
+        }
+        return false;
+    }
+
+    fn find_agent(
+        ref world: WorldStorage,
+        mut tile: Tile,
+        map_config: MapConfig,
+        troop_stamina_config: TroopStaminaConfig,
+        current_tick: u64,
+        vrf_seed: u256,
+    ) -> bool {
+        if map_config.agent_discovery_prob == 0 {
+            return false;
+        }
+
+        let agent_lottery_won = iAgentDiscoveryImpl::lottery(map_config, vrf_seed, world);
+        if agent_lottery_won {
+            if AgentCountImpl::limit_reached(world) {
+                return false;
+            }
+            let troop_limit_config: TroopLimitConfig = CombatConfigImpl::troop_limit_config(ref world);
+            iAgentDiscoveryImpl::create(
+                ref world, ref tile, vrf_seed, troop_limit_config, troop_stamina_config, current_tick,
+            );
+            return true;
+        }
+        return false;
+    }
+}
+
+#[dojo::contract]
+pub mod troop_movement_util_systems {
+    use dojo::world::{WorldStorage, WorldStorageTrait};
+    use crate::constants::DEFAULT_NS;
+    use crate::models::config::{MapConfig, TroopLimitConfig, TroopStaminaConfig};
+    use crate::models::events::ExploreFind;
+    use crate::models::map::Tile;
+    use super::{ITroopMovementUtilSystems, movement_discovery};
 
     #[abi(embed_v0)]
     impl TroopMovementUtilImpl of ITroopMovementUtilSystems<ContractState> {
         fn find_treasure(
             self: @ContractState,
             vrf_seed: u256,
-            mut tile: Tile,
+            tile: Tile,
             caller: starknet::ContractAddress,
             map_config: MapConfig,
             troop_limit_config: TroopLimitConfig,
@@ -531,193 +1502,23 @@ pub mod troop_movement_util_systems {
         ) -> (bool, ExploreFind) {
             // ensure caller is the troop movement systems because this changes state
             let mut world = self.world(DEFAULT_NS());
+            let _caller = caller;
+            let _troop_limit_config = troop_limit_config;
 
-            // ensure caller is the troop movement systems
-            let (troop_movement_systems_address, _) = world.dns(@"troop_movement_systems").unwrap();
-            assert!(
-                starknet::get_caller_address() == troop_movement_systems_address,
-                "caller must be the troop movement systems",
-            );
+            assert_called_by_troop_movement_systems(world);
 
-            //////////////////////////////////////
-            /// TIME BASED GLOBAL DISCOVERY
-            //////////////////////////////////////
-
-            // note that relic chests cant be found on reserved tiles. the logic for
-            // that is handled in iRelicChestDiscoveryImpl::discover
-            let (relic_chest_discovery_systems, _) = world.dns(@"relic_chest_discovery_systems").unwrap();
-            let relic_chest_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                contract_address: relic_chest_discovery_systems,
-            };
-            relic_chest_discovery_systems
-                .find_treasure(
-                    vrf_seed,
-                    tile,
-                    caller,
-                    map_config,
-                    troop_limit_config,
-                    troop_stamina_config,
-                    current_tick,
-                    season_mode_on,
-                );
-
-            //////////////////////////////////////
-            /// LOTTERY BASED PERSONAL DISCOVERY
-            //////////////////////////////////////
-
-            // If the tile is reserved, no structure discovery can happen on it
-            let coord: Coord = tile.into();
-            let structure_reservation: StructureReservation = world.read_model(coord);
-            if structure_reservation.reserved {
-                return (false, ExploreFind::None);
-            }
-
-            let (hyperstructure_discovery_systems, _) = world.dns(@"hyperstructure_discovery_systems").unwrap();
-            let hyperstructure_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                contract_address: hyperstructure_discovery_systems,
-            };
-
-            let (found_hyperstructure, _) = hyperstructure_discovery_systems
-                .find_treasure(
-                    vrf_seed,
-                    tile,
-                    starknet::get_caller_address(),
-                    map_config,
-                    troop_limit_config,
-                    troop_stamina_config,
-                    current_tick,
-                    season_mode_on,
-                );
-            if found_hyperstructure {
-                return (true, ExploreFind::Hyperstructure);
-            } else {
-                // perform lottery to discover mine
-                let (mine_discovery_systems, _) = world.dns(@"mine_discovery_systems").unwrap();
-                let mine_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                    contract_address: mine_discovery_systems,
-                };
-                let (found_mine, _) = mine_discovery_systems
-                    .find_treasure(
-                        vrf_seed,
-                        tile,
-                        starknet::get_caller_address(),
-                        map_config,
-                        troop_limit_config,
-                        troop_stamina_config,
-                        current_tick,
-                        season_mode_on,
-                    );
-                if found_mine {
-                    return (true, ExploreFind::Mine);
-                } else {
-                    // perform lottery to discover holy site (blitz mode only)
-                    let (holysite_discovery_systems, _) = world.dns(@"holysite_discovery_systems").unwrap();
-                    let holysite_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                        contract_address: holysite_discovery_systems,
-                    };
-                    let (found_holysite, _) = holysite_discovery_systems
-                        .find_treasure(
-                            vrf_seed,
-                            tile,
-                            starknet::get_caller_address(),
-                            map_config,
-                            troop_limit_config,
-                            troop_stamina_config,
-                            current_tick,
-                            season_mode_on,
-                        );
-                    if found_holysite {
-                        return (true, ExploreFind::HolySite);
-                    } else {
-                        // perform lottery to discover bitcoin mine (Ethereal layer only)
-                        if tile.alt {
-                            let (bitcoin_mine_discovery_systems, _) = world
-                                .dns(@"bitcoin_mine_discovery_systems")
-                                .unwrap();
-                            let bitcoin_mine_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                                contract_address: bitcoin_mine_discovery_systems,
-                            };
-                            let (found_bitcoin_mine, _) = bitcoin_mine_discovery_systems
-                                .find_treasure(
-                                    vrf_seed,
-                                    tile,
-                                    starknet::get_caller_address(),
-                                    map_config,
-                                    troop_limit_config,
-                                    troop_stamina_config,
-                                    current_tick,
-                                    season_mode_on,
-                                );
-                            if found_bitcoin_mine {
-                                return (true, ExploreFind::BitcoinMine);
-                            }
-                        }
-
-                        // perform lottery to discover camp (blitz mode only)
-                        let (camp_discovery_systems, _) = world.dns(@"camp_discovery_systems").unwrap();
-                        let camp_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                            contract_address: camp_discovery_systems,
-                        };
-                        let (found_camp, _) = camp_discovery_systems
-                            .find_treasure(
-                                vrf_seed,
-                                tile,
-                                starknet::get_caller_address(),
-                                map_config,
-                                troop_limit_config,
-                                troop_stamina_config,
-                                current_tick,
-                                season_mode_on,
-                            );
-                        if found_camp {
-                            return (true, ExploreFind::Camp);
-                        } else {
-                            // perform lottery to discover agent
-                            let (agent_discovery_systems, _) = world.dns(@"agent_discovery_systems").unwrap();
-                            let agent_discovery_systems = ITroopMovementUtilSystemsDispatcher {
-                                contract_address: agent_discovery_systems,
-                            };
-
-                            let (found_agent, _) = agent_discovery_systems
-                                .find_treasure(
-                                    vrf_seed,
-                                    tile,
-                                    starknet::get_caller_address(),
-                                    map_config,
-                                    troop_limit_config,
-                                    troop_stamina_config,
-                                    current_tick,
-                                    season_mode_on,
-                                );
-                            if found_agent {
-                                return (true, ExploreFind::Agent);
-                            } else {
-                                // let quest_config: QuestConfig = WorldConfigUtilImpl::get_member(
-                                //     world, selector!("quest_config"),
-                                // );
-                                // let quest_game_registry: QuestGameRegistry = world.read_model(VERSION);
-                                // let feature_toggle: QuestFeatureFlag = world.read_model(VERSION);
-                                // let quest_game_count = quest_game_registry.games.len();
-                                // if quest_game_count > 0 && feature_toggle.enabled {
-                                //     let quest_lottery_won: bool = iQuestDiscoveryImpl::lottery(
-                                //         quest_config, vrf_seed, world,
-                                //     );
-                                //     if quest_lottery_won {
-                                //         let (quest_system_address, _) = world.dns(@"quest_systems").unwrap();
-                                //         let quest_system = IQuestSystemsDispatcher {
-                                //             contract_address: quest_system_address,
-                                //         };
-                                //         quest_system.create_quest(tile, vrf_seed);
-                                //         return (true, ExploreFind::Quest);
-                                //     }
-                                // }
-                                return (false, ExploreFind::None);
-                            }
-                        }
-                    }
-                }
-            }
+            movement_discovery::find_treasure(
+                ref world, vrf_seed, tile, caller, map_config, troop_stamina_config, current_tick, season_mode_on,
+            )
         }
+    }
+
+    fn assert_called_by_troop_movement_systems(world: WorldStorage) {
+        let (troop_movement_systems_address, _) = world.dns(@"troop_movement_systems").unwrap();
+        assert!(
+            starknet::get_caller_address() == troop_movement_systems_address,
+            "caller must be the troop movement systems",
+        );
     }
 }
 

--- a/contracts/game/src/systems/combat/contracts/troop_movement.cairo
+++ b/contracts/game/src/systems/combat/contracts/troop_movement.cairo
@@ -16,48 +16,33 @@ pub trait ITroopMovementSystems<TContractState> {
 pub mod troop_movement_systems {
     use core::num::traits::zero::Zero;
     use dojo::event::EventStorage;
-    use dojo::model::{Model, ModelStorage};
-    use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
+    use dojo::model::ModelStorage;
+    use dojo::world::{IWorldDispatcherTrait, WorldStorageTrait};
     use starknet::ContractAddress;
     use crate::alias::ID;
-    use crate::constants::{DAYDREAMS_AGENT_ID, DEFAULT_NS, RESOURCE_PRECISION, ResourceTypes};
-    use crate::models::agent::AgentOwner;
+    use crate::constants::DEFAULT_NS;
     use crate::models::config::{
-        BlitzExplorationConfig, CombatConfigImpl, MapConfig, SeasonConfigImpl, TickImpl, TickTrait, TroopLimitConfig,
-        TroopStaminaConfig, VictoryPointsGrantConfig, WorldConfigUtilImpl,
+        CombatConfigImpl, MapConfig, SeasonConfigImpl, TickImpl, TickTrait, TroopLimitConfig, TroopStaminaConfig,
+        VictoryPointsGrantConfig, WorldConfigUtilImpl,
     };
     use crate::models::events::{
-        ExploreFind, ExplorerExtractRewardStory, ExplorerMoveStory, PointsActivity, PointsRegisteredStory, Story,
-        StoryEvent,
+        ExploreFind, ExplorerMoveStory, PointsActivity, PointsRegisteredStory, Story, StoryEvent,
     };
     use crate::models::hyperstructure::PlayerRegisteredPointsImpl;
     use crate::models::map::{BiomeDiscovered, Tile, TileImpl, TileOccupier};
-    use crate::models::map2::{TileOpt, TileOptDataReadTrait, TileOptDataWriteTrait};
-    use crate::models::owner::OwnerAddressTrait;
+    use crate::models::map2::TileOpt;
     use crate::models::position::{Coord, CoordTrait, Direction};
-    use crate::models::resource::production::production::Production;
-    use crate::models::resource::resource::{
-        Resource, ResourceImpl, ResourceWeightImpl, SingleResourceImpl, SingleResourceStoreImpl, WeightStoreImpl,
-    };
-    use crate::models::rng::{RNG, RNG_TX_SEED_INCREMENT};
-    use crate::models::stamina::StaminaTrait;
-    use crate::models::structure::{StructureBaseStoreImpl, StructureOwnerStoreImpl};
-    use crate::models::troop::{ExplorerTroops, GuardImpl, TroopsTrait};
-    use crate::models::weight::{Weight, WeightImpl};
+    use crate::models::structure::StructureOwnerStoreImpl;
+    use crate::models::troop::{ExplorerTroops, GuardImpl};
     use crate::system_libraries::rng_library::{IRNGlibraryDispatcherTrait, rng_library};
-    use crate::systems::utils::blitz_profile::iBlitzProfileImpl;
-    use crate::systems::utils::hyperstructure::iHyperstructureDiscoveryImpl;
     use crate::systems::utils::map::IMapImpl;
-    use crate::systems::utils::mine::iMineDiscoveryImpl;
-    use crate::systems::utils::troop::{iAgentDiscoveryImpl, iExplorerImpl, iTroopImpl};
+    use crate::systems::utils::troop::iExplorerImpl;
     use crate::utils::achievements::index::{AchievementTrait, Tasks};
     use crate::utils::cartridge::vrf::Source;
     use crate::utils::map::biomes::{Biome, get_biome_from_world};
-    use crate::utils::math::PercentageValueImpl;
-    use crate::utils::random::{VRFImpl, random};
     use super::{
-        ITroopMovementSystems, ITroopMovementUtilSystemsDispatcher, ITroopMovementUtilSystemsDispatcherTrait,
-        movement_discovery,
+        ITroopMovementRewardSystemsDispatcher, ITroopMovementRewardSystemsDispatcherTrait, ITroopMovementSystems,
+        ITroopMovementUtilSystemsDispatcher, ITroopMovementUtilSystemsDispatcherTrait,
     };
 
     // to be removed
@@ -84,9 +69,6 @@ pub mod troop_movement_systems {
         pub coord: Coord,
         pub timestamp: u64,
     }
-
-    const NON_BLITZ_EXPLORATION_REWARD_WEIGHT_TOTAL: u128 = 10_022_132;
-
     #[abi(embed_v0)]
     impl TroopMovementSystemsImpl of ITroopMovementSystems<ContractState> {
         fn explorer_move(
@@ -373,133 +355,11 @@ pub mod troop_movement_systems {
         }
 
         fn explorer_explore_and_extract(
-            ref self: ContractState, explorer_id: ID, mut directions: Span<Direction>,
+            ref self: ContractState, explorer_id: ID, directions: Span<Direction>,
         ) -> Span<Tile> {
-            let mut tiles_to_return: Array<Tile> = array![];
-
-            assert!(directions.len().is_non_zero(), "directions must be more than 0");
-            let original_directions = directions;
-
-            let mut world = self.world(DEFAULT_NS());
-            SeasonConfigImpl::get(world).assert_started_and_not_over();
-
-            let mut explorer: ExplorerTroops = world.read_model(explorer_id);
-            let caller = starknet::get_caller_address();
-            let explorer_owner = assert_explorer_caller_and_resolve_event_owner(ref world, explorer, caller);
-
-            let start_coord = explorer.coord;
-            assert!(explorer.troops.count.is_non_zero(), "explorer is dead");
-
-            let from = explorer.coord;
-            let mut source_tile_opt: TileOpt = world.read_model((from.alt, from.x, from.y));
-            assert!(
-                explorer_id == TileOptDataReadTrait::occupier_id(source_tile_opt.data),
-                "tile occupier should be explorer",
-            );
-
-            let block_timestamp = starknet::get_block_timestamp();
-            let current_tick: u64 = TickImpl::get_tick_interval(ref world).current();
-            let troop_stamina_config: TroopStaminaConfig = CombatConfigImpl::troop_stamina_config(ref world);
-            let victory_points_grant_config: VictoryPointsGrantConfig = WorldConfigUtilImpl::get_member(
-                world, selector!("victory_points_grant_config"),
-            );
-            let map_config: MapConfig = WorldConfigUtilImpl::get_member(world, selector!("map_config"));
-            let blitz_mode_on: bool = WorldConfigUtilImpl::get_member(world, selector!("blitz_mode_on"));
-            let season_mode_on = !blitz_mode_on;
-
-            let next = explorer.coord.neighbor(*directions.pop_front().unwrap());
-            let mut target_tile_opt: TileOpt = world.read_model((next.alt, next.x, next.y));
-            let mut target_tile: Tile = target_tile_opt.into();
-            assert!(target_tile.not_occupied(), "one of the tiles in path is occupied");
-            assert!(directions.len().is_zero(), "explorer can only move one direction when exploring");
-
-            let biome = get_biome_from_world(world, next.alt, next.x.into(), next.y.into());
-
-            let (explore, explore_find, occupy_destination, movement_vrf_seed) = discover_target_if_needed(
-                ref world,
-                ref target_tile,
-                caller,
-                next,
-                biome,
-                map_config,
-                troop_stamina_config,
-                victory_points_grant_config,
-                current_tick,
-                block_timestamp,
-                season_mode_on,
-            );
-
-            explorer.coord = next;
-            let explorer_occupier_type = TileOptDataReadTrait::occupier_type(source_tile_opt.data);
-            let explorer_occupier_is_structure = TileOptDataReadTrait::occupier_is_structure(source_tile_opt.data);
-
-            let mut reward_tile: Tile = target_tile;
-            if occupy_destination {
-                occupy_tile_with_existing_occupier_memory(
-                    ref target_tile, explorer_occupier_type, explorer_occupier_is_structure, explorer_id,
-                );
-                reward_tile = target_tile;
-            } else {
-                explorer.coord = from;
-                let source_tile: Tile = source_tile_opt.into();
-                reward_tile = source_tile;
-            }
-
-            let tile_to_return = target_tile;
-            tiles_to_return.append(tile_to_return);
-
-            assert!(explorer.coord.alt == false, "Eternum: explorer must be on surface to extract reward");
-            assert!(explorer_id == reward_tile.occupier_id, "tile occupier should be explorer");
-            assert!(reward_tile.biome != Biome::None.into(), "tile must be explored");
-
-            let reward_vrf_seed: u256 = movement_vrf_seed + RNG_TX_SEED_INCREMENT;
-            let should_grant_reward = !reward_tile.reward_extracted;
-            if should_grant_reward {
-                IMapImpl::mark_reward_extracted_memory(ref reward_tile);
-            }
-
-            store_combined_explore_tiles(
-                ref world, ref source_tile_opt, ref target_tile_opt, reward_tile, occupy_destination,
-            );
-
-            burn_single_step_stamina_cost(ref explorer, troop_stamina_config, explore, biome, current_tick);
-            burn_explorer_food_cost_with_deferred_weight_store(ref world, explorer, troop_stamina_config, explore);
-
-            let tx_hash = starknet::get_tx_info().unbox().transaction_hash;
-            emit_explorer_move_stories(
-                ref world,
-                explorer,
-                explorer_owner,
-                caller,
-                explorer_id,
-                start_coord,
-                original_directions,
-                explore,
-                explore_find,
-                victory_points_grant_config,
-                tx_hash,
-                block_timestamp,
-            );
-
-            world.write_model(@explorer);
-
-            if should_grant_reward {
-                grant_explorer_reward_and_emit(
-                    ref world,
-                    explorer,
-                    explorer_owner,
-                    caller,
-                    reward_tile,
-                    reward_vrf_seed,
-                    current_tick,
-                    map_config,
-                    blitz_mode_on,
-                    tx_hash,
-                    block_timestamp,
-                );
-            }
-
-            tiles_to_return.span()
+            let tiles_to_return = self.explorer_move(explorer_id, directions, true);
+            self.explorer_extract_reward(explorer_id);
+            tiles_to_return
         }
 
         fn explorer_extract_reward(ref self: ContractState, explorer_id: ID) {
@@ -510,702 +370,11 @@ pub mod troop_movement_systems {
             let mut explorer: ExplorerTroops = world.read_model(explorer_id);
             explorer.assert_caller_structure_or_agent_owner(ref world);
 
-            // ensure explorer is at the surface
-            assert!(explorer.coord.alt == false, "Eternum: explorer must be on surface to extract reward");
-
-            // ensure explorer is alive
-            assert!(explorer.troops.count.is_non_zero(), "explorer is dead");
-
-            // ensure explorer tile is correct
-            let tile_opt: TileOpt = world.read_model((explorer.coord.alt, explorer.coord.x, explorer.coord.y));
-            let mut tile: Tile = tile_opt.into();
-            assert!(explorer_id == tile.occupier_id, "tile occupier should be explorer");
-            assert!(tile.biome != Biome::None.into(), "tile must be explored");
-
-            // ensure to consume vrf seed even if tile.reward_extracted is true
-            // to prevent client errors
-            let rng_library_dispatcher = rng_library::get_dispatcher(@world);
-            let vrf_seed: u256 = rng_library_dispatcher.get_random_number(Source::Salt(tile.to_seed()), world);
-
-            if tile.reward_extracted {
-                return;
-            }
-            assert!(tile.reward_extracted == false, "tile reward already extracted");
-
-            // mark reward as extracted
-            IMapImpl::mark_reward_extracted(ref world, ref tile);
-
-            // get relevant data to grant reward
-            let blitz_mode_on: bool = WorldConfigUtilImpl::get_member(world, selector!("blitz_mode_on"));
-            let blitz_exploration_config: BlitzExplorationConfig = WorldConfigUtilImpl::get_member(
-                world, selector!("blitz_exploration_config"),
-            );
-            let blitz_exploration_reward_profile_id = iBlitzProfileImpl::resolve_blitz_profile_id(
-                blitz_exploration_config.reward_profile_id,
-            );
-            let current_tick: u64 = TickImpl::get_tick_interval(ref world).current();
-            let map_config: MapConfig = WorldConfigUtilImpl::get_member(world, selector!("map_config"));
-
-            // grant resource reward for exploration
-            let (explore_reward_type, explore_reward_amount) = iExplorerImpl::exploration_reward(
-                ref world,
-                Option::Some(explorer),
-                current_tick,
-                map_config,
-                vrf_seed,
-                blitz_mode_on,
-                blitz_exploration_reward_profile_id,
-            );
-
-            let exploration_reward_receiver: ID = iExplorerImpl::exploration_reward_receiver(
-                ref world, blitz_mode_on, explorer, explore_reward_type,
-            );
-            let resource_weight_grams: u128 = ResourceWeightImpl::grams(ref world, explore_reward_type);
-            let mut reward_receiver_weight: Weight = WeightStoreImpl::retrieve(ref world, exploration_reward_receiver);
-            let mut resource = SingleResourceStoreImpl::retrieve(
-                ref world,
-                exploration_reward_receiver,
-                explore_reward_type,
-                ref reward_receiver_weight,
-                resource_weight_grams,
-                true,
-            );
-            resource.add(explore_reward_amount, ref reward_receiver_weight, resource_weight_grams);
-            resource.store(ref world);
-            reward_receiver_weight.store(ref world, exploration_reward_receiver);
-
-            // emit event
-            let explorer_owner: ContractAddress = StructureOwnerStoreImpl::retrieve(ref world, explorer.owner);
-            world
-                .emit_event(
-                    @StoryEvent {
-                        id: world.dispatcher.uuid(),
-                        owner: Option::Some(explorer_owner),
-                        entity_id: Option::Some(explorer_id),
-                        tx_hash: starknet::get_tx_info().unbox().transaction_hash,
-                        story: Story::ExplorerExtractRewardStory(
-                            ExplorerExtractRewardStory {
-                                explorer_owner,
-                                explorer_id,
-                                explorer_structure_id: explorer.owner,
-                                coord: tile.into(),
-                                reward_resource_type: explore_reward_type,
-                                reward_resource_amount: explore_reward_amount,
-                            },
-                        ),
-                        timestamp: starknet::get_block_timestamp(),
-                    },
-                );
-
-            world
-                .emit_event(
-                    @ExplorerRewardEvent {
-                        explorer_id,
-                        explorer_structure_id: explorer.owner,
-                        explorer_owner_address: starknet::get_caller_address(),
-                        reward_resource_id: explore_reward_type,
-                        reward_resource_amount: explore_reward_amount,
-                        coord: explorer.coord,
-                        timestamp: starknet::get_block_timestamp(),
-                    },
-                );
-        }
-    }
-
-    #[inline(always)]
-    fn discover_target_if_needed(
-        ref world: WorldStorage,
-        ref target_tile: Tile,
-        caller: ContractAddress,
-        target_coord: Coord,
-        biome: Biome,
-        map_config: MapConfig,
-        troop_stamina_config: TroopStaminaConfig,
-        victory_points_grant_config: VictoryPointsGrantConfig,
-        current_tick: u64,
-        block_timestamp: u64,
-        season_mode_on: bool,
-    ) -> (bool, ExploreFind, bool, u256) {
-        if target_tile.discovered() {
-            let movement_vrf_seed = derive_initial_tx_random_seed(ref world, Source::Salt(target_tile.to_seed()));
-            return (false, ExploreFind::None, true, movement_vrf_seed);
-        }
-
-        IMapImpl::explore_memory(ref target_tile, biome);
-
-        PlayerRegisteredPointsImpl::register_points(
-            ref world, caller, victory_points_grant_config.explore_tiles_points.into(),
-        );
-
-        let vrf_seed: u256 = derive_initial_tx_random_seed(ref world, Source::Salt(target_tile.to_seed()));
-        let (found_treasure, explore_find) = movement_discovery::find_treasure(
-            ref world, vrf_seed, target_tile, caller, map_config, troop_stamina_config, current_tick, season_mode_on,
-        );
-
-        let mut occupy_destination = true;
-        if found_treasure {
-            occupy_destination = false;
-            let target_tile_opt: TileOpt = world.read_model((target_coord.alt, target_coord.x, target_coord.y));
-            target_tile = target_tile_opt.into();
-        }
-
-        AchievementTrait::progress(world, caller.into(), Tasks::EXPLORE, 1, block_timestamp);
-        progress_discovery_achievement(world, caller, explore_find, block_timestamp);
-        mark_biome_discovered_if_needed(ref world, caller, biome, block_timestamp);
-
-        (true, explore_find, occupy_destination, vrf_seed)
-    }
-
-    #[inline(always)]
-    fn store_combined_explore_tiles(
-        ref world: WorldStorage,
-        ref source_tile_opt: TileOpt,
-        ref target_tile_opt: TileOpt,
-        reward_tile: Tile,
-        occupy_destination: bool,
-    ) {
-        if occupy_destination {
-            source_tile_opt.data = TileOptDataWriteTrait::without_occupier(source_tile_opt.data);
-            target_tile_opt
-                .data =
-                    TileOptDataWriteTrait::with_tile_state(
-                        target_tile_opt.data,
-                        reward_tile.biome,
-                        reward_tile.occupier_type,
-                        reward_tile.occupier_is_structure,
-                        reward_tile.occupier_id,
-                        reward_tile.reward_extracted,
-                    );
-            world.write_model(@source_tile_opt);
-            world.write_model(@target_tile_opt);
-        } else {
-            source_tile_opt
-                .data =
-                    TileOptDataWriteTrait::with_reward_extracted(source_tile_opt.data, reward_tile.reward_extracted);
-            world.write_model(@source_tile_opt);
-        }
-    }
-
-    #[inline(always)]
-    fn progress_discovery_achievement(
-        world: WorldStorage, caller: ContractAddress, explore_find: ExploreFind, block_timestamp: u64,
-    ) {
-        match explore_find {
-            ExploreFind::None => {},
-            ExploreFind::Hyperstructure => {
-                AchievementTrait::progress(world, caller.into(), Tasks::HYPERSTRUCTURE_DISCOVER, 1, block_timestamp);
-            },
-            ExploreFind::Mine => {
-                AchievementTrait::progress(world, caller.into(), Tasks::MINE_DISCOVER, 1, block_timestamp);
-            },
-            ExploreFind::Agent => {
-                AchievementTrait::progress(world, caller.into(), Tasks::AGENT_DISCOVER, 1, block_timestamp);
-            },
-            ExploreFind::Quest => {
-                AchievementTrait::progress(world, caller.into(), Tasks::QUEST_DISCOVER, 1, block_timestamp);
-            },
-            ExploreFind::Village => {},
-            ExploreFind::HolySite => {
-                AchievementTrait::progress(world, caller.into(), Tasks::HOLYSITE_DISCOVER, 1, block_timestamp);
-            },
-            ExploreFind::Camp => {
-                AchievementTrait::progress(world, caller.into(), Tasks::CAMP_DISCOVER, 1, block_timestamp);
-            },
-            ExploreFind::BitcoinMine => {},
-        }
-    }
-
-    #[inline(always)]
-    fn mark_biome_discovered_if_needed(
-        ref world: WorldStorage, caller: ContractAddress, biome: Biome, block_timestamp: u64,
-    ) {
-        let biome_u8: u8 = biome.into();
-        let mut biome_discovered: BiomeDiscovered = world.read_model((caller, biome_u8));
-        if !biome_discovered.discovered {
-            biome_discovered.discovered = true;
-            world.write_model(@biome_discovered);
-
-            AchievementTrait::progress(world, caller.into(), Tasks::BIOME_DISCOVER, 1, block_timestamp);
-        }
-    }
-
-    #[inline(always)]
-    fn assert_explorer_caller_and_resolve_event_owner(
-        ref world: WorldStorage, explorer: ExplorerTroops, caller: ContractAddress,
-    ) -> ContractAddress {
-        if explorer.owner == DAYDREAMS_AGENT_ID {
-            let agent_owner: AgentOwner = world.read_model(explorer.explorer_id);
-            assert!(agent_owner.address == caller, "caller is not the agent owner");
-            return StructureOwnerStoreImpl::retrieve(ref world, explorer.owner);
-        }
-
-        let explorer_owner = StructureOwnerStoreImpl::retrieve(ref world, explorer.owner);
-        explorer_owner.assert_caller_owner();
-        explorer_owner
-    }
-
-    #[inline(always)]
-    fn derive_initial_tx_random_seed(ref world: WorldStorage, source: Source) -> u256 {
-        let tx_hash = starknet::get_tx_info().unbox().transaction_hash;
-        let rng: RNG = world.read_model(tx_hash);
-        let mut seed = rng.seed;
-        if seed.is_zero() {
-            let vrf_provider: ContractAddress = WorldConfigUtilImpl::get_member(
-                world, selector!("vrf_provider_address"),
-            );
-            seed = VRFImpl::seed(source, vrf_provider);
-        }
-        seed + RNG_TX_SEED_INCREMENT
-    }
-
-    #[inline(always)]
-    fn occupy_tile_with_existing_occupier_memory(
-        ref tile: Tile, occupier_type: u8, occupier_is_structure: bool, occupier_id: ID,
-    ) {
-        tile.occupier_type = occupier_type;
-        tile.occupier_id = occupier_id;
-        tile.occupier_is_structure = occupier_is_structure;
-    }
-
-    #[inline(always)]
-    fn emit_explorer_move_stories(
-        ref world: WorldStorage,
-        explorer: ExplorerTroops,
-        explorer_owner: ContractAddress,
-        caller: ContractAddress,
-        explorer_id: ID,
-        start_coord: Coord,
-        original_directions: Span<Direction>,
-        explore: bool,
-        explore_find: ExploreFind,
-        victory_points_grant_config: VictoryPointsGrantConfig,
-        tx_hash: felt252,
-        block_timestamp: u64,
-    ) {
-        world
-            .emit_event(
-                @StoryEvent {
-                    id: world.dispatcher.uuid(),
-                    owner: Option::Some(explorer_owner),
-                    entity_id: Option::Some(explorer_id),
-                    tx_hash,
-                    story: Story::ExplorerMoveStory(
-                        ExplorerMoveStory {
-                            explorer_owner,
-                            explorer_id,
-                            explorer_structure_id: explorer.owner,
-                            start_coord,
-                            end_coord: explorer.coord,
-                            directions: original_directions,
-                            explore,
-                            explore_find,
-                        },
-                    ),
-                    timestamp: block_timestamp,
-                },
-            );
-
-        if explore {
-            let points_registered_story = PointsRegisteredStory {
-                owner_address: explorer_owner,
-                activity: PointsActivity::Exploration,
-                points: victory_points_grant_config.explore_tiles_points.into(),
+            let (troop_movement_reward_systems_address, _) = world.dns(@"troop_movement_reward_systems").unwrap();
+            let troop_movement_reward_systems = ITroopMovementRewardSystemsDispatcher {
+                contract_address: troop_movement_reward_systems_address,
             };
-            world
-                .emit_event(
-                    @StoryEvent {
-                        id: world.dispatcher.uuid(),
-                        owner: Option::Some(explorer_owner),
-                        entity_id: Option::Some(explorer_id),
-                        tx_hash,
-                        story: Story::PointsRegisteredStory(points_registered_story),
-                        timestamp: block_timestamp,
-                    },
-                );
-        }
-
-        world
-            .emit_event(
-                @ExplorerMoveEvent {
-                    explorer_id,
-                    explorer_structure_id: explorer.owner,
-                    explorer_owner_address: caller,
-                    explore_find: explore_find,
-                    timestamp: block_timestamp,
-                },
-            );
-    }
-
-    #[inline(always)]
-    fn grant_explorer_reward_and_emit(
-        ref world: WorldStorage,
-        explorer: ExplorerTroops,
-        explorer_owner: ContractAddress,
-        caller: ContractAddress,
-        reward_tile: Tile,
-        vrf_seed: u256,
-        current_tick: u64,
-        map_config: MapConfig,
-        blitz_mode_on: bool,
-        tx_hash: felt252,
-        block_timestamp: u64,
-    ) {
-        let blitz_exploration_reward_profile_id = if blitz_mode_on {
-            let blitz_exploration_config: BlitzExplorationConfig = WorldConfigUtilImpl::get_member(
-                world, selector!("blitz_exploration_config"),
-            );
-            iBlitzProfileImpl::resolve_blitz_profile_id(blitz_exploration_config.reward_profile_id)
-        } else {
-            0
-        };
-
-        let (explore_reward_type, explore_reward_amount) = if blitz_mode_on {
-            iExplorerImpl::exploration_reward(
-                ref world,
-                Option::Some(explorer),
-                current_tick,
-                map_config,
-                vrf_seed,
-                blitz_mode_on,
-                blitz_exploration_reward_profile_id,
-            )
-        } else {
-            non_blitz_exploration_reward(explorer, current_tick, map_config, vrf_seed, block_timestamp)
-        };
-
-        if blitz_mode_on {
-            let exploration_reward_receiver = iExplorerImpl::exploration_reward_receiver(
-                ref world, blitz_mode_on, explorer, explore_reward_type,
-            );
-            grant_resource_reward_to_producing_receiver(
-                ref world, exploration_reward_receiver, explore_reward_type, explore_reward_amount,
-            );
-        } else {
-            grant_resource_reward_to_non_producing_receiver(
-                ref world, explorer.explorer_id, explore_reward_type, explore_reward_amount,
-            );
-        }
-
-        world
-            .emit_event(
-                @StoryEvent {
-                    id: world.dispatcher.uuid(),
-                    owner: Option::Some(explorer_owner),
-                    entity_id: Option::Some(explorer.explorer_id),
-                    tx_hash,
-                    story: Story::ExplorerExtractRewardStory(
-                        ExplorerExtractRewardStory {
-                            explorer_owner,
-                            explorer_id: explorer.explorer_id,
-                            explorer_structure_id: explorer.owner,
-                            coord: reward_tile.into(),
-                            reward_resource_type: explore_reward_type,
-                            reward_resource_amount: explore_reward_amount,
-                        },
-                    ),
-                    timestamp: block_timestamp,
-                },
-            );
-
-        world
-            .emit_event(
-                @ExplorerRewardEvent {
-                    explorer_id: explorer.explorer_id,
-                    explorer_structure_id: explorer.owner,
-                    explorer_owner_address: caller,
-                    reward_resource_id: explore_reward_type,
-                    reward_resource_amount: explore_reward_amount,
-                    coord: explorer.coord,
-                    timestamp: block_timestamp,
-                },
-            );
-    }
-
-    #[inline(always)]
-    fn grant_resource_reward_to_producing_receiver(
-        ref world: WorldStorage, entity_id: ID, resource_type: u8, amount: u128,
-    ) {
-        assert!(entity_id.is_non_zero(), "entity id not found");
-        assert!(resource_type.is_non_zero(), "invalid resource specified");
-
-        let resource_weight_grams: u128 = ResourceWeightImpl::grams(ref world, resource_type);
-        let mut entity_weight: Weight = WeightStoreImpl::retrieve(ref world, entity_id);
-        let mut resource = SingleResourceStoreImpl::retrieve(
-            ref world, entity_id, resource_type, ref entity_weight, resource_weight_grams, true,
-        );
-        resource.add(amount, ref entity_weight, resource_weight_grams);
-        resource.store(ref world);
-        entity_weight.store(ref world, entity_id);
-    }
-
-    #[inline(always)]
-    fn grant_resource_reward_to_non_producing_receiver(
-        ref world: WorldStorage, entity_id: ID, resource_type: u8, amount: u128,
-    ) {
-        assert!(entity_id.is_non_zero(), "entity id not found");
-        assert!(resource_type.is_non_zero(), "invalid resource specified");
-
-        let resource_weight_grams: u128 = ResourceWeightImpl::grams(ref world, resource_type);
-        let mut entity_weight: Weight = WeightStoreImpl::retrieve(ref world, entity_id);
-        let balance: u128 = ResourceImpl::read_balance(ref world, entity_id, resource_type);
-        let (storable_amount, total_weight) = storable_resource_amount(
-            amount, entity_weight.unused(), resource_weight_grams,
-        );
-        ResourceImpl::write_balance(ref world, entity_id, resource_type, balance + storable_amount);
-        entity_weight.add(total_weight);
-        entity_weight.store(ref world, entity_id);
-    }
-
-    #[inline(always)]
-    fn storable_resource_amount(amount: u128, storage_left: u128, unit_weight: u128) -> (u128, u128) {
-        let mut max_storable: u128 = amount;
-        let mut total_weight: u128 = unit_weight * amount;
-
-        if storage_left < total_weight {
-            max_storable = storage_left / unit_weight;
-            total_weight = max_storable * unit_weight;
-        }
-
-        (max_storable, total_weight)
-    }
-
-    #[inline(always)]
-    fn non_blitz_exploration_reward(
-        explorer: ExplorerTroops, current_tick: u64, map_config: MapConfig, vrf_seed: u256, block_timestamp: u64,
-    ) -> (u8, u128) {
-        let reward_resource_type = non_blitz_exploration_reward_resource(vrf_seed, block_timestamp);
-        let reward_resource_amount = non_blitz_exploration_reward_amount(explorer, current_tick, map_config);
-        (reward_resource_type, reward_resource_amount)
-    }
-
-    #[inline(always)]
-    fn non_blitz_exploration_reward_amount(explorer: ExplorerTroops, current_tick: u64, map_config: MapConfig) -> u128 {
-        let mut reward_resource_amount: u128 = map_config.reward_resource_amount.into();
-        let mut reward_boost_percent: u128 = explorer.troops.boosts.incr_explore_reward_percent_num.into();
-        if reward_boost_percent.is_zero() {
-            return reward_resource_amount * RESOURCE_PRECISION;
-        }
-        if current_tick > explorer.troops.boosts.incr_explore_reward_end_tick.into() {
-            return reward_resource_amount * RESOURCE_PRECISION;
-        }
-
-        reward_resource_amount += (reward_resource_amount * reward_boost_percent) / PercentageValueImpl::_100().into();
-        reward_resource_amount * RESOURCE_PRECISION
-    }
-
-    #[inline(always)]
-    fn non_blitz_exploration_reward_resource(vrf_seed: u256, block_timestamp: u64) -> u8 {
-        let reward_salt: u128 = block_timestamp.into() + 18;
-        let reward_roll = random(vrf_seed, reward_salt, NON_BLITZ_EXPLORATION_REWARD_WEIGHT_TOTAL);
-        non_blitz_exploration_reward_resource_from_roll(reward_roll)
-    }
-
-    #[inline(always)]
-    fn non_blitz_exploration_reward_resource_from_roll(reward_roll: u128) -> u8 {
-        if reward_roll < 2_018_108 {
-            return ResourceTypes::WOOD;
-        }
-        if reward_roll < 3_604_023 {
-            return ResourceTypes::STONE;
-        }
-        if reward_roll < 5_146_478 {
-            return ResourceTypes::COAL;
-        }
-        if reward_roll < 6_210_059 {
-            return ResourceTypes::COPPER;
-        }
-        if reward_roll < 7_101_809 {
-            return ResourceTypes::OBSIDIAN;
-        }
-        if reward_roll < 7_802_413 {
-            return ResourceTypes::SILVER;
-        }
-        if reward_roll < 8_276_860 {
-            return ResourceTypes::IRONWOOD;
-        }
-        if reward_roll < 8_661_971 {
-            return ResourceTypes::COLD_IRON;
-        }
-        if reward_roll < 9_029_778 {
-            return ResourceTypes::GOLD;
-        }
-        if reward_roll < 9_268_812 {
-            return ResourceTypes::HARTWOOD;
-        }
-        if reward_roll < 9_389_536 {
-            return ResourceTypes::DIAMONDS;
-        }
-        if reward_roll < 9_488_932 {
-            return ResourceTypes::SAPPHIRE;
-        }
-        if reward_roll < 9_585_109 {
-            return ResourceTypes::RUBY;
-        }
-        if reward_roll < 9_681_286 {
-            return ResourceTypes::DEEP_CRYSTAL;
-        }
-        if reward_roll < 9_750_501 {
-            return ResourceTypes::IGNIUM;
-        }
-        if reward_roll < 9_815_692 {
-            return ResourceTypes::ETHEREAL_SILICA;
-        }
-        if reward_roll < 9_871_628 {
-            return ResourceTypes::TRUE_ICE;
-        }
-        if reward_roll < 9_916_296 {
-            return ResourceTypes::TWILIGHT_QUARTZ;
-        }
-        if reward_roll < 9_953_721 {
-            return ResourceTypes::ALCHEMICAL_SILVER;
-        }
-        if reward_roll < 9_975_854 {
-            return ResourceTypes::ADAMANTINE;
-        }
-        if reward_roll < 9_990_743 {
-            return ResourceTypes::MITHRAL;
-        }
-        if reward_roll < 9_999_999 {
-            return ResourceTypes::DRAGONHIDE;
-        }
-        ResourceTypes::EARTHEN_SHARD
-    }
-
-    #[inline(always)]
-    fn burn_explorer_food_cost_with_deferred_weight_store(
-        ref world: WorldStorage, explorer: ExplorerTroops, troop_stamina_config: TroopStaminaConfig, explore: bool,
-    ) {
-        if explorer.owner == DAYDREAMS_AGENT_ID {
-            return;
-        }
-
-        let (wheat_cost, fish_cost) = food_costs_for_movement(troop_stamina_config, explore);
-        let troop_count = explorer.troops.count.into() / RESOURCE_PRECISION;
-        let wheat_burn_amount: u128 = wheat_cost * troop_count;
-        let fish_burn_amount: u128 = fish_cost * troop_count;
-        let wheat_weight_grams: u128 = ResourceWeightImpl::grams(ref world, ResourceTypes::WHEAT);
-        let fish_weight_grams: u128 = ResourceWeightImpl::grams(ref world, ResourceTypes::FISH);
-
-        let mut explorer_weight: Weight = WeightStoreImpl::retrieve(ref world, explorer.owner);
-        burn_structure_food_resource(
-            ref world,
-            explorer.owner,
-            selector!("WHEAT_BALANCE"),
-            selector!("WHEAT_PRODUCTION"),
-            wheat_burn_amount,
-            wheat_weight_grams,
-            ref explorer_weight,
-        );
-        burn_structure_food_resource(
-            ref world,
-            explorer.owner,
-            selector!("FISH_BALANCE"),
-            selector!("FISH_PRODUCTION"),
-            fish_burn_amount,
-            fish_weight_grams,
-            ref explorer_weight,
-        );
-        explorer_weight.store(ref world, explorer.owner);
-    }
-
-    #[inline(always)]
-    fn food_costs_for_movement(troop_stamina_config: TroopStaminaConfig, explore: bool) -> (u128, u128) {
-        if explore {
-            return (
-                troop_stamina_config.stamina_explore_wheat_cost.into(),
-                troop_stamina_config.stamina_explore_fish_cost.into(),
-            );
-        }
-
-        (troop_stamina_config.stamina_travel_wheat_cost.into(), troop_stamina_config.stamina_travel_fish_cost.into())
-    }
-
-    #[inline(always)]
-    fn burn_single_step_stamina_cost(
-        ref explorer: ExplorerTroops,
-        troop_stamina_config: TroopStaminaConfig,
-        explore: bool,
-        biome: Biome,
-        current_tick: u64,
-    ) {
-        let stamina_cost = single_step_stamina_cost(ref explorer, troop_stamina_config, explore, biome);
-        explorer
-            .troops
-            .stamina
-            .spend(
-                ref explorer.troops.boosts,
-                explorer.troops.category,
-                explorer.troops.tier,
-                troop_stamina_config,
-                stamina_cost,
-                current_tick,
-                true,
-            );
-    }
-
-    #[inline(always)]
-    fn single_step_stamina_cost(
-        ref explorer: ExplorerTroops, troop_stamina_config: TroopStaminaConfig, explore: bool, biome: Biome,
-    ) -> u64 {
-        if explore {
-            return troop_stamina_config.stamina_explore_stamina_cost.into();
-        }
-
-        let mut stamina_cost: u64 = troop_stamina_config.stamina_travel_stamina_cost.into();
-        let (add, stamina_bonus) = explorer.troops.stamina_travel_bonus(biome, troop_stamina_config);
-        if add {
-            stamina_cost += stamina_bonus.into();
-        } else {
-            stamina_cost -= stamina_bonus.into();
-        }
-        stamina_cost
-    }
-
-    #[inline(always)]
-    fn burn_structure_food_resource(
-        ref world: WorldStorage,
-        structure_id: ID,
-        balance_selector: felt252,
-        production_selector: felt252,
-        burn_amount: u128,
-        resource_weight_grams: u128,
-        ref structure_weight: Weight,
-    ) {
-        let resource_ptr = Model::<Resource>::ptr_from_keys(structure_id);
-        let mut balance: u128 = world.read_member(resource_ptr, balance_selector);
-        let mut production: Production = world.read_member(resource_ptr, production_selector);
-        let produces = production.building_count.is_non_zero();
-        if produces {
-            harvest_active_food_production(ref production, ref balance, ref structure_weight, resource_weight_grams);
-        }
-
-        assert!(balance >= burn_amount, "insufficient food balance");
-        world.write_member(resource_ptr, balance_selector, balance - burn_amount);
-        if produces {
-            world.write_member(resource_ptr, production_selector, production);
-        }
-
-        structure_weight.deduct(burn_amount * resource_weight_grams);
-    }
-
-    #[inline(always)]
-    fn harvest_active_food_production(
-        ref production: Production, ref balance: u128, ref structure_weight: Weight, resource_weight_grams: u128,
-    ) {
-        let now: u32 = starknet::get_block_timestamp().try_into().unwrap();
-        if production.last_updated_at == now {
-            return;
-        }
-
-        let start_at = production.last_updated_at;
-        production.last_updated_at = now;
-        let harvest_amount: u128 = ((now - start_at).into()) * production.production_rate.into();
-        if harvest_amount.is_non_zero() {
-            let (storable_amount, total_weight) = storable_resource_amount(
-                harvest_amount, structure_weight.unused(), resource_weight_grams,
-            );
-            balance += storable_amount;
-            structure_weight.add(total_weight);
+            troop_movement_reward_systems.extract_reward(explorer_id, starknet::get_caller_address());
         }
     }
 }
@@ -1226,6 +395,11 @@ pub trait ITroopMovementUtilSystems<T> {
         current_tick: u64,
         season_mode_on: bool,
     ) -> (bool, ExploreFind);
+}
+
+#[starknet::interface]
+pub trait ITroopMovementRewardSystems<T> {
+    fn extract_reward(self: @T, explorer_id: ID, caller: starknet::ContractAddress);
 }
 
 pub mod movement_discovery {
@@ -1519,6 +693,171 @@ pub mod troop_movement_util_systems {
             starknet::get_caller_address() == troop_movement_systems_address,
             "caller must be the troop movement systems",
         );
+    }
+}
+
+#[dojo::contract]
+pub mod troop_movement_reward_systems {
+    use core::num::traits::zero::Zero;
+    use dojo::event::EventStorage;
+    use dojo::model::ModelStorage;
+    use dojo::world::{IWorldDispatcherTrait, WorldStorage, WorldStorageTrait};
+    use starknet::ContractAddress;
+    use crate::alias::ID;
+    use crate::constants::DEFAULT_NS;
+    use crate::models::config::{BlitzExplorationConfig, MapConfig, TickImpl, TickTrait, WorldConfigUtilImpl};
+    use crate::models::events::{ExplorerExtractRewardStory, Story, StoryEvent};
+    use crate::models::map::{Tile, TileImpl};
+    use crate::models::map2::TileOpt;
+    use crate::models::resource::resource::{
+        ResourceWeightImpl, SingleResourceImpl, SingleResourceStoreImpl, WeightStoreImpl,
+    };
+    use crate::models::structure::StructureOwnerStoreImpl;
+    use crate::models::troop::ExplorerTroops;
+    use crate::models::weight::Weight;
+    use crate::system_libraries::rng_library::{IRNGlibraryDispatcherTrait, rng_library};
+    use crate::systems::utils::blitz_profile::iBlitzProfileImpl;
+    use crate::systems::utils::map::IMapImpl;
+    use crate::systems::utils::troop::iExplorerImpl;
+    use crate::utils::cartridge::vrf::Source;
+    use crate::utils::map::biomes::Biome;
+    use super::ITroopMovementRewardSystems;
+    use super::troop_movement_systems::ExplorerRewardEvent;
+
+    #[abi(embed_v0)]
+    impl TroopMovementRewardImpl of ITroopMovementRewardSystems<ContractState> {
+        fn extract_reward(self: @ContractState, explorer_id: ID, caller: ContractAddress) {
+            let mut world = self.world(DEFAULT_NS());
+            assert_called_by_troop_movement_systems(world);
+
+            let explorer: ExplorerTroops = assert_explorer_can_extract_reward(ref world, explorer_id);
+            let mut tile = read_explorer_reward_tile(world, explorer);
+            let vrf_seed = consume_explorer_reward_seed(world, tile);
+
+            if tile.reward_extracted {
+                return;
+            }
+
+            IMapImpl::mark_reward_extracted(ref world, ref tile);
+
+            let (explore_reward_type, explore_reward_amount) = grant_explorer_reward(ref world, explorer, vrf_seed);
+            emit_explorer_reward_events(
+                ref world, explorer, explorer_id, tile, explore_reward_type, explore_reward_amount, caller,
+            );
+        }
+    }
+
+    fn assert_called_by_troop_movement_systems(world: WorldStorage) {
+        let (troop_movement_systems_address, _) = world.dns(@"troop_movement_systems").unwrap();
+        assert!(
+            starknet::get_caller_address() == troop_movement_systems_address,
+            "caller must be the troop movement systems",
+        );
+    }
+
+    fn assert_explorer_can_extract_reward(ref world: WorldStorage, explorer_id: ID) -> ExplorerTroops {
+        let explorer: ExplorerTroops = world.read_model(explorer_id);
+        assert!(explorer.coord.alt == false, "Eternum: explorer must be on surface to extract reward");
+        assert!(explorer.troops.count.is_non_zero(), "explorer is dead");
+        explorer
+    }
+
+    fn read_explorer_reward_tile(world: WorldStorage, explorer: ExplorerTroops) -> Tile {
+        let tile_opt: TileOpt = world.read_model((explorer.coord.alt, explorer.coord.x, explorer.coord.y));
+        let tile: Tile = tile_opt.into();
+        assert!(explorer.explorer_id == tile.occupier_id, "tile occupier should be explorer");
+        assert!(tile.biome != Biome::None.into(), "tile must be explored");
+        tile
+    }
+
+    fn consume_explorer_reward_seed(world: WorldStorage, tile: Tile) -> u256 {
+        let rng_library_dispatcher = rng_library::get_dispatcher(@world);
+        rng_library_dispatcher.get_random_number(Source::Salt(tile.to_seed()), world)
+    }
+
+    fn grant_explorer_reward(ref world: WorldStorage, explorer: ExplorerTroops, vrf_seed: u256) -> (u8, u128) {
+        let blitz_mode_on: bool = WorldConfigUtilImpl::get_member(world, selector!("blitz_mode_on"));
+        let blitz_exploration_config: BlitzExplorationConfig = WorldConfigUtilImpl::get_member(
+            world, selector!("blitz_exploration_config"),
+        );
+        let blitz_exploration_reward_profile_id = iBlitzProfileImpl::resolve_blitz_profile_id(
+            blitz_exploration_config.reward_profile_id,
+        );
+        let current_tick: u64 = TickImpl::get_tick_interval(ref world).current();
+        let map_config: MapConfig = WorldConfigUtilImpl::get_member(world, selector!("map_config"));
+
+        let (explore_reward_type, explore_reward_amount) = iExplorerImpl::exploration_reward(
+            ref world,
+            Option::Some(explorer),
+            current_tick,
+            map_config,
+            vrf_seed,
+            blitz_mode_on,
+            blitz_exploration_reward_profile_id,
+        );
+
+        let reward_receiver = iExplorerImpl::exploration_reward_receiver(
+            ref world, blitz_mode_on, explorer, explore_reward_type,
+        );
+        grant_resource_reward(ref world, reward_receiver, explore_reward_type, explore_reward_amount);
+
+        (explore_reward_type, explore_reward_amount)
+    }
+
+    fn grant_resource_reward(ref world: WorldStorage, receiver_id: ID, resource_type: u8, resource_amount: u128) {
+        let resource_weight_grams: u128 = ResourceWeightImpl::grams(ref world, resource_type);
+        let mut reward_receiver_weight: Weight = WeightStoreImpl::retrieve(ref world, receiver_id);
+        let mut resource = SingleResourceStoreImpl::retrieve(
+            ref world, receiver_id, resource_type, ref reward_receiver_weight, resource_weight_grams, true,
+        );
+        resource.add(resource_amount, ref reward_receiver_weight, resource_weight_grams);
+        resource.store(ref world);
+        reward_receiver_weight.store(ref world, receiver_id);
+    }
+
+    fn emit_explorer_reward_events(
+        ref world: WorldStorage,
+        explorer: ExplorerTroops,
+        explorer_id: ID,
+        tile: Tile,
+        reward_resource_type: u8,
+        reward_resource_amount: u128,
+        caller: ContractAddress,
+    ) {
+        let explorer_owner: ContractAddress = StructureOwnerStoreImpl::retrieve(ref world, explorer.owner);
+        world
+            .emit_event(
+                @StoryEvent {
+                    id: world.dispatcher.uuid(),
+                    owner: Option::Some(explorer_owner),
+                    entity_id: Option::Some(explorer_id),
+                    tx_hash: starknet::get_tx_info().unbox().transaction_hash,
+                    story: Story::ExplorerExtractRewardStory(
+                        ExplorerExtractRewardStory {
+                            explorer_owner,
+                            explorer_id,
+                            explorer_structure_id: explorer.owner,
+                            coord: tile.into(),
+                            reward_resource_type,
+                            reward_resource_amount,
+                        },
+                    ),
+                    timestamp: starknet::get_block_timestamp(),
+                },
+            );
+
+        world
+            .emit_event(
+                @ExplorerRewardEvent {
+                    explorer_id,
+                    explorer_structure_id: explorer.owner,
+                    explorer_owner_address: caller,
+                    reward_resource_id: reward_resource_type,
+                    reward_resource_amount,
+                    coord: explorer.coord,
+                    timestamp: starknet::get_block_timestamp(),
+                },
+            );
     }
 }
 

--- a/contracts/game/src/systems/combat/tests/test_troop_movement_active.cairo
+++ b/contracts/game/src/systems/combat/tests/test_troop_movement_active.cairo
@@ -366,86 +366,171 @@ mod tests {
     }
 
     #[test]
-    fn test_explorer_explore_and_extract_does_not_store_unused_final_rng_seed() {
+    fn test_explorer_explore_and_extract_stores_same_final_rng_seed_as_legacy_path() {
         let (
-            mut world,
-            movement_addr,
-            movement,
+            mut legacy_world,
+            legacy_movement_addr,
+            legacy_movement,
             _realm_id,
-            realm_owner,
-            explorer_id,
+            legacy_realm_owner,
+            legacy_explorer_id,
             _source_coord,
             _target_coord,
-            target_direction,
+            legacy_target_direction,
         ) =
             setup_no_treasure_explorer();
 
         let explore_tx_hash = 0x4558504c4f52455f54585f48415348;
         start_cheat_transaction_hash_global(explore_tx_hash);
-        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+        run_legacy_explore_then_extract(
+            legacy_movement_addr, legacy_movement, legacy_realm_owner, legacy_explorer_id, legacy_target_direction,
+        );
         stop_cheat_transaction_hash_global();
 
-        let rng: RNG = world.read_model(explore_tx_hash);
-        assert!(rng.seed == 0, "combined explore should not persist unused final rng seed");
+        let (
+            mut combined_world,
+            combined_movement_addr,
+            combined_movement,
+            _combined_realm_id,
+            combined_realm_owner,
+            combined_explorer_id,
+            _combined_source_coord,
+            _combined_target_coord,
+            combined_target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        start_cheat_transaction_hash_global(explore_tx_hash);
+        run_combined_explore_and_extract(
+            combined_movement_addr,
+            combined_movement,
+            combined_realm_owner,
+            combined_explorer_id,
+            combined_target_direction,
+        );
+        stop_cheat_transaction_hash_global();
+
+        let legacy_rng: RNG = legacy_world.read_model(explore_tx_hash);
+        let combined_rng: RNG = combined_world.read_model(explore_tx_hash);
+        assert!(combined_rng.seed == legacy_rng.seed, "combined explore rng seed should match legacy path");
     }
 
     #[test]
-    fn test_explorer_explore_and_extract_uses_seeded_rng_without_storing_unused_final_seed() {
+    fn test_explorer_explore_and_extract_advances_seeded_rng_like_legacy_path() {
         let (
-            mut world,
-            movement_addr,
-            movement,
-            realm_id,
-            realm_owner,
-            explorer_id,
-            source_coord,
-            target_coord,
-            target_direction,
+            mut legacy_world,
+            legacy_movement_addr,
+            legacy_movement,
+            _legacy_realm_id,
+            legacy_realm_owner,
+            legacy_explorer_id,
+            _legacy_source_coord,
+            _legacy_target_coord,
+            legacy_target_direction,
         ) =
             setup_no_treasure_explorer();
 
         let explore_tx_hash = 0x5345454445445f4558504c4f52455f54585f48415348;
         let seeded_rng = 987654321;
-        world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
+        legacy_world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
 
         start_cheat_transaction_hash_global(explore_tx_hash);
-        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+        run_legacy_explore_then_extract(
+            legacy_movement_addr, legacy_movement, legacy_realm_owner, legacy_explorer_id, legacy_target_direction,
+        );
         stop_cheat_transaction_hash_global();
 
-        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+        let (
+            mut combined_world,
+            combined_movement_addr,
+            combined_movement,
+            combined_realm_id,
+            combined_realm_owner,
+            combined_explorer_id,
+            combined_source_coord,
+            combined_target_coord,
+            combined_target_direction,
+        ) =
+            setup_no_treasure_explorer();
+        combined_world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
 
-        let rng: RNG = world.read_model(explore_tx_hash);
-        assert!(rng.seed == seeded_rng, "combined explore should not persist the unused final seeded rng");
+        start_cheat_transaction_hash_global(explore_tx_hash);
+        run_combined_explore_and_extract(
+            combined_movement_addr,
+            combined_movement,
+            combined_realm_owner,
+            combined_explorer_id,
+            combined_target_direction,
+        );
+        stop_cheat_transaction_hash_global();
+
+        assert_explore_without_treasure_result(
+            ref combined_world, combined_realm_id, combined_explorer_id, combined_source_coord, combined_target_coord,
+        );
+
+        let legacy_rng: RNG = legacy_world.read_model(explore_tx_hash);
+        let combined_rng: RNG = combined_world.read_model(explore_tx_hash);
+        assert!(combined_rng.seed == legacy_rng.seed, "combined seeded rng should match legacy path");
     }
 
     #[test]
-    fn test_explorer_explore_and_extract_uses_seeded_rng_and_reuses_discovered_biome() {
+    fn test_explorer_explore_and_extract_advances_seeded_rng_like_legacy_path_with_reused_biome() {
         let (
-            mut world,
-            movement_addr,
-            movement,
-            realm_id,
-            realm_owner,
-            explorer_id,
-            source_coord,
-            target_coord,
-            target_direction,
+            mut legacy_world,
+            legacy_movement_addr,
+            legacy_movement,
+            _legacy_realm_id,
+            legacy_realm_owner,
+            legacy_explorer_id,
+            _legacy_source_coord,
+            legacy_target_coord,
+            legacy_target_direction,
         ) =
             setup_no_treasure_explorer();
 
         let explore_tx_hash = 0x5345454445445f52455045415445445f4558504c4f5245;
         let seeded_rng = 987654321;
-        world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
-        mark_target_biome_discovered(ref world, realm_owner, target_coord);
+        legacy_world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
+        mark_target_biome_discovered(ref legacy_world, legacy_realm_owner, legacy_target_coord);
 
         start_cheat_transaction_hash_global(explore_tx_hash);
-        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+        run_legacy_explore_then_extract(
+            legacy_movement_addr, legacy_movement, legacy_realm_owner, legacy_explorer_id, legacy_target_direction,
+        );
         stop_cheat_transaction_hash_global();
 
-        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+        let (
+            mut combined_world,
+            combined_movement_addr,
+            combined_movement,
+            combined_realm_id,
+            combined_realm_owner,
+            combined_explorer_id,
+            combined_source_coord,
+            combined_target_coord,
+            combined_target_direction,
+        ) =
+            setup_no_treasure_explorer();
+        combined_world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
+        mark_target_biome_discovered(ref combined_world, combined_realm_owner, combined_target_coord);
 
-        let rng: RNG = world.read_model(explore_tx_hash);
-        assert!(rng.seed == seeded_rng, "combined repeated explore should not persist the unused final seeded rng");
+        start_cheat_transaction_hash_global(explore_tx_hash);
+        run_combined_explore_and_extract(
+            combined_movement_addr,
+            combined_movement,
+            combined_realm_owner,
+            combined_explorer_id,
+            combined_target_direction,
+        );
+        stop_cheat_transaction_hash_global();
+
+        assert_explore_without_treasure_result(
+            ref combined_world, combined_realm_id, combined_explorer_id, combined_source_coord, combined_target_coord,
+        );
+
+        let legacy_rng: RNG = legacy_world.read_model(explore_tx_hash);
+        let combined_rng: RNG = combined_world.read_model(explore_tx_hash);
+        assert!(combined_rng.seed == legacy_rng.seed, "combined reused-biome rng should match legacy path");
     }
 
     #[test]

--- a/contracts/game/src/systems/combat/tests/test_troop_movement_active.cairo
+++ b/contracts/game/src/systems/combat/tests/test_troop_movement_active.cairo
@@ -1,0 +1,498 @@
+//! Active movement tests for current packed TileOpt movement flows.
+
+#[cfg(test)]
+mod tests {
+    use dojo::model::ModelStorage;
+    use dojo::world::WorldStorageTrait;
+    use snforge_std::{
+        start_cheat_block_timestamp_global, start_cheat_caller_address, start_cheat_chain_id_global,
+        start_cheat_transaction_hash_global, stop_cheat_caller_address, stop_cheat_transaction_hash_global,
+    };
+    use crate::alias::ID;
+    use crate::constants::{RESOURCE_PRECISION, ResourceTypes};
+    use crate::models::config::{MapConfig, WorldConfigUtilImpl};
+    use crate::models::map::{BiomeDiscovered, Tile, TileTrait};
+    use crate::models::map2::TileOpt;
+    use crate::models::position::{Coord, CoordTrait, Direction};
+    use crate::models::resource::production::production::Production;
+    use crate::models::resource::resource::ResourceImpl;
+    use crate::models::rng::RNG;
+    use crate::models::troop::{ExplorerTroops, TroopTier, TroopType};
+    use crate::systems::combat::contracts::troop_management::{
+        ITroopManagementSystemsDispatcher, ITroopManagementSystemsDispatcherTrait,
+    };
+    use crate::systems::combat::contracts::troop_movement::{
+        ITroopMovementSystemsDispatcher, ITroopMovementSystemsDispatcherTrait,
+    };
+    use crate::utils::map::biomes::get_biome_from_world;
+    use crate::utils::testing::helpers::{
+        MOCK_MAP_CONFIG, MOCK_TICK_CONFIG, MOCK_TROOP_STAMINA_CONFIG, setup_troop_management_world,
+        spawn_guard_test_realm, tgrant_resources,
+    };
+
+    fn get_no_treasure_map_config() -> MapConfig {
+        let mut config = MOCK_MAP_CONFIG();
+        config.shards_mines_win_probability = 0;
+        config.shards_mines_fail_probability = 10_000;
+        config.hyps_win_prob = 0;
+        config.hyps_fail_prob = 10_000;
+        config.holysite_win_probability = 0;
+        config.holysite_fail_probability = 10_000;
+        config.agent_discovery_prob = 0;
+        config.agent_discovery_fail_prob = 10_000;
+        config.camp_win_probability = 0;
+        config.camp_fail_probability = 10_000;
+        config.bitcoin_mine_win_probability = 0;
+        config.bitcoin_mine_fail_probability = 10_000;
+        config
+    }
+
+    fn read_tile(ref world: dojo::world::WorldStorage, coord: Coord) -> Tile {
+        let tile_opt: TileOpt = world.read_model((coord.alt, coord.x, coord.y));
+        tile_opt.into()
+    }
+
+    fn setup_no_treasure_explorer() -> (
+        dojo::world::WorldStorage,
+        starknet::ContractAddress,
+        ITroopMovementSystemsDispatcher,
+        ID,
+        starknet::ContractAddress,
+        ID,
+        Coord,
+        Coord,
+        Direction,
+    ) {
+        let mut world = setup_troop_management_world();
+        start_cheat_chain_id_global('SN_TEST');
+        WorldConfigUtilImpl::set_member(ref world, selector!("map_config"), get_no_treasure_map_config());
+
+        let realm_owner = starknet::contract_address_const::<'realm_owner'>();
+        let realm_coord = Coord { alt: false, x: 10, y: 10 };
+        let realm_id = spawn_guard_test_realm(ref world, 1, realm_owner, realm_coord);
+
+        let troop_amount = 1 * RESOURCE_PRECISION;
+        tgrant_resources(
+            ref world,
+            realm_id,
+            array![
+                (ResourceTypes::KNIGHT_T1, troop_amount), (ResourceTypes::WHEAT, 100 * RESOURCE_PRECISION),
+                (ResourceTypes::FISH, 100 * RESOURCE_PRECISION),
+            ]
+                .span(),
+        );
+
+        let (management_addr, _) = world.dns(@"troop_management_systems").unwrap();
+        let management = ITroopManagementSystemsDispatcher { contract_address: management_addr };
+        let (movement_addr, _) = world.dns(@"troop_movement_systems").unwrap();
+        let movement = ITroopMovementSystemsDispatcher { contract_address: movement_addr };
+
+        let spawn_direction = Direction::NorthEast;
+        start_cheat_block_timestamp_global(MOCK_TICK_CONFIG().armies_tick_in_seconds);
+        start_cheat_caller_address(management_addr, realm_owner);
+        let explorer_id = management
+            .explorer_create(realm_id, TroopType::Knight, TroopTier::T1, troop_amount, spawn_direction);
+        stop_cheat_caller_address(management_addr);
+
+        let source_coord = realm_coord.neighbor(spawn_direction);
+        let target_direction = Direction::East;
+        let target_coord = source_coord.neighbor(target_direction);
+
+        (
+            world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        )
+    }
+
+    fn run_combined_explore_and_extract(
+        movement_addr: starknet::ContractAddress,
+        movement: ITroopMovementSystemsDispatcher,
+        realm_owner: starknet::ContractAddress,
+        explorer_id: ID,
+        target_direction: Direction,
+    ) {
+        start_cheat_caller_address(movement_addr, realm_owner);
+        movement.explorer_explore_and_extract(explorer_id, array![target_direction].span());
+        stop_cheat_caller_address(movement_addr);
+    }
+
+    fn run_legacy_explore_then_extract(
+        movement_addr: starknet::ContractAddress,
+        movement: ITroopMovementSystemsDispatcher,
+        realm_owner: starknet::ContractAddress,
+        explorer_id: ID,
+        target_direction: Direction,
+    ) {
+        start_cheat_caller_address(movement_addr, realm_owner);
+        movement.explorer_move(explorer_id, array![target_direction].span(), true);
+        movement.explorer_extract_reward(explorer_id);
+        stop_cheat_caller_address(movement_addr);
+    }
+
+    fn assert_explore_position_and_tiles(
+        ref world: dojo::world::WorldStorage, explorer_id: ID, source_coord: Coord, target_coord: Coord,
+    ) {
+        let explorer: ExplorerTroops = world.read_model(explorer_id);
+        assert!(explorer.coord == target_coord, "explorer should end on explored target");
+
+        let source_tile = read_tile(ref world, source_coord);
+        assert!(source_tile.occupier_id == 0, "source tile should be empty");
+
+        let target_tile = read_tile(ref world, target_coord);
+        assert!(target_tile.discovered(), "target tile should be discovered");
+        assert!(target_tile.occupier_id == explorer_id, "target tile should be occupied by explorer");
+        assert!(target_tile.reward_extracted, "target reward should be extracted");
+    }
+
+    fn assert_explore_without_treasure_result(
+        ref world: dojo::world::WorldStorage, realm_id: ID, explorer_id: ID, source_coord: Coord, target_coord: Coord,
+    ) {
+        assert_explore_position_and_tiles(ref world, explorer_id, source_coord, target_coord);
+
+        let wheat_balance = ResourceImpl::read_balance(ref world, realm_id, ResourceTypes::WHEAT);
+        assert!(wheat_balance < 100 * RESOURCE_PRECISION, "explore should still burn food");
+    }
+
+    fn enable_food_production(ref world: dojo::world::WorldStorage, realm_id: ID, wheat_rate: u64, fish_rate: u64) {
+        ResourceImpl::write_production(
+            ref world,
+            realm_id,
+            ResourceTypes::WHEAT,
+            Production { building_count: 1, production_rate: wheat_rate, output_amount_left: 0, last_updated_at: 0 },
+        );
+        ResourceImpl::write_production(
+            ref world,
+            realm_id,
+            ResourceTypes::FISH,
+            Production { building_count: 1, production_rate: fish_rate, output_amount_left: 0, last_updated_at: 0 },
+        );
+    }
+
+    fn assert_food_production_was_harvested_and_burned(
+        ref world: dojo::world::WorldStorage, realm_id: ID, wheat_rate: u64, fish_rate: u64,
+    ) {
+        let now = MOCK_TICK_CONFIG().armies_tick_in_seconds;
+        let now_u32: u32 = now.try_into().unwrap();
+        let troop_stamina_config = MOCK_TROOP_STAMINA_CONFIG();
+        let expected_wheat = 100 * RESOURCE_PRECISION
+            + (now.into() * wheat_rate.into())
+            - troop_stamina_config.stamina_explore_wheat_cost.into();
+        let expected_fish = 100 * RESOURCE_PRECISION
+            + (now.into() * fish_rate.into())
+            - troop_stamina_config.stamina_explore_fish_cost.into();
+
+        let wheat_balance = ResourceImpl::read_balance(ref world, realm_id, ResourceTypes::WHEAT);
+        let fish_balance = ResourceImpl::read_balance(ref world, realm_id, ResourceTypes::FISH);
+        assert!(wheat_balance == expected_wheat, "wheat production should be harvested before burn");
+        assert!(fish_balance == expected_fish, "fish production should be harvested before burn");
+
+        let wheat_production = ResourceImpl::read_production(ref world, realm_id, ResourceTypes::WHEAT);
+        let fish_production = ResourceImpl::read_production(ref world, realm_id, ResourceTypes::FISH);
+        assert!(wheat_production.last_updated_at == now_u32, "wheat production timestamp should update");
+        assert!(fish_production.last_updated_at == now_u32, "fish production timestamp should update");
+    }
+
+    fn exploration_reward_resource_types() -> Array<u8> {
+        array![
+            ResourceTypes::WOOD, ResourceTypes::STONE, ResourceTypes::COAL, ResourceTypes::COPPER,
+            ResourceTypes::OBSIDIAN, ResourceTypes::SILVER, ResourceTypes::IRONWOOD, ResourceTypes::COLD_IRON,
+            ResourceTypes::GOLD, ResourceTypes::HARTWOOD, ResourceTypes::DIAMONDS, ResourceTypes::SAPPHIRE,
+            ResourceTypes::RUBY, ResourceTypes::DEEP_CRYSTAL, ResourceTypes::IGNIUM, ResourceTypes::ETHEREAL_SILICA,
+            ResourceTypes::TRUE_ICE, ResourceTypes::TWILIGHT_QUARTZ, ResourceTypes::ALCHEMICAL_SILVER,
+            ResourceTypes::ADAMANTINE, ResourceTypes::MITHRAL, ResourceTypes::DRAGONHIDE, ResourceTypes::EARTHEN_SHARD,
+        ]
+    }
+
+    fn assert_reward_balances_match(
+        ref legacy_world: dojo::world::WorldStorage,
+        legacy_explorer_id: ID,
+        ref combined_world: dojo::world::WorldStorage,
+        combined_explorer_id: ID,
+    ) {
+        let mut resource_types = exploration_reward_resource_types();
+        let mut legacy_total = 0;
+        let mut combined_total = 0;
+        loop {
+            match resource_types.pop_front() {
+                Option::Some(resource_type) => {
+                    let legacy_balance = ResourceImpl::read_balance(
+                        ref legacy_world, legacy_explorer_id, resource_type,
+                    );
+                    let combined_balance = ResourceImpl::read_balance(
+                        ref combined_world, combined_explorer_id, resource_type,
+                    );
+                    assert!(legacy_balance == combined_balance, "reward balance should match legacy path");
+                    legacy_total += legacy_balance;
+                    combined_total += combined_balance;
+                },
+                Option::None => { break; },
+            }
+        }
+
+        let expected_total = MOCK_MAP_CONFIG().reward_resource_amount.into() * RESOURCE_PRECISION;
+        assert!(legacy_total == expected_total, "legacy reward total should match config");
+        assert!(combined_total == expected_total, "combined reward total should match config");
+    }
+
+    fn mark_target_biome_discovered(
+        ref world: dojo::world::WorldStorage, realm_owner: starknet::ContractAddress, target_coord: Coord,
+    ) {
+        let biome = get_biome_from_world(world, target_coord.alt, target_coord.x.into(), target_coord.y.into());
+        let biome_u8: u8 = biome.into();
+        world.write_model(@BiomeDiscovered { by_address: realm_owner, biome: biome_u8, discovered: true });
+    }
+
+    #[test]
+    fn test_no_treasure_explorer_setup_baseline() {
+        let (mut world, _, _, _, _, explorer_id, source_coord, _, _) = setup_no_treasure_explorer();
+
+        let explorer: ExplorerTroops = world.read_model(explorer_id);
+        assert!(explorer.coord == source_coord, "explorer should start adjacent to realm");
+    }
+
+    #[test]
+    fn test_legacy_explorer_move_then_extract_without_treasure() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        run_legacy_explore_then_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+
+        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_marks_target_reward_extracted_without_treasure() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+
+        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_reuses_discovered_biome_without_changing_outcome() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        mark_target_biome_discovered(ref world, realm_owner, target_coord);
+
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+
+        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_grants_same_reward_as_legacy_extract() {
+        let (
+            mut legacy_world,
+            legacy_movement_addr,
+            legacy_movement,
+            _legacy_realm_id,
+            legacy_realm_owner,
+            legacy_explorer_id,
+            _legacy_source_coord,
+            _legacy_target_coord,
+            legacy_target_direction,
+        ) =
+            setup_no_treasure_explorer();
+        let reward_tx_hash = 0x4558504c4f52455f5245574152445f4d41544348;
+        start_cheat_transaction_hash_global(reward_tx_hash);
+        run_legacy_explore_then_extract(
+            legacy_movement_addr, legacy_movement, legacy_realm_owner, legacy_explorer_id, legacy_target_direction,
+        );
+        stop_cheat_transaction_hash_global();
+
+        let (
+            mut combined_world,
+            combined_movement_addr,
+            combined_movement,
+            _combined_realm_id,
+            combined_realm_owner,
+            combined_explorer_id,
+            _combined_source_coord,
+            _combined_target_coord,
+            combined_target_direction,
+        ) =
+            setup_no_treasure_explorer();
+        start_cheat_transaction_hash_global(reward_tx_hash);
+        run_combined_explore_and_extract(
+            combined_movement_addr,
+            combined_movement,
+            combined_realm_owner,
+            combined_explorer_id,
+            combined_target_direction,
+        );
+        stop_cheat_transaction_hash_global();
+
+        assert_reward_balances_match(ref legacy_world, legacy_explorer_id, ref combined_world, combined_explorer_id);
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_does_not_store_unused_final_rng_seed() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            _realm_id,
+            realm_owner,
+            explorer_id,
+            _source_coord,
+            _target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        let explore_tx_hash = 0x4558504c4f52455f54585f48415348;
+        start_cheat_transaction_hash_global(explore_tx_hash);
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+        stop_cheat_transaction_hash_global();
+
+        let rng: RNG = world.read_model(explore_tx_hash);
+        assert!(rng.seed == 0, "combined explore should not persist unused final rng seed");
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_uses_seeded_rng_without_storing_unused_final_seed() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        let explore_tx_hash = 0x5345454445445f4558504c4f52455f54585f48415348;
+        let seeded_rng = 987654321;
+        world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
+
+        start_cheat_transaction_hash_global(explore_tx_hash);
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+        stop_cheat_transaction_hash_global();
+
+        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+
+        let rng: RNG = world.read_model(explore_tx_hash);
+        assert!(rng.seed == seeded_rng, "combined explore should not persist the unused final seeded rng");
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_uses_seeded_rng_and_reuses_discovered_biome() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        let explore_tx_hash = 0x5345454445445f52455045415445445f4558504c4f5245;
+        let seeded_rng = 987654321;
+        world.write_model(@RNG { tx_hash: explore_tx_hash, seed: seeded_rng });
+        mark_target_biome_discovered(ref world, realm_owner, target_coord);
+
+        start_cheat_transaction_hash_global(explore_tx_hash);
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+        stop_cheat_transaction_hash_global();
+
+        assert_explore_without_treasure_result(ref world, realm_id, explorer_id, source_coord, target_coord);
+
+        let rng: RNG = world.read_model(explore_tx_hash);
+        assert!(rng.seed == seeded_rng, "combined repeated explore should not persist the unused final seeded rng");
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_burns_single_step_explore_stamina() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            _realm_id,
+            realm_owner,
+            explorer_id,
+            _source_coord,
+            _target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+
+        let explorer: ExplorerTroops = world.read_model(explorer_id);
+        let expected_stamina = MOCK_TROOP_STAMINA_CONFIG().stamina_initial.into()
+            - MOCK_TROOP_STAMINA_CONFIG().stamina_explore_stamina_cost.into();
+        assert!(explorer.troops.stamina.amount == expected_stamina, "single explore should burn one stamina step");
+    }
+
+    #[test]
+    fn test_explorer_explore_and_extract_harvests_active_food_production_before_burn() {
+        let (
+            mut world,
+            movement_addr,
+            movement,
+            realm_id,
+            realm_owner,
+            explorer_id,
+            source_coord,
+            target_coord,
+            target_direction,
+        ) =
+            setup_no_treasure_explorer();
+
+        let wheat_rate = 10;
+        let fish_rate = 7;
+        enable_food_production(ref world, realm_id, wheat_rate, fish_rate);
+
+        run_combined_explore_and_extract(movement_addr, movement, realm_owner, explorer_id, target_direction);
+
+        assert_explore_position_and_tiles(ref world, explorer_id, source_coord, target_coord);
+        assert_food_production_was_harvested_and_burned(ref world, realm_id, wheat_rate, fish_rate);
+    }
+}

--- a/contracts/game/src/systems/quest/contracts.cairo
+++ b/contracts/game/src/systems/quest/contracts.cairo
@@ -525,7 +525,8 @@ mod tests {
     };
     use crate::systems::combat::contracts::troop_movement::{
         ITroopMovementSystemsDispatcher, ITroopMovementSystemsDispatcherTrait, agent_discovery_systems,
-        hyperstructure_discovery_systems, mine_discovery_systems, troop_movement_systems, troop_movement_util_systems,
+        hyperstructure_discovery_systems, mine_discovery_systems, troop_movement_reward_systems, troop_movement_systems,
+        troop_movement_util_systems,
     };
     use crate::systems::quest::constants::{
         MAXIMUM_QUEST_CAPACITY, MINIMUM_QUEST_CAPACITY, QUEST_REWARD_BASE_MULTIPLIER, VERSION,
@@ -579,6 +580,7 @@ mod tests {
                 TestResource::Contract(troop_management_systems::TEST_CLASS_HASH),
                 TestResource::Contract(troop_movement_systems::TEST_CLASS_HASH),
                 TestResource::Contract(troop_movement_util_systems::TEST_CLASS_HASH),
+                TestResource::Contract(troop_movement_reward_systems::TEST_CLASS_HASH),
                 TestResource::Contract(agent_discovery_systems::TEST_CLASS_HASH),
                 TestResource::Contract(hyperstructure_discovery_systems::TEST_CLASS_HASH),
                 TestResource::Contract(mine_discovery_systems::TEST_CLASS_HASH),
@@ -602,6 +604,8 @@ mod tests {
             ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_systems")
                 .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
             ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_util_systems")
+                .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+            ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_reward_systems")
                 .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
             ContractDefTrait::new(DEFAULT_NS(), @"agent_discovery_systems")
                 .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),

--- a/contracts/game/src/systems/utils/map.cairo
+++ b/contracts/game/src/systems/utils/map.cairo
@@ -125,18 +125,23 @@ pub impl IMapImpl of IMapTrait {
 
 
     fn explore(ref world: WorldStorage, ref tile: Tile, biome: Biome) {
-        tile.biome = biome.into();
-
-        let tile_opt: TileOpt = tile.into();
-        world.write_model(@tile_opt);
+        Self::explore_memory(ref tile, biome);
+        Self::store_tile(ref world, tile);
         // todo add event {if not already explored}
     }
 
+    fn explore_memory(ref tile: Tile, biome: Biome) {
+        tile.biome = biome.into();
+    }
+
     fn mark_reward_extracted(ref world: WorldStorage, ref tile: Tile) {
-        tile.reward_extracted = true;
-        let tile_opt: TileOpt = tile.into();
-        world.write_model(@tile_opt);
+        Self::mark_reward_extracted_memory(ref tile);
+        Self::store_tile(ref world, tile);
         // todo add event {if not already extracted}
+    }
+
+    fn mark_reward_extracted_memory(ref tile: Tile) {
+        tile.reward_extracted = true;
     }
 
     fn explore_ring(ref world: WorldStorage, start_coord: Coord, mut radius: u32) {
@@ -155,6 +160,12 @@ pub impl IMapImpl of IMapTrait {
     }
 
     fn occupy(ref world: WorldStorage, ref tile: Tile, category: TileOccupier, id: ID) {
+        Self::occupy_memory(ref tile, category, id);
+        Self::store_tile(ref world, tile);
+        // todo add event {if not already explored}
+    }
+
+    fn occupy_memory(ref tile: Tile, category: TileOccupier, id: ID) {
         tile.occupier_type = category.into();
         tile.occupier_id = id;
         tile.occupier_is_structure = match category {
@@ -180,9 +191,11 @@ pub impl IMapImpl of IMapTrait {
             TileOccupier::ExplorerCrossbowmanT3Daydreams => false,
             _ => true,
         };
+    }
+
+    fn store_tile(ref world: WorldStorage, tile: Tile) {
         let tile_opt: TileOpt = tile.into();
         world.write_model(@tile_opt);
-        // todo add event {if not already explored}
     }
 
     fn unoccupy(ref world: WorldStorage, ref tile: Tile) {
@@ -205,4 +218,3 @@ pub impl IMapImpl of IMapTrait {
         false
     }
 }
-

--- a/contracts/game/src/utils/achievements/index.cairo
+++ b/contracts/game/src/utils/achievements/index.cairo
@@ -91,6 +91,7 @@ pub impl AchievementImpl of AchievementTrait {
     }
 
 
+    #[inline(always)]
     fn progress(world: WorldStorage, player_id: felt252, task_id: felt252, count: u32, time: u64) {
         let store: Store = StoreTrait::new(world);
         store.progress(player_id: player_id, task_id: task_id, count: count.into(), time: time)

--- a/contracts/game/src/utils/testing/helpers.cairo
+++ b/contracts/game/src/utils/testing/helpers.cairo
@@ -615,15 +615,17 @@ pub fn namespace_def_combat() -> NamespaceDef {
             TestResource::Model("StructureVillageSlots"), TestResource::Model("StructureBuildings"),
             TestResource::Model("Building"), // Troop models
             TestResource::Model("ExplorerTroops"), // Map models
-            TestResource::Model("TileOpt"), TestResource::Model("BiomeDiscovered"),
-            TestResource::Model("Wonder"), // Resource models
-            TestResource::Model("Resource"),
-            TestResource::Model("ResourceList"), TestResource::Model("ResourceFactoryConfig"),
-            // Contracts
+            TestResource::Model("TileOpt"), TestResource::Model("BiomeDiscovered"), TestResource::Model("Wonder"),
+            TestResource::Model("StructureReservation"), // Discovery models
+            TestResource::Model("RNG"),
+            TestResource::Model("PlayerRegisteredPoints"), TestResource::Model("SeasonPrize"),
+            TestResource::Model("HyperstructureGlobals"), TestResource::Model("AgentCount"),
+            TestResource::Model("AgentLifetimeCount"), TestResource::Model("AgentConfig"), // Resource models
+            TestResource::Model("Resource"), TestResource::Model("ResourceList"),
+            TestResource::Model("ResourceFactoryConfig"), // Contracts
             TestResource::Contract("troop_management_systems"), TestResource::Contract("troop_movement_systems"),
             TestResource::Contract("troop_battle_systems"), TestResource::Contract("village_systems"),
-            TestResource::Contract("realm_internal_systems"), TestResource::Contract("resource_systems"),
-            // Libraries
+            TestResource::Contract("realm_internal_systems"), TestResource::Contract("resource_systems"), // Libraries
             TestResource::Library(("structure_creation_library", "0_1_18")),
             TestResource::Library(("biome_library", "0_1_13")), TestResource::Library(("rng_library", "0_1_16")),
             TestResource::Library(("combat_library", "0_1_14")),
@@ -631,7 +633,8 @@ pub fn namespace_def_combat() -> NamespaceDef {
                 ("raid_library", "0_1_0"),
             ), // Events - TrophyProgression is from achievement crate, declared via build-external-contracts
             TestResource::Event("StoryEvent"), TestResource::Event("ExplorerMoveEvent"),
-            TestResource::Event("BattleEvent"), TestResource::Event("TrophyProgression"),
+            TestResource::Event("ExplorerRewardEvent"), TestResource::Event("BattleEvent"),
+            TestResource::Event("TrophyProgression"),
         ]
             .span(),
     }
@@ -1186,17 +1189,25 @@ pub fn namespace_def_troop_management() -> NamespaceDef {
             TestResource::Model("StructureVillageSlots"), TestResource::Model("StructureBuildings"),
             TestResource::Model("Building"), // Troop models
             TestResource::Model("ExplorerTroops"), // Map models
-            TestResource::Model("TileOpt"), TestResource::Model("BiomeDiscovered"),
-            TestResource::Model("Wonder"), // Resource models
-            TestResource::Model("Resource"),
-            TestResource::Model("ResourceList"), TestResource::Model("ResourceFactoryConfig"),
-            // Events
-            TestResource::Event("TrophyProgression"), TestResource::Event("StoryEvent"),
-            TestResource::Event("ExplorerMoveEvent"), // Contracts
+            TestResource::Model("TileOpt"), TestResource::Model("BiomeDiscovered"), TestResource::Model("Wonder"),
+            TestResource::Model("StructureReservation"), // Discovery models
+            TestResource::Model("RNG"),
+            TestResource::Model("PlayerRegisteredPoints"), TestResource::Model("SeasonPrize"),
+            TestResource::Model("HyperstructureGlobals"), TestResource::Model("AgentCount"),
+            TestResource::Model("AgentLifetimeCount"), TestResource::Model("AgentConfig"), // Resource models
+            TestResource::Model("Resource"), TestResource::Model("ResourceList"),
+            TestResource::Model("ResourceFactoryConfig"), // Events
+            TestResource::Event("TrophyProgression"),
+            TestResource::Event("StoryEvent"), TestResource::Event("ExplorerMoveEvent"),
+            TestResource::Event("ExplorerRewardEvent"), // Contracts
             TestResource::Contract("troop_management_systems"),
-            TestResource::Contract("troop_movement_systems"), TestResource::Contract("village_systems"),
-            TestResource::Contract("realm_internal_systems"), TestResource::Contract("resource_systems"),
-            // Libraries
+            TestResource::Contract("troop_movement_systems"), TestResource::Contract("troop_movement_util_systems"),
+            TestResource::Contract("relic_chest_discovery_systems"),
+            TestResource::Contract("hyperstructure_discovery_systems"),
+            TestResource::Contract("mine_discovery_systems"), TestResource::Contract("holysite_discovery_systems"),
+            TestResource::Contract("camp_discovery_systems"), TestResource::Contract("agent_discovery_systems"),
+            TestResource::Contract("village_systems"), TestResource::Contract("realm_internal_systems"),
+            TestResource::Contract("resource_systems"), // Libraries
             TestResource::Library(("structure_creation_library", "0_1_18")),
             TestResource::Library(("biome_library", "0_1_13")), TestResource::Library(("rng_library", "0_1_16")),
             TestResource::Library(("combat_library", "0_1_14")),
@@ -1210,6 +1221,20 @@ pub fn contract_defs_troop_management() -> Span<ContractDef> {
         ContractDefTrait::new(DEFAULT_NS(), @"troop_management_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
         ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_util_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"relic_chest_discovery_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"hyperstructure_discovery_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"mine_discovery_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"holysite_discovery_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"camp_discovery_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"agent_discovery_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
         ContractDefTrait::new(DEFAULT_NS(), @"village_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),

--- a/contracts/game/src/utils/testing/helpers.cairo
+++ b/contracts/game/src/utils/testing/helpers.cairo
@@ -624,8 +624,9 @@ pub fn namespace_def_combat() -> NamespaceDef {
             TestResource::Model("Resource"), TestResource::Model("ResourceList"),
             TestResource::Model("ResourceFactoryConfig"), // Contracts
             TestResource::Contract("troop_management_systems"), TestResource::Contract("troop_movement_systems"),
-            TestResource::Contract("troop_battle_systems"), TestResource::Contract("village_systems"),
-            TestResource::Contract("realm_internal_systems"), TestResource::Contract("resource_systems"), // Libraries
+            TestResource::Contract("troop_movement_reward_systems"), TestResource::Contract("troop_battle_systems"),
+            TestResource::Contract("village_systems"), TestResource::Contract("realm_internal_systems"),
+            TestResource::Contract("resource_systems"), // Libraries
             TestResource::Library(("structure_creation_library", "0_1_18")),
             TestResource::Library(("biome_library", "0_1_13")), TestResource::Library(("rng_library", "0_1_16")),
             TestResource::Library(("combat_library", "0_1_14")),
@@ -646,6 +647,8 @@ pub fn contract_defs_combat() -> Span<ContractDef> {
         ContractDefTrait::new(DEFAULT_NS(), @"troop_management_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
         ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_reward_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
         ContractDefTrait::new(DEFAULT_NS(), @"troop_battle_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
@@ -1202,6 +1205,7 @@ pub fn namespace_def_troop_management() -> NamespaceDef {
             TestResource::Event("ExplorerRewardEvent"), // Contracts
             TestResource::Contract("troop_management_systems"),
             TestResource::Contract("troop_movement_systems"), TestResource::Contract("troop_movement_util_systems"),
+            TestResource::Contract("troop_movement_reward_systems"),
             TestResource::Contract("relic_chest_discovery_systems"),
             TestResource::Contract("hyperstructure_discovery_systems"),
             TestResource::Contract("mine_discovery_systems"), TestResource::Contract("holysite_discovery_systems"),
@@ -1223,6 +1227,8 @@ pub fn contract_defs_troop_management() -> Span<ContractDef> {
         ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
         ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_util_systems")
+            .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
+        ContractDefTrait::new(DEFAULT_NS(), @"troop_movement_reward_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),
         ContractDefTrait::new(DEFAULT_NS(), @"relic_chest_discovery_systems")
             .with_writer_of([dojo::utils::bytearray_hash(DEFAULT_NS())].span()),

--- a/packages/provider/src/explorer-explore.test.ts
+++ b/packages/provider/src/explorer-explore.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { EternumProvider, TransactionType } from "./index";
+
+const makeProvider = () => {
+  const provider = Object.create(EternumProvider.prototype) as any;
+  provider.manifest = {
+    world: { address: "0xworld" },
+    contracts: [{ tag: "s1_eternum-troop_movement_systems", address: "0xmovement" }],
+  };
+  provider.VRF_PROVIDER_ADDRESS = "0xvrf";
+  provider.promiseQueue = {
+    enqueue: vi.fn().mockResolvedValue({ transaction_hash: "0xexplore" }),
+  };
+  return provider;
+};
+
+describe("EternumProvider.explorer_explore", () => {
+  it("uses the combined explore and extract entrypoint to avoid the extra system call", async () => {
+    const provider = makeProvider();
+    const signer = { address: "0xabc" };
+
+    await provider.explorer_explore({
+      signer,
+      explorer_id: 42,
+      directions: [0],
+      vrf_source_salt: "0xfeed",
+    });
+
+    expect(provider.promiseQueue.enqueue).toHaveBeenCalledWith({
+      signer,
+      transactionType: TransactionType.EXPLORE,
+      calls: [
+        {
+          contractAddress: "0xvrf",
+          entrypoint: "request_random",
+          calldata: ["0xmovement", 1, "0xfeed"],
+        },
+        {
+          contractAddress: "0xmovement",
+          entrypoint: "explorer_explore_and_extract",
+          calldata: [42, [0]],
+        },
+      ],
+    });
+  });
+});

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -726,7 +726,10 @@ export class EternumProvider extends EnhancedDojoProvider {
 
   private getExploreTransactionExplorerId(transactionDetails: AllowArray<Call>): string | undefined {
     const explorerCall = this.getTransactionCalls(transactionDetails).find(
-      (detail) => detail.entrypoint === "explorer_move" || detail.entrypoint === "explorer_extract_reward",
+      (detail) =>
+        detail.entrypoint === "explorer_move" ||
+        detail.entrypoint === "explorer_extract_reward" ||
+        detail.entrypoint === "explorer_explore_and_extract",
     );
     if (!Array.isArray(explorerCall?.calldata)) {
       return undefined;
@@ -3302,7 +3305,7 @@ export class EternumProvider extends EnhancedDojoProvider {
     const troopMovementSystemsAddress = getContractByName(this.manifest, `${NAMESPACE}-troop_movement_systems`);
     const callData: Call[] = [];
 
-    // explorer_move now consumes Source::Salt(tile.to_seed()).
+    // explorer_explore_and_extract consumes Source::Salt(tile.to_seed()).
     if (isVrfEnabled(this.VRF_PROVIDER_ADDRESS)) {
       if (vrf_source_salt === undefined) {
         throw new Error(
@@ -3318,18 +3321,11 @@ export class EternumProvider extends EnhancedDojoProvider {
       );
     }
 
-    // Explorer move with explore=1
+    // Explorer move and reward extraction in one system entrypoint.
     callData.push({
       contractAddress: troopMovementSystemsAddress,
-      entrypoint: "explorer_move",
-      calldata: [explorer_id, directions, 1],
-    });
-
-    // Extract reward
-    callData.push({
-      contractAddress: troopMovementSystemsAddress,
-      entrypoint: "explorer_extract_reward",
-      calldata: [explorer_id],
+      entrypoint: "explorer_explore_and_extract",
+      calldata: [explorer_id, directions],
     });
 
     return await this.promiseQueue.enqueue({ signer, calls: callData, transactionType: TransactionType.EXPLORE });


### PR DESCRIPTION
Adds `explorer_explore_and_extract` so provider explore does VRF plus one combined movement/reward system call instead of VRF plus move plus extract.
Optimizes the hot path with packed tile mutations, lazy VRF config reads, and specialized food/weight updates while preserving reward and RNG behavior through active movement tests.
Updates web/mobile session policies for the new entrypoint.
Validation: `scarb test --no-warnings`, `pnpm run format`, `pnpm run knip`, `pnpm --dir packages/provider test --run`, `pnpm run build:packages`, `pnpm --dir packages/client build`, `pnpm run build`, `pnpm run build:mobile`, and `git diff --check`; root recursive tests still have unrelated workspace failures/timeouts noted locally.