### PR TITLE
fix(client): hex-encode every torii clause key; boot-fetch PlayersRankFinal on s2

### DIFF
--- a/client/apps/game/src/dojo/game-scope.ts
+++ b/client/apps/game/src/dojo/game-scope.ts
@@ -54,7 +54,8 @@ export const appchainModel = (name: string): string => `${namespaceForChain("app
  * Torii KeysClause slot encoding: keys MUST be unpadded hex. Decimal key
  * strings do not survive the grpc key encoding and match nothing — the Aug 10
  * Building-clause incident, later found again in getEntitiesFromTorii. Every
- * clause key goes through this one encoder.
+ * clause key this app builds goes through this encoder (packages/torii has
+ * its own twin, toriiKey, for the query builders that cannot import the app).
  */
 export const hexKey = (value: number | bigint): string => `0x${BigInt(value).toString(16)}`;
 

--- a/client/apps/game/src/dojo/game-scope.ts
+++ b/client/apps/game/src/dojo/game-scope.ts
@@ -50,8 +50,16 @@ export const gameModel = (name: string): string => `${activeNamespace}-${name}`;
  */
 export const appchainModel = (name: string): string => `${namespaceForChain("appchain")}-${name}`;
 
+/**
+ * Torii KeysClause slot encoding: keys MUST be unpadded hex. Decimal key
+ * strings do not survive the grpc key encoding and match nothing — the Aug 10
+ * Building-clause incident, later found again in getEntitiesFromTorii. Every
+ * clause key goes through this one encoder.
+ */
+export const hexKey = (value: number | bigint): string => `0x${BigInt(value).toString(16)}`;
+
 /** The active game id as a KeysClause key slot (unpadded hex — D16-pinned encoding). */
-export const gameIdKey = (): string => `0x${activeGameId.toString(16)}`;
+export const gameIdKey = (): string => hexKey(activeGameId);
 
 /**
  * RECS entity keys for per-game models (gameEntityKey, buildingEntityKey) and

--- a/client/apps/game/src/dojo/queries-authoritative-ingest.test.ts
+++ b/client/apps/game/src/dojo/queries-authoritative-ingest.test.ts
@@ -40,7 +40,9 @@ describe("targeted Torii query ingest", () => {
       expect.objectContaining({
         clause: {
           Keys: {
-            keys: ["0xf", "10775"],
+            // Keys must be hex: a decimal id string does not survive the grpc
+            // key encoding and matches nothing (10775 = 0x2a17).
+            keys: ["0xf", "0x2a17"],
             pattern_matching: "VariableLen",
             models: [],
           },

--- a/client/apps/game/src/dojo/queries.ts
+++ b/client/apps/game/src/dojo/queries.ts
@@ -54,9 +54,12 @@ const clearConfigFetchCache = () => {
   }
 };
 
-const isValidId = (id: unknown): id is ID => typeof id === "number" && Number.isFinite(id);
+// Integer guards double as hexKey's precondition: BigInt() throws on a
+// fractional number, and one bad value must skip its own entity, not abort
+// the whole batched clause.
+const isValidId = (id: unknown): id is ID => typeof id === "number" && Number.isInteger(id) && id > 0;
 const hasValidPosition = (position: HexPosition | undefined): position is HexPosition =>
-  !!position && Number.isFinite(position.col) && Number.isFinite(position.row);
+  !!position && Number.isInteger(position.col) && Number.isInteger(position.row);
 
 export const getStructuresDataFromTorii = async (
   client: ToriiClient,
@@ -432,10 +435,16 @@ export const getOwnedArmiesFromTorii = async (client: ToriiClient, owners: numbe
 
 export const getBuildingsFromTorii = async (client: ToriiClient, structurePositions: HexPosition[]) => {
   const buildingModel = gameModel("Building");
+  // One malformed position must not abort the whole batched clause (hexKey
+  // throws on non-integers).
+  const validPositions = structurePositions.filter(hasValidPosition);
+  if (validPositions.length === 0) {
+    return;
+  }
   const query = {
     Composite: {
       operator: "Or" as LogicalOperator,
-      clauses: structurePositions.map((position) => ({
+      clauses: validPositions.map((position) => ({
         Keys: {
           // s2 Building is keyed (game_id, alt, outer_col, outer_row, ...) —
           // structures never sit on the alt plane (Cairo pins alt to false),

--- a/client/apps/game/src/dojo/queries.ts
+++ b/client/apps/game/src/dojo/queries.ts
@@ -12,7 +12,7 @@ import {
   debouncedGetOwnedArmiesFromTorii,
 } from "./debounced-queries";
 import { fetchEntitiesIntoGameSync } from "./gamewide-sync-adapter";
-import { gameIdKey, gameModel, getScopedGameId, isGameScoped } from "./game-scope";
+import { gameIdKey, gameModel, getScopedGameId, hexKey, isGameScoped } from "./game-scope";
 
 const CONFIG_FETCH_CACHE_PREFIX = "eternum:config-fetched";
 
@@ -144,6 +144,7 @@ export const getConfigFromTorii = async (client: ToriiClient, onBackgroundRefres
       "BlitzSettlement",
       "BlitzEntryTokenRegister",
       "PlayersRankTrial",
+      "PlayersRankFinal",
       "MMRGameMeta",
       "PlayerRank",
       "RankPrize",
@@ -332,8 +333,9 @@ export const getEntitiesFromTorii = async (client: ToriiClient, entityIDs: ID[],
     return;
   }
 
-  // s2 per-game models key entities as (game_id, entity_id, ...).
-  const entityKeys = (id: ID): string[] => (isGameScoped() ? [gameIdKey(), id.toString()] : [id.toString()]);
+  // s2 per-game models key entities as (game_id, entity_id, ...). Keys must be
+  // hex — a decimal id string matches nothing (see hexKey).
+  const entityKeys = (id: ID): string[] => (isGameScoped() ? [gameIdKey(), hexKey(id)] : [hexKey(id)]);
 
   const query =
     validEntityIDs.length === 1
@@ -440,8 +442,8 @@ export const getBuildingsFromTorii = async (client: ToriiClient, structurePositi
           // so match it exactly: a mid-pattern undefined wildcard does not
           // survive the grpc key encoding and matches nothing.
           keys: isGameScoped()
-            ? [gameIdKey(), "0x0", `0x${position.col.toString(16)}`, `0x${position.row.toString(16)}`]
-            : [`0x${position.col.toString(16)}`, `0x${position.row.toString(16)}`],
+            ? [gameIdKey(), hexKey(0), hexKey(position.col), hexKey(position.row)]
+            : [hexKey(position.col), hexKey(position.row)],
           pattern_matching: "VariableLen" as PatternMatching,
           models: [buildingModel],
         },

--- a/client/apps/game/src/ui/features/landing/components/selected-world-entity-wait.ts
+++ b/client/apps/game/src/ui/features/landing/components/selected-world-entity-wait.ts
@@ -1,4 +1,4 @@
-import { namespaceForChain } from "@/dojo/game-scope";
+import { hexKey, namespaceForChain } from "@/dojo/game-scope";
 import { resolveAppchainWorldIdForGame } from "@/runtime/world/game-registry";
 import { buildWorldProfile } from "@/runtime/world/profile-builder";
 import { getDefaultWorld, getWorldById } from "@/runtime/world/world-directory";
@@ -84,7 +84,7 @@ const resolveEntitySubscriptionTarget = async ({
 };
 
 const buildSelectedWorldEntityClause = (target: EntitySubscriptionTarget, modelNames: readonly string[]): Clause => {
-  const scopedKey = target.gameId && target.gameId > 0 ? `0x${target.gameId.toString(16)}` : undefined;
+  const scopedKey = target.gameId && target.gameId > 0 ? hexKey(target.gameId) : undefined;
   return buildGameSyncModelKeysClause(
     modelNames.map((modelName) => ({
       model: `${target.namespace}-${modelName}`,

--- a/client/apps/game/src/ui/features/landing/components/selected-world-entity-wait.ts
+++ b/client/apps/game/src/ui/features/landing/components/selected-world-entity-wait.ts
@@ -84,7 +84,8 @@ const resolveEntitySubscriptionTarget = async ({
 };
 
 const buildSelectedWorldEntityClause = (target: EntitySubscriptionTarget, modelNames: readonly string[]): Clause => {
-  const scopedKey = target.gameId && target.gameId > 0 ? hexKey(target.gameId) : undefined;
+  const scopedKey =
+    target.gameId && Number.isInteger(target.gameId) && target.gameId > 0 ? hexKey(target.gameId) : undefined;
   return buildGameSyncModelKeysClause(
     modelNames.map((modelName) => ({
       model: `${target.namespace}-${modelName}`,

--- a/packages/torii/src/queries/torii-client/army.ts
+++ b/packages/torii/src/queries/torii-client/army.ts
@@ -1,10 +1,10 @@
 import { ID } from "@bibliothecadao/types";
 import { PatternMatching, Query, ToriiClient } from "@dojoengine/torii-wasm";
 import { getExplorerFromToriiEntity, getResourcesFromToriiEntity } from "../../parser/torii-client";
-import { getSqlGameScope } from "../../utils/sql";
+import { getSqlGameScope, scopedEntityKeys } from "../../utils/sql";
 
 export const getExplorerFromToriiClient = async (toriiClient: ToriiClient, entityId: ID) => {
-  const { namespace, gameId } = getSqlGameScope();
+  const { namespace } = getSqlGameScope();
   const models = [`${namespace}-ExplorerTroops`, `${namespace}-Resource`];
   const query: Query = {
     pagination: {
@@ -18,8 +18,8 @@ export const getExplorerFromToriiClient = async (toriiClient: ToriiClient, entit
     historical: false,
     clause: {
       Keys: {
-        // s2 per-game models key entities as (game_id, entity_id)
-        keys: gameId > 0 ? [`0x${gameId.toString(16)}`, entityId.toString()] : [entityId.toString()],
+        // s2 per-game models key entities as (game_id, entity_id); keys must be hex.
+        keys: scopedEntityKeys(entityId),
         pattern_matching: "FixedLen" as PatternMatching,
         models,
       },

--- a/packages/torii/src/queries/torii-client/structure.ts
+++ b/packages/torii/src/queries/torii-client/structure.ts
@@ -3,10 +3,10 @@ import { PatternMatching, Query, ToriiClient } from "@dojoengine/torii-wasm";
 import { getStructureFromToriiEntity } from "../../parser/torii-client";
 import { getProductionBoostFromToriiEntity } from "../../parser/torii-client/production-boost";
 import { getResourcesFromToriiEntity } from "../../parser/torii-client/resources";
-import { getSqlGameScope } from "../../utils/sql";
+import { getSqlGameScope, scopedEntityKeys } from "../../utils/sql";
 
 export const getStructureFromToriiClient = async (toriiClient: ToriiClient, entityId: ID) => {
-  const { namespace, gameId } = getSqlGameScope();
+  const { namespace } = getSqlGameScope();
   const models = [`${namespace}-Structure`, `${namespace}-Resource`, `${namespace}-ProductionBoostBonus`];
   const query: Query = {
     pagination: {
@@ -20,8 +20,8 @@ export const getStructureFromToriiClient = async (toriiClient: ToriiClient, enti
     historical: false,
     clause: {
       Keys: {
-        // s2 per-game models key entities as (game_id, entity_id)
-        keys: gameId > 0 ? [`0x${gameId.toString(16)}`, entityId.toString()] : [entityId.toString()],
+        // s2 per-game models key entities as (game_id, entity_id); keys must be hex.
+        keys: scopedEntityKeys(entityId),
         pattern_matching: "FixedLen" as PatternMatching,
         models,
       },

--- a/packages/torii/src/utils/sql.ts
+++ b/packages/torii/src/utils/sql.ts
@@ -48,6 +48,17 @@ export const getSqlGameScope = (): { namespace: string; gameId: number } => ({
   gameId: sqlGameId,
 });
 
+/**
+ * Torii KeysClause slots MUST be unpadded hex — decimal key strings do not
+ * survive the grpc key encoding and match nothing. This package's one encoder
+ * for gRPC clause keys (the game client has its own in dojo/game-scope.ts).
+ */
+export const toriiKey = (value: number | bigint): string => `0x${BigInt(value).toString(16)}`;
+
+/** (game_id, entity_id) key tuple for a targeted per-entity gRPC clause. */
+export const scopedEntityKeys = (entityId: number): string[] =>
+  sqlGameId > 0 ? [toriiKey(sqlGameId), toriiKey(entityId)] : [toriiKey(entityId)];
+
 const GAME_FILTER_MARKER = /\{GF(?::([A-Za-z_][\w]*))?\}/g;
 
 /** Explicit scope for queries that target a world other than the ambient one


### PR DESCRIPTION
## The bug (BL-8 on the triage backlog)

Decimal key strings in torii KeysClauses don't survive the grpc key encoding and match nothing — the exact class behind the Aug 10 Building-clause incident ("decimal keys match nothing on s2"). It was alive in one more place: `getEntitiesFromTorii` built its keys as `[gameIdKey(), id.toString()]` — hex game id, **decimal entity id** — so every targeted per-entity fetch on s2 (the tile panel's structure Re-sync, entity refetches) rode a clause that can silently return nothing.

## The fix

- One encoder owns clause-key formatting: `hexKey()` in `game-scope.ts`, right next to `gameIdKey` (which now reuses it). The entity-keys builder, the Building-position clause (previously inline hex), and the landing entity-wait clause all route through it — no per-call-site formatting left to drift.
- The ingest test now pins the hex form (`10775` → `0x2a17`) so the decimal regression can't come back silently.
- `PlayersRankFinal` joins the s2 game-scoped boot config fetch — present in the legacy branch but missing from the s2 list, leaving finalized-leaderboard rows dependent on stream-only delivery after boot.

## Verification

- Client 2950/2950, `tsc`, `pnpm run format`, `pnpm run knip` green.
- Live check after deploy: the tile panel's "Re-sync structure" button on s2 actually refreshes balances (it was the main consumer of the broken clause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)