### PR TITLE
P9 triage: chain-time re-anchoring, delivery visibility, game-scoped leaderboard, army slot audits

### DIFF
--- a/client/apps/game/src/services/blitz/blitz-settlement-players.ts
+++ b/client/apps/game/src/services/blitz/blitz-settlement-players.ts
@@ -1,3 +1,4 @@
+import { belongsToActiveGame } from "@bibliothecadao/eternum";
 import type { ClientComponents } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
 import { type Entity, getComponentValue, Has } from "@dojoengine/recs";
@@ -11,7 +12,7 @@ export const readBlitzSettlementPlayerAddresses = (
 ): bigint[] =>
   blitzSettlementEntities
     .map((entityId) => getComponentValue(components.BlitzSettlement, entityId))
-    .filter((settlement): settlement is NonNullable<typeof settlement> => Boolean(settlement))
+    .filter((settlement): settlement is NonNullable<typeof settlement> => belongsToActiveGame(settlement))
     .map((settlement) => settlement.player as unknown as bigint);
 
 export const useBlitzSettlementPlayerAddresses = (components: BlitzSettlementComponents): bigint[] => {

--- a/client/apps/game/src/three/managers/army-manager.ts
+++ b/client/apps/game/src/three/managers/army-manager.ts
@@ -100,7 +100,26 @@ import { reconcileVisibleArmySet } from "./army-visible-set-reconciler";
 import { resolvePointLabelTextureFlipY } from "./point-label-texture-policy";
 import { PointsLabelRenderer } from "./points-label-renderer";
 import { resolveArmySlotCompactionPlan } from "./army-slot-compaction";
-import { auditArmyRenderIntegrity, auditArmySlots, type ArmySlotAuditEntry } from "./army-slot-auditor";
+import {
+  auditArmyRenderIntegrity,
+  auditArmySlots,
+  type ArmyRenderViolation,
+  type ArmySlotAuditEntry,
+  type DrawnSlotPositionEntry,
+} from "./army-slot-auditor";
+
+const renderViolationSignature = (violation: ArmyRenderViolation): string => {
+  switch (violation.kind) {
+    case "orphaned-drawn-slot":
+      return `orphan:${violation.slot}:${violation.owner}`;
+    case "visible-not-drawn":
+      return `missing:${violation.entityId}`;
+    case "stale-drawn-position":
+      return `stale:${violation.entityId}:${violation.slot}`;
+    case "duplicate-drawn-owner":
+      return `dup:${violation.owner}:${violation.slots.join(",")}`;
+  }
+};
 import { resolveMovementPath } from "./army-move-path";
 import { shouldUseWorkerPathForArmy } from "./army-movement-path-strategy";
 import { addVisibleArmyOrderEntry, removeVisibleArmyOrderEntry, replaceVisibleArmyOrder } from "./army-visible-order";
@@ -2288,6 +2307,12 @@ export class ArmyManager {
   //   2. visible-not-drawn — a tracked army that should be visible in the
   //      committed chunk but has no drawn model (a spawn that never appeared).
   //      Re-run its render, which is idempotent and self-gating.
+  //   3. stale-drawn-position — a live, stationary army whose drawn matrix sits
+  //      on a different hex than its authoritative position: the model stands
+  //      at the OLD hex while the label follows the entity. Re-render rewrites
+  //      the matrix from the same source the label reads.
+  //   4. duplicate-drawn-owner — one entity owning two drawn slots; purge every
+  //      slot except the model's source-of-truth one.
   // The label path is unaffected because labels read instanceData.position, not
   // the slot — which is exactly why labels keep working while models ghost.
   private reconcileArmyRenderIntegrity(): void {
@@ -2309,6 +2334,7 @@ export class ArmyManager {
       drawnSlotOwners: this.armyModel.collectDrawnSlotOwners(),
       liveEntityIds,
       visibleUndrawnEntityIds,
+      drawnPositionEntries: this.collectStationaryDrawnPositions(liveEntityIds),
     });
 
     if (violations.length === 0) {
@@ -2317,20 +2343,34 @@ export class ArmyManager {
 
     let purgedAny = false;
     for (const violation of violations) {
-      if (violation.kind === "orphaned-drawn-slot") {
-        this.armyModel.purgeDrawnSlot(violation.slot);
-        purgedAny = true;
-        incrementWorldmapRenderCounter("armyRenderIntegrityHealOrphanSlot");
-      } else {
-        void this.renderArmyIntoCurrentChunkIfVisible(this.toNumericId(violation.entityId));
-        incrementWorldmapRenderCounter("armyRenderIntegrityHealVisibleUndrawn");
+      switch (violation.kind) {
+        case "orphaned-drawn-slot":
+          this.armyModel.purgeDrawnSlot(violation.slot);
+          purgedAny = true;
+          incrementWorldmapRenderCounter("armyRenderIntegrityHealOrphanSlot");
+          break;
+        case "duplicate-drawn-owner": {
+          const ssotSlot = this.armyModel.getEntitySlot(violation.owner);
+          for (const slot of violation.slots) {
+            if (slot === ssotSlot) continue;
+            this.armyModel.purgeDrawnSlot(slot);
+            purgedAny = true;
+          }
+          incrementWorldmapRenderCounter("armyRenderIntegrityHealDuplicateOwner");
+          break;
+        }
+        case "stale-drawn-position":
+          void this.renderArmyIntoCurrentChunkIfVisible(violation.entityId);
+          incrementWorldmapRenderCounter("armyRenderIntegrityHealStalePosition");
+          break;
+        default:
+          void this.renderArmyIntoCurrentChunkIfVisible(this.toNumericId(violation.entityId));
+          incrementWorldmapRenderCounter("armyRenderIntegrityHealVisibleUndrawn");
+          break;
       }
 
       if (import.meta.env?.DEV) {
-        const signature =
-          violation.kind === "orphaned-drawn-slot"
-            ? `orphan:${violation.slot}:${violation.owner}`
-            : `missing:${violation.entityId}`;
+        const signature = renderViolationSignature(violation);
         if (!this.loggedSlotViolations.has(signature)) {
           this.loggedSlotViolations.add(signature);
           console.warn("[ArmyManager] render-integrity heal", violation);
@@ -2343,6 +2383,29 @@ export class ArmyManager {
     if (purgedAny) {
       this.markVisibleArmyPresentationDirty();
     }
+  }
+
+  // Drawn matrix vs authoritative position for every live, stationary, drawn
+  // army. Moving armies are excluded — mid-spline the matrix legitimately
+  // trails the entity — and mid-transition renders are queued, not stale.
+  private collectStationaryDrawnPositions(liveEntityIds: Set<number>): DrawnSlotPositionEntry[] {
+    if (this.isArmyChunkTransitioning || !isCommittedManagerChunk(this.currentChunkKey)) return [];
+    const entries: DrawnSlotPositionEntry[] = [];
+    for (const entityId of liveEntityIds) {
+      const instanceData = this.armyModel.getInstanceData(entityId);
+      if (!instanceData || instanceData.isMoving) continue;
+      const slot = instanceData.matrixIndex;
+      if (slot === undefined) continue;
+      const drawn = this.armyModel.getDrawnSlotPosition(slot);
+      if (!drawn) continue;
+      entries.push({
+        entityId,
+        slot,
+        drawn: { x: drawn.x, z: drawn.z },
+        expected: { x: instanceData.position.x, z: instanceData.position.z },
+      });
+    }
+    return entries;
   }
 
   // Reports when the manager's slot mirror (visibleArmyIndices) drifts from the

--- a/client/apps/game/src/three/managers/army-model.ts
+++ b/client/apps/game/src/three/managers/army-model.ts
@@ -1056,6 +1056,26 @@ export class ArmyModel {
     return result;
   }
 
+  /**
+   * The translation the GPU is actually drawing for a slot, read from the
+   * instance matrix of the first model holding it. This is deliberately NOT
+   * instanceData.position — comparing the two is how the render-integrity
+   * auditor detects a stale matrix (model on the old hex, label on the new).
+   */
+  public getDrawnSlotPosition(slot: number): Vector3 | undefined {
+    const read = (models: Iterable<ModelData>): Vector3 | undefined => {
+      for (const modelData of models) {
+        if (!modelData.activeInstances.has(slot)) continue;
+        const mesh = modelData.instancedMeshes[0];
+        if (!mesh || slot >= mesh.count) continue;
+        mesh.getMatrixAt(slot, this.dummyMatrix);
+        return new Vector3().setFromMatrixPosition(this.dummyMatrix);
+      }
+      return undefined;
+    };
+    return read(this.models.values()) ?? read(this.cosmeticModels.values());
+  }
+
   /** True when the entity's slot is present and drawn in its active base or cosmetic model. */
   public isEntityDrawn(entityId: number): boolean {
     const slot = this.instanceData.get(entityId)?.matrixIndex;

--- a/client/apps/game/src/three/managers/army-slot-auditor.test.ts
+++ b/client/apps/game/src/three/managers/army-slot-auditor.test.ts
@@ -116,4 +116,39 @@ describe("auditArmyRenderIntegrity", () => {
 
     expect(violations).toContainEqual({ kind: "visible-not-drawn", entityId: 7 });
   });
+
+  it("flags a stationary army whose drawn matrix drifted from its authoritative position", () => {
+    const violations = auditArmyRenderIntegrity({
+      drawnSlotOwners: [{ slot: 0, owner: 1 }],
+      liveEntityIds: new Set([1]),
+      visibleUndrawnEntityIds: [],
+      drawnPositionEntries: [{ entityId: 1, slot: 0, drawn: { x: 0, z: 0 }, expected: { x: 3, z: 4 } }],
+    });
+
+    expect(violations).toContainEqual({ kind: "stale-drawn-position", entityId: 1, slot: 0, driftDistance: 5 });
+  });
+
+  it("tolerates sub-epsilon drift on drawn positions (float noise, not a ghost)", () => {
+    const violations = auditArmyRenderIntegrity({
+      drawnSlotOwners: [{ slot: 0, owner: 1 }],
+      liveEntityIds: new Set([1]),
+      visibleUndrawnEntityIds: [],
+      drawnPositionEntries: [{ entityId: 1, slot: 0, drawn: { x: 0.1, z: 0 }, expected: { x: 0, z: 0 } }],
+    });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("flags one entity owning two drawn slots (a frozen duplicate)", () => {
+    const violations = auditArmyRenderIntegrity({
+      drawnSlotOwners: [
+        { slot: 0, owner: 1 },
+        { slot: 5, owner: 1 },
+      ],
+      liveEntityIds: new Set([1]),
+      visibleUndrawnEntityIds: [],
+    });
+
+    expect(violations).toContainEqual({ kind: "duplicate-drawn-owner", owner: 1, slots: [0, 5] });
+  });
 });

--- a/client/apps/game/src/three/managers/army-slot-auditor.ts
+++ b/client/apps/game/src/three/managers/army-slot-auditor.ts
@@ -38,6 +38,14 @@ interface DrawnSlotOwner {
   owner: number | undefined;
 }
 
+/** A drawn slot's GPU position paired with the entity's authoritative position. */
+export interface DrawnSlotPositionEntry {
+  entityId: number;
+  slot: number;
+  drawn: { x: number; z: number };
+  expected: { x: number; z: number };
+}
+
 export interface ArmyRenderIntegrityInput {
   /** Slots the GPU is currently drawing, with their recorded owner entity. */
   drawnSlotOwners: DrawnSlotOwner[];
@@ -49,6 +57,13 @@ export interface ArmyRenderIntegrityInput {
    * it owns the chunk/visibility predicates.
    */
   visibleUndrawnEntityIds: Array<number | string>;
+  /**
+   * Drawn matrix positions vs authoritative positions for stationary drawn
+   * armies. The caller excludes moving armies — mid-spline drift is expected.
+   */
+  drawnPositionEntries?: DrawnSlotPositionEntry[];
+  /** Hex-plane drift beyond this is a stale matrix, not float noise. */
+  positionDriftEpsilon?: number;
 }
 
 export type ArmyRenderViolation =
@@ -66,7 +81,26 @@ export type ArmyRenderViolation =
       // label reads instanceData.position, not the slot.
       kind: "visible-not-drawn";
       entityId: number | string;
+    }
+  | {
+      // A live, stationary army whose drawn matrix sits away from its
+      // authoritative position — the model stands on the OLD hex while the
+      // label (reading instanceData.position) stands on the new one. This is
+      // the both-directions desync a stale slot matrix manufactures.
+      kind: "stale-drawn-position";
+      entityId: number;
+      slot: number;
+      driftDistance: number;
+    }
+  | {
+      // One entity recorded as the owner of two or more drawn slots — the
+      // extra slot draws a second, frozen copy of the unit.
+      kind: "duplicate-drawn-owner";
+      owner: number;
+      slots: number[];
     };
+
+const DEFAULT_POSITION_DRIFT_EPSILON = 0.75;
 
 /**
  * Detect the two user-visible ghosting symptoms directly, rather than only the
@@ -76,14 +110,36 @@ export type ArmyRenderViolation =
 export function auditArmyRenderIntegrity(input: ArmyRenderIntegrityInput): ArmyRenderViolation[] {
   const violations: ArmyRenderViolation[] = [];
 
+  const slotsByOwner = new Map<number, number[]>();
   for (const { slot, owner } of input.drawnSlotOwners) {
     if (owner === undefined || !input.liveEntityIds.has(owner)) {
       violations.push({ kind: "orphaned-drawn-slot", slot, owner });
+      continue;
+    }
+    const slots = slotsByOwner.get(owner);
+    if (slots) {
+      slots.push(slot);
+    } else {
+      slotsByOwner.set(owner, [slot]);
+    }
+  }
+
+  for (const [owner, slots] of slotsByOwner) {
+    if (slots.length > 1) {
+      violations.push({ kind: "duplicate-drawn-owner", owner, slots });
     }
   }
 
   for (const entityId of input.visibleUndrawnEntityIds) {
     violations.push({ kind: "visible-not-drawn", entityId });
+  }
+
+  const epsilon = input.positionDriftEpsilon ?? DEFAULT_POSITION_DRIFT_EPSILON;
+  for (const { entityId, slot, drawn, expected } of input.drawnPositionEntries ?? []) {
+    const driftDistance = Math.hypot(drawn.x - expected.x, drawn.z - expected.z);
+    if (driftDistance > epsilon) {
+      violations.push({ kind: "stale-drawn-position", entityId, slot, driftDistance });
+    }
   }
 
   return violations;

--- a/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
+++ b/client/apps/game/src/three/perf/worldmap-render-diagnostics.ts
@@ -67,7 +67,9 @@ export type WorldmapRenderCounter =
   | "armyRecsSweepSnappedPosition"
   | "armyRecsSweepRestoredAlive"
   | "armyRenderIntegrityHealOrphanSlot"
-  | "armyRenderIntegrityHealVisibleUndrawn";
+  | "armyRenderIntegrityHealVisibleUndrawn"
+  | "armyRenderIntegrityHealStalePosition"
+  | "armyRenderIntegrityHealDuplicateOwner";
 
 export interface WorldmapZoomTelemetrySummary {
   controlsChangeEvents: number;
@@ -188,6 +190,8 @@ const createDiagnosticsState = (): WorldmapRenderDiagnosticsSnapshot => ({
     armyRecsSweepRestoredAlive: 0,
     armyRenderIntegrityHealOrphanSlot: 0,
     armyRenderIntegrityHealVisibleUndrawn: 0,
+    armyRenderIntegrityHealStalePosition: 0,
+    armyRenderIntegrityHealDuplicateOwner: 0,
   },
   forceRefreshReasons: {
     default: 0,

--- a/client/apps/game/src/ui/features/prize/components/blitz-mmr-table.tsx
+++ b/client/apps/game/src/ui/features/prize/components/blitz-mmr-table.tsx
@@ -1,7 +1,7 @@
 import { useBlitzSettlementPlayerAddresses } from "@/services/blitz/blitz-settlement-players";
 import { displayAddress } from "@/ui/utils/utils";
 import { getMMRTierFromRaw, MMR_TOKEN_DECIMALS } from "@/ui/utils/mmr-tiers";
-import { getAddressName, toHexString } from "@bibliothecadao/eternum";
+import { belongsToActiveGame, getAddressName, toHexString } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
@@ -63,7 +63,7 @@ export const BlitzMMRTable = () => {
     const points = new Map<bigint, bigint>();
     playerRegisteredPointsEntities.forEach((eid) => {
       const value = getComponentValue(components.PlayerRegisteredPoints, eid);
-      if (!value) return;
+      if (!value || !belongsToActiveGame(value)) return;
       points.set(value.address as unknown as bigint, value.registered_points as bigint);
     });
     return points;

--- a/client/apps/game/src/ui/features/prize/components/claim-blitz-prize-button.tsx
+++ b/client/apps/game/src/ui/features/prize/components/claim-blitz-prize-button.tsx
@@ -6,7 +6,7 @@ import { useEntityQuery } from "@dojoengine/react";
 import { Has, getComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@bibliothecadao/eternum";
 import { useEffect, useMemo, useState } from "react";
-import { configManager } from "@bibliothecadao/eternum";
+import { belongsToActiveGame, configManager } from "@bibliothecadao/eternum";
 import { shortString } from "starknet";
 import { gameEntityKey } from "@/dojo/game-scope";
 
@@ -61,7 +61,10 @@ export const ClaimBlitzPrizeButton = ({ className }: { className?: string }) => 
   // Read finalized trial (single model)
   const finalEntities = useEntityQuery([Has(components.PlayersRankFinal)]);
   const final = useMemo(
-    () => (finalEntities[0] ? getComponentValue(components.PlayersRankFinal, finalEntities[0]) : undefined),
+    () =>
+      finalEntities
+        .map((entity) => getComponentValue(components.PlayersRankFinal, entity))
+        .find((row) => belongsToActiveGame(row)),
     [finalEntities],
   );
 

--- a/client/apps/game/src/ui/features/prize/components/winners-table.tsx
+++ b/client/apps/game/src/ui/features/prize/components/winners-table.tsx
@@ -3,7 +3,7 @@ import { estimateClaimableChests } from "@/services/review/chest-reward-estimate
 import { normalizeNonZeroAddress } from "@/services/review/sql-parse-utils";
 import { displayAddress } from "@/ui/utils/utils";
 import { buildApiUrl, fetchWithErrorHandling } from "@bibliothecadao/torii";
-import { getAddressName, toHexString, configManager } from "@bibliothecadao/eternum";
+import { belongsToActiveGame, getAddressName, toHexString, configManager } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
@@ -103,7 +103,10 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
   // Get the finalized trial
   const finalEntities = useEntityQuery([Has(components.PlayersRankFinal)]);
   const final = useMemo(
-    () => (finalEntities[0] ? getComponentValue(components.PlayersRankFinal, finalEntities[0]) : undefined),
+    () =>
+      finalEntities
+        .map((entity) => getComponentValue(components.PlayersRankFinal, entity))
+        .find((row) => belongsToActiveGame(row)),
     [finalEntities, components.PlayersRankFinal],
   );
   const finalTrialId = final?.trial_id as bigint | undefined;
@@ -117,7 +120,7 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
     const points = new Map<bigint, bigint>();
     playerRegisteredPointsEntities.forEach((eid) => {
       const value = getComponentValue(components.PlayerRegisteredPoints, eid);
-      if (!value) return;
+      if (!value || !belongsToActiveGame(value)) return;
       points.set(value.address as unknown as bigint, value.registered_points as bigint);
     });
     return points;
@@ -231,6 +234,7 @@ export const WinnersTable = ({ trialId }: { trialId?: bigint }) => {
       .filter(
         (r) =>
           r &&
+          belongsToActiveGame(r) &&
           ((r as { trial_id?: bigint }).trial_id === undefined || (r as { trial_id?: bigint }).trial_id === useTrialId),
       )
       .map((r) => {

--- a/client/apps/game/src/ui/features/social/player/use-in-game-leaderboard.ts
+++ b/client/apps/game/src/ui/features/social/player/use-in-game-leaderboard.ts
@@ -1,7 +1,7 @@
 import { useResolvedWorldGameMode } from "@/config/game-modes/use-game-mode-config";
 import { useCoarseCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { LEADERBOARD_UPDATE_INTERVAL } from "@/ui/constants";
-import { LeaderboardManager } from "@bibliothecadao/eternum";
+import { belongsToActiveGame, LeaderboardManager } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { type ClientComponents, ContractAddress } from "@bibliothecadao/types";
 import { useEntityQuery } from "@dojoengine/react";
@@ -52,15 +52,17 @@ const buildFinalizedBlitzLeaderboard = (
   components: ClientComponents,
   entities: FinalizedLeaderboardEntities,
 ): InGameLeaderboard | null => {
-  const finalTrial = entities.finalEntities[0]
-    ? getComponentValue(components.PlayersRankFinal, entities.finalEntities[0])
-    : undefined;
+  // Multi-game store: another game's finalized trial or rank rows must never
+  // decide (or feed) THIS game's finalized leaderboard.
+  const finalTrial = entities.finalEntities
+    .map((entity) => getComponentValue(components.PlayersRankFinal, entity))
+    .find((row) => belongsToActiveGame(row));
   if (!finalTrial) return null;
 
   const registeredPointsLookup = buildRegisteredPointsLookup(
     entities.registeredPointsEntities
       .map((entity) => getComponentValue(components.PlayerRegisteredPoints, entity))
-      .filter((row): row is NonNullable<typeof row> => Boolean(row))
+      .filter((row): row is NonNullable<typeof row> => belongsToActiveGame(row))
       .map((row) => ({
         address: row.address as unknown as bigint,
         registeredPoints: row.registered_points as bigint,
@@ -69,7 +71,7 @@ const buildFinalizedBlitzLeaderboard = (
   const finalizedStandings = buildFinalizedBlitzStandingLookup(
     entities.playerRankEntities
       .map((entity) => getComponentValue(components.PlayerRank, entity))
-      .filter((row): row is NonNullable<typeof row> => Boolean(row))
+      .filter((row): row is NonNullable<typeof row> => belongsToActiveGame(row))
       .map((row) => ({
         playerAddress: row.player as unknown as bigint,
         rank: row.rank as bigint | number,

--- a/client/apps/game/src/ui/features/world/containers/top-header/structure-picker/chip.tsx
+++ b/client/apps/game/src/ui/features/world/containers/top-header/structure-picker/chip.tsx
@@ -2,7 +2,7 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { useBlitzRealmProvision } from "@/ui/modules/entity-details/hooks/use-blitz-realm-provision";
 import { useRealmUpgradeAndProvision } from "@/ui/modules/entity-details/hooks/use-realm-upgrade-and-provision";
-import { useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
+import { formatIncomingEta, useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
 import {
   formatPopulationStatusLabel,
   formatUsedBuildingTilesLabel,
@@ -136,15 +136,23 @@ export const StructureRealmActions = ({ structureEntityId, className }: Structur
               <div
                 key={`${req.resource}-${req.amount}`}
                 className={clsx(
-                  "flex items-center gap-2 rounded border px-2 py-1",
+                  "rounded border px-2 py-1",
                   isMet ? "border-gold/20 bg-gold/5" : "border-red-400/40 bg-red-500/5",
                 )}
               >
-                <ResourceIcon resource={ResourcesIds[req.resource]} size="xs" withTooltip={false} />
-                <span className="flex-1 text-xs text-gold/80">{ResourcesIds[req.resource]}</span>
-                <span className={clsx("text-xs font-semibold", isMet ? "text-gold" : "text-red-300")}>
-                  {Math.floor(req.current).toLocaleString()} / {req.amount.toLocaleString()}
-                </span>
+                <div className="flex items-center gap-2">
+                  <ResourceIcon resource={ResourcesIds[req.resource]} size="xs" withTooltip={false} />
+                  <span className="flex-1 text-xs text-gold/80">{ResourcesIds[req.resource]}</span>
+                  <span className={clsx("text-xs font-semibold", isMet ? "text-gold" : "text-red-300")}>
+                    {Math.floor(req.current).toLocaleString()} / {req.amount.toLocaleString()}
+                  </span>
+                </div>
+                {req.incoming && (
+                  <div className="pl-6 text-xxs text-emerald-300/90">
+                    +{Math.floor(req.incoming.amount).toLocaleString()} in transit,{" "}
+                    {formatIncomingEta(req.incoming.etaSeconds)}
+                  </div>
+                )}
               </div>
             );
           })}

--- a/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts
+++ b/client/apps/game/src/ui/modules/entity-details/hooks/use-structure-upgrade.ts
@@ -3,7 +3,7 @@ import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useProvisionalInputLock } from "@/hooks/use-provisional-input-lock";
 import { configManager, divideByPrecision, getBalance, getRealmInfo, ResourceManager } from "@bibliothecadao/eternum";
 import { requireActiveGameSyncRuntime, trackProvisionalTransaction } from "@bibliothecadao/eternum/game-sync";
-import { useDojo } from "@bibliothecadao/react";
+import { useArrivalsByStructure, useDojo } from "@bibliothecadao/react";
 import { ContractAddress, getLevelName, ResourcesIds } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
 import { useCallback, useMemo } from "react";
@@ -13,11 +13,18 @@ interface RawUpgradeCost {
   amount: number;
 }
 
+interface IncomingRequirementDelivery {
+  amount: number;
+  etaSeconds: number;
+}
+
 interface UpgradeRequirement {
   resource: number;
   amount: number;
   current: number;
   progress: number;
+  /** Resources already sent to this structure but still riding the delivery tick. */
+  incoming: IncomingRequirementDelivery | null;
 }
 
 interface StructureUpgradeResult {
@@ -39,6 +46,12 @@ interface StructureUpgradeResult {
 
 const readRealmInfo = (realmEntity: string, components: unknown) =>
   getRealmInfo(realmEntity as never, components as never) ?? null;
+
+export const formatIncomingEta = (etaSeconds: number): string => {
+  if (etaSeconds <= 0) return "landing";
+  if (etaSeconds < 90) return `in ${Math.ceil(etaSeconds)}s`;
+  return `in ${Math.ceil(etaSeconds / 60)}m`;
+};
 
 export const useStructureUpgrade = (structureEntityId: number | null): StructureUpgradeResult | null => {
   const { setup, account } = useDojo();
@@ -70,19 +83,39 @@ export const useStructureUpgrade = (structureEntityId: number | null): Structure
     return (configManager.realmUpgradeCosts[nextLevel] as RawUpgradeCost[]) || [];
   }, [nextLevel]);
 
+  // Sent resources ride the delivery tick and belong to no balance while in
+  // transit; surfacing them here is what tells the player their transfer is
+  // coming instead of the requirement row silently staying red.
+  const pendingArrivals = useArrivalsByStructure(structureEntityId ?? 0);
+  const incomingByResource = useMemo(() => {
+    const incoming = new Map<number, IncomingRequirementDelivery>();
+    for (const arrival of pendingArrivals) {
+      const etaSeconds = Math.max(0, Number(arrival.arrivesAt) - currentDefaultTick);
+      for (const { resourceId, amount } of arrival.resources) {
+        const entry = incoming.get(resourceId) ?? { amount: 0, etaSeconds };
+        entry.amount += divideByPrecision(amount);
+        entry.etaSeconds = Math.min(entry.etaSeconds, etaSeconds);
+        incoming.set(resourceId, entry);
+      }
+    }
+    return incoming;
+  }, [currentDefaultTick, pendingArrivals]);
+
   const requirements = useMemo<UpgradeRequirement[]>(() => {
     if (!structureInfo || !nextLevel || !structureEntityId) return [];
     return rawCosts.map((cost) => {
       const rawBalance = getBalance(structureEntityId, cost.resource, currentDefaultTick, setup.components).balance;
       const current = divideByPrecision(Number.isFinite(rawBalance) ? rawBalance : 0);
+      const incoming = incomingByResource.get(cost.resource) ?? null;
       return {
         resource: cost.resource,
         amount: cost.amount,
         current,
         progress: cost.amount > 0 ? Math.min(100, (current * 100) / cost.amount) : 100,
+        incoming: incoming && incoming.amount > 0 ? incoming : null,
       };
     });
-  }, [currentDefaultTick, nextLevel, rawCosts, setup.components, structureEntityId, structureInfo]);
+  }, [currentDefaultTick, incomingByResource, nextLevel, rawCosts, setup.components, structureEntityId, structureInfo]);
 
   const upgradeReadiness = useMemo(() => {
     if (!structureInfo || !nextLevel) {

--- a/client/apps/game/src/ui/modules/entity-details/realm/realm-details.tsx
+++ b/client/apps/game/src/ui/modules/entity-details/realm/realm-details.tsx
@@ -18,7 +18,7 @@ import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress, RealmLevels, ResourcesIds, StructureType } from "@bibliothecadao/types";
 import { useMemo } from "react";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
-import { useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
+import { formatIncomingEta, useStructureUpgrade } from "@/ui/modules/entity-details/hooks/use-structure-upgrade";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { HUD_LABEL } from "@/ui/design-system/atoms/hud-typography";
 import ChevronsUp from "lucide-react/dist/esm/icons/chevrons-up";
@@ -175,15 +175,19 @@ export const RealmUpgradeCompact = () => {
       <SectionRow label={`Upgrade to ${upgradeTargetLabel}`}>
         {requirements.map((req) => {
           const isMet = req.current >= req.amount;
+          const incomingTitle = req.incoming
+            ? ` (+${Math.floor(req.incoming.amount).toLocaleString()} in transit, ${formatIncomingEta(req.incoming.etaSeconds)})`
+            : "";
           return (
             <span
               key={`${req.resource}-${req.amount}`}
               className={CHIP_BASE}
-              title={`${ResourcesIds[req.resource] ?? `Resource ${req.resource}`} — need ${req.amount.toLocaleString()}`}
+              title={`${ResourcesIds[req.resource] ?? `Resource ${req.resource}`} — need ${req.amount.toLocaleString()}${incomingTitle}`}
             >
               <ResourceIcon withTooltip={false} resource={ResourcesIds[req.resource]} size="xs" />
               <span className={isMet ? "text-gold" : "text-red-300"}>{Math.floor(req.current).toLocaleString()}</span>
               <span className={isMet ? "text-gold/55" : "text-red-300/80"}>/ {req.amount.toLocaleString()}</span>
+              {req.incoming && <span className="text-emerald-300/90">↑</span>}
             </span>
           );
         })}

--- a/client/apps/game/src/ui/shared/components/chain-time-poller.tsx
+++ b/client/apps/game/src/ui/shared/components/chain-time-poller.tsx
@@ -1,4 +1,4 @@
-import { setBlockTimestampSource } from "@bibliothecadao/eternum";
+import { setBlockTimestampSource, setChainTimestampEvidenceSink } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import { useEffect } from "react";
 
@@ -6,6 +6,32 @@ import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
 import { CHAIN_TIME_DEBUG_STORAGE_KEY, logChainTimeDebug } from "@/utils/chain-time-debug";
 
 const POLL_INTERVAL_MS = 10_000;
+
+// Row-evidence heartbeats: a chain-written timestamp ahead of the clock proves
+// chain time has reached that moment (see reportObservedChainTimestamp). The
+// flush is deferred because evidence surfaces inside balance reads during React
+// renders, and applied through setHeartbeat, which already ratchets
+// monotonically and caps forward lead. Timestamps past any plausible clock
+// drift are bad data, not evidence.
+const MAX_EVIDENCE_FUTURE_MS = 10 * 60 * 1000;
+let pendingEvidenceTimestampMs = 0;
+let evidenceFlushScheduled = false;
+
+const bindRowEvidenceSink = () => {
+  setChainTimestampEvidenceSink((timestampSeconds) => {
+    const timestampMs = timestampSeconds * 1000;
+    if (timestampMs > Date.now() + MAX_EVIDENCE_FUTURE_MS) return;
+    pendingEvidenceTimestampMs = Math.max(pendingEvidenceTimestampMs, timestampMs);
+    if (evidenceFlushScheduled) return;
+    evidenceFlushScheduled = true;
+    window.setTimeout(() => {
+      evidenceFlushScheduled = false;
+      const timestamp = pendingEvidenceTimestampMs;
+      pendingEvidenceTimestampMs = 0;
+      useChainTimeStore.getState().setHeartbeat({ timestamp, source: "row-evidence" });
+    }, 0);
+  });
+};
 
 export const ChainTimePoller = () => {
   const {
@@ -18,8 +44,9 @@ export const ChainTimePoller = () => {
 
   useEffect(() => {
     setBlockTimestampSource(() => useChainTimeStore.getState().getNowSeconds());
+    bindRowEvidenceSink();
     logChainTimeDebug("source_bound", {
-      source: "useChainTimeStore.getNowSeconds",
+      source: "useChainTimeStore.getNowSeconds + row-evidence sink",
       pollIntervalMs: POLL_INTERVAL_MS,
       debugStorageKey: CHAIN_TIME_DEBUG_STORAGE_KEY,
     });

--- a/packages/core/src/managers/config-manager.ts
+++ b/packages/core/src/managers/config-manager.ts
@@ -1365,6 +1365,20 @@ export class ClientConfigManager {
 
 export const configManager = ClientConfigManager.instance();
 
+/**
+ * Per-game rows in a multi-game store: does this row belong to the active
+ * game? Unscoped boots and landing flows can leave other games' rows in RECS,
+ * so any read that aggregates a game-keyed model's VALUES (rather than looking
+ * up by a gameEntityKey, which embeds the game id) must filter through this.
+ * Legacy single-game worlds have no active game id and accept every row.
+ */
+export const belongsToActiveGame = (value: { game_id?: unknown } | undefined | null): boolean => {
+  if (!value) return false;
+  const activeGameId = ClientConfigManager.instance().getActiveGameId();
+  if (!(activeGameId > 0)) return true;
+  return Number(value.game_id ?? 0) === activeGameId;
+};
+
 // The key helpers live in ./game-entity-keys (a leaf module). worldConfigKey
 // is not re-exported here: its only consumers import the subpath entry.
 export { buildingEntityKey, gameEntityKey } from "./game-entity-keys";

--- a/packages/core/src/managers/leaderboard-manager.test.ts
+++ b/packages/core/src/managers/leaderboard-manager.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+
+import { ContractAddress, createClientComponents, defineContractComponents } from "@bibliothecadao/types";
+import { createWorld, setComponent } from "@dojoengine/recs";
+import { getEntityIdFromKeys } from "@dojoengine/utils";
+import { afterEach, describe, expect, it } from "vitest";
+import { ClientConfigManager } from "./config-manager";
+import { LeaderboardManager } from "./leaderboard-manager";
+
+const PLAYER = 0x3e1a40b7n;
+const POINTS_PRECISION = 1_000_000n;
+
+afterEach(() => ClientConfigManager.instance().setActiveGame(0, 0));
+
+describe("LeaderboardManager game scoping", () => {
+  it("reads registered points from the active game's row, not another game's row for the same address", () => {
+    const components = createTestComponents();
+    // Seed the current game first, then an older game's row for the same
+    // address, so an unscoped address-keyed pass would let the old row win.
+    seedRegisteredPoints(components, 23, PLAYER, 17_332n);
+    seedRegisteredPoints(components, 15, PLAYER, 5_275n);
+    const manager = new LeaderboardManager(components);
+
+    ClientConfigManager.instance().setActiveGame(23, 0);
+    expect(manager.getPlayerRegisteredPoints(ContractAddress(PLAYER))).toBe(17_332);
+
+    ClientConfigManager.instance().setActiveGame(15, 0);
+    expect(manager.getPlayerRegisteredPoints(ContractAddress(PLAYER))).toBe(5_275);
+  });
+
+  it("builds the points map from active-game rows only", () => {
+    const components = createTestComponents();
+    seedRegisteredPoints(components, 23, PLAYER, 17_332n);
+    seedRegisteredPoints(components, 15, PLAYER, 5_275n);
+    ClientConfigManager.instance().setActiveGame(23, 0);
+    const manager = new LeaderboardManager(components);
+
+    const pointsPerPlayer = (manager as unknown as { getPlayerPoints: () => Map<ContractAddress, number> })[
+      "getPlayerPoints"
+    ]();
+
+    expect(pointsPerPlayer.get(ContractAddress(PLAYER))).toBe(17_332);
+  });
+
+  it("keeps legacy single-game worlds (no active game id) unfiltered", () => {
+    const components = createTestComponents();
+    seedRegisteredPoints(components, 0, PLAYER, 1_460n);
+    ClientConfigManager.instance().setActiveGame(0, 0);
+    const manager = new LeaderboardManager(components);
+
+    expect(manager.getPlayerRegisteredPoints(ContractAddress(PLAYER))).toBe(1_460);
+  });
+});
+
+function createTestComponents() {
+  const world = createWorld();
+  return createClientComponents({ contractComponents: defineContractComponents(world) });
+}
+
+function seedRegisteredPoints(
+  components: ReturnType<typeof createTestComponents>,
+  gameId: number,
+  address: bigint,
+  points: bigint,
+) {
+  setComponent(components.PlayerRegisteredPoints, getEntityIdFromKeys([BigInt(gameId), address]), {
+    game_id: gameId,
+    address,
+    registered_points: points * POINTS_PRECISION,
+    prize_claimed: false,
+  });
+}

--- a/packages/core/src/managers/leaderboard-manager.ts
+++ b/packages/core/src/managers/leaderboard-manager.ts
@@ -9,7 +9,7 @@ import {
   runQuery,
 } from "@dojoengine/recs";
 import { getGuildFromPlayerAddress, getRealmCountPerHyperstructure } from "../utils";
-import { ClientConfigManager, gameEntityKey } from "./config-manager";
+import { belongsToActiveGame, ClientConfigManager, gameEntityKey } from "./config-manager";
 
 interface ContractAddressAndAmount {
   key: false;
@@ -86,12 +86,10 @@ export class LeaderboardManager {
   private activeGameRows<S extends Schema>(
     component: Component<S>,
   ): Array<{ entity: Entity; value: ComponentValue<S> }> {
-    const activeGameId = ClientConfigManager.instance().getActiveGameId();
     const rows: Array<{ entity: Entity; value: ComponentValue<S> }> = [];
     for (const entity of runQuery([Has(component)])) {
       const value = getComponentValue(component, entity);
-      if (!value) continue;
-      if (activeGameId > 0 && Number((value as { game_id?: unknown }).game_id ?? 0) !== activeGameId) continue;
+      if (!value || !belongsToActiveGame(value)) continue;
       rows.push({ entity, value });
     }
     return rows;

--- a/packages/core/src/managers/leaderboard-manager.ts
+++ b/packages/core/src/managers/leaderboard-manager.ts
@@ -1,5 +1,13 @@
 import { type ClientComponents, ContractAddress, type ID } from "@bibliothecadao/types";
-import { Has, getComponentValue, runQuery } from "@dojoengine/recs";
+import {
+  type Component,
+  type ComponentValue,
+  type Entity,
+  Has,
+  type Schema,
+  getComponentValue,
+  runQuery,
+} from "@dojoengine/recs";
 import { getGuildFromPlayerAddress, getRealmCountPerHyperstructure } from "../utils";
 import { ClientConfigManager, gameEntityKey } from "./config-manager";
 
@@ -68,6 +76,25 @@ export class LeaderboardManager {
       LeaderboardManager._instance = new LeaderboardManager(components, unregisteredShareholderPointsUpdateInterval);
     }
     return LeaderboardManager._instance;
+  }
+
+  // Multi-game worlds stream every game's rows into RECS (finished games
+  // included), and every leaderboard fact is per-game: an address-keyed map fed
+  // from unscoped rows lets another game's row win arbitrarily. All reads go
+  // through this chokepoint. Legacy worlds have no active game id and keep
+  // their single-game rows unfiltered.
+  private activeGameRows<S extends Schema>(
+    component: Component<S>,
+  ): Array<{ entity: Entity; value: ComponentValue<S> }> {
+    const activeGameId = ClientConfigManager.instance().getActiveGameId();
+    const rows: Array<{ entity: Entity; value: ComponentValue<S> }> = [];
+    for (const entity of runQuery([Has(component)])) {
+      const value = getComponentValue(component, entity);
+      if (!value) continue;
+      if (activeGameId > 0 && Number((value as { game_id?: unknown }).game_id ?? 0) !== activeGameId) continue;
+      rows.push({ entity, value });
+    }
+    return rows;
   }
 
   public initialize() {
@@ -180,16 +207,10 @@ export class LeaderboardManager {
     // Clear previous cache
     this.unregisteredShareholderPointsCache.clear();
 
-    // Get all hyperstructures
-    const allHyperstructuresShareholders = runQuery([Has(this.components.HyperstructureShareholders)]);
-
-    for (const hyperstructureShareholdersEntityId of allHyperstructuresShareholders) {
-      const hyperstructureShareholders = getComponentValue(
-        this.components.HyperstructureShareholders,
-        hyperstructureShareholdersEntityId,
-      );
-      if (!hyperstructureShareholders) continue;
-
+    // Get the active game's hyperstructures
+    for (const { entity: hyperstructureShareholdersEntityId, value: hyperstructureShareholders } of this.activeGameRows(
+      this.components.HyperstructureShareholders,
+    )) {
       const hyperstructure = getComponentValue(this.components.Hyperstructure, hyperstructureShareholdersEntityId);
 
       const pointsPerSecond = hyperstructure ? pointsPerSecondWithoutMultiplier * hyperstructure.points_multiplier : 0;
@@ -267,12 +288,7 @@ export class LeaderboardManager {
    * Get only the registered points for a specific player (without unregistered shareholder points)
    */
   public getPlayerRegisteredPoints(playerAddress: ContractAddress): number {
-    const registeredPoints = runQuery([Has(this.components.PlayerRegisteredPoints)]);
-
-    for (const entityId of registeredPoints) {
-      const playerRegisteredPoints = getComponentValue(this.components.PlayerRegisteredPoints, entityId);
-      if (!playerRegisteredPoints) continue;
-
+    for (const { value: playerRegisteredPoints } of this.activeGameRows(this.components.PlayerRegisteredPoints)) {
       if (ContractAddress(playerRegisteredPoints.address) === playerAddress) {
         const pointsPrecision = 1_000_000n;
         return Number(playerRegisteredPoints.registered_points / pointsPrecision);
@@ -331,16 +347,11 @@ export class LeaderboardManager {
       totalPoints: number;
     }> = [];
 
-    const allHyperstructuresShareholders = runQuery([Has(this.components.HyperstructureShareholders)]);
     const realmCountPerHyperstructure = getRealmCountPerHyperstructure(this.components);
 
-    for (const hyperstructureShareholdersEntityId of allHyperstructuresShareholders) {
-      const hyperstructureShareholders = getComponentValue(
-        this.components.HyperstructureShareholders,
-        hyperstructureShareholdersEntityId,
-      );
-      if (!hyperstructureShareholders) continue;
-
+    for (const { value: hyperstructureShareholders } of this.activeGameRows(
+      this.components.HyperstructureShareholders,
+    )) {
       const shareholders = hyperstructureShareholders.shareholders as unknown as ContractAddressAndAmount[];
       const startTimestamp = Number(hyperstructureShareholders.start_at);
 
@@ -379,13 +390,8 @@ export class LeaderboardManager {
   private getPlayerPoints(): Map<ContractAddress, number> {
     const pointsPerPlayer = new Map<ContractAddress, number>();
 
-    // Get registered points from on-chain data
-    const registredPoints = runQuery([Has(this.components.PlayerRegisteredPoints)]);
-
-    for (const entityId of registredPoints) {
-      const playerRegisteredPoints = getComponentValue(this.components.PlayerRegisteredPoints, entityId);
-      if (!playerRegisteredPoints) continue;
-
+    // Get the active game's registered points from on-chain data
+    for (const { value: playerRegisteredPoints } of this.activeGameRows(this.components.PlayerRegisteredPoints)) {
       const playerAddress = ContractAddress(playerRegisteredPoints.address);
       const pointsPrecision = 1_000_000n;
       const registeredPoints = Number(playerRegisteredPoints.registered_points / pointsPrecision);
@@ -455,11 +461,9 @@ export class LeaderboardManager {
   }
 
   public getHyperstructuresWithSharesFromPlayer = (address: ContractAddress) => {
-    const hyperstructures = runQuery([Has(this.components.Hyperstructure)]);
-    const hyperstructuresWithShares: ID[] = Array.from(hyperstructures)
-      .map((entityId) => {
-        const hyperstructure = getComponentValue(this.components.Hyperstructure, entityId);
-        if (!hyperstructure || !hyperstructure.initialized) return;
+    const hyperstructuresWithShares: ID[] = this.activeGameRows(this.components.Hyperstructure)
+      .map(({ value: hyperstructure }) => {
+        if (!hyperstructure.initialized) return;
         const playerShares = this.getPlayerShares(address, hyperstructure.hyperstructure_id);
         if (playerShares > 0) return hyperstructure.hyperstructure_id;
       })

--- a/packages/core/src/managers/resource-manager.optimistic-update.test.ts
+++ b/packages/core/src/managers/resource-manager.optimistic-update.test.ts
@@ -9,8 +9,8 @@ import {
 } from "@bibliothecadao/types";
 import { Type as RecsType, createWorld, getComponentValue, setComponent, type ComponentValue } from "@dojoengine/recs";
 import { getEntityIdFromKeys } from "@dojoengine/utils";
-import { afterEach, describe, expect, it } from "vitest";
-import { setBlockTimestampSource } from "../utils/timestamp";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setBlockTimestampSource, setChainTimestampEvidenceSink } from "../utils/timestamp";
 import { ResourceManager } from "./resource-manager";
 
 type ResourceValue = ComponentValue<ClientComponents["Resource"]["schema"]>;
@@ -112,7 +112,14 @@ describe("ResourceManager provisional writes", () => {
 });
 
 describe("production extrapolation clamps", () => {
+  afterEach(() => {
+    setChainTimestampEvidenceSink(null);
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
   it("contributes zero production when last_updated_at is ahead of the current tick", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const components = createTestComponents();
     seedResource(components, 1, {
       WHEAT_BALANCE: precise(5),
@@ -125,6 +132,40 @@ describe("production extrapolation clamps", () => {
     expect(new ResourceManager(components, 1).balanceWithProduction(1100, ResourcesIds.Wheat).balance).toBe(
       Number(precise(5)),
     );
+  });
+
+  it("reports a row ahead of the clock as chain-time evidence so the clock can re-anchor", () => {
+    const observed: number[] = [];
+    setChainTimestampEvidenceSink((timestampSeconds) => observed.push(timestampSeconds));
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      WHEAT_BALANCE: precise(5),
+      WHEAT_PRODUCTION: production({ production_rate: RESOURCE_PRECISION, last_updated_at: 1110 }),
+      weight: { capacity: storeCapacityGrams(1000), weight: 0n },
+    });
+
+    ResourceManager.balanceWithProduction(readResource(components, 1), 1100, ResourcesIds.Wheat);
+
+    expect(observed).toContain(1110);
+  });
+
+  it("warns loudly, with throttling, when the floor discards accrual beyond clock jitter", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T00:00:00Z"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const components = createTestComponents();
+    seedResource(components, 1, {
+      WHEAT_BALANCE: precise(5),
+      WHEAT_PRODUCTION: production({ production_rate: RESOURCE_PRECISION, last_updated_at: 2000 }),
+      weight: { capacity: storeCapacityGrams(1000), weight: 0n },
+    });
+    const row = readResource(components, 1);
+
+    ResourceManager.balanceWithProduction(row, 1100, ResourcesIds.Wheat);
+    ResourceManager.balanceWithProduction(row, 1100, ResourcesIds.Wheat);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("900s ahead of the client clock");
   });
 
   it("contributes zero production when the store is over capacity", () => {

--- a/packages/core/src/managers/resource-manager.ts
+++ b/packages/core/src/managers/resource-manager.ts
@@ -9,7 +9,7 @@ import {
   type ProvisionalIntentLockUntil,
 } from "../sync/provisional-write-manager";
 import { divideByPrecision, getBuildingCount, gramToKg, kgToGram, multiplyByPrecision } from "../utils";
-import { getBlockTimestamp } from "../utils/timestamp";
+import { getBlockTimestamp, reportObservedChainTimestamp } from "../utils/timestamp";
 import { configManager, gameEntityKey } from "./config-manager";
 
 export interface ResourceProductionData {
@@ -93,9 +93,31 @@ const RESOURCE_BALANCE_FIELDS = {
 
 // Rows indexed from preconfirmed blocks can carry a last_updated_at ahead of the
 // client's chain-time heartbeat; elapsed production floors at zero, never negative.
+// The floor silently discards real accrual, so a row ahead of the clock is also
+// reported as chain-time evidence (the clock re-anchors and the next read heals)
+// and a large discard — beyond normal block/poll jitter — warns loudly.
+const ELAPSED_FLOOR_WARN_THRESHOLD_SECONDS = 30;
+const ELAPSED_FLOOR_WARN_INTERVAL_MS = 60_000;
+let lastElapsedFloorWarnAtMs = 0;
+
 const elapsedProductionTicks = (lastUpdatedAt: number, currentTick: number): number => {
   const elapsed = currentTick - lastUpdatedAt;
-  return Number.isFinite(elapsed) && elapsed > 0 ? Math.floor(elapsed) : 0;
+  if (!Number.isFinite(elapsed)) return 0;
+  if (elapsed > 0) return Math.floor(elapsed);
+
+  if (elapsed < 0) {
+    reportObservedChainTimestamp(lastUpdatedAt);
+    if (
+      elapsed < -ELAPSED_FLOOR_WARN_THRESHOLD_SECONDS &&
+      Date.now() - lastElapsedFloorWarnAtMs > ELAPSED_FLOOR_WARN_INTERVAL_MS
+    ) {
+      lastElapsedFloorWarnAtMs = Date.now();
+      console.warn(
+        `[ChainTime] production row is ${Math.round(-elapsed)}s ahead of the client clock — accrual display floored to zero (row last_updated_at=${lastUpdatedAt}, client tick=${currentTick})`,
+      );
+    }
+  }
+  return 0;
 };
 
 const resourceUnitWeightGrams = (resourceId: ResourcesIds): bigint =>

--- a/packages/core/src/utils/hyperstructure.ts
+++ b/packages/core/src/utils/hyperstructure.ts
@@ -53,9 +53,14 @@ export const getEffectiveHyperstructureRealmCount = (realmCountWithinRadius: num
 };
 
 export const getRealmCountPerHyperstructure = (components: ClientComponents): Map<ID, number> => {
+  // Every game shares the same settlement coordinate space, so an unscoped
+  // Structure sweep would count other games' realms into this game's radii.
+  const activeGameId = configManager.getActiveGameId();
   const structures = [...runQuery([Has(components.Structure)])].flatMap((entity) => {
     const structure = getComponentValue(components.Structure, entity);
-    return structure ? [structure] : [];
+    if (!structure) return [];
+    if (activeGameId > 0 && Number(structure.game_id ?? 0) !== activeGameId) return [];
+    return [structure];
   });
   const realms = structures.filter((structure) => structure.category === StructureType.Realm);
   const radiusSquared = getHyperstructureRealmCheckRadius() ** 2;

--- a/packages/core/src/utils/hyperstructure.ts
+++ b/packages/core/src/utils/hyperstructure.ts
@@ -2,7 +2,7 @@ import { ClientComponents, type ID, ResourcesIds, StructureType } from "@bibliot
 import { ComponentValue, getComponentValue, Has, runQuery } from "@dojoengine/recs";
 import { configManager } from "../managers";
 import { divideByPrecision } from "./utils";
-import { gameEntityKey } from "../managers/config-manager";
+import { belongsToActiveGame, gameEntityKey } from "../managers/config-manager";
 
 type BlitzMapDistanceProfile = {
   baseDistance: number;
@@ -55,12 +55,9 @@ export const getEffectiveHyperstructureRealmCount = (realmCountWithinRadius: num
 export const getRealmCountPerHyperstructure = (components: ClientComponents): Map<ID, number> => {
   // Every game shares the same settlement coordinate space, so an unscoped
   // Structure sweep would count other games' realms into this game's radii.
-  const activeGameId = configManager.getActiveGameId();
   const structures = [...runQuery([Has(components.Structure)])].flatMap((entity) => {
     const structure = getComponentValue(components.Structure, entity);
-    if (!structure) return [];
-    if (activeGameId > 0 && Number(structure.game_id ?? 0) !== activeGameId) return [];
-    return [structure];
+    return structure && belongsToActiveGame(structure) ? [structure] : [];
   });
   const realms = structures.filter((structure) => structure.category === StructureType.Realm);
   const radiusSquared = getHyperstructureRealmCheckRadius() ** 2;

--- a/packages/core/src/utils/timestamp.ts
+++ b/packages/core/src/utils/timestamp.ts
@@ -25,6 +25,22 @@ export const setBlockTimestampSource = (source: TimestampSource | null) => {
   timestampSource = source ? () => Math.floor(source()) : defaultTimestampSource;
 };
 
+// A chain-written timestamp ahead of the local chain-time estimate is proof the
+// chain's clock has reached that moment. Reporting it lets the clock re-anchor
+// instead of silently under-reporting elapsed time (the invariant the display
+// math needs is client-time >= every last_updated_at the client holds).
+type ChainTimestampEvidenceSink = (timestampSeconds: number) => void;
+let chainTimestampEvidenceSink: ChainTimestampEvidenceSink | null = null;
+
+export const setChainTimestampEvidenceSink = (sink: ChainTimestampEvidenceSink | null) => {
+  chainTimestampEvidenceSink = sink;
+};
+
+export const reportObservedChainTimestamp = (timestampSeconds: number) => {
+  if (!Number.isFinite(timestampSeconds) || timestampSeconds <= 0) return;
+  chainTimestampEvidenceSink?.(timestampSeconds);
+};
+
 export const getBlockTimestamp = () => {
   const timestamp = timestampSource();
   const tickConfigArmies = configManager.getTick(TickIds.Armies);


### PR DESCRIPTION
Four fixes from the Aug 18 post-deploy triage (design doc ratified by the owner), in the owner's priority order.

## Wheat display (lane 3)

**Root cause:** the client clock anchors to polled `getBlock("latest")` timestamps, so rows touched by newer blocks sit ahead of it. That skew used to display negative food; #4891's elapsed floor converted it into a silent accrual discard — balance surfaces showed stored-only (the tester's castle blocked an upgrade on 1,006/2,400 wheat while its harvestable balance was ~11k).

- `elapsedProductionTicks` now reports any row timestamp ahead of the clock as chain-time evidence; the poller feeds it into `setHeartbeat` (already monotonic + lead-capped), so the clock re-anchors and the next read shows full accrual. Discards beyond 30s warn, throttled — the floor is no longer a silent default consuming gameplay math.
- Transfers ride the delivery tick invisibly for up to 3 minutes — the other half of the tester report. Upgrade requirements now show `+N in transit, in Xm` from pending arrivals.

## Leaderboard totals (lane 1)

`LeaderboardManager` iterated `PlayerRegisteredPoints` across every game into an address-keyed map — last row wins. Convicted exactly on the live world: the displayed 8.94K was game 15's row (5,275) + live share accrual; game 23's truth was 17,332. All five read sites now filter to the active game through one chokepoint; `getRealmCountPerHyperstructure` gets the same filter (all games share one settlement coordinate space). The gamewide subscription clause was checked and is already game-keyed; no sync change.

## Army model/label ghosts (lane 2)

One stale slot matrix manufactures both screenshot symptoms (model on the old hex, label on the new). The self-healer gains `stale-drawn-position` (GPU matrix vs `instanceData.position`, stationary armies only, 0.75 epsilon) and `duplicate-drawn-owner` violations, with heals, render counters, and one-shot dev logs to name the writer. Session gate: zero stale-position heals with 40+ armies moving.

## Verification

- packages/core vitest: 145/145 (6 new gates)
- client suite: 2,950/2,950 (3 new auditor gates)
- tsc clean in core + client, `pnpm run format`, `pnpm run knip`

Non-goals: the writer fix for army ghosts lands after the heal counters convict it in a live session; the tester capture protocol (CHAIN_TIME_DEBUG + ?logs=1) verifies the wheat fix in the wild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)