### PR TITLE
feat(sync): render chests from the world projection

### DIFF
--- a/client/apps/game/scripts/run-game-sync-headless-smoke.mjs
+++ b/client/apps/game/scripts/run-game-sync-headless-smoke.mjs
@@ -2,12 +2,13 @@
 
 import {
   GameSyncRuntime,
+  WorldSpatialProjection,
   buildGameSyncModelKeysClause,
   createTimerGameSyncScheduler,
   getGameSyncModelsForChannel,
 } from "@bibliothecadao/eternum/game-sync";
 import { tileOptToTile } from "@bibliothecadao/eternum";
-import { defineContractComponents } from "@bibliothecadao/types";
+import { TileOccupier, defineContractComponents } from "@bibliothecadao/types";
 import { createWorld, getComponentEntities, getComponentValue, removeComponent } from "@dojoengine/recs";
 import { createClient } from "@dojoengine/sdk";
 import { setEntities } from "@dojoengine/state";
@@ -152,6 +153,26 @@ const findHexOccupancy = (tileOptComponent, col, row) => {
   throw new Error(`No TileOpt row found at (${col}, ${row})`);
 };
 
+const verifyChestProjection = (projection, occupancy) => {
+  const projectedChestSnapshot = projection.getChests();
+  const projectedChests = projection.getChestsAtHex({ col: occupancy.col, row: occupancy.row });
+  const expectedChestId = occupancy.occupierType === TileOccupier.Chest ? occupancy.occupierId : undefined;
+  const matchesOccupancy = projectedChests.some(({ entityId }) => entityId === expectedChestId);
+
+  if (expectedChestId !== undefined && !matchesOccupancy) {
+    throw new Error(`Projection is missing chest ${expectedChestId} at (${occupancy.col}, ${occupancy.row})`);
+  }
+  if (expectedChestId === undefined && projectedChests.length > 0) {
+    throw new Error(`Projection contains a chest on non-chest tile (${occupancy.col}, ${occupancy.row})`);
+  }
+
+  return {
+    chestCount: projectedChestSnapshot.length,
+    chestsAtCoordinate: projectedChests,
+    sampleChest: projectedChestSnapshot[0] ?? null,
+  };
+};
+
 const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
 const run = async (config) => {
@@ -175,13 +196,22 @@ const run = async (config) => {
       scheduler: createTimerGameSyncScheduler(),
       eventIdentityLimit: EVENT_IDENTITY_LIMIT,
     });
+    const projection = new WorldSpatialProjection({ tileOptComponent: contractComponents.TileOpt });
+    runtime.installWorldSpatialProjection(projection);
     if (config.watchMs > 0) await delay(config.watchMs);
 
     const occupancy = findHexOccupancy(contractComponents.TileOpt, config.col, config.row);
     if (config.expectedOccupierId !== undefined && occupancy.occupierId !== config.expectedOccupierId) {
       throw new Error(`Expected occupier ${config.expectedOccupierId}, received ${occupancy.occupierId}`);
     }
-    console.log(JSON.stringify({ status: runtime.getStatus(), occupancy, metrics: runtime.getMetrics() }, null, 2));
+    const spatialProjection = verifyChestProjection(projection, occupancy);
+    console.log(
+      JSON.stringify(
+        { status: runtime.getStatus(), occupancy, spatialProjection, metrics: runtime.getMetrics() },
+        null,
+        2,
+      ),
+    );
   } finally {
     runtime.dispose();
   }

