### PR TITLE
test(core): lock combat simulator biome table and golden damage values

### DIFF
--- a/packages/core/src/utils/combat-simulator.biome.test.ts
+++ b/packages/core/src/utils/combat-simulator.biome.test.ts
@@ -1,0 +1,220 @@
+import { BiomeType, TroopTier, TroopType, WORLD_CONFIG_ID } from "@bibliothecadao/types";
+import { describe, expect, it, vi } from "vitest";
+
+import { configManager } from "../managers/config-manager";
+import { type Army, CombatSimulator } from "./combat-simulator";
+
+// The simulator resolves configManager through the managers barrel, whose
+// circular import chain leaves the binding undefined under vitest; delegate
+// lazily to the real singleton instead of stubbing the biome logic away.
+vi.mock("../managers", () => ({
+  configManager: {
+    getBiomeCombatBonus: (troopType: TroopType, biome: BiomeType) =>
+      configManager.getBiomeCombatBonus(troopType, biome),
+  },
+}));
+
+vi.mock("@dojoengine/recs", () => ({
+  getComponentValue: (component: unknown, entity: unknown) => {
+    if (component instanceof Map) {
+      return component.get(entity);
+    }
+    return undefined;
+  },
+}));
+
+vi.mock("@dojoengine/utils", () => ({
+  getEntityIdFromKeys: (keys: bigint[]) => keys.map((key) => key.toString()).join(":"),
+}));
+
+// The biome table scales with the on-chain damage_biome_bonus_num, so the world
+// config is stubbed with the official Blitz value while the table logic itself
+// runs unmocked.
+const OFFICIAL_BIOME_BONUS_NUM = 3000;
+
+Object.assign(configManager, {
+  components: {
+    WorldConfig: new Map([
+      [WORLD_CONFIG_ID.toString(), { troop_damage_config: { damage_biome_bonus_num: OFFICIAL_BIOME_BONUS_NUM } }],
+    ]),
+  },
+});
+
+const ADVANTAGE = 1 + OFFICIAL_BIOME_BONUS_NUM / 10_000;
+const DISADVANTAGE = 1 - OFFICIAL_BIOME_BONUS_NUM / 10_000;
+const NEUTRAL = 1;
+
+// Expected multipliers transcribed from the contract's biome table
+// (contracts/game/src/models/troop.cairo -> _biome_damage_bonus) so a drift on
+// either side of the TS/Cairo pair fails this suite.
+const EXPECTED_BIOME_DAMAGE_MULTIPLIERS: Record<BiomeType, Record<TroopType, number>> = {
+  [BiomeType.None]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: NEUTRAL,
+  },
+  [BiomeType.DeepOcean]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: ADVANTAGE,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.Ocean]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: ADVANTAGE,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.Beach]: {
+    [TroopType.Knight]: DISADVANTAGE,
+    [TroopType.Crossbowman]: ADVANTAGE,
+    [TroopType.Paladin]: NEUTRAL,
+  },
+  [BiomeType.Scorched]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: ADVANTAGE,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.Bare]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: DISADVANTAGE,
+    [TroopType.Paladin]: ADVANTAGE,
+  },
+  [BiomeType.Tundra]: {
+    [TroopType.Knight]: DISADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: ADVANTAGE,
+  },
+  [BiomeType.Snow]: {
+    [TroopType.Knight]: DISADVANTAGE,
+    [TroopType.Crossbowman]: ADVANTAGE,
+    [TroopType.Paladin]: NEUTRAL,
+  },
+  [BiomeType.TemperateDesert]: {
+    [TroopType.Knight]: DISADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: ADVANTAGE,
+  },
+  [BiomeType.Shrubland]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: DISADVANTAGE,
+    [TroopType.Paladin]: ADVANTAGE,
+  },
+  [BiomeType.Taiga]: {
+    [TroopType.Knight]: ADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.Grassland]: {
+    [TroopType.Knight]: NEUTRAL,
+    [TroopType.Crossbowman]: DISADVANTAGE,
+    [TroopType.Paladin]: ADVANTAGE,
+  },
+  [BiomeType.TemperateDeciduousForest]: {
+    [TroopType.Knight]: ADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.TemperateRainForest]: {
+    [TroopType.Knight]: ADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.SubtropicalDesert]: {
+    [TroopType.Knight]: DISADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: ADVANTAGE,
+  },
+  [BiomeType.TropicalSeasonalForest]: {
+    [TroopType.Knight]: ADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+  [BiomeType.TropicalRainForest]: {
+    [TroopType.Knight]: ADVANTAGE,
+    [TroopType.Crossbowman]: NEUTRAL,
+    [TroopType.Paladin]: DISADVANTAGE,
+  },
+};
+
+const baseArmy = (troopType: TroopType): Army => ({
+  stamina: 100,
+  troopCount: 1_000,
+  troopType,
+  tier: TroopTier.T2,
+  battle_cooldown_end: 0,
+});
+
+describe("ClientConfigManager biome combat bonus", () => {
+  it("matches the on-chain biome damage table for every biome and troop type", () => {
+    for (const biome of Object.values(BiomeType)) {
+      for (const troopType of Object.values(TroopType)) {
+        expect(configManager.getBiomeCombatBonus(troopType, biome), `${troopType} in ${biome}`).toBeCloseTo(
+          EXPECTED_BIOME_DAMAGE_MULTIPLIERS[biome][troopType],
+        );
+      }
+    }
+  });
+});
+
+describe("CombatSimulator with real biome modifiers", () => {
+  it("boosts an advantaged melee attacker without touching a neutral defender", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+
+    const neutral = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Knight),
+      baseArmy(TroopType.Crossbowman),
+      BiomeType.None,
+    );
+    const taiga = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Knight),
+      baseArmy(TroopType.Crossbowman),
+      BiomeType.Taiga,
+    );
+
+    expect(taiga.attackerDamage).toBeCloseTo(neutral.attackerDamage * ADVANTAGE);
+    expect(taiga.defenderDamage).toBeCloseTo(neutral.defenderDamage);
+  });
+
+  it("penalizes a disadvantaged melee attacker while boosting an advantaged defender", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+
+    const neutral = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Paladin),
+      baseArmy(TroopType.Knight),
+      BiomeType.None,
+    );
+    const taiga = simulator.simulateBattle(0, baseArmy(TroopType.Paladin), baseArmy(TroopType.Knight), BiomeType.Taiga);
+
+    expect(taiga.attackerDamage).toBeCloseTo(neutral.attackerDamage * DISADVANTAGE);
+    expect(taiga.defenderDamage).toBeCloseTo(neutral.defenderDamage * ADVANTAGE);
+  });
+
+  it("ignores the biome modifier for ranged attacks", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+    const rangedContext = { attackDistance: 2 };
+
+    const neutral = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Crossbowman),
+      baseArmy(TroopType.Knight),
+      BiomeType.None,
+      [],
+      [],
+      rangedContext,
+    );
+    const scorched = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Crossbowman),
+      baseArmy(TroopType.Knight),
+      BiomeType.Scorched,
+      [],
+      [],
+      rangedContext,
+    );
+
+    expect(scorched.attackerDamage).toBeCloseTo(neutral.attackerDamage);
+    expect(scorched.defenderDamage).toBe(0);
+  });
+});

