### PR TITLE
[codex] Fail fast on invalid Slot auth

### DIFF
--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -799,6 +799,55 @@ jobs:
           }
           EOF
 
+      - name: Validate Slot auth
+        run: |
+          set -euo pipefail
+          source .context/game-launch/launch-env.sh
+
+          launch_step_reaches_indexer() {
+            if [ "${GAME_LAUNCH_KIND}" = "game" ]; then
+              case "${GAME_LAUNCH_STEP}" in
+                full|create-world|wait-for-factory-index|configure-world|grant-lootchest-role|grant-village-pass-role|create-banks|create-indexer)
+                  return 0
+                  ;;
+                *)
+                  return 1
+                  ;;
+              esac
+            fi
+
+            case "${GAME_LAUNCH_STEP}" in
+              full|create-series|create-worlds|wait-for-factory-indexes|configure-worlds|grant-lootchest-roles|grant-village-pass-roles|create-banks|create-indexers)
+                return 0
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          if [ "${GAME_LAUNCH_SKIP_INDEXER:-}" = "true" ]; then
+            echo "Skipping Slot auth validation because indexer creation is disabled."
+            exit 0
+          fi
+
+          if ! launch_step_reaches_indexer; then
+            echo "Skipping Slot auth validation because this launch step does not create indexers."
+            exit 0
+          fi
+
+          if [ -z "${SLOT_AUTH:-}" ]; then
+            echo "Missing SLOT_AUTH. Configure a valid Slot auth token before launching indexers." >&2
+            exit 1
+          fi
+
+          if ! slot auth info >/tmp/slot-auth-info.log 2>&1; then
+            echo "SLOT_AUTH is not accepted by the Slot CLI. Refresh the GitHub secret with a current token from slot auth token." >&2
+            exit 1
+          fi
+
+          echo "Slot auth validated for indexer deployment."
+
       - name: Record launch input
         run: |
           set -euo pipefail

--- a/config/deployer/clean/README.md
+++ b/config/deployer/clean/README.md
@@ -81,9 +81,11 @@ GitHub Actions credentials are selected through GitHub Environments:
 - environment `slot.blitz`
   - var: `GAME_LAUNCH_DOJO_ACCOUNT_ADDRESS`
   - secret: `GAME_LAUNCH_DOJO_PRIVATE_KEY`
+  - secret: `SLOT_AUTH`
 - environment `slot.eternum`
   - var: `GAME_LAUNCH_DOJO_ACCOUNT_ADDRESS`
   - secret: `GAME_LAUNCH_DOJO_PRIVATE_KEY`
+  - secret: `SLOT_AUTH`
 - environment `mainnet.blitz`
   - var: `GAME_LAUNCH_DOJO_ACCOUNT_ADDRESS`
   - secret: `GAME_LAUNCH_DOJO_PRIVATE_KEY`
@@ -97,9 +99,9 @@ The workflow does not need CI-provided defaults for Torii namespaces, Cartridge 
 are defaulted inside the clean deployer module, and the VRF provider default matches the shared slot value from the game
 env files.
 
-The clean deployer creates indexers only by dispatching `.github/workflows/factory-torii-deployer.yml` directly with
-GitHub's workflow API. It waits for that workflow run to finish, and only marks the indexer as created when the workflow
-concludes with `success`.
+The clean deployer creates indexers by calling the Slot CLI directly. It validates the configured `SLOT_AUTH` before
+launch steps that can reach indexer creation, then verifies whether the target Torii deployment already exists before
+creating a new one.
 
 When running locally, the clean deployer can fill in missing GitHub dispatch inputs from local tooling:
 