--- a/client/apps/game/src/dojo/sync.regression.source.test.ts
+++ b/client/apps/game/src/dojo/sync.regression.source.test.ts
@@ -42,6 +42,7 @@ describe("network boot-regression guards", () => {
     expect(source).toContain("createGamewideSyncSession");
     expect(source).toContain("await runtime.recover()");
     expect(source).toContain("shouldUseLegacyBoundedSpatialSync()");
+    expect(source).toContain("installActiveWorldSpatialProjection(setup)");
   });
 
   it("connection-health-monitor exposes the boot grace gate", () => {

--- a/client/apps/game/src/dojo/sync.test.ts
+++ b/client/apps/game/src/dojo/sync.test.ts
@@ -122,6 +122,12 @@ function createSyncHarness() {
   };
 
   const setup = {
+    components: {
+      TileOpt: {
+        entities: function* () {},
+        update$: { subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })) },
+      },
+    },
     network: {
       toriiClient: client,
       contractComponents: [],

--- a/client/apps/game/src/dojo/sync.ts
+++ b/client/apps/game/src/dojo/sync.ts
@@ -18,6 +18,7 @@ import {
   getGameSyncModelsForChannel,
   installFreshGameSyncRuntime,
   requireActiveGameSyncRuntime,
+  WorldSpatialProjection,
 } from "@bibliothecadao/eternum/game-sync";
 import type { GameSyncRuntimeMetrics } from "@bibliothecadao/eternum/game-sync";
 import type { Component, Entity, Metadata, Schema } from "@dojoengine/recs";
@@ -864,6 +865,12 @@ const startLegacyBoundedSyncSession = async (input: {
 
 const getOrInstallGameSyncRuntime = () => getActiveGameSyncRuntime() ?? installFreshGameSyncRuntime();
 
+const installActiveWorldSpatialProjection = (setup: SetupResult): void => {
+  getOrInstallGameSyncRuntime().installWorldSpatialProjection(
+    new WorldSpatialProjection({ tileOptComponent: setup.components.TileOpt }),
+  );
+};
+
 export const initialSync = async (
   setup: SetupResult,
   state: AppStore,
@@ -904,6 +911,7 @@ export const initialSync = async (
     } else {
       await getOrInstallGameSyncRuntime().startSession(createActiveGamewideSyncSession(sessionInput));
     }
+    installActiveWorldSpatialProjection(setup);
     // Handshakes are transport freshness. Data freshness is recorded by stream
     // updates, so quiet worlds do not look stale after a successful boot.
   } catch (error) {

--- a/client/apps/game/src/three/managers/chest-manager.spatial-index.test.ts
+++ b/client/apps/game/src/three/managers/chest-manager.spatial-index.test.ts
@@ -10,10 +10,12 @@ function readChestManagerSource(): string {
 }
 
 describe("ChestManager spatial index", () => {
-  it("uses bucketed chest lookups instead of filtering every chest on each chunk render", () => {
+  it("queries the shared projection instead of owning chest truth", () => {
     const source = readChestManagerSource();
 
-    expect(source).toMatch(/chunkToChests/);
-    expect(source).not.toMatch(/Array\.from\(chests\.values\(\)\)\s*\.filter/);
+    expect(source).toMatch(/worldSpatialProjection\s*\.getChestsInBounds/);
+    expect(source).not.toContain("class Chests");
+    expect(source).not.toContain("chestHexCoords");
+    expect(source).not.toContain("chunkToChests");
   });
 });

--- a/client/apps/game/src/three/managers/chest-manager.ts
+++ b/client/apps/game/src/three/managers/chest-manager.ts
@@ -2,8 +2,7 @@ import { ChestModelPath } from "@/three/constants";
 import InstancedModel from "@/three/managers/instanced-model";
 import { FELT_CENTER } from "@/ui/config";
 import { Position } from "@bibliothecadao/eternum";
-
-import { ChestData, ChestSystemUpdate } from "@bibliothecadao/eternum";
+import type { ChestSpatialRenderable, WorldSpatialProjection } from "@bibliothecadao/eternum/game-sync";
 import { ID } from "@bibliothecadao/types";
 import * as THREE from "three";
 import { CSS2DObject } from "three/examples/jsm/renderers/CSS2DRenderer.js";
@@ -42,8 +41,7 @@ export class ChestManager {
   private renderChunkSize: RenderChunkSize;
   private hexagonScene?: HexagonScene;
   private dummy: THREE.Object3D = new THREE.Object3D();
-  chests: Chests = new Chests();
-  private visibleChests: ChestData[] = [];
+  private visibleChests: readonly ChestSpatialRenderable[] = [];
   private currentChunkKey: string | null = MANAGER_UNCOMMITTED_CHUNK;
   private entityIdLabels: Map<ID, CSS2DObject> = new Map();
   private labelsGroup: THREE.Group;
@@ -53,24 +51,26 @@ export class ChestManager {
   private scale: number = 1;
   private chunkSize: number;
   private currentCameraView: CameraView;
-  chestHexCoords: Map<number, Set<number>> = new Map();
   private animations: Map<number, THREE.AnimationMixer> = new Map();
   private animationClips: THREE.AnimationClip[] = [];
   private chunkSwitchPromise: Promise<void> | null = null; // Track ongoing chunk switches
   private latestTransitionToken = 0;
   private transitionChunkByToken: Map<number, string> = new Map();
   private pointsRenderer?: PointsLabelRenderer; // Points-based icon renderer
-  private chunkToChests: Map<string, Set<ID>> = new Map();
+  private readonly worldSpatialProjection: WorldSpatialProjection;
+  private unsubscribeProjection: () => void;
   private isDestroyed = false;
 
   constructor(
     scene: THREE.Scene,
     renderChunkSize: RenderChunkSize,
+    worldSpatialProjection: WorldSpatialProjection,
     labelsGroup?: THREE.Group,
     hexagonScene?: HexagonScene,
     chunkSize: number = Math.max(1, Math.floor(renderChunkSize.width / 2)),
   ) {
     this.scene = scene;
+    this.worldSpatialProjection = worldSpatialProjection;
     this.hexagonScene = hexagonScene;
     this.labelsGroup = labelsGroup || new THREE.Group();
     this.renderChunkSize = renderChunkSize;
@@ -88,6 +88,12 @@ export class ChestManager {
     if (hexagonScene) {
       hexagonScene.addCameraViewListener(this.handleCameraViewChange);
     }
+
+    this.unsubscribeProjection = worldSpatialProjection.subscribe(() => {
+      if (isCommittedManagerChunk(this.currentChunkKey)) {
+        this.renderVisibleChests(this.currentChunkKey);
+      }
+    });
   }
 
   public getVisibleCount(): number {
@@ -163,6 +169,7 @@ export class ChestManager {
   public destroy() {
     // Guard the async loadModel completion from re-adding resources after teardown.
     this.isDestroyed = true;
+    this.unsubscribeProjection();
 
     // Clean up camera view listener
     if (this.hexagonScene) {
@@ -187,9 +194,6 @@ export class ChestManager {
     this.entityIdLabels.forEach((label) => this.labelsGroup.remove(label));
     this.entityIdLabels.clear();
 
-    // Drop spatial/index maps so despawned chests are not retained.
-    this.chunkToChests.clear();
-    this.chestHexCoords.clear();
     this.entityIdMap.clear();
     this.chestInstanceIndices.clear();
     this.chestInstanceOrder = [];
@@ -237,29 +241,6 @@ export class ChestManager {
       .catch((error) => {
         console.error(`Failed to load chest model:`, error);
       });
-  }
-
-  async onUpdate(update: ChestSystemUpdate) {
-    const { occupierId, hexCoords } = update;
-    const normalizedCoord = { col: hexCoords.col - FELT_CENTER(), row: hexCoords.row - FELT_CENTER() };
-    // Add the chest to the map
-    const position = new Position({ x: hexCoords.col, y: hexCoords.row });
-    const previousChest = this.chests.getChest(occupierId);
-
-    if (!this.chestHexCoords.has(normalizedCoord.col)) {
-      this.chestHexCoords.set(normalizedCoord.col, new Set());
-    }
-    if (!this.chestHexCoords.get(normalizedCoord.col)!.has(normalizedCoord.row)) {
-      this.chestHexCoords.get(normalizedCoord.col)!.add(normalizedCoord.row);
-    }
-
-    this.chests.addChest(occupierId, position);
-    this.updateChestSpatialIndex(occupierId, previousChest, this.chests.getChest(occupierId));
-
-    // Re-render if we have a current chunk
-    if (isCommittedManagerChunk(this.currentChunkKey)) {
-      this.renderVisibleChests(this.currentChunkKey);
-    }
   }
 
   async updateChunk(chunkKey: string, options?: ManagerChunkUpdateOptions) {
@@ -311,61 +292,24 @@ export class ChestManager {
     });
   }
 
-  private getChestWorldPosition = (chestEntityId: ID, hexCoords: Position) => {
-    const { x: hexCoordsX, y: hexCoordsY } = hexCoords.getNormalized();
+  private getChestWorldPosition = (chest: ChestSpatialRenderable) => {
+    const { x: hexCoordsX, y: hexCoordsY } = new Position({
+      x: chest.hexCoords.col,
+      y: chest.hexCoords.row,
+    }).getNormalized();
     const basePosition = getWorldPositionForHex({ col: hexCoordsX, row: hexCoordsY });
     return basePosition;
   };
 
-  private isChestVisible(chest: ChestData, startRow: number, startCol: number) {
-    const { x, y } = chest.hexCoords.getNormalized();
+  private getVisibleChestsForChunk(startRow: number, startCol: number): readonly ChestSpatialRenderable[] {
     const bounds = getRenderBounds(startRow, startCol, this.renderChunkSize, this.chunkSize);
-    const insideChunk = x >= bounds.minCol && x <= bounds.maxCol && y >= bounds.minRow && y <= bounds.maxRow;
-
-    if (!insideChunk) {
-      return false;
-    }
-
-    // Skip frustum culling during chunk updates - bounds check is sufficient.
-    // Frustum culling can fail when the camera is still animating to the new chunk position,
-    // causing chests to not appear until the next frame/click.
-    return true;
-  }
-
-  private getVisibleChestsForChunk(chests: Map<ID, ChestData>, startRow: number, startCol: number): ChestData[] {
-    const bounds = getRenderBounds(startRow, startCol, this.renderChunkSize, this.chunkSize);
-    const startBucketX = Math.floor(bounds.minCol / this.chunkSize);
-    const endBucketX = Math.floor(bounds.maxCol / this.chunkSize);
-    const startBucketY = Math.floor(bounds.minRow / this.chunkSize);
-    const endBucketY = Math.floor(bounds.maxRow / this.chunkSize);
-    const visibleChests: ChestData[] = [];
-    const seenChestIds = new Set<ID>();
-
-    for (let bx = startBucketX; bx <= endBucketX; bx++) {
-      for (let by = startBucketY; by <= endBucketY; by++) {
-        const chestIds = this.chunkToChests.get(`${bx},${by}`);
-        if (!chestIds) {
-          continue;
-        }
-
-        for (const chestId of chestIds) {
-          if (seenChestIds.has(chestId)) {
-            continue;
-          }
-          const chest = chests.get(chestId);
-          if (!chest || !this.isChestVisible(chest, startRow, startCol)) {
-            continue;
-          }
-          seenChestIds.add(chestId);
-          visibleChests.push({
-            entityId: chest.entityId,
-            hexCoords: chest.hexCoords,
-          });
-        }
-      }
-    }
-
-    return visibleChests;
+    const center = FELT_CENTER();
+    return this.worldSpatialProjection.getChestsInBounds({
+      minCol: bounds.minCol + center,
+      maxCol: bounds.maxCol + center,
+      minRow: bounds.minRow + center,
+      maxRow: bounds.maxRow + center,
+    });
   }
 
   private renderVisibleChests(chunkKey: string) {
@@ -373,9 +317,8 @@ export class ChestManager {
       return;
     }
 
-    const allChests = this.chests.getChests();
     const [startRow, startCol] = chunkKey.split(",").map(Number);
-    const visibleChests = this.getVisibleChestsForChunk(allChests, startRow, startCol);
+    const visibleChests = this.getVisibleChestsForChunk(startRow, startCol);
     const visibleChestIds = new Set<ID>(visibleChests.map((chest) => chest.entityId));
 
     this.visibleChests = visibleChests;
@@ -405,7 +348,7 @@ export class ChestManager {
 
     if (this.pointsRenderer) {
       const nextPointConfigs = visibleChests.map((chest) => {
-        const iconPosition = this.getChestWorldPosition(chest.entityId, chest.hexCoords);
+        const iconPosition = this.getChestWorldPosition(chest);
         iconPosition.y += 2;
         return {
           entityId: chest.entityId,
@@ -419,7 +362,7 @@ export class ChestManager {
     }
   }
 
-  private addChestInstance(chest: ChestData) {
+  private addChestInstance(chest: ChestSpatialRenderable) {
     const index = this.chestInstanceOrder.length;
     this.chestInstanceOrder.push(chest.entityId);
     this.chestInstanceIndices.set(chest.entityId, index);
@@ -428,7 +371,7 @@ export class ChestManager {
     this.updateChestLabelPosition(chest);
   }
 
-  private updateChestInstance(chest: ChestData) {
+  private updateChestInstance(chest: ChestSpatialRenderable) {
     const index = this.chestInstanceIndices.get(chest.entityId);
     if (index === undefined) {
       return;
@@ -450,7 +393,7 @@ export class ChestManager {
     if (index !== lastIndex) {
       this.chestInstanceOrder[index] = lastEntityId;
       this.chestInstanceIndices.set(lastEntityId, index);
-      const lastChest = this.chests.getChest(lastEntityId);
+      const lastChest = this.worldSpatialProjection.getChest(lastEntityId);
       if (lastChest) {
         this.writeChestInstance(lastChest, index);
       }
@@ -463,10 +406,10 @@ export class ChestManager {
     this.removeEntityIdLabel(entityId);
   }
 
-  private writeChestInstance(chest: ChestData, index: number) {
-    const position = this.getChestWorldPosition(chest.entityId, chest.hexCoords);
+  private writeChestInstance(chest: ChestSpatialRenderable, index: number) {
+    const position = this.getChestWorldPosition(chest);
     position.y += 0.05;
-    const { x, y } = chest.hexCoords.getContract();
+    const { col: x, row: y } = chest.hexCoords;
 
     this.dummy.position.copy(position);
     const rotationSeed = hashCoordinates(x, y);
@@ -477,12 +420,12 @@ export class ChestManager {
     this.chestModel.setMatrixAt(index, this.dummy.matrix);
   }
 
-  private updateChestLabelPosition(chest: ChestData) {
+  private updateChestLabelPosition(chest: ChestSpatialRenderable) {
     const existingLabel = this.entityIdLabels.get(chest.entityId);
     if (!existingLabel) {
       return;
     }
-    const updatedPosition = this.getChestWorldPosition(chest.entityId, chest.hexCoords);
+    const updatedPosition = this.getChestWorldPosition(chest);
     updatedPosition.y += 1.5;
     existingLabel.position.copy(updatedPosition);
   }
@@ -495,9 +438,15 @@ export class ChestManager {
     }
   }
 
-  private addEntityIdLabel(chest: ChestData, position: THREE.Vector3) {
+  private addEntityIdLabel(chest: ChestSpatialRenderable, position: THREE.Vector3) {
     // Use centralized chest label creation
-    const labelDiv = createChestLabel(chest, this.currentCameraView);
+    const labelDiv = createChestLabel(
+      {
+        entityId: chest.entityId,
+        hexCoords: new Position({ x: chest.hexCoords.col, y: chest.hexCoords.row }),
+      },
+      this.currentCameraView,
+    );
 
     const label = new CSS2DObject(labelDiv);
     label.position.copy(position);
@@ -523,19 +472,19 @@ export class ChestManager {
   }
 
   public showLabel(entityId: ID): HoverLabelShowResult {
-    const chest = this.chests.getChest(entityId);
+    const chest = this.worldSpatialProjection.getChest(entityId);
     if (!chest) {
       return { status: "missing" };
     }
 
-    const position = this.getChestWorldPosition(chest.entityId, chest.hexCoords);
+    const position = this.getChestWorldPosition(chest);
     position.y += 0.05;
 
     const existingLabel = this.entityIdLabels.get(entityId);
     if (existingLabel) {
       const wasDetached = existingLabel.parent !== this.labelsGroup;
       const wasHidden = existingLabel.visible !== true || existingLabel.element.style.display === "none";
-      const updatedPosition = this.getChestWorldPosition(chest.entityId, chest.hexCoords);
+      const updatedPosition = this.getChestWorldPosition(chest);
       updatedPosition.y += 1.5;
       existingLabel.position.copy(updatedPosition);
       if (wasDetached) {
@@ -599,85 +548,10 @@ export class ChestManager {
     });
   }
 
-  public async removeChest(entityId: ID) {
-    const existingChest = this.chests.getChest(entityId);
-    if (!existingChest) {
-      return;
-    }
-
-    // Remove chest from tracking
-    this.chests.removeChest(entityId);
-    this.updateChestSpatialIndex(entityId, existingChest, null);
-
-    this.removeEntityIdLabel(entityId);
-
-    // Re-render visible chests
-    if (isCommittedManagerChunk(this.currentChunkKey)) {
-      this.renderVisibleChests(this.currentChunkKey);
-    }
-  }
-
   public update(deltaTime: number) {
     // Update animations
     this.animations.forEach((mixer) => {
       mixer.update(deltaTime);
     });
-  }
-
-  private getChestSpatialKey(col: number, row: number): string {
-    return `${Math.floor(col / this.chunkSize)},${Math.floor(row / this.chunkSize)}`;
-  }
-
-  private updateChestSpatialIndex(entityId: ID, previousChest: ChestData | null, nextChest: ChestData | null): void {
-    if (previousChest) {
-      const { x, y } = previousChest.hexCoords.getNormalized();
-      const previousKey = this.getChestSpatialKey(x, y);
-      const previousBucket = this.chunkToChests.get(previousKey);
-      previousBucket?.delete(entityId);
-      if (previousBucket && previousBucket.size === 0) {
-        this.chunkToChests.delete(previousKey);
-      }
-    }
-
-    if (!nextChest) {
-      return;
-    }
-
-    const { x, y } = nextChest.hexCoords.getNormalized();
-    const nextKey = this.getChestSpatialKey(x, y);
-    let nextBucket = this.chunkToChests.get(nextKey);
-    if (!nextBucket) {
-      nextBucket = new Set<ID>();
-      this.chunkToChests.set(nextKey, nextBucket);
-    }
-    nextBucket.add(entityId);
-  }
-}
-
-class Chests {
-  private chests: Map<ID, ChestData> = new Map();
-
-  addChest(occupierId: ID, hexCoords: Position) {
-    this.chests.set(occupierId, {
-      entityId: occupierId,
-      hexCoords,
-    });
-  }
-
-  removeChest(entityId: ID): ChestData | null {
-    const chest = this.chests.get(entityId);
-    if (chest) {
-      this.chests.delete(entityId);
-      return chest;
-    }
-    return null;
-  }
-
-  getChest(entityId: ID): ChestData | null {
-    return this.chests.get(entityId) || null;
-  }
-
-  getChests(): Map<ID, ChestData> {
-    return this.chests;
   }
 }

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
@@ -66,7 +66,6 @@ export type WorldmapRenderCounter =
   | "preparedChunkPrewarmHits"
   | "preparedChunkPrewarmMisses"
   | "globalSpatialRecsHydratedTiles"
-  | "globalSpatialRecsHydratedChests"
   | "globalSpatialRecsHydratedStructures"
   | "spatialBoundsSwitchRequests"
   | "spatialBoundsSwitchApplied"
@@ -214,7 +213,6 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     preparedChunkPrewarmHits: 0,
     preparedChunkPrewarmMisses: 0,
     globalSpatialRecsHydratedTiles: 0,
-    globalSpatialRecsHydratedChests: 0,
     globalSpatialRecsHydratedStructures: 0,
     spatialBoundsSwitchRequests: 0,
     spatialBoundsSwitchApplied: 0,

--- a/client/apps/game/src/three/scenes/worldmap-army-bootstrap-fetch.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-army-bootstrap-fetch.test.ts
@@ -72,8 +72,8 @@ describe("worldmap army bootstrap fetch", () => {
     );
     const stagedHydrationBody = extractMethodBody(source, "private async hydrateRenderAreaFromGlobalSpatialState(");
     expect(stagedHydrationBody).toContain("hydrateExploredTilesFromGlobalTileOptRecs");
-    expect(stagedHydrationBody).toContain("hydrateChestsFromGlobalTileOptRecs");
     expect(stagedHydrationBody).toContain("hydrateStructuresFromGlobalTileOptRecs");
     expect(stagedHydrationBody).toContain("global_spatial_recs_hydrated");
+    expect(stagedHydrationBody).not.toContain("chestManager");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap-hover-label-wiring.source.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-hover-label-wiring.source.test.ts
@@ -38,9 +38,13 @@ describe("worldmap hover label wiring", () => {
     expect(extractSourceBetween(source, "await this.trackStructureHydrationUpdate(value", "const newCount")).toContain(
       "this.reconcileHoverLabels()",
     );
-    expect(extractSourceBetween(source, "this.chestManager.onUpdate(update)", "}),")).toContain(
-      "this.reconcileHoverLabels()",
-    );
+    expect(
+      extractSourceBetween(
+        source,
+        "private bindWorldSpatialProjectionLifecycle()",
+        "private bindWorldmapCameraViewLifecycle()",
+      ),
+    ).toContain("this.reconcileHoverLabels()");
     expect(extractSourceBetween(source, "public updateArmyHexes(", "public updateStructureHexes(")).not.toContain(
       "reconcileHoverLabels",
     );

--- a/client/apps/game/src/three/scenes/worldmap-spatial-sql-fetch.wiring.test.ts
+++ b/client/apps/game/src/three/scenes/worldmap-spatial-sql-fetch.wiring.test.ts
@@ -14,17 +14,19 @@ const extractGlobalSpatialHydration = (source: string): string => {
 };
 
 describe("worldmap global spatial hydration", () => {
-  it("hydrates render areas from the global RECS spatial sync instead of per-area SQL", () => {
+  it("hydrates remaining render state without rebuilding chest truth per area", () => {
     const source = readSource("src/three/scenes/worldmap.tsx");
     const methodSource = extractGlobalSpatialHydration(source);
 
     expect(source).not.toContain("private async runSpatialSqlFetch");
     expect(source).not.toContain("spatial_sql_fetch_timeout");
     expect(methodSource).toContain("hydrateExploredTilesFromGlobalTileOptRecs");
-    expect(methodSource).toContain("hydrateChestsFromGlobalTileOptRecs");
     expect(methodSource).toContain("hydrateStructuresFromGlobalTileOptRecs");
-    expect(methodSource).toContain("chestManager.onUpdate");
     expect(methodSource).toContain("applyStructureTileUpdate");
     expect(methodSource).toContain("global_spatial_recs_hydrated");
+    expect(source).not.toContain("hydrateChestsFromGlobalTileOptRecs");
+    expect(source).not.toContain("chestManager.onUpdate");
+    expect(source).not.toContain("repairChestTileIfStale");
+    expect(source).toContain("worldSpatialProjection.getChestsAtHex");
   });
 });

--- a/client/apps/game/src/three/scenes/worldmap.tsx
+++ b/client/apps/game/src/three/scenes/worldmap.tsx
@@ -6,7 +6,7 @@ import {
   ARMY_AUTHORITATIVE_SWEEP_INTERVAL_MS,
   sweepArmiesAgainstTorii,
 } from "@/dojo/army-authoritative-reconciler";
-import { ensureStructureSynced, getTilesForPositionsFromTorii } from "@/dojo/queries";
+import { ensureStructureSynced } from "@/dojo/queries";
 import { initializeSyncSimulator } from "@/dojo/sync-simulator";
 import { getBoundedSpatialMapModels, getGlobalSpatialMapModels } from "@/dojo/torii-spatial-models";
 import { shouldUseLegacyBoundedSpatialSync } from "@/dojo/game-sync-mode";
@@ -65,6 +65,7 @@ import { WorldmapPerfSimulation } from "@/three/scenes/worldmap-perf-simulation"
 import { playResourceSound } from "@/three/sound/utils";
 import { LeftView } from "@/types";
 import { configManager, Position } from "@bibliothecadao/eternum";
+import { requireActiveGameSyncRuntime, type WorldSpatialProjection } from "@bibliothecadao/eternum/game-sync";
 import { gameWorkerManager } from "../../managers/game-worker-manager";
 
 import { FELT_CENTER, IS_FLAT_MODE } from "@/ui/config";
@@ -79,7 +80,6 @@ import {
   ActionType,
   ArmyActionManager,
   BattleEventSystemUpdate,
-  ChestSystemUpdate,
   DEFAULT_COORD_ALT,
   divideByPrecision,
   ExplorerRewardSystemUpdate,
@@ -89,7 +89,6 @@ import {
   getGuardsByStructure,
   getStructureInfoFromTileOccupier,
   getTileAt,
-  isTileOccupierChest,
   isTileOccupierReservedHyperstructure,
   recordArmyMovementLatencyPhase,
   ReservedHyperstructureTileSystemUpdate,
@@ -923,14 +922,13 @@ export default class WorldmapScene extends WarpTravel {
   private structureManager!: StructureManager;
   private memoryMonitor?: MemoryMonitor;
   private chestManager!: ChestManager;
+  private worldSpatialProjection!: WorldSpatialProjection;
+  private unsubscribeWorldSpatialProjection?: () => void;
   private exploredTiles: Map<number, Map<number, BiomeType>> = new Map();
   // normalized positions and if they are allied or not
   private armyHexes: Map<number, Map<number, HexEntityInfo>> = new Map();
   // normalized positions and if they are allied or not
   private structureHexes: Map<number, Map<number, HexEntityInfo>> = new Map();
-  // normalized positions and if they are allied or not
-  // normalized positions and if they are allied or not
-  private chestHexes: Map<number, Map<number, HexEntityInfo>> = new Map();
   // store armies positions by ID, to remove previous positions when army moves
   // normalized coordinates
   private armiesPositions: Map<ID, HexPosition> = new Map();
@@ -1202,6 +1200,7 @@ export default class WorldmapScene extends WarpTravel {
     this.initializeWorldmapManagers();
     this.configureWorldmapRecoveryLifecycle();
     this.initializeWorldmapSupportManagers();
+    this.bindWorldSpatialProjectionLifecycle();
     this.bindWorldmapCameraViewLifecycle();
     this.registerWorldUpdateSubscriptions();
     this.initializeWorldmapInteractionRuntime();
@@ -1571,6 +1570,7 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private initializeWorldmapManagers(): void {
+    this.worldSpatialProjection = requireActiveGameSyncRuntime().requireWorldSpatialProjection();
     this.armyLabelsGroup = new Group();
     this.armyLabelsGroup.name = "ArmyLabelsGroup";
     this.structureLabelsGroup = new Group();
@@ -1625,7 +1625,14 @@ export default class WorldmapScene extends WarpTravel {
       this.chunkSize,
     );
     this.reservedHyperstructureManager = new ReservedHyperstructureManager(this.scene);
-    this.chestManager = new ChestManager(this.scene, this.renderChunkSize, this.chestLabelsGroup, this, this.chunkSize);
+    this.chestManager = new ChestManager(
+      this.scene,
+      this.renderChunkSize,
+      this.worldSpatialProjection,
+      this.chestLabelsGroup,
+      this,
+      this.chunkSize,
+    );
 
     // Bootstrap applyQualityFeatures may have run before these managers existed; apply the
     // latest known quality limits now that the managers are available.
@@ -1692,6 +1699,12 @@ export default class WorldmapScene extends WarpTravel {
     );
   }
 
+  private bindWorldSpatialProjectionLifecycle(): void {
+    this.unsubscribeWorldSpatialProjection = this.worldSpatialProjection.subscribe(() => {
+      this.reconcileHoverLabels();
+    });
+  }
+
   private bindWorldmapCameraViewLifecycle(): void {
     this.addCameraViewListener((view: CameraView) => {
       this.hoverLabelManager.updateCameraView(view);
@@ -1712,7 +1725,6 @@ export default class WorldmapScene extends WarpTravel {
     this.registerStructureWorldUpdateSubscriptions();
     this.registerTileWorldUpdateSubscriptions();
     this.registerReservedHyperstructureWorldUpdateSubscriptions();
-    this.registerChestWorldUpdateSubscriptions();
     this.registerExplorerRewardWorldUpdateSubscriptions();
   }
 
@@ -2005,21 +2017,6 @@ export default class WorldmapScene extends WarpTravel {
     if (structureTileActions.shouldRefreshVisibleChunks) {
       this.requestChunkRefresh(true, "structure_count_change");
     }
-  }
-
-  private registerChestWorldUpdateSubscriptions(): void {
-    this.addWorldUpdateSubscription(
-      this.worldUpdateListener.Chest.onTileUpdate((update: ChestSystemUpdate) => {
-        this.updateChestHexes(update);
-        this.chestManager.onUpdate(update);
-        this.reconcileHoverLabels();
-      }),
-    );
-    this.addWorldUpdateSubscription(
-      this.worldUpdateListener.Chest.onDeadChest((entityId) => {
-        this.deleteChest(entityId);
-      }),
-    );
   }
 
   private registerReservedHyperstructureWorldUpdateSubscriptions(): void {
@@ -2851,10 +2848,16 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   protected getHexagonEntity(hexCoords: HexPosition) {
-    const hex = new Position({ x: hexCoords.col, y: hexCoords.row }).getNormalized();
+    const position = new Position({ x: hexCoords.col, y: hexCoords.row });
+    const hex = position.getNormalized();
+    const contractHex = position.getContract();
     const army = this.armyHexes.get(hex.x)?.get(hex.y);
     const structure = this.structureHexes.get(hex.x)?.get(hex.y);
-    const chest = this.chestHexes.get(hex.x)?.get(hex.y);
+    const projectedChest = this.worldSpatialProjection.getChestsAtHex({
+      col: contractHex.x,
+      row: contractHex.y,
+    })[0];
+    const chest = projectedChest ? { id: projectedChest.entityId, owner: 0n } : undefined;
 
     return { army, structure, chest };
   }
@@ -2883,7 +2886,6 @@ export default class WorldmapScene extends WarpTravel {
     return {
       army: cachedEntities.army ? undefined : this.resolveArmyHoverLabelEntityFromManager(hexCoords),
       structure: cachedEntities.structure ? undefined : this.resolveStructureHoverLabelEntityFromManager(hexCoords),
-      chest: cachedEntities.chest ? undefined : this.resolveChestHoverLabelEntityFromManager(hexCoords),
     };
   }
 
@@ -2899,15 +2901,6 @@ export default class WorldmapScene extends WarpTravel {
   private resolveStructureHoverLabelEntityFromManager(hexCoords: HexPosition): HexEntityInfo | undefined {
     const structure = this.structureManager.getStructureByHexCoords(hexCoords);
     return structure ? { id: structure.entityId, owner: structure.owner.address } : undefined;
-  }
-
-  private resolveChestHoverLabelEntityFromManager(hexCoords: HexPosition): HexEntityInfo | undefined {
-    const chest = Array.from(this.chestManager.chests.getChests().values()).find((candidate) => {
-      const normalized = candidate.hexCoords.getNormalized();
-      return normalized.x === hexCoords.col && normalized.y === hexCoords.row;
-    });
-
-    return chest ? { id: chest.entityId, owner: 0n } : undefined;
   }
 
   private resolveRaycastArmyHoverTarget() {
@@ -3071,10 +3064,6 @@ export default class WorldmapScene extends WarpTravel {
       return;
     }
 
-    if (chest) {
-      void this.repairChestTileIfStale(hexCoords);
-    }
-
     if (structure) {
       console.log("[Worldmap] Structure entity id clicked:", structure.id);
     }
@@ -3107,32 +3096,6 @@ export default class WorldmapScene extends WarpTravel {
       ...this.getInteractionDebugSnapshot(),
     });
     this.clearEntitySelection();
-  }
-
-  // A clicked chest mesh proves a chest exists here (its stream update built
-  // the mesh), but the side panel reads the RECS TileOpt row, which a
-  // hydration snapshot taken before the spawn can overwrite. Repair on
-  // action: refetch this one tile row so the relic panel appears in place.
-  private async repairChestTileIfStale(hexCoords: HexPosition): Promise<void> {
-    const contract = new Position({ x: hexCoords.col, y: hexCoords.row }).getContract();
-    const tile = getTileAt(this.dojo.components, DEFAULT_COORD_ALT, contract.x, contract.y);
-    if (tile && isTileOccupierChest(tile.occupier_type)) {
-      return;
-    }
-
-    const toriiClient = this.dojo.network?.toriiClient;
-    const contractComponents = this.dojo.network?.contractComponents as unknown as
-      | Parameters<typeof getTilesForPositionsFromTorii>[1]
-      | undefined;
-    if (!toriiClient || !contractComponents) {
-      return;
-    }
-
-    try {
-      await getTilesForPositionsFromTorii(toriiClient, contractComponents, [{ col: contract.x, row: contract.y }]);
-    } catch (error) {
-      console.error("[WorldmapScene] Failed to repair chest tile from Torii", error);
-    }
   }
 
   protected handleHexSelection(hexCoords: HexPosition, isMine: boolean) {
@@ -4429,7 +4392,7 @@ export default class WorldmapScene extends WarpTravel {
       this.structureHexes,
       this.armyHexes,
       this.exploredTiles,
-      this.chestHexes,
+      this.buildProjectedChestActionIndex(),
       currentDefaultTick,
       currentArmiesTick,
       playerAddress,
@@ -4458,6 +4421,17 @@ export default class WorldmapScene extends WarpTravel {
     this.updateStructureOwnershipPulses(owningStructureId ?? undefined, extraHexes, extraHexes);
     this.applyContextualHoverPalette(this.previouslyHoveredHex ?? null);
     return true;
+  }
+
+  private buildProjectedChestActionIndex(): Map<number, Map<number, HexEntityInfo>> {
+    const index = new Map<number, Map<number, HexEntityInfo>>();
+    this.worldSpatialProjection.getChests().forEach((chest) => {
+      const normalized = new Position({ x: chest.hexCoords.col, y: chest.hexCoords.row }).getNormalized();
+      const row = index.get(normalized.x) ?? new Map<number, HexEntityInfo>();
+      row.set(normalized.y, { id: chest.entityId, owner: 0n });
+      index.set(normalized.x, row);
+    });
+    return index;
   }
 
   private clearMovementActionOptionsForSelectedArmy(entityId: ID): void {
@@ -5687,19 +5661,6 @@ export default class WorldmapScene extends WarpTravel {
     };
   }
 
-  public deleteChest(entityId: ID) {
-    this.chestManager.removeChest(entityId);
-    // Find and remove from chestHexes
-    this.chestHexes.forEach((rowMap) => {
-      rowMap.forEach((hex, row) => {
-        if (hex.id === entityId) {
-          rowMap.delete(row);
-        }
-      });
-    });
-    this.reconcileHoverLabels();
-  }
-
   // used to track the position of the armies on the map
   public updateArmyHexes(update: {
     entityId: ID;
@@ -5897,24 +5858,6 @@ export default class WorldmapScene extends WarpTravel {
     gameWorkerManager.updateStructureHex(newPos.col, newPos.row, structureInfo);
     this.invalidateAllChunkCachesContainingHex(newPos.col, newPos.row);
     return { oldPos, newPos };
-  }
-
-  // update chest hexes on the map
-  public updateChestHexes(update: ChestSystemUpdate) {
-    const {
-      hexCoords: { col, row },
-      occupierId,
-    } = update;
-
-    const normalized = new Position({ x: col, y: row }).getNormalized();
-
-    const newCol = normalized.x;
-    const newRow = normalized.y;
-
-    if (!this.chestHexes.has(newCol)) {
-      this.chestHexes.set(newCol, new Map());
-    }
-    this.chestHexes.get(newCol)?.set(newRow, { id: occupierId, owner: 0n });
   }
 
   public async updateExploredHex(update: TileSystemUpdate) {
@@ -9758,16 +9701,12 @@ export default class WorldmapScene extends WarpTravel {
     const hydratedTileCount = shouldHydrateTileOpt
       ? this.hydrateExploredTilesFromGlobalTileOptRecs(fetchKey, localBounds, tileOptEntries)
       : 0;
-    const hydratedChestCount = shouldHydrateTileOpt
-      ? this.hydrateChestsFromGlobalTileOptRecs(fetchKey, tileOptEntries)
-      : 0;
     const hydratedStructureCount = shouldHydrateStructures
       ? await this.hydrateStructuresFromGlobalTileOptRecs(fetchKey, tileOptEntries)
       : 0;
 
     this.traceChunk("global_spatial_recs_hydrated", {
       fetchKey,
-      hydratedChestCount,
       hydratedStructureCount,
       hydratedTileCount,
       tileOptCandidateCount: tileOptEntries.length,
@@ -9854,32 +9793,6 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     return hydratedStructureCount;
-  }
-
-  private hydrateChestsFromGlobalTileOptRecs(
-    _fetchKey: string,
-    entries: readonly GlobalTileOptHydrationEntry[],
-  ): number {
-    let hydratedChestCount = 0;
-    for (const entry of entries) {
-      if (!isTileOccupierChest(entry.tile.occupier_type)) {
-        continue;
-      }
-
-      const update: ChestSystemUpdate = {
-        occupierId: entry.tile.occupier_id,
-        hexCoords: { col: entry.tile.col, row: entry.tile.row },
-      };
-      this.updateChestHexes(update);
-      void this.chestManager.onUpdate(update);
-      hydratedChestCount += 1;
-    }
-
-    if (hydratedChestCount > 0) {
-      incrementWorldmapRenderCounter("globalSpatialRecsHydratedChests", hydratedChestCount);
-    }
-
-    return hydratedChestCount;
   }
 
   private shouldFetchTileOpt(stages: readonly WorldmapRenderAreaHydrationStage[]): boolean {
@@ -11890,6 +11803,8 @@ export default class WorldmapScene extends WarpTravel {
 
     this.disposeStoreSubscriptions();
     this.disposeWorldUpdateSubscriptions();
+    this.unsubscribeWorldSpatialProjection?.();
+    this.unsubscribeWorldSpatialProjection = undefined;
     this.pendingArmyMovements.forEach((_record, entityId) => this.clearPendingArmyMovement(entityId));
     this.pendingArmyMovementVisualLifecycleDisposers.forEach((dispose) => dispose());
     this.pendingArmyMovementVisualLifecycleDisposers.clear();

--- a/client/apps/game/src/ui/features/world/latest-features.ts
+++ b/client/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,14 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-08-13",
+    title: "Reliable Map Chests",
+    description:
+      "Fixed relic chests so discoveries, moves, and removals stay current while you pan around the world map without an extra area fetch.",
+    type: "fix",
+    gameSlug: "world",
+  },
+  {
+    date: "2026-08-13",
     title: "Whole-World Live Sync",
     description:
       "Improved map synchronization so offscreen armies, structures, resources, and chests stay current and are ready when you move the camera, including after reconnecting.",

--- a/docs/architecture/sync-s2-recovery-contract.md
+++ b/docs/architecture/sync-s2-recovery-contract.md
@@ -49,8 +49,9 @@ adapter test.
 ## Headless and measurement
 
 `pnpm --dir client/apps/game smoke:game-sync-headless -- --help` documents the repeatable live smoke. It instantiates
-the same `GameSyncRuntime`, a RECS world, and a Torii provider in Node, hydrates every page, and prints decoded
-occupancy plus runtime metrics without DOM, React, or Three.js.
+the same `GameSyncRuntime`, a RECS world, the session-owned `WorldSpatialProjection`, and a Torii provider in Node. It
+hydrates every page and prints decoded occupancy, projected chest occupancy, and runtime metrics without DOM, React, or
+Three.js.
 
 On 2026-08-13, game 13 against `https://torii.jcndata.com` hydrated 2,472 entities across five pages in 2,598 ms. The
 largest scheduled RECS batch took 23 ms, and the requested coordinate decoded correctly. The one-second observation
@@ -59,3 +60,7 @@ runtime and printed by the smoke's `--watch-ms` mode; a non-zero active-battle c
 window and is an explicit merge-gate measurement, not a fabricated result.
 
 The machine-readable capture is `docs/architecture/sync-s2-headless-measurement.json`.
+
+The S3 chest conversion was also checked against a live chest. Game 13 decoded chest 10,775 at
+`(1076167049, 1076167075)`, and the projection returned that same entity at that coordinate. The machine-readable
+capture is `docs/architecture/sync-s3-chest-projection-measurement.json`.

--- a/docs/architecture/sync-s3-chest-projection-measurement.json
+++ b/docs/architecture/sync-s3-chest-projection-measurement.json
@@ -1,0 +1,57 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-08-13T22:57:55+02:00",
+  "command": "pnpm --dir client/apps/game smoke:game-sync-headless",
+  "target": {
+    "toriiUrl": "https://torii.jcndata.com",
+    "worldAddress": "0x78ff85ac450bb559c97966b64666fd5292f4a98756a607349d9f93f4563bdd2",
+    "namespace": "s2",
+    "gameId": 13,
+    "coordinate": {
+      "col": 1076167049,
+      "row": 1076167075
+    },
+    "expectedOccupierId": 10775
+  },
+  "result": {
+    "status": "running",
+    "occupancy": {
+      "tileEntityId": "0x3bc8c5b71cdba3a74303f9e34677d36f4255ae0aac49ba0c56003c8472532e1",
+      "col": 1076167049,
+      "row": 1076167075,
+      "occupierId": 10775,
+      "occupierType": 34
+    },
+    "spatialProjection": {
+      "chestCount": 4,
+      "chestsAtCoordinate": [
+        {
+          "kind": "chest",
+          "entityId": 10775,
+          "hexCoords": {
+            "col": 1076167049,
+            "row": 1076167075
+          }
+        }
+      ],
+      "sampleChest": {
+        "kind": "chest",
+        "entityId": 10775,
+        "hexCoords": {
+          "col": 1076167049,
+          "row": 1076167075
+        }
+      }
+    },
+    "metrics": {
+      "appliedBatchCount": 5,
+      "lastRecoveryDurationMs": 2173,
+      "maxBatchApplyDurationMs": 19,
+      "peakLiveUpdatesPerSecond": 0,
+      "snapshotEntityCount": 2472,
+      "snapshotPageCount": 5,
+      "totalLiveEntityUpdates": 0,
+      "totalLiveEventUpdates": 0
+    }
+  }
+}

--- a/docs/plans/sync-s3-slices-codex-brief.md
+++ b/docs/plans/sync-s3-slices-codex-brief.md
@@ -1,0 +1,84 @@
+# Sync S3 Slice Brief — Structures, then Armies
+
+Context: executes §S3 of `docs/plans/sync-overhaul-codex-brief.md`. The merged chest slice is the reference
+implementation — same projection pattern, same deletion discipline. One slice per PR, short branches off the updated
+`feat/single-world-blitz` base: `feat/sync-s3-structures`, then `feat/sync-s3-armies`. KISS: each slice is judged by
+what it deletes.
+
+## The truth vs render-resource rule (read before deleting anything in a manager)
+
+The managers hold two kinds of state and only one is a target. **Truth state** — who exists and where (worldmap's
+`structureHexes`, `structuresPositions`, `armiesPositions`, manager `armies`/`lastKnownVisibleHexes` maps, stream-driven
+add/remove flows) — is replaced by the projection. **Render-resource state** — instanced-model pools, instance-index ↔
+entity bindings, label objects, animation/tween bookkeeping, movement listeners, cosmetic registries — is legitimate
+GPU/scene bookkeeping and stays. Deleting a binding map is not a win; it is a regression.
+
+## Slice 2 — Structures (`feat/sync-s3-structures`)
+
+**Renderable and source.** Extend the projection with `StructureSpatialRenderable { entityId, hexCoords, occupierType }`
+derived from TileOpt exactly like chests: existence and mesh variant come from `occupier_type` (realm levels, wonder
+levels, hyperstructure levels, mine/village/bank/holy-site/camp/bitcoin variants — `getStructureInfoFromTileOccupier`
+already classifies them), alt rows filtered in the resolver. **Owner is not projection state**: interaction paths
+(click, hover label, ally coloring, isMine) read the `Structure` model from RECS at interaction time — the projection
+stays identity+location, per its own doc comment. Adjudicate `ReservedHyperstructure` (occupier 39) explicitly: it
+renders but has no Structure entity — decide its renderable shape in the projection, don't special-case it in the scene.
+
+**Deletions (the point of the slice):**
+
+- `structureHexes` and `structuresPositions` scene maps (`worldmap.tsx:931,937`) and every read path that walks them.
+- The scene's structure stream subscriptions: `Structure.onStructureUpdate` (`worldmap.tsx:1913`) and
+  `Structure.onTileUpdate` (`worldmap.tsx:1951`).
+- The async enrichment behind them: `resolveStructureTileUpdateFromTileOpt` and the `"structure"`/`"structure-tile"`
+  sequential-update scopes in `world-update-listener.ts` — the convergent projection makes update order irrelevant,
+  which is the whole reason those scopes exist.
+- `hydrateStructuresFromGlobalTileOptRecs` and the structure arm of render-area hydration.
+- `ensureStructureSynced` + `ensureStructureQueriedMethod` (`worldmap.tsx:1032-1047`) — the structure repair fetch. Same
+  rollback-mode caveat as chests: legacy mode loses this healing; accepted and documented.
+
+**Regression pins to keep green:** hyperstructure construction pops in on the map without leaving bounds (the Aug 13
+vanish-bug acceptance); provision/settle flows still surface new realms; the reserved-HS "Create Here" flow still sees
+the tile flip. Update source-pin tests to assert the projection wiring; never delete them to make room.
+
+## Slice 3 — Armies (`feat/sync-s3-armies`)
+
+**Source model decision (fact-level ownership applied).** An army's existence and position is ONE fact with ONE owner:
+`ExplorerTroops` (exists iff `troops.count > 0`, position = `coord`, mesh variant = category + tier). The projection
+derives armies from ExplorerTroops only. TileOpt's explorer occupier values stop driving rendering — today's
+`Army.onTileUpdate` path infers army death from tile-leave heuristics ("left tile but still exists — likely moving",
+`world-update-listener.ts:297-317`) precisely because it watches the wrong model. Those heuristics, the `"army-tile"`
+sequential scope, and `onDeadArmy` are deleted, not ported.
+
+**Rebuild cost (owner-ratified design input, 2026-08-14).** Coalesce projection rebuilds to at most once per scheduler
+tick — one rebuild and one listener notification per ingest batch, however many army updates it carried. Measure against
+the owner's captured peak update rate (the owner holds the number and supplies it privately — peak-rate figures are NOT
+committed to the repo). Move to incremental per-entity updates only if that measurement demands it; at blitz cardinality
+(~40 ExplorerTroops rows) coalesced full rebuild is the expected winner.
+
+**Pending movement stays an overlay.** The projection is RECS-pure. The renderer merges valid-pending > RECS through the
+existing accessor; the movement animation handoff (start/complete/visual-cancel listeners, transition tokens) is
+render-resource state and stays. Idempotent upsert must not restart a tween the army is already running — diff the
+authoritative target against the animation's target before touching it.
+
+**Deletions:** `armiesPositions` (`worldmap.tsx:934`) and its lookups (battle positions, entity-action resolver,
+selection paths); the scene's army stream subscriptions; the tile-leave inference machinery above;
+`lastKnownVisibleHexes` and any manager map whose job was remembering authoritative positions. Adjudicate
+`army-authoritative-reconciler.ts`: delete if the game-wide stream + projection supersede it, or state in the PR why it
+survives to S4.
+
+## Cross-slice constraints
+
+- Net-negative LOC per slice on tracked files, or the PR explains why not.
+- Every renderable resolver filters `alt` rows — no exceptions, ever.
+- Camera stays a pure view filter; no new fetch paths. The chunk-hydration fetches that remain after these slices are S4
+  deletion targets, not load-bearing dependencies — do not add callers.
+- Panels keep reading RECS selectors directly; nothing UI-side routes through the projection.
+- Spires and quest tiles: if their rendering turns out to ride the deleted structure streams, convert them in the
+  structures slice with the same pattern (flag it in the PR); do not leave them on a dead path and do not start a fourth
+  slice without asking.
+- AGENTS.md guardrails binding; cite the fact-ownership rule in each PR description.
+
+## Explicitly NOT these slices
+
+- MapDataStore/minimap conversion, stamina comparator collapse, legacy adapter + flag deletion, live-state SqlApi
+  deletions — all S4.
+- Peak-rate captures in the repo (owner-held, supplied out of band).

--- a/packages/core/src/sync/game-sync-runtime.test.ts
+++ b/packages/core/src/sync/game-sync-runtime.test.ts
@@ -292,6 +292,37 @@ describe("GameSyncRuntime recovery", () => {
 });
 
 describe("GameSyncRuntime lifecycle", () => {
+  it("owns and replaces the session spatial projection", () => {
+    const runtime = new GameSyncRuntime();
+    const first = { start: vi.fn(), dispose: vi.fn() };
+    const second = { start: vi.fn(), dispose: vi.fn() };
+
+    runtime.installWorldSpatialProjection(first as never);
+    runtime.installWorldSpatialProjection(second as never);
+
+    expect(first.start).toHaveBeenCalledOnce();
+    expect(first.dispose).toHaveBeenCalledOnce();
+    expect(second.start).toHaveBeenCalledOnce();
+    expect(runtime.requireWorldSpatialProjection()).toBe(second);
+
+    runtime.dispose();
+    expect(second.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("does not retain a spatial projection that fails to start", () => {
+    const runtime = new GameSyncRuntime();
+    const projection = {
+      start: vi.fn(() => {
+        throw new Error("projection failed");
+      }),
+      dispose: vi.fn(),
+    };
+
+    expect(() => runtime.installWorldSpatialProjection(projection as never)).toThrow("projection failed");
+    expect(projection.dispose).toHaveBeenCalledOnce();
+    expect(() => runtime.requireWorldSpatialProjection()).toThrow("has not been installed");
+  });
+
   it("preserves the cancellation guard but force-cancels on dispose", async () => {
     const runtime = new GameSyncRuntime();
     const writer = { cancel: vi.fn() };

--- a/packages/core/src/sync/game-sync-runtime.ts
+++ b/packages/core/src/sync/game-sync-runtime.ts
@@ -1,6 +1,7 @@
 import { EntityIngestQueue, type EntityIngestBatchInfo } from "./entity-ingest-queue";
 import type { GameSyncEntity, GameSyncRuntimeMetrics, GameSyncSessionStart, GameSyncWriter } from "./game-sync-types";
 import { createMicrotaskGameSyncScheduler } from "./scheduler";
+import type { WorldSpatialProjection } from "./world-spatial-projection";
 
 export type GameSyncRuntimeStatus = "idle" | "subscribing" | "snapshotting" | "replaying" | "running" | "stopped";
 
@@ -65,6 +66,7 @@ export class GameSyncRuntime {
   private status: GameSyncRuntimeStatus = "idle";
   private session: GameSyncSessionStart | null = null;
   private ingestQueue: EntityIngestQueue | null = null;
+  private worldSpatialProjection: WorldSpatialProjection | null = null;
   private recentEventIdentities = new Map<string, true>();
   private liveUpdateTimestamps: number[] = [];
   private receiveSequence = 0;
@@ -83,6 +85,7 @@ export class GameSyncRuntime {
   }
 
   public async startSession(input: GameSyncSessionStart): Promise<void> {
+    this.disposeWorldSpatialProjection();
     this.session = input;
     this.recentEventIdentities.clear();
     this.liveUpdateTimestamps = [];
@@ -98,6 +101,7 @@ export class GameSyncRuntime {
 
   /** Complete S1 lifecycle retained only for the bounded rollback adapter. */
   public async startLegacySession(input: LegacyGameSyncSessionStart): Promise<void> {
+    this.disposeWorldSpatialProjection();
     this.session = null;
     const generation = this.beginRun("subscribing");
 
@@ -147,10 +151,29 @@ export class GameSyncRuntime {
     this.legacyPlayerWriter = null;
   }
 
+  public installWorldSpatialProjection(projection: WorldSpatialProjection): void {
+    this.disposeWorldSpatialProjection();
+    try {
+      projection.start();
+      this.worldSpatialProjection = projection;
+    } catch (error) {
+      projection.dispose();
+      throw error;
+    }
+  }
+
+  public requireWorldSpatialProjection(): WorldSpatialProjection {
+    if (!this.worldSpatialProjection) {
+      throw new Error("WorldSpatialProjection has not been installed for the active game");
+    }
+    return this.worldSpatialProjection;
+  }
+
   public dispose(): void {
     this.generation += 1;
     this.cancelWriterImmediately();
     this.cancelPlayerWriter();
+    this.disposeWorldSpatialProjection();
     this.ingestQueue?.dispose();
     this.ingestQueue = null;
     this.session = null;
@@ -352,6 +375,11 @@ export class GameSyncRuntime {
   private cancelWriterImmediately(): void {
     this.writer?.cancel();
     this.writer = null;
+  }
+
+  private disposeWorldSpatialProjection(): void {
+    this.worldSpatialProjection?.dispose();
+    this.worldSpatialProjection = null;
   }
 }
 

--- a/packages/core/src/sync/index.ts
+++ b/packages/core/src/sync/index.ts
@@ -5,3 +5,4 @@ export * from "./model-manifest";
 export * from "./model-stream-clause";
 export * from "./player-structure-sync-writer";
 export * from "./scheduler";
+export * from "./world-spatial-projection";

--- a/packages/core/src/sync/world-spatial-projection.test.ts
+++ b/packages/core/src/sync/world-spatial-projection.test.ts
@@ -1,0 +1,117 @@
+import { TileOccupier } from "@bibliothecadao/types";
+import { Type, createWorld, defineComponent, removeComponent, setComponent } from "@dojoengine/recs";
+import { describe, expect, it, vi } from "vitest";
+import { WorldSpatialProjection } from "./world-spatial-projection";
+
+const encodeTile = (input: { alt?: boolean; col: number; row: number; occupierId: number; occupierType: number }) =>
+  (BigInt(input.alt ? 1 : 0) << 127n) |
+  (BigInt(input.col) << 81n) |
+  (BigInt(input.row) << 49n) |
+  (BigInt(input.occupierId) << 9n) |
+  (BigInt(input.occupierType) << 1n);
+
+const createHarness = () => {
+  const world = createWorld();
+  const tileOpt = defineComponent(world, {
+    game_id: Type.Number,
+    alt: Type.Boolean,
+    col: Type.Number,
+    row: Type.Number,
+    data: Type.BigInt,
+  });
+  const writeTile = (
+    entityId: string,
+    input: { alt?: boolean; col: number; row: number; occupierId: number; occupierType?: number },
+    skipUpdateStream = false,
+  ) => {
+    setComponent(
+      tileOpt,
+      entityId,
+      {
+        game_id: 13,
+        alt: input.alt ?? false,
+        col: input.col,
+        row: input.row,
+        data: encodeTile({ ...input, occupierType: input.occupierType ?? TileOccupier.Chest }),
+      },
+      { skipUpdateStream },
+    );
+  };
+
+  return { projection: new WorldSpatialProjection({ tileOptComponent: tileOpt, bucketSize: 8 }), tileOpt, writeTile };
+};
+
+describe("WorldSpatialProjection", () => {
+  it("rebuilds a surface-chest index from RECS and excludes non-renderable tiles", () => {
+    const { projection, writeTile } = createHarness();
+    writeTile("chest", { col: 100, row: 200, occupierId: 7 });
+    writeTile("ethereal-chest", { alt: true, col: 100, row: 200, occupierId: 8 });
+    writeTile("plain-tile", { col: 101, row: 200, occupierId: 0, occupierType: TileOccupier.None });
+
+    projection.start();
+
+    expect(projection.getChests()).toEqual([{ kind: "chest", entityId: 7, hexCoords: { col: 100, row: 200 } }]);
+    expect(projection.getChestsAtHex({ col: 100, row: 200 }).map(({ entityId }) => entityId)).toEqual([7]);
+    expect(
+      projection
+        .getChestsInBounds({ minCol: 96, maxCol: 100, minRow: 196, maxRow: 204 })
+        .map(({ entityId }) => entityId),
+    ).toEqual([7]);
+  });
+
+  it.each(["destination-first", "origin-first"] as const)(
+    "converges to the current RECS position when the %s update lands first",
+    (updateOrder) => {
+      const { projection, tileOpt, writeTile } = createHarness();
+      writeTile("destination", { col: 20, row: 21, occupierId: 0, occupierType: TileOccupier.None });
+      writeTile("origin", { col: 10, row: 11, occupierId: 7 });
+      projection.start();
+
+      if (updateOrder === "destination-first") {
+        writeTile("destination", { col: 20, row: 21, occupierId: 7 });
+        removeComponent(tileOpt, "origin");
+      } else {
+        removeComponent(tileOpt, "origin");
+        writeTile("destination", { col: 20, row: 21, occupierId: 7 });
+      }
+
+      expect(projection.getChest(7)?.hexCoords).toEqual({ col: 20, row: 21 });
+      expect(projection.getChestsAtHex({ col: 10, row: 11 })).toEqual([]);
+      expect(projection.getChestsAtHex({ col: 20, row: 21 }).map(({ entityId }) => entityId)).toEqual([7]);
+    },
+  );
+
+  it("restores missed updates and deletions from a full rebuild", () => {
+    const { projection, tileOpt, writeTile } = createHarness();
+    writeTile("chest", { col: 10, row: 11, occupierId: 7 });
+    projection.start();
+
+    removeComponent(tileOpt, "chest", { skipUpdateStream: true });
+    expect(projection.getChest(7)).toBeDefined();
+
+    projection.rebuild();
+
+    expect(projection.getChest(7)).toBeUndefined();
+  });
+
+  it("publishes one complete change and detaches cleanly", () => {
+    const { projection, writeTile } = createHarness();
+    const listener = vi.fn();
+    projection.start();
+    const unsubscribe = projection.subscribe(listener);
+
+    writeTile("chest", { col: 10, row: 11, occupierId: 7 });
+
+    expect(listener).toHaveBeenCalledWith([
+      { entityId: 7, current: { kind: "chest", entityId: 7, hexCoords: { col: 10, row: 11 } } },
+    ]);
+
+    unsubscribe();
+    writeTile("second", { col: 12, row: 13, occupierId: 8 });
+    expect(listener).toHaveBeenCalledOnce();
+
+    projection.dispose();
+    writeTile("third", { col: 14, row: 15, occupierId: 9 });
+    expect(projection.getChests()).toEqual([]);
+  });
+});

--- a/packages/core/src/sync/world-spatial-projection.ts
+++ b/packages/core/src/sync/world-spatial-projection.ts
@@ -1,0 +1,216 @@
+import type { ID, TileOpt } from "@bibliothecadao/types";
+import { TileOccupier } from "@bibliothecadao/types";
+import { getComponentValue, type Component, type Metadata, type Schema } from "@dojoengine/recs";
+import { tileOptToTile } from "../utils/tile-opt";
+
+export interface WorldSpatialHex {
+  readonly col: number;
+  readonly row: number;
+}
+
+export interface WorldSpatialBounds {
+  readonly minCol: number;
+  readonly maxCol: number;
+  readonly minRow: number;
+  readonly maxRow: number;
+}
+
+export interface ChestSpatialRenderable {
+  readonly kind: "chest";
+  readonly entityId: ID;
+  /** Contract-space coordinates, matching TileOpt. */
+  readonly hexCoords: WorldSpatialHex;
+}
+
+export interface ChestSpatialProjectionChange {
+  readonly entityId: ID;
+  readonly previous?: ChestSpatialRenderable;
+  readonly current?: ChestSpatialRenderable;
+}
+
+export interface WorldSpatialProjectionOptions {
+  tileOptComponent: Component<Schema, Metadata, unknown>;
+  bucketSize?: number;
+}
+
+type ChestProjectionListener = (changes: readonly ChestSpatialProjectionChange[]) => void;
+
+const DEFAULT_SPATIAL_BUCKET_SIZE = 32;
+
+const chestHexKey = ({ col, row }: WorldSpatialHex): string => `${col}:${row}`;
+
+const chestBucketKey = ({ col, row }: WorldSpatialHex, bucketSize: number): string =>
+  `${Math.floor(col / bucketSize)}:${Math.floor(row / bucketSize)}`;
+
+const isSameChest = (left: ChestSpatialRenderable, right: ChestSpatialRenderable): boolean =>
+  left.hexCoords.col === right.hexCoords.col && left.hexCoords.row === right.hexCoords.row;
+
+const resolveChestRenderable = (tileOpt: TileOpt | undefined): ChestSpatialRenderable | undefined => {
+  if (!tileOpt) return undefined;
+
+  const tile = tileOptToTile(tileOpt);
+  if (tile.alt || tile.occupier_type !== TileOccupier.Chest) return undefined;
+
+  return Object.freeze({
+    kind: "chest" as const,
+    entityId: tile.occupier_id,
+    hexCoords: Object.freeze({ col: tile.col, row: tile.row }),
+  });
+};
+
+const hasChestProjectionChange = (value: readonly unknown[]): boolean => {
+  const [current, previous] = value as [TileOpt | undefined, TileOpt | undefined];
+  return resolveChestRenderable(current) !== undefined || resolveChestRenderable(previous) !== undefined;
+};
+
+/**
+ * Rebuildable spatial read model derived exclusively from authoritative RECS facts.
+ *
+ * The projection stores renderable identity and location only. Gameplay panels
+ * continue to read RECS directly; renderers use this index to select visible
+ * entities without introducing another source of gameplay truth.
+ */
+export class WorldSpatialProjection {
+  private readonly tileOptComponent: Component<Schema, Metadata, unknown>;
+  private readonly bucketSize: number;
+  private chestsById = new Map<ID, ChestSpatialRenderable>();
+  private chestIdsByHex = new Map<string, Set<ID>>();
+  private chestIdsByBucket = new Map<string, Set<ID>>();
+  private listeners = new Set<ChestProjectionListener>();
+  private unsubscribeTileOpt: (() => void) | null = null;
+
+  constructor({ tileOptComponent, bucketSize = DEFAULT_SPATIAL_BUCKET_SIZE }: WorldSpatialProjectionOptions) {
+    if (!Number.isFinite(bucketSize) || bucketSize <= 0) {
+      throw new Error(`WorldSpatialProjection requires a positive bucket size; received ${bucketSize}`);
+    }
+
+    this.tileOptComponent = tileOptComponent;
+    this.bucketSize = Math.floor(bucketSize);
+  }
+
+  public start(): void {
+    if (this.unsubscribeTileOpt) return;
+
+    const subscription = this.tileOptComponent.update$.subscribe(({ value }) => {
+      if (!hasChestProjectionChange(value)) return;
+      this.rebuild();
+    });
+    this.unsubscribeTileOpt = () => subscription.unsubscribe();
+    try {
+      this.rebuild();
+    } catch (error) {
+      this.dispose();
+      throw error;
+    }
+  }
+
+  public rebuild(): void {
+    const nextChests = new Map<ID, ChestSpatialRenderable>();
+    for (const entity of this.tileOptComponent.entities()) {
+      const tileOpt = getComponentValue(this.tileOptComponent, entity) as TileOpt | undefined;
+      const chest = resolveChestRenderable(tileOpt);
+      if (chest) nextChests.set(chest.entityId, chest);
+    }
+
+    this.replaceChestState(nextChests);
+  }
+
+  public getChest(entityId: ID): ChestSpatialRenderable | undefined {
+    return this.chestsById.get(entityId);
+  }
+
+  public getChests(): readonly ChestSpatialRenderable[] {
+    return [...this.chestsById.values()];
+  }
+
+  public getChestsAtHex(hexCoords: WorldSpatialHex): readonly ChestSpatialRenderable[] {
+    const entityIds = this.chestIdsByHex.get(chestHexKey(hexCoords));
+    if (!entityIds) return [];
+    return [...entityIds].flatMap((entityId) => {
+      const chest = this.chestsById.get(entityId);
+      return chest ? [chest] : [];
+    });
+  }
+
+  public getChestsInBounds(bounds: WorldSpatialBounds): readonly ChestSpatialRenderable[] {
+    const startBucketCol = Math.floor(bounds.minCol / this.bucketSize);
+    const endBucketCol = Math.floor(bounds.maxCol / this.bucketSize);
+    const startBucketRow = Math.floor(bounds.minRow / this.bucketSize);
+    const endBucketRow = Math.floor(bounds.maxRow / this.bucketSize);
+    const candidates = new Set<ID>();
+
+    for (let bucketCol = startBucketCol; bucketCol <= endBucketCol; bucketCol += 1) {
+      for (let bucketRow = startBucketRow; bucketRow <= endBucketRow; bucketRow += 1) {
+        this.chestIdsByBucket.get(`${bucketCol}:${bucketRow}`)?.forEach((entityId) => candidates.add(entityId));
+      }
+    }
+
+    return [...candidates].flatMap((entityId) => {
+      const chest = this.chestsById.get(entityId);
+      if (!chest || !this.isChestInsideBounds(chest, bounds)) return [];
+      return [chest];
+    });
+  }
+
+  public subscribe(listener: ChestProjectionListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  public dispose(): void {
+    this.unsubscribeTileOpt?.();
+    this.unsubscribeTileOpt = null;
+    this.listeners.clear();
+    this.chestsById.clear();
+    this.chestIdsByHex.clear();
+    this.chestIdsByBucket.clear();
+  }
+
+  private replaceChestState(nextChests: Map<ID, ChestSpatialRenderable>): void {
+    const changes = this.resolveChestChanges(nextChests);
+    this.chestsById = nextChests;
+    this.chestIdsByHex = this.buildChestIndex(nextChests, (chest) => chestHexKey(chest.hexCoords));
+    this.chestIdsByBucket = this.buildChestIndex(nextChests, (chest) =>
+      chestBucketKey(chest.hexCoords, this.bucketSize),
+    );
+    if (changes.length > 0) this.listeners.forEach((listener) => listener(changes));
+  }
+
+  private resolveChestChanges(nextChests: Map<ID, ChestSpatialRenderable>): ChestSpatialProjectionChange[] {
+    const changes: ChestSpatialProjectionChange[] = [];
+
+    this.chestsById.forEach((previous, entityId) => {
+      const current = nextChests.get(entityId);
+      if (!current) changes.push({ entityId, previous });
+      else if (!isSameChest(previous, current)) changes.push({ entityId, previous, current });
+    });
+    nextChests.forEach((current, entityId) => {
+      if (!this.chestsById.has(entityId)) changes.push({ entityId, current });
+    });
+
+    return changes;
+  }
+
+  private buildChestIndex(
+    chests: Map<ID, ChestSpatialRenderable>,
+    resolveKey: (chest: ChestSpatialRenderable) => string,
+  ): Map<string, Set<ID>> {
+    const index = new Map<string, Set<ID>>();
+    chests.forEach((chest) => {
+      const key = resolveKey(chest);
+      const entityIds = index.get(key) ?? new Set<ID>();
+      entityIds.add(chest.entityId);
+      index.set(key, entityIds);
+    });
+    return index;
+  }
+
+  private isChestInsideBounds(chest: ChestSpatialRenderable, bounds: WorldSpatialBounds): boolean {
+    return (
+      chest.hexCoords.col >= bounds.minCol &&
+      chest.hexCoords.col <= bounds.maxCol &&
+      chest.hexCoords.row >= bounds.minRow &&
+      chest.hexCoords.row <= bounds.maxRow
+    );
+  }
+}

--- a/packages/core/src/utils/tile-opt.ts
+++ b/packages/core/src/utils/tile-opt.ts
@@ -1,0 +1,37 @@
+import type { ID, Tile, TileOpt } from "@bibliothecadao/types";
+
+const OCCUPIER_IS_STRUCTURE_SHIFT = 0;
+const OCCUPIER_IS_STRUCTURE_MASK = 0x1n;
+const OCCUPIER_TYPE_SHIFT = 1;
+const OCCUPIER_TYPE_MASK = 0xffn;
+const OCCUPIER_ID_SHIFT = 9;
+const OCCUPIER_ID_MASK = 0xffffffffn;
+const BIOME_SHIFT = 41;
+const BIOME_MASK = 0xffn;
+const ROW_SHIFT = 49;
+const ROW_MASK = 0xffffffffn;
+const COL_SHIFT = 81;
+const COL_MASK = 0xffffffffn;
+const REWARD_EXTRACTED_SHIFT = 113;
+const REWARD_EXTRACTED_MASK = 0x1n;
+const ALT_SHIFT = 127;
+const ALT_MASK = 0x1n;
+
+const extractPackedTileField = (data: bigint, shift: number, mask: bigint): bigint => (data >> BigInt(shift)) & mask;
+
+/** Decode the contract's packed TileOpt representation without runtime dependencies. */
+export function tileOptToTile(tileOpt?: TileOpt): Tile {
+  if (!tileOpt) return null as unknown as Tile;
+
+  const { data } = tileOpt;
+  return {
+    alt: extractPackedTileField(data, ALT_SHIFT, ALT_MASK) !== 0n,
+    col: Number(extractPackedTileField(data, COL_SHIFT, COL_MASK)),
+    row: Number(extractPackedTileField(data, ROW_SHIFT, ROW_MASK)),
+    biome: Number(extractPackedTileField(data, BIOME_SHIFT, BIOME_MASK)),
+    occupier_id: Number(extractPackedTileField(data, OCCUPIER_ID_SHIFT, OCCUPIER_ID_MASK)) as ID,
+    occupier_type: Number(extractPackedTileField(data, OCCUPIER_TYPE_SHIFT, OCCUPIER_TYPE_MASK)),
+    occupier_is_structure: extractPackedTileField(data, OCCUPIER_IS_STRUCTURE_SHIFT, OCCUPIER_IS_STRUCTURE_MASK) !== 0n,
+    reward_extracted: extractPackedTileField(data, REWARD_EXTRACTED_SHIFT, REWARD_EXTRACTED_MASK) !== 0n,
+  };
+}

--- a/packages/core/src/utils/tile.ts
+++ b/packages/core/src/utils/tile.ts
@@ -1,81 +1,14 @@
-import type { ClientComponents, ID, Tile, TileOpt } from "@bibliothecadao/types";
+import type { ClientComponents, Tile, TileOpt } from "@bibliothecadao/types";
 import { getComponentValue, type Entity } from "@dojoengine/recs";
 import { gameEntityKey } from "../managers/config-manager";
+import { tileOptToTile } from "./tile-opt";
+
+export { tileOptToTile } from "./tile-opt";
 
 /**
  * Default alt value for standard hex coordinates (non-alt map)
  */
 export const DEFAULT_COORD_ALT = false;
-
-/**
- * Bit shift and mask constants matching the Cairo contract implementation
- * Layout (LSB -> MSB): occupier_is_structure, occupier_type, occupier_id, biome, row, col, reward_extracted, ... , alt (bit 127).
- */
-const OCCUPIER_IS_STRUCTURE_SHIFT = 0;
-const OCCUPIER_IS_STRUCTURE_MASK = 0x1n;
-
-const OCCUPIER_TYPE_SHIFT = 1;
-const OCCUPIER_TYPE_MASK = 0xffn;
-
-const OCCUPIER_ID_SHIFT = 9;
-const OCCUPIER_ID_MASK = 0xffffffffn;
-
-const BIOME_SHIFT = 41;
-const BIOME_MASK = 0xffn;
-
-const ROW_SHIFT = 49;
-const ROW_MASK = 0xffffffffn;
-
-const COL_SHIFT = 81;
-const COL_MASK = 0xffffffffn;
-
-const REWARD_EXTRACTED_SHIFT = 113;
-const REWARD_EXTRACTED_MASK = 0x1n;
-
-const ALT_SHIFT = 127;
-const ALT_MASK = 0x1n;
-
-/**
- * Extract a field value from packed data using bitwise operations
- */
-function extractField(data: bigint, shift: number, mask: bigint): bigint {
-  return (data >> BigInt(shift)) & mask;
-}
-
-/**
- * Convert a TileOpt (optimized/packed) to a Tile (unpacked) structure.
- * This function mirrors the Cairo contract's TileOptIntoTile implementation.
- *
- * @param tileOpt - The optimized tile data from the contract
- * @returns Unpacked Tile with all fields extracted
- */
-export function tileOptToTile(tileOpt?: TileOpt): Tile {
-  if (!tileOpt) {
-    return null as unknown as Tile;
-  }
-
-  const { data } = tileOpt;
-
-  const occupier_is_structure = extractField(data, OCCUPIER_IS_STRUCTURE_SHIFT, OCCUPIER_IS_STRUCTURE_MASK) !== 0n;
-  const occupier_type = Number(extractField(data, OCCUPIER_TYPE_SHIFT, OCCUPIER_TYPE_MASK));
-  const occupier_id = Number(extractField(data, OCCUPIER_ID_SHIFT, OCCUPIER_ID_MASK)) as ID;
-  const biome = Number(extractField(data, BIOME_SHIFT, BIOME_MASK));
-  const row = Number(extractField(data, ROW_SHIFT, ROW_MASK));
-  const col = Number(extractField(data, COL_SHIFT, COL_MASK));
-  const reward_extracted = extractField(data, REWARD_EXTRACTED_SHIFT, REWARD_EXTRACTED_MASK) !== 0n;
-  const alt = extractField(data, ALT_SHIFT, ALT_MASK) !== 0n;
-
-  return {
-    alt,
-    col,
-    row,
-    biome,
-    occupier_id,
-    occupier_type,
-    occupier_is_structure,
-    reward_extracted,
-  };
-}
 
 /**
  * Get a Tile component value and automatically convert from TileOpt to Tile.


### PR DESCRIPTION
## What changed

This is the first S3 projection slice. It adds a session-owned, headless `WorldSpatialProjection` derived from RECS `TileOpt` state and moves chest rendering onto that projection.

The projection supports full rebuilds, change-diffed add/remove/move notifications, and bucketed bounds lookups. `GameSyncRuntime` owns its install/dispose lifecycle, while `ChestManager` now subscribes only to projected chest changes.

The former chest truth/cache paths are deleted: the scene-local `chestHexes` map, both chest-specific Torii subscriptions, the linear hover fallback, chunk chest hydration, and the repair fetch.

## Why

Chest state had multiple owners across RECS, Torii subscriptions, and scene-local caches. Those paths could disagree, which made stale or alt-layer ghost chests possible.

RECS remains the sole owner of current entity truth. The projection is a disposable, fully rebuildable spatial index over RECS; it does not introduce a second authoritative store. The alt-layer eligibility rule lives in the renderable resolver, so invalid chest state cannot enter the renderer.

## User impact

Chest meshes, hover labels, and move/removal updates now converge through one session-scoped path. Camera movement only filters the freshest projected state and no longer triggers chest repair work.

## Verification

- `pnpm run format`
- `pnpm run knip` (exit 0; five existing configuration hints)
- core sync suite: 28/28
- client typecheck: clean
- full client suite: 3,354/3,355; only the documented instanced-model timeout flake
- live headless smoke: 2,472 entities across five pages, expected chest 10,775 decoded and projected at the requested coordinate
- independent reviewer verification and approval

## Scope and rollout notes

Structures follow in a separate S3 PR. Armies remain a later slice and will use incremental per-entity updates unless measurement justifies rebuilds. In explicit legacy rollback mode, deleting the chest repair fetch means chest-staleness healing is reduced; that is an accepted emergency-path tradeoff until S4 removes the legacy adapter.