### PR TITLE
Stop food balances displaying negative under provisional overlays

### DIFF
--- a/client/apps/game/src/dojo/gamewide-sync-adapter.ts
+++ b/client/apps/game/src/dojo/gamewide-sync-adapter.ts
@@ -281,7 +281,12 @@ const reportProvisionalIntentStalled = (info: GameSyncProvisionalIntentStalledIn
 };
 
 const reportProvisionalIntentPhase = (info: GameSyncProvisionalIntentPhaseInfo): void => {
-  if (import.meta.env.DEV) console.info("[GameSync] provisional intent phase", info);
+  if (import.meta.env.DEV && info.phase === "baseline_delta_before_hash") {
+    // Convicts the echo-races-execute() case in session logs.
+    console.warn("[GameSync] authoritative echo observed before the transaction hash bound", info);
+  } else if (import.meta.env.DEV) {
+    console.info("[GameSync] provisional intent phase", info);
+  }
   captureClientEvent("game_sync_provisional_intent_phase", {
     phase: info.phase,
     intent_id: info.intentId,

--- a/docs/plans/negative-food-balance-codex-brief.md
+++ b/docs/plans/negative-food-balance-codex-brief.md
@@ -1,0 +1,99 @@
+# Negative food balance — Codex brief
+
+Motto: **KISS, always. Systemic fixes over point patches.**
+
+Context: players report wheat balances displaying negative. Investigation (Aug 18) traced it to the provisional resource
+override interacting with food's harvest-on-touch accounting, with reconciliation stalls stretching the visible window
+to 30s. Every item below cites its evidence; `logs.txt` at repo root is the convicting session.
+
+How the bug works, end to end:
+
+1. Wheat/Fish display is extrapolated: `stored balance + rate × (tick − last_updated_at)`
+   (`packages/core/src/managers/resource-manager.ts:146`). On-chain, accrual is lazy — any spend harvests pending
+   production into the stored balance and resets `last_updated_at` first
+   (`contracts/game/src/models/resource/resource.cairo:78-94`). So the stored RECS balance is routinely far below the
+   displayed balance; the difference is un-harvested accrual.
+2. The optimistic patch is accrual-blind and absolute: `resolveOptimisticResourceChangesPatch`
+   (`resource-manager.ts:207`) pins `WHEAT_BALANCE = raw stored balance + delta`. A spend validated against the
+   displayed balance (e.g. explore food costs, `army-action-manager.ts:120,389,418`) can legally exceed the stored
+   balance → the pinned value is negative.
+3. RECS overrides shallow-merge per top-level field (`overridableComponent` in `@dojoengine/recs`): the patch touches
+   only `WHEAT_BALANCE` + `weight`, so when the authoritative echo lands underneath with a harvest-reset
+   `WHEAT_PRODUCTION.last_updated_at`, the extrapolation term collapses to ~0 while the stale negative balance stays
+   pinned. The UI shows the raw negative number until the override is removed.
+4. Removal takes ≥2.5s by design (`PROVISIONAL_RECONCILIATION_HOLD_MS`, `provisional-write-manager.ts:50`) — and
+   `logs.txt` shows dozens of `confirmed provisional intent has not reconciled after 30s` with
+   `unmatchedWrites: Array(1)`, i.e. the full stall-tripwire window, routinely.
+
+Wheat-only reports are expected: only continuous-production resources carry accrual large enough for a valid spend to
+exceed the stored balance, and wheat is the dominant cost on the most frequent actions.
+
+---
+
+## 1. Make provisional resource patches harvest-aware (primary fix)
+
+The override must predict the post-tx row, mirroring what the chain does: harvest, then apply the delta. Today it
+predicts a row the chain will never write (pre-harvest balance + delta).
+
+**Fix:** in `resolveOptimisticResourceChangesPatch` (`resource-manager.ts:207`), for each touched resource that has an
+active production row, mirror `SingleResourceStoreImpl::retrieve` (`resource.cairo:78-94`):
+
+- fold the capacity-limited accrued production into the patched balance (reuse the existing display math —
+  `_amountProduced` + `_limitProductionByStoreCapacity`; do not write new math),
+- include the production struct in the patch with `last_updated_at = currentDefaultTick` (same `getBlockTimestamp()`
+  source the display uses) and, for non-continuous resources, `output_amount_left` reduced by the harvested amount,
+- add the harvested amount's weight to the weight patch alongside the delta's weight.
+
+The pinned balance then equals `extrapolated balance + delta` — non-negative for any UI-validated spend — and because
+the production row is pinned too, the echo landing underneath can no longer change what displays. This also removes the
+current ~2.5s downward flicker (harvested accrual visually vanishing) on every action, not just the negative case.
+
+Resources without a production row keep the current patch shape unchanged. Reconciliation evidence is untouched:
+`baselineDeltaFields` still compares balance fields against the authoritative baseline.
+
+**Gate:** unit tests in `resource-manager.optimistic-update.test.ts`:
+
+- producing wheat row with stale `last_updated_at`, stored balance below the spend → patch balance ≥ 0 and equal to
+  extrapolated − cost; patch contains the production row with `last_updated_at` = current tick;
+- apply the patch as an override, then write an authoritative echo underneath with a fresh `last_updated_at` → composed
+  `balanceWithProduction` never dips below the pinned prediction and never goes negative.
+
+Run with `pnpm exec vitest run` in `packages/core` (bare `pnpm test` there is watch mode).
+
+## 2. Re-evaluate reconciliation matches when the tx hash binds
+
+Baseline-delta evidence is discarded while `transactionHashAtMs === undefined` (`provisional-write-manager.ts:326`), and
+a write's match is only re-evaluated on the _next_ observation of that row. If the Torii echo races `account.execute()`
+returning the hash (realistic with preconfirmed indexing), the first echo is wasted and an otherwise-idle structure gets
+no second Resource update inside 30s → the stalls in `logs.txt`.
+
+**Fix:** in `bindTransaction` (`provisional-write-manager.ts:173`), re-run `updateWriteMatch` for every write that has
+an accumulated `authoritativePatch` — the merged patch is already stored on the write, so this is local and cheap. Add a
+dev-only log when an observation is evaluated with no bound hash, so the next `logs.txt` convicts any remaining stall
+cause by name (the stall message already carries unmatched model names).
+
+**Gate:** unit test in `provisional-write-manager.test.ts`: observe a qualifying echo _before_ `bindTransaction`, then
+bind → the write matches with no further observations. Live session: `not reconciled after 30s` count drops to ~zero
+during normal play.
+
+## 3. Clamp the sibling extrapolation math
+
+`calculateResourceProductionData` already floors negative tick deltas with a comment acknowledging the case
+(`resource-manager.ts:952`), but its siblings `_amountProduced` (`:425`) and `_amountProducedStatic` (`:818`) do not — a
+row whose `last_updated_at` is ahead of client chain-time (Torii indexes preconfirmed blocks; the chain-time poller
+reads `getBlock("latest")`) contributes _negative_ production. Likewise the instance capacity clamp
+(`Math.max(0, capacityLeft)`, `:402`) is missing from `_limitProductionByStoreCapacityStatic` (`:835`), so an
+over-capacity structure _subtracts_ from the displayed balance in the static path the resource table uses
+(`entity-resource-table-new.tsx:249`).
+
+**Fix:** one shared elapsed-ticks helper (floored at 0) used by all three sites; one capacity-limit implementation
+(clamped) with the instance method delegating to it. Success is deletion — three ad-hoc copies become one of each.
+
+**Gate:** unit tests: a production row with `last_updated_at` ahead of the current tick contributes zero (never
+negative) production in both instance and static paths; an over-capacity row contributes zero (never negative) in the
+static path.
+
+---
+
+Required checks before finishing: `pnpm run format`, `pnpm run knip`. No Cairo changes are in scope. Commit bodies must
+describe the change (no subject-only commits).

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -848,10 +848,11 @@ export class ClientConfigManager {
   }
 
   getTick(tickId: TickIds) {
-    return this.getValueOrDefault(() => {
-      // Fixed 1s tick never reads config — stays silent on a missing row.
-      if (tickId === TickIds.Default) return 1;
+    // Fixed 1s tick never reads config — it must hold before hydration too,
+    // ahead of getValueOrDefault's not-hydrated-yet default.
+    if (tickId === TickIds.Default) return 1;
 
+    return this.getValueOrDefault(() => {
       const rulebook = this.getRulebook();
       if (!rulebook) return undefined;
       const tickConfig = rulebook.tick_config;

--- a/packages/core/src/managers/resource-manager.optimistic-update.test.ts
+++ b/packages/core/src/managers/resource-manager.optimistic-update.test.ts
@@ -7,12 +7,15 @@ import {
   createClientComponents,
   defineContractComponents,
 } from "@bibliothecadao/types";
-import { Type as RecsType, createWorld, setComponent, type ComponentValue } from "@dojoengine/recs";
+import { Type as RecsType, createWorld, getComponentValue, setComponent, type ComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { setBlockTimestampSource } from "../utils/timestamp";
 import { ResourceManager } from "./resource-manager";
 
 type ResourceValue = ComponentValue<ClientComponents["Resource"]["schema"]>;
+
+afterEach(() => setBlockTimestampSource(null));
 
 describe("ResourceManager provisional writes", () => {
   it("builds one overlay with baseline-delta evidence for every touched balance", () => {
@@ -52,6 +55,93 @@ describe("ResourceManager provisional writes", () => {
       baselineDeltaFields: ["ESSENCE_BALANCE", "RELIC_E1_BALANCE"],
       patch: { ESSENCE_BALANCE: precise(75), RELIC_E1_BALANCE: 0n },
     });
+  });
+
+  it("folds pending food accrual into the pin and resets the production clock", () => {
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      WHEAT_BALANCE: precise(5),
+      WHEAT_PRODUCTION: production({ production_rate: RESOURCE_PRECISION, last_updated_at: 1000 }),
+      weight: { capacity: storeCapacityGrams(1000), weight: 0n },
+    });
+    setBlockTimestampSource(() => 1100);
+
+    const write = new ResourceManager(components, 1).resolveProvisionalResourceWrite([
+      { resourceId: ResourcesIds.Wheat, amount: -60 },
+    ]);
+
+    // 100s of accrual at 1/s harvests into the pin; the spend must never sink it below zero.
+    expect(write?.patch).toMatchObject({
+      WHEAT_BALANCE: precise(5 + 100 - 60),
+      WHEAT_PRODUCTION: production({ production_rate: RESOURCE_PRECISION, last_updated_at: 1100 }),
+    });
+
+    // The authoritative echo resets the production clock underneath the overlay;
+    // the shallow-merged view must display the pinned prediction, never negative.
+    const echoedRowUnderOverlay = { ...readResource(components, 1), ...write?.patch } as ResourceValue;
+    const displayed = ResourceManager.balanceWithProduction(echoedRowUnderOverlay, 1100, ResourcesIds.Wheat);
+    expect(displayed.balance).toBe(Number(precise(45)));
+  });
+
+  it("caps a non-continuous harvest at output_amount_left and decrements it in the pin", () => {
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      STONE_BALANCE: precise(10),
+      STONE_PRODUCTION: production({
+        production_rate: RESOURCE_PRECISION,
+        output_amount_left: precise(30),
+        last_updated_at: 1000,
+      }),
+      weight: { capacity: storeCapacityGrams(1000), weight: 0n },
+    });
+    setBlockTimestampSource(() => 1100);
+
+    const write = new ResourceManager(components, 1).resolveProvisionalResourceWrite([
+      { resourceId: ResourcesIds.Stone, amount: -20 },
+    ]);
+
+    expect(write?.patch).toMatchObject({
+      STONE_BALANCE: precise(10 + 30 - 20),
+      STONE_PRODUCTION: production({
+        production_rate: RESOURCE_PRECISION,
+        output_amount_left: 0n,
+        last_updated_at: 1100,
+      }),
+    });
+  });
+});
+
+describe("production extrapolation clamps", () => {
+  it("contributes zero production when last_updated_at is ahead of the current tick", () => {
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      WHEAT_BALANCE: precise(5),
+      WHEAT_PRODUCTION: production({ production_rate: RESOURCE_PRECISION, last_updated_at: 2000 }),
+      weight: { capacity: storeCapacityGrams(1000), weight: 0n },
+    });
+
+    const row = readResource(components, 1);
+    expect(ResourceManager.balanceWithProduction(row, 1100, ResourcesIds.Wheat).balance).toBe(Number(precise(5)));
+    expect(new ResourceManager(components, 1).balanceWithProduction(1100, ResourcesIds.Wheat).balance).toBe(
+      Number(precise(5)),
+    );
+  });
+
+  it("contributes zero production when the store is over capacity", () => {
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      STONE_BALANCE: precise(10),
+      STONE_PRODUCTION: production({
+        production_rate: RESOURCE_PRECISION,
+        output_amount_left: precise(1000),
+        last_updated_at: 1000,
+      }),
+      weight: { capacity: storeCapacityGrams(10), weight: storeCapacityGrams(20) },
+    });
+
+    const displayed = ResourceManager.balanceWithProduction(readResource(components, 1), 1100, ResourcesIds.Stone);
+    expect(displayed.balance).toBe(Number(precise(10)));
+    expect(displayed.hasReachedMaxCapacity).toBe(true);
   });
 });
 
@@ -118,4 +208,16 @@ function isNestedSchema(value: unknown): value is Record<string, unknown> {
 
 function precise(amount: number) {
   return BigInt(amount) * BigInt(RESOURCE_PRECISION);
+}
+
+function production(overrides: Record<string, unknown>) {
+  return { building_count: 1, production_rate: 0, output_amount_left: 0n, last_updated_at: 0, ...overrides };
+}
+
+function storeCapacityGrams(kg: number) {
+  return BigInt(kg) * 1000n * BigInt(RESOURCE_PRECISION);
+}
+
+function readResource(components: ClientComponents, entityId: number): ResourceValue {
+  return getComponentValue(components.Resource, getEntityIdFromKeys([BigInt(entityId)]))!;
 }

--- a/packages/core/src/managers/resource-manager.ts
+++ b/packages/core/src/managers/resource-manager.ts
@@ -9,6 +9,7 @@ import {
   type ProvisionalIntentLockUntil,
 } from "../sync/provisional-write-manager";
 import { divideByPrecision, getBuildingCount, gramToKg, kgToGram, multiplyByPrecision } from "../utils";
+import { getBlockTimestamp } from "../utils/timestamp";
 import { configManager, gameEntityKey } from "./config-manager";
 
 export interface ResourceProductionData {
@@ -89,6 +90,16 @@ const RESOURCE_BALANCE_FIELDS = {
   [ResourcesIds.TroopProductionRelic2]: "RELIC_E18_BALANCE",
   [ResourcesIds.Research]: "RESEARCH_BALANCE",
 } as const satisfies Partial<Record<ResourcesIds, keyof ResourceValue>>;
+
+// Rows indexed from preconfirmed blocks can carry a last_updated_at ahead of the
+// client's chain-time heartbeat; elapsed production floors at zero, never negative.
+const elapsedProductionTicks = (lastUpdatedAt: number, currentTick: number): number => {
+  const elapsed = currentTick - lastUpdatedAt;
+  return Number.isFinite(elapsed) && elapsed > 0 ? Math.floor(elapsed) : 0;
+};
+
+const resourceUnitWeightGrams = (resourceId: ResourcesIds): bigint =>
+  BigInt(kgToGram(configManager.getResourceWeightKg(resourceId) || 0));
 
 // s2 changed production_rate to u64 (schema: number); internal math stays bigint.
 // Absent members (partial RECS rows, test fixtures) normalize to zero production.
@@ -187,7 +198,7 @@ export class ResourceManager {
     const balance = this.balance(resourceId);
     if (!production)
       return { balance: Number(balance), hasReachedMaxCapacity: false, amountProduced: 0n, amountProducedLimited: 0n };
-    const amountProduced = this._amountProduced(production, currentTick, resourceId);
+    const amountProduced = ResourceManager._amountProducedStatic(production, currentTick, resourceId);
     const amountProducedLimited = this._limitProductionByStoreCapacity(amountProduced, resourceId);
     return {
       balance: Number(balance + amountProducedLimited),
@@ -217,18 +228,64 @@ export class ResourceManager {
     const patch: Record<string, unknown> = {};
     let nextWeight = currentWeight.weight;
 
+    // The chain harvests pending production into the balance before any spend or
+    // deposit touches it (SingleResourceStoreImpl::retrieve). The overlay must
+    // predict that post-harvest row: fold the accrual into the pinned balance AND
+    // pin the production clock together — otherwise the authoritative echo resets
+    // last_updated_at underneath the overlay while the stale accrual-blind balance
+    // stays pinned on top, displaying below zero for any spend the UI validated
+    // against the accrual-inclusive balance.
+    const touchedResourceIds = [...new Set(applicableChanges.map(({ resourceId }) => resourceId))];
+    touchedResourceIds.forEach((resourceId) => {
+      const harvest = this.resolveProvisionalHarvest(currentResource, resourceId);
+      if (!harvest) return;
+      const balanceField = RESOURCE_BALANCE_FIELDS[resourceId as keyof typeof RESOURCE_BALANCE_FIELDS];
+      patch[balanceField] = this.balance(resourceId) + harvest.balanceGained;
+      patch[harvest.productionField] = harvest.production;
+      nextWeight += resourceUnitWeightGrams(resourceId) * harvest.balanceGained;
+    });
+
     applicableChanges.forEach(({ resourceId, amount }) => {
       const balanceField = RESOURCE_BALANCE_FIELDS[resourceId as keyof typeof RESOURCE_BALANCE_FIELDS];
       const amountWithPrecision = BigInt(Math.floor(multiplyByPrecision(amount)));
       const patchedBalance = patch[balanceField];
       patch[balanceField] =
         (typeof patchedBalance === "bigint" ? patchedBalance : this.balance(resourceId)) + amountWithPrecision;
-      const resourceWeight = configManager.getResourceWeightKg(resourceId) || 0;
-      nextWeight += BigInt(kgToGram(resourceWeight)) * amountWithPrecision;
+      nextWeight += resourceUnitWeightGrams(resourceId) * amountWithPrecision;
     });
 
     patch.weight = { ...currentWeight, weight: nextWeight };
     return patch as Partial<ResourceValue>;
+  }
+
+  // Mirrors ProductionImpl::harvest + SingleResource::add: accrued production since
+  // last_updated_at, capped by output_amount_left (non-continuous) and by store
+  // capacity, with the production clock reset to the current tick.
+  private resolveProvisionalHarvest(
+    resource: ResourceValue | undefined,
+    resourceId: ResourcesIds,
+  ): { productionField: string; production: Record<string, unknown>; balanceGained: bigint } | null {
+    if (!resource) return null;
+    const balanceField = RESOURCE_BALANCE_FIELDS[resourceId as keyof typeof RESOURCE_BALANCE_FIELDS];
+    if (!balanceField) return null;
+    const productionField = balanceField.replace(/_BALANCE$/, "_PRODUCTION");
+    const storedProduction = (resource as Record<string, unknown>)[productionField];
+    if (typeof storedProduction !== "object" || storedProduction === null) return null;
+
+    const production = ResourceManager.balanceAndProduction(resource, resourceId).production;
+    const currentTick = getBlockTimestamp().currentDefaultTick;
+    const amountProduced = ResourceManager._amountProducedStatic(production, currentTick, resourceId);
+    if (amountProduced <= 0n) return null;
+
+    const balanceGained = this._limitProductionByStoreCapacity(amountProduced, resourceId);
+    const outputAmountLeft = ResourceManager.isContinuousProductionResource(resourceId)
+      ? production.output_amount_left
+      : production.output_amount_left - amountProduced;
+    return {
+      productionField,
+      production: { ...storedProduction, output_amount_left: outputAmountLeft, last_updated_at: currentTick },
+      balanceGained,
+    };
   }
 
   public resolveProvisionalResourceWrite(
@@ -399,40 +456,12 @@ export class ResourceManager {
 
   private _limitProductionByStoreCapacity(amountProduced: bigint, resourceId: ResourcesIds): bigint {
     const { capacityKg, capacityUsedKg } = this.getStoreCapacityKg();
-    const capacityLeft = Math.max(0, capacityKg - capacityUsedKg);
-
-    const maxAmountStorable = multiplyByPrecision(capacityLeft / (configManager.getResourceWeightKg(resourceId) || 1));
-
-    if (amountProduced > maxAmountStorable) {
-      return BigInt(maxAmountStorable);
-    }
-    return amountProduced;
-  }
-
-  private _amountProduced(
-    production: {
-      building_count: number;
-      production_rate: bigint;
-      output_amount_left: bigint;
-      last_updated_at: number;
-    },
-    currentTick: number,
-    resourceId: ResourcesIds,
-  ): bigint {
-    if (!production || production.building_count === 0) return 0n;
-    if (production.production_rate === 0n) return 0n;
-
-    const ticksSinceLastUpdate = currentTick - production.last_updated_at;
-    let totalAmountProduced = BigInt(ticksSinceLastUpdate) * production.production_rate;
-
-    if (
-      !ResourceManager.isContinuousProductionResource(resourceId) &&
-      totalAmountProduced > production.output_amount_left
-    ) {
-      totalAmountProduced = production.output_amount_left;
-    }
-
-    return totalAmountProduced;
+    return ResourceManager._limitProductionByStoreCapacityStatic(
+      amountProduced,
+      configManager.getResourceWeightKg(resourceId) || 0,
+      capacityKg,
+      capacityUsedKg,
+    );
   }
 
   /**
@@ -792,8 +821,8 @@ export class ResourceManager {
     const amountProducedLimited = this._limitProductionByStoreCapacityStatic(
       amountProduced,
       resourceWeightKg,
-      Number(resource?.weight.capacity || 0),
-      Number(resource?.weight.weight || 0),
+      gramToKg(divideByPrecision(Number(resource?.weight.capacity || 0))),
+      gramToKg(divideByPrecision(Number(resource?.weight.weight || 0))),
     );
 
     return {
@@ -815,7 +844,7 @@ export class ResourceManager {
     if (!production || production.building_count === 0) return 0n;
     if (production.production_rate === 0n) return 0n;
 
-    const ticksSinceLastUpdate = currentTick - production.last_updated_at;
+    const ticksSinceLastUpdate = elapsedProductionTicks(production.last_updated_at, currentTick);
     let totalAmountProduced = BigInt(ticksSinceLastUpdate) * production.production_rate;
 
     const isContinuousProductionResource = ResourceManager.isContinuousProductionResource(resourceId);
@@ -832,7 +861,7 @@ export class ResourceManager {
     storeCapacityKg: number,
     storeUsedKg: number,
   ): bigint {
-    const capacityLeft = storeCapacityKg - storeUsedKg;
+    const capacityLeft = Math.max(0, storeCapacityKg - storeUsedKg);
     const maxAmountStorable = multiplyByPrecision(capacityLeft / (resourceWeightKg || 1));
 
     if (amountProduced > maxAmountStorable) {
@@ -948,10 +977,7 @@ export class ResourceManager {
   ): ResourceProductionData {
     const productionPerSecond = divideByPrecision(Number(productionInfo.production.production_rate || 0), false);
 
-    // A pre-config tick or a malformed row must degrade to "no elapsed production", never throw.
-    const rawTicksSinceLastUpdate = currentTick - productionInfo.production.last_updated_at;
-    const ticksSinceLastUpdate =
-      Number.isFinite(rawTicksSinceLastUpdate) && rawTicksSinceLastUpdate > 0 ? Math.floor(rawTicksSinceLastUpdate) : 0;
+    const ticksSinceLastUpdate = elapsedProductionTicks(productionInfo.production.last_updated_at, currentTick);
     const totalAmountProduced = BigInt(ticksSinceLastUpdate) * productionInfo.production.production_rate;
     const isContinuousProductionResource = ResourceManager.isContinuousProductionResource(resourceId);
     const remainingOutput = isContinuousProductionResource

--- a/packages/core/src/sync/game-sync-types.ts
+++ b/packages/core/src/sync/game-sync-types.ts
@@ -61,7 +61,7 @@ export interface GameSyncProvisionalIntentStalledInfo {
 }
 
 export interface GameSyncProvisionalIntentPhaseInfo {
-  phase: "created" | "transaction_hash" | "authoritative_echo";
+  phase: "created" | "transaction_hash" | "authoritative_echo" | "baseline_delta_before_hash";
   intentId: string;
   transactionHash?: string;
   model?: string;

--- a/packages/core/src/sync/provisional-write-manager.test.ts
+++ b/packages/core/src/sync/provisional-write-manager.test.ts
@@ -53,7 +53,38 @@ describe("ProvisionalWriteManager", () => {
     expect(outcomes).toHaveBeenCalledWith("settled");
   });
 
-  it("counts baseline-delta evidence only after a transaction hash exists", () => {
+  it("matches a baseline-delta echo that raced the transaction hash once it binds", () => {
+    vi.useFakeTimers();
+    const store = createStore({ WOOD_BALANCE: 100n });
+    const phases: string[] = [];
+    const manager = new ProvisionalWriteManager(store, {
+      onIntentPhase: ({ phase }) => phases.push(phase),
+    });
+    const intent = manager.createIntent([
+      {
+        entityId: "0x2",
+        model: "Resource",
+        patch: { WOOD_BALANCE: 90n },
+        baselineDeltaFields: ["WOOD_BALANCE"],
+      },
+    ]);
+    const outcomes = vi.fn();
+    intent.subscribe(outcomes);
+
+    // Torii's preconfirmed echo can land before execute() returns the hash.
+    manager.observeAuthoritativeObservations([
+      { type: "model", entityId: "0x2", model: "Resource", value: { WOOD_BALANCE: 90n } },
+    ]);
+    expect(phases).toContain("baseline_delta_before_hash");
+
+    intent.bindTransaction("0xtx");
+    intent.confirm();
+    vi.advanceTimersByTime(2_500);
+
+    expect(outcomes).toHaveBeenCalledWith("settled");
+  });
+
+  it("does not treat a bound hash alone as baseline-delta evidence", () => {
     vi.useFakeTimers();
     const store = createStore({ WOOD_BALANCE: 100n });
     const manager = new ProvisionalWriteManager(store);
@@ -68,9 +99,6 @@ describe("ProvisionalWriteManager", () => {
     const outcomes = vi.fn();
     intent.subscribe(outcomes);
 
-    manager.observeAuthoritativeObservations([
-      { type: "model", entityId: "0x2", model: "Resource", value: { WOOD_BALANCE: 90n } },
-    ]);
     intent.bindTransaction("0xtx");
     intent.confirm();
     vi.advanceTimersByTime(2_500);

--- a/packages/core/src/sync/provisional-write-manager.ts
+++ b/packages/core/src/sync/provisional-write-manager.ts
@@ -35,6 +35,7 @@ interface TrackedIntent {
   createdAtMs: number;
   transactionHashAtMs?: number;
   hasReportedAuthoritativeEcho: boolean;
+  hasReportedPreHashEcho: boolean;
   outcomeListeners: Set<(outcome: ProvisionalIntentOutcome) => void>;
 }
 
@@ -121,6 +122,7 @@ export class ProvisionalWriteManager {
       lockUntil: options.lockUntil ?? "transaction-hash",
       createdAtMs: Date.now(),
       hasReportedAuthoritativeEcho: false,
+      hasReportedPreHashEcho: false,
       outcomeListeners: new Set(),
     };
     if (!tracked.writes.some((write) => this.hasAuthoritativeEvidence(write))) {
@@ -161,6 +163,7 @@ export class ProvisionalWriteManager {
         intent.transactionHash = transactionHash;
         intent.transactionHashAtMs = Date.now();
         intent.status = "pending";
+        this.reevaluateObservedWrites(intent);
         this.reportIntentPhase(intent, "transaction_hash");
         this.publishState();
       },
@@ -299,12 +302,32 @@ export class ProvisionalWriteManager {
     authoritativePatch: Record<string, unknown> | null,
   ): boolean {
     if (write.baselineDeltaFields?.length) {
-      if (intent.transactionHashAtMs === undefined) return false;
+      if (intent.transactionHashAtMs === undefined) {
+        this.reportPreHashEcho(intent, write.model);
+        return false;
+      }
       return write.baselineDeltaFields.some(
         (field) => !matchesPatch(authoritativePatch?.[field], write.authoritativeBaseline?.[field]),
       );
     }
     return write.matchPatch === undefined || matchesPatch(authoritativePatch, write.matchPatch);
+  }
+
+  // Baseline-delta evidence observed before the transaction hash binds is rejected,
+  // and a match is otherwise only re-attempted on the next observation of the row —
+  // which an idle structure may not produce inside the stall window. An echo that
+  // raced execute() returning the hash must be re-evaluated the moment it binds.
+  private reevaluateObservedWrites(intent: TrackedIntent): void {
+    intent.writes.forEach((write) => {
+      if (write.matched || write.authoritativePatch === undefined) return;
+      this.updateWriteMatch(intent, write, write.authoritativePatch);
+    });
+  }
+
+  private reportPreHashEcho(intent: TrackedIntent, model: string): void {
+    if (intent.hasReportedPreHashEcho) return;
+    intent.hasReportedPreHashEcho = true;
+    this.reportIntentPhase(intent, "baseline_delta_before_hash", model);
   }
 
   private hasMatchedAuthoritativeEvidence(write: TrackedWrite): boolean {

--- a/packages/core/src/utils/timestamp.ts
+++ b/packages/core/src/utils/timestamp.ts
@@ -1,5 +1,8 @@
 import { TickIds } from "@bibliothecadao/types";
-import { configManager } from "..";
+// Imported from the concrete module, not a barrel: barrel cycles leave this
+// module's consumers with uninitialized re-export bindings. configManager is
+// only dereferenced at call time, which keeps the remaining cycle harmless.
+import { configManager } from "../managers/config-manager";
 
 type TimestampSource = () => number;
 


### PR DESCRIPTION
Players reported wheat balances going negative in the client. The investigation (brief: `docs/plans/negative-food-balance-codex-brief.md`, committed here) traced it to the provisional resource overlay: it pins an absolute balance computed from the raw stored value, which for wheat/fish excludes un-harvested production accrual. A spend the UI validated against the accrual-inclusive displayed balance therefore pins a negative number, and the moment the authoritative echo resets the production clock underneath the overlay (the chain harvests on touch), the extrapolation term that was masking the negative collapses and it displays raw — routinely for the full 30s reconciliation-stall window visible in the Aug 18 session log.

Three changes:

1. **Harvest-aware provisional patches** (`resource-manager.ts`). The patch now mirrors the chain's harvest-before-touch: capacity-limited accrual folds into the pinned balance, the production row is pinned with `last_updated_at = now` (with `output_amount_left` decremented for non-continuous resources), and harvested weight is accounted. The pin predicts the post-tx row, so it cannot go negative for a validated spend, and the echo landing underneath no longer changes what displays — this also removes the downward flicker of the harvested accrual on every action.

2. **Reconciliation re-evaluates on hash bind** (`provisional-write-manager.ts`). Baseline-delta evidence observed before the transaction hash bound was discarded and only re-attempted on the next observation of the row — which an idle structure may not produce inside the stall window. `bindTransaction` now re-runs the match against the accumulated patch, and a dev warn plus a `baseline_delta_before_hash` phase event convict the race in session logs.

3. **Clamped, unified extrapolation math** (`resource-manager.ts`). One shared elapsed-ticks helper (floored at zero — previously only one of three sites guarded rows whose `last_updated_at` runs ahead of client chain-time) and one clamped capacity limiter. The static limiter also received raw precision-grams where kg was expected, leaving its cap inert under capacity and negative when over; both callers now feed kg. `getTick(Default)` returns its fixed 1s ahead of the config-hydration gate so pre-hydration ticks are correct.

Verification: `packages/core` vitest 135/135, client suite 2943/2943, `tsc` clean in both packages, `pnpm run format` and `pnpm run knip` clean. New unit gates: the harvest-aware pin for wheat (continuous) and output-capped stone (non-continuous), the pre-hash echo matching on bind, the future-`last_updated_at` clamp in both display paths, and the over-capacity clamp.

Non-goals: `timeUntilValueReached`/`getProductionEndsAt` still do raw tick subtraction (cosmetic countdowns only), and the Research continuous-production mismatch with the chain's food-only free production is untouched.

Note for #4890: `reportProvisionalIntentPhase` in `gamewide-sync-adapter.ts` will conflict trivially with the perf branch's console-discipline/PostHog-removal changes — the resolution is the perf branch's shape plus the `baseline_delta_before_hash` warn branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)