--- a/config/deployer/clean/tests/launch-runner.test.ts
+++ b/config/deployer/clean/tests/launch-runner.test.ts
@@ -143,6 +143,19 @@ mock.module("starknet", () => ({
   shortString: {
     encodeShortString: (value: string) => `felt:${value}`,
   },
+  CallData: {
+    compile: (values: unknown[]) => values,
+  },
+  constants: {
+    LegacyUDC: {
+      ADDRESS: "0xudc",
+    },
+  },
+  hash: {
+    calculateContractAddressFromHash: () => "0xentrytoken",
+    computePedersenHash: () => "0xsalt",
+    getSelectorFromName: (name: string) => `selector:${name}`,
+  },
 }));
 
 mock.module("../config/config-loader", () => ({
@@ -290,7 +303,7 @@ describe("runLaunchStep mainnet launch steps", () => {
     expect(createGameExecuteMock.mock.calls[0]?.[0]).toEqual({
       contractAddress: factoryAddress,
       entrypoint: "create_game",
-      calldata: ["felt:alpha", 50, "180", "0x0", 0],
+      calldata: ["felt:alpha", 50, "140", "0x0", 0],
     });
     expect(waitForTransactionMock.mock.calls).toHaveLength(15);
     expect(createGameDelayMock.mock.calls).toHaveLength(14);
@@ -321,7 +334,7 @@ describe("runLaunchStep mainnet launch steps", () => {
       process.stderr.write = originalWrite;
     }
 
-    expect(capturedLogs.join("")).toContain('Raw create_game calldata: ["felt:alpha",50,"180","0x0",0]');
+    expect(capturedLogs.join("")).toContain('Raw create_game calldata: ["felt:alpha",50,"140","0x0",0]');
   });
 
   test("submits create_game five times on slot across five retries", async () => {
@@ -340,7 +353,7 @@ describe("runLaunchStep mainnet launch steps", () => {
     expect(createGameExecuteMock.mock.calls[0]?.[0]).toEqual({
       contractAddress: factoryAddress,
       entrypoint: "create_game",
-      calldata: ["felt:alpha", 300, "180", "0x0", 0],
+      calldata: ["felt:alpha", 300, "140", "0x0", 0],
     });
     expect(waitForTransactionMock.mock.calls).toHaveLength(5);
     expect(createGameDelayMock).not.toHaveBeenCalled();
@@ -563,7 +576,7 @@ describe("runLaunchStep mainnet launch steps", () => {
       privateKey,
     });
 
-    expect(summary.entryTokenAddress).toBe("0x55587061e1f470c749e9f7e568a3eb8b8d2335ac2c9b5adf8d9669fb378b38");
+    expect(summary.entryTokenAddress).toBe("0xentrytoken");
   });
 
   test("reserves blitz hyperstructures in one fixed-size call when one batch is enough", async () => {


### PR DESCRIPTION
## Summary

Adds a fail-fast Slot auth validation step to the game launch workflow before launch input is recorded or deploy steps run. Updates clean deployer docs to list `SLOT_AUTH` for Slot environments and describe the current direct Slot CLI indexer path. Refreshes stale launch-runner test mocks and expectations that drifted from the current deployer behavior.

## Root Cause

BLITZ Slot launches could complete world/configuration work and then fail at indexer creation when the repository `SLOT_AUTH` secret was expired or malformed. The failing run for `bltz-froth-492` reached `Create indexer` and Slot rejected the configured auth.

## Impact

Future Slot launches that can reach indexer creation now validate `SLOT_AUTH` up front. Bad or missing auth fails before the workflow records launch input or performs deploy work, making the failure cheaper and clearer.

## Verification

- Refreshed the repository `SLOT_AUTH` secret with a validated Slot auth payload.
- Resumed `bltz-froth-492` from `create-indexer`; run succeeded: https://github.com/BibliothecaDAO/eternum/actions/runs/28321106393
- Created Torii indexer: https://api.cartridge.gg/x/bltz-froth-492/torii
- `pnpm run format`
- `pnpm run knip`
- `bun test config/deployer/clean/tests/launch-request.test.ts config/deployer/clean/tests/launch-runner.test.ts config/deployer/clean/tests/slot-torii.test.ts`
- `git diff --check`
- `pnpm exec prettier --check .github/workflows/game-launch.yml`