--- a/packages/core/src/utils/combat-simulator.test.ts
+++ b/packages/core/src/utils/combat-simulator.test.ts
@@ -124,3 +124,89 @@ describe("CombatSimulator Combat v3 context", () => {
     expect(params.stamina_defense_req).toBe(40);
   });
 });
+
+// Absolute damage numbers derived by hand from the v3 formula with the default
+// Blitz-60 parameters (scaling factor 2, T1 value 100, T2 x3, T3 x9, beta 0.2):
+// damage = 2 x troops x tier_ratio x role_multipliers / total_troops^0.2.
+// Unlike the ratio tests above, these fail if any coefficient drifts.
+describe("CombatSimulator damage formula golden values", () => {
+  it("deals the exact mirrored damage in a symmetric melee battle", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+
+    const result = simulator.simulateBattle(0, baseArmy(TroopType.Knight), baseArmy(TroopType.Knight), BiomeType.Taiga);
+
+    // 2 x 1000 / 2000^0.2
+    expect(result.attackerDamage).toBeCloseTo(437.3448, 3);
+    expect(result.defenderDamage).toBeCloseTo(437.3448, 3);
+    // A 1:1 damage ratio sits below the 2.5 refund threshold on both sides.
+    expect(result.attackerRefundMultiplier).toBe(0);
+    expect(result.defenderRefundMultiplier).toBe(0);
+  });
+
+  it("applies tier damage multipliers to both sides of a T3 versus T1 battle", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+    const attacker = { ...baseArmy(TroopType.Knight), tier: TroopTier.T3 };
+    const defender = { ...baseArmy(TroopType.Knight), tier: TroopTier.T1 };
+
+    const result = simulator.simulateBattle(0, attacker, defender, BiomeType.Taiga);
+
+    // 2 x 1000 x 9 / 2000^0.2 and 2 x 1000 x (1/9) / 2000^0.2
+    expect(result.attackerDamage).toBeCloseTo(3936.1035, 3);
+    expect(result.defenderDamage).toBeCloseTo(48.5939, 3);
+  });
+
+  it("deals the exact ranged Crossbowman damage in the field", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+
+    const result = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Crossbowman),
+      baseArmy(TroopType.Knight),
+      BiomeType.Taiga,
+      [],
+      [],
+      { attackDistance: 2 },
+    );
+
+    // 0.7 x 2 x 1000 / 2000^0.2
+    expect(result.attackerDamage).toBeCloseTo(306.1414, 3);
+    expect(result.defenderDamage).toBe(0);
+  });
+
+  it("deals the exact ranged Crossbowman damage against a structure guard", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+
+    const result = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Crossbowman),
+      baseArmy(TroopType.Paladin),
+      BiomeType.Taiga,
+      [],
+      [],
+      { attackDistance: 2, defenderIsStructureGuard: true },
+    );
+
+    // 0.3 x 2 x 1000 / 2000^0.2
+    expect(result.attackerDamage).toBeCloseTo(131.2034, 3);
+    expect(result.defenderDamage).toBe(0);
+  });
+
+  it("deals the exact Knight assault damage into a Knight structure guard", () => {
+    const simulator = new CombatSimulator(CombatSimulator.getDefaultParameters());
+
+    const result = simulator.simulateBattle(
+      0,
+      baseArmy(TroopType.Knight),
+      baseArmy(TroopType.Knight),
+      BiomeType.Taiga,
+      [],
+      [],
+      { defenderIsStructureGuard: true },
+    );
+
+    // Assault bonus and guard damage reduction stack: 1.15 x 0.85 x 2 x 1000 / 2000^0.2
+    expect(result.attackerDamage).toBeCloseTo(427.5046, 3);
+    // The guard's own damage keeps the plain symmetric value.
+    expect(result.defenderDamage).toBeCloseTo(437.3448, 3);
+  });
+});


