### PR TITLE
fix(client,core): leaderboard points from one source; rebind the manager on reboot

### DIFF
--- a/client/apps/game/src/services/leaderboard/player-activity-breakdown-service.ts
+++ b/client/apps/game/src/services/leaderboard/player-activity-breakdown-service.ts
@@ -4,6 +4,12 @@ import type { PlayerActivityBreakdown } from "@bibliothecadao/torii";
 export interface PlayerLeaderboardActivityEntry {
   address: string;
   activityBreakdown: PlayerActivityBreakdown;
+  // The breakdown's own total (registered + live shareholder points) and the
+  // server-side rank over it. The POINTS/RANK columns display these so one
+  // source feeds the whole leaderboard row (owner ruling: points are the sum
+  // of the breakdown columns).
+  totalPoints: number;
+  rank: number | null;
 }
 
 export const fetchLeaderboardActivityBreakdowns = async (limit: number): Promise<PlayerLeaderboardActivityEntry[]> => {
@@ -13,6 +19,8 @@ export const fetchLeaderboardActivityBreakdowns = async (limit: number): Promise
   const rows = await sqlApi.fetchPlayerLeaderboard(safeLimit, 0);
   return rows.flatMap((row) => {
     const address = row.playerAddress?.trim();
-    return address ? [{ address, activityBreakdown: row.activityBreakdown }] : [];
+    return address
+      ? [{ address, activityBreakdown: row.activityBreakdown, totalPoints: row.totalPoints, rank: row.rank ?? null }]
+      : [];
   });
 };

--- a/client/apps/game/src/ui/features/social/player/in-game-leaderboard-ownership.source.test.ts
+++ b/client/apps/game/src/ui/features/social/player/in-game-leaderboard-ownership.source.test.ts
@@ -23,13 +23,19 @@ describe("in-game leaderboard fact ownership", () => {
     expect(rankPillSources[1]).toContain("useInGameLeaderboard");
   });
 
