### PR TITLE
fix(client): refresh the SQL leaderboard aggregate on a 30s tick

### DIFF
--- a/client/apps/game/src/ui/features/social/player/players-panel.tsx
+++ b/client/apps/game/src/ui/features/social/player/players-panel.tsx
@@ -21,6 +21,12 @@ import ChevronUp from "lucide-react/dist/esm/icons/chevron-up";
 import Search from "lucide-react/dist/esm/icons/search";
 import { KeyboardEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { gameEntityKey } from "@/dojo/game-scope";
+import { useCoarseCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
+
+// The SQL aggregate feeding POINTS/RANK must keep pace with the RECS-fed HUD
+// rank pill while the panel stays open — a one-shot fetch froze the columns
+// until a manual refresh.
+const ACTIVITY_REFRESH_WINDOW_SECONDS = 30;
 
 const SOCIAL_LEADERBOARD_LIMIT = 1000;
 
@@ -69,9 +75,10 @@ export const PlayersPanel = ({
     }
   }, []);
 
+  const activityRefreshTick = useCoarseCurrentDefaultTick(ACTIVITY_REFRESH_WINDOW_SECONDS);
   useEffect(() => {
     void refreshActivityBreakdowns();
-  }, [refreshActivityBreakdowns]);
+  }, [refreshActivityBreakdowns, activityRefreshTick]);
 
   useEffect(() => {
     const handler = setTimeout(() => {


### PR DESCRIPTION
Follow-up to #4896, which merged just before this review fix landed on its branch.

The one-shot breakdown fetch froze the POINTS/RANK columns for as long as the leaderboard modal stayed open (manual refresh only), while the RECS-fed HUD rank pill kept ticking — the same player could show two different totals on screen. The panel now refetches the SQL aggregate on a 30s coarse tick (the existing tick hook — no `setInterval`), so the columns track play within one window.

Verified on the original branch: client 2950/2950, tsc, format, knip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)