### PR DESCRIPTION
### What

Test-only PR, no behavior change. It adds coverage for two gaps in
`packages/core` around `combat-simulator.ts`:

1. **The biome combat table was completely untested.** The existing combat
   tests mock `configManager.getBiomeCombatBonus` to `1`, so none of the
   16 biomes × 3 troop types multipliers were ever exercised. The new
   `combat-simulator.biome.test.ts` checks `getBiomeCombatBonus` cell by cell
   against the multipliers transcribed from the contract table
   (`contracts/game/src/models/troop.cairo` → `_biome_damage_bonus`), and runs
   the real (unmocked) modifier through `simulateBattle`: advantaged/neutral
   attacker and defender directions, plus the "range-2 attacks ignore biome"
   exception.

2. **No test pinned an absolute damage number.** Every existing damage
   assertion is a ratio between two simulations, so a drifting coefficient
   (scaling factor, tier value, beta) that shifts both sides equally would go
   unnoticed. The new golden-value block in `combat-simulator.test.ts` pins
   hand-derived absolute results for: symmetric melee, T3-vs-T1 tier
   asymmetry, ranged Crossbowman in the field (×0.7) and against a structure
   guard (×0.3), and Knight structure assault (×1.15 out, ×0.85 in).

The only mocking in the biome file is at the data layer: `getComponentValue`
is stubbed (same idiom as `army-action-manager.test.ts`) so the world config
returns the official `damage_biome_bonus_num = 3000`; the table logic itself
runs for real. Routing the managers barrel to the real `config-manager`
module works around a circular-import issue that only exists under vitest.

### Verification

- `pnpm run build:packages` then `pnpm --dir packages/core test run`:
  21 files, 107 tests passing (98 existing + 9 new), ~4s.
- `pnpm run format` clean (it also reformatted six untouched `client/` files
  that were stale; those are not included here).
- `pnpm run knip` exits clean with no findings.

### Non-goals

- No source changes; the tests lock in current TS behavior.
- Stamina/refund/cooldown edge cases, relic stacking, and `StaminaManager`
  coverage are left for a follow-up PR to keep this one reviewable.

### Questions for maintainers

While cross-reading the TS simulator against `troop.cairo`, two small
divergences came up. Neither is covered (or changed) by this PR — asking
whether they are intentional before touching anything:

1. **Melee defender stamina loss is not clamped in TS.** The contract clamps
   the defender's loss to their current stamina and refunds from the clamped
   amount (`troop.cairo:771-772`: `BRAVO_STAMINA_LOSS = min(stamina,
   defense_req)`). The TS melee branch (`combat-simulator.ts:218-229`)
   subtracts the full `defense_req`, so a defender with stamina 10 against a
   requirement of 40 ends at −30 in the simulator while the chain stops at 0.
   Intentional simplification for the preview UI, or worth a small follow-up
   fix?

2. **Ranged defense stamina cost rounds in opposite directions.** The
   contract computes `stamina_defense_req / 2` with u64 floor division
   (`troop.cairo:765`); TS uses `Math.ceil(defense_req / 2)`
   (`combat-simulator.ts:214-216`). Invisible with the current even config
   (40 → 20 both ways), but an odd value would put the preview off by one.
   Should TS mirror the floor?

Happy to file either as a follow-up once you confirm the intended behavior.