-  it("uses SQL only for the in-session immutable-history activity breakdown", () => {
+  it("feeds the live leaderboard row from the one SQL aggregate; finalized standings stay on RECS", () => {
     const panelSource = readSource("src/ui/features/social/player/players-panel.tsx");
     const playerListSource = readSource("src/ui/features/social/player/player-list.tsx");
     const activityServiceSource = readSource("src/services/leaderboard/player-activity-breakdown-service.ts");
 
+    // Owner ruling (Aug 2026): in a LIVE game, the POINTS/RANK columns display
+    // the same SQL leaderboard aggregate that feeds the breakdown columns, so a
+    // row's total is always the sum of what it shows. Finalized games keep the
+    // RECS-backed final standings, and tx flows (register/claim) stay on RECS.
     expect(panelSource).toContain("useInGameLeaderboard");
     expect(panelSource).toContain("fetchLeaderboardActivityBreakdowns");
+    expect(panelSource).toContain("activityEntry?.totalPoints");
+    expect(panelSource).toContain("isFinalized ? (standing?.points ?? 0)");
     expect(panelSource).not.toContain("setInterval");
     expect(panelSource).not.toContain("useLandingLeaderboardStore");
     expect(panelSource).not.toContain("LandingLeaderboardEntry");
@@ -38,7 +44,7 @@ describe("in-game leaderboard fact ownership", () => {
     expect(playerListSource).not.toContain("leaderboardRankOverride");
     expect(playerListSource).not.toContain("leaderboardPointsOverride");
     expect(activityServiceSource).toContain("row.activityBreakdown");
+    expect(activityServiceSource).toContain("row.totalPoints");
     expect(activityServiceSource).not.toContain("row.registeredPoints");
-    expect(activityServiceSource).not.toContain("row.rank");
   });
 });

--- a/client/apps/game/src/ui/features/social/player/players-panel.tsx
+++ b/client/apps/game/src/ui/features/social/player/players-panel.tsx
@@ -25,7 +25,7 @@ import { gameEntityKey } from "@/dojo/game-scope";
 const SOCIAL_LEADERBOARD_LIMIT = 1000;
 
 const buildActivityBreakdownLookup = (entries: PlayerLeaderboardActivityEntry[]) =>
-  new Map(entries.map((entry) => [normalizeLeaderboardAddress(entry.address), entry.activityBreakdown]));
+  new Map(entries.map((entry) => [normalizeLeaderboardAddress(entry.address), entry]));
 
 export const PlayersPanel = ({
   players,
@@ -52,7 +52,7 @@ export const PlayersPanel = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [showPointsBreakdown, setShowPointsBreakdown] = useState(false);
   const [activityBreakdownsByAddress, setActivityBreakdownsByAddress] = useState(
-    () => new Map<string, PlayerLeaderboardActivityEntry["activityBreakdown"]>(),
+    () => new Map<string, PlayerLeaderboardActivityEntry>(),
   );
   const [isActivityBreakdownFetching, setIsActivityBreakdownFetching] = useState(false);
   const mode = useGameModeConfig();
@@ -108,9 +108,21 @@ export const PlayersPanel = ({
               ?.whitelisted ?? false;
         }
         const standing = standingsByAddress.get(normalizeLeaderboardAddress(player.address));
-        const rank = standing?.rank ?? (isFinalized ? Number.MAX_SAFE_INTEGER : player.rank);
-        const points = standing?.points ?? (isFinalized ? 0 : player.points);
-        const activityBreakdown = activityBreakdownsByAddress.get(normalizeLeaderboardAddress(player.address)) ?? null;
+        const activityEntry = activityBreakdownsByAddress.get(normalizeLeaderboardAddress(player.address)) ?? null;
+
+        // Finalized games rank by the on-chain final standings. Live games rank
+        // by the SQL leaderboard total — the same source as the breakdown
+        // columns, so POINTS is always the sum of what the row displays (owner
+        // ruling). The RECS standing is only the pre-fetch fallback.
+        const liveRank = activityEntry?.rank ?? standing?.rank ?? player.rank;
+        const livePoints = activityEntry?.totalPoints ?? standing?.points ?? player.points;
+        const rank = isFinalized ? (standing?.rank ?? Number.MAX_SAFE_INTEGER) : liveRank;
+        const points = isFinalized ? (standing?.points ?? 0) : livePoints;
+        const includesLiveShareholderPoints = isFinalized
+          ? false
+          : activityEntry
+            ? activityEntry.activityBreakdown.hyperstructureShare.points > 0
+            : (standing?.includesLiveShareholderPoints ?? false);
 
         return {
           ...player,
@@ -120,8 +132,8 @@ export const PlayersPanel = ({
           rank,
           isInvited,
           guild,
-          activityBreakdown,
-          includesLiveShareholderPoints: standing?.includesLiveShareholderPoints ?? false,
+          activityBreakdown: activityEntry?.activityBreakdown ?? null,
+          includesLiveShareholderPoints,
         };
       });
     return playersWithStructures;

--- a/packages/core/src/managers/leaderboard-manager.ts
+++ b/packages/core/src/managers/leaderboard-manager.ts
@@ -61,9 +61,10 @@ export class LeaderboardManager {
   private readonly unregisteredShareholderPointsUpdateInterval: number;
   private pendingSharePointsClaims: Map<ContractAddress, PendingSharePointsClaim> = new Map();
   private readonly pendingSharePointsClaimTtlMs: number = 2 * 60 * 1000;
+  private readonly warnedMissingHyperstructureEntities: Set<Entity> = new Set();
 
   constructor(
-    private readonly components: ClientComponents,
+    private components: ClientComponents,
     unregisteredShareholderPointsUpdateInterval: number = 10000,
   ) {
     this.unregisteredShareholderPointsUpdateInterval = unregisteredShareholderPointsUpdateInterval;
@@ -74,8 +75,21 @@ export class LeaderboardManager {
   public static instance(components: ClientComponents, unregisteredShareholderPointsUpdateInterval?: number) {
     if (!LeaderboardManager._instance) {
       LeaderboardManager._instance = new LeaderboardManager(components, unregisteredShareholderPointsUpdateInterval);
+    } else if (LeaderboardManager._instance.components !== components) {
+      // The game route rebuilds its RECS world (and components) on every boot
+      // (retry, reconnect, re-entry). A singleton pinned to the first boot's
+      // components reads a dead world forever — every points read returns
+      // empty. Re-bind to the live components and drop caches built on the
+      // old world.
+      LeaderboardManager._instance.rebindComponents(components);
     }
     return LeaderboardManager._instance;
+  }
+
+  private rebindComponents(components: ClientComponents) {
+    this.components = components;
+    this.pendingSharePointsClaims.clear();
+    this.forceRefresh();
   }
 
   // Multi-game worlds stream every game's rows into RECS (finished games
@@ -210,6 +224,15 @@ export class LeaderboardManager {
       this.components.HyperstructureShareholders,
     )) {
       const hyperstructure = getComponentValue(this.components.Hyperstructure, hyperstructureShareholdersEntityId);
+      if (!hyperstructure && !this.warnedMissingHyperstructureEntities.has(hyperstructureShareholdersEntityId)) {
+        // A shareholders row without its Hyperstructure row zeroes every
+        // shareholder's live points via the fallback below — that must be a
+        // loud sync gap, never a silent zero.
+        this.warnedMissingHyperstructureEntities.add(hyperstructureShareholdersEntityId);
+        console.warn(
+          `[LeaderboardManager] Hyperstructure row missing for shareholders entity ${String(hyperstructureShareholdersEntityId)}; shareholder points read as 0`,
+        );
+      }
 
       const pointsPerSecond = hyperstructure ? pointsPerSecondWithoutMultiplier * hyperstructure.points_multiplier : 0;
       const shareholders = hyperstructureShareholders.shareholders as unknown as ContractAddressAndAmount[];

--- a/packages/core/src/sync/model-manifest.ts
+++ b/packages/core/src/sync/model-manifest.ts
@@ -74,6 +74,9 @@ export const GAME_SYNC_MODEL_MANIFEST: readonly GameSyncModelDefinition[] = [
   globalEntity("HyperstrtConstructConfig", { s2Scope: "chain" }),
   globalEntity("HyperstructureGlobals"),
   globalEntity("Hyperstructure"),
+  // Live shareholder points read these rows; without a stream/snapshot channel
+  // a mid-game hyperstructure claim never reaches RECS until a reload.
+  globalEntity("HyperstructureShareholders"),
   globalEntity("WeightConfig", { s2Scope: "chain" }),
   globalEntity("ResourceFactoryConfig", { s2Scope: "chain" }),
   globalEntity("BuildingCategoryConfig", { s2Scope: "chain" }),


### PR DESCRIPTION
## The bug (BL-2 on the triage backlog)

Game 24 playtest: every player's POINTS showed 0 and RANK showed "-" for the whole game while the breakdown columns (Tiles/Crates/Rifts/HS) were correct. Chain truth was fine the entire time — `PlayerRegisteredPoints` rows existed from minute 1 with values matching the column sums.

## Root causes

1. **Dead-world singleton.** `LeaderboardManager.instance(components)` pins the components object from the first call and ignored the argument forever. The game route rebuilds its RECS world on every boot (`<ReadyApp key={bootToken}>` — retry, reconnect, re-entry), so a multi-boot tab session left the manager querying a world that no longer receives writes: empty `playersByRank`, zeros for everyone, immune to stream recoveries. `instance()` now re-binds to the live components (mirroring `ClientConfigManager.setDojo`) and drops caches built on the old world — this also repairs every other consumer (register button, guilds, prize panels).
2. **One row, two sources.** The POINTS/RANK cells read RECS while their own breakdown columns read the SQL leaderboard aggregate. Per owner ruling, a live game's POINTS is now the same SQL total the columns already sum to (`PlayerLeaderboardRow.totalPoints`, server-ranked); finalized games keep the RECS-backed final standings, and tx flows (register/claim) stay on RECS. The fact-ownership source test is updated to pin the new rule.
3. **`HyperstructureShareholders` was absent from the gamewide sync manifest** — a mid-game hyperstructure claim never streamed to RECS, so live shareholder points could only be as fresh as the last per-structure fetch. Added to the manifest (game-scoped, ~20 rows/game).
4. A shareholders row missing its `Hyperstructure` row silently zeroed every shareholder's live points (`pointsPerSecond = 0` fallback) — now warns once per entity.

## Verification

- Core 149/149, client 2950/2950, `tsc`, `pnpm run format`, `pnpm run knip` green.
- Live gate: next playtest, mid-game leaderboard POINTS equals the column sum for every player; entering via a retry/reconnect (forced reboot) still shows live points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)