### PR TITLE
fix(provider): real revert reasons + preflight abort; feat(client): movement-blocked stamina bar

### DIFF
--- a/client/apps/game/src/ui/features/world/components/armies/army-movement-readiness.test.ts
+++ b/client/apps/game/src/ui/features/world/components/armies/army-movement-readiness.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveArmyMovementReadiness } from "./army-movement-readiness";
+import { formatTravelBlockedSummary } from "./army-warning-copy";
+
+const READY_INPUTS = {
+  currentStamina: 90,
+  minTravelStamina: 20,
+  minExploreStamina: 30,
+  travelFoodCosts: { wheatPayAmount: 500, fishPayAmount: 0 },
+  exploreFoodCosts: { wheatPayAmount: 1_000, fishPayAmount: 0 },
+  food: { wheat: 2_000, fish: 0 },
+};
+
+describe("deriveArmyMovementReadiness", () => {
+  it("is fully ready when stamina and food cover both actions", () => {
+    const readiness = deriveArmyMovementReadiness(READY_INPUTS);
+    expect(readiness.canTravel).toBe(true);
+    expect(readiness.canExplore).toBe(true);
+  });
+
+  it("blocks travel on missing wheat even at high stamina (the red-bar case)", () => {
+    const readiness = deriveArmyMovementReadiness({
+      ...READY_INPUTS,
+      food: { wheat: 100, fish: 0 },
+    });
+    expect(readiness.canTravel).toBe(false);
+    expect(readiness.hasTravelStaminaWarning).toBe(false);
+    expect(readiness.foodWarnings.travel.missingWheat).toBe(400);
+  });
+
+  it("keeps travel open when only the pricier explore is food-blocked", () => {
+    const readiness = deriveArmyMovementReadiness({
+      ...READY_INPUTS,
+      food: { wheat: 700, fish: 0 },
+    });
+    expect(readiness.canTravel).toBe(true);
+    expect(readiness.canExplore).toBe(false);
+  });
+
+  it("blocks travel below the cheapest neighbor's stamina cost", () => {
+    const readiness = deriveArmyMovementReadiness({
+      ...READY_INPUTS,
+      currentStamina: 10,
+    });
+    expect(readiness.canTravel).toBe(false);
+    expect(readiness.hasTravelStaminaWarning).toBe(true);
+  });
+
+  it("treats an unknown food balance (Infinity) as never blocking", () => {
+    const readiness = deriveArmyMovementReadiness({
+      ...READY_INPUTS,
+      food: { wheat: Number.POSITIVE_INFINITY, fish: Number.POSITIVE_INFINITY },
+    });
+    expect(readiness.canTravel).toBe(true);
+    expect(readiness.foodWarnings.combined.hasWarning).toBe(false);
+  });
+});
+
+describe("formatTravelBlockedSummary", () => {
+  const formatAmount = (amount: number) => `${amount}`;
+
+  it("names both missing stamina and missing wheat", () => {
+    expect(
+      formatTravelBlockedSummary({
+        staminaBlocked: true,
+        minTravelStamina: 25,
+        missingWheat: 1_240,
+        missingFish: 0,
+        wheatLabel: "wheat",
+        formatAmount,
+      }),
+    ).toBe("Cannot travel — needs 25+ stamina and 1240 wheat");
+  });
+
+  it("returns null when nothing is missing", () => {
+    expect(
+      formatTravelBlockedSummary({
+        staminaBlocked: false,
+        minTravelStamina: 25,
+        missingWheat: 0,
+        missingFish: 0,
+        wheatLabel: "wheat",
+        formatAmount,
+      }),
+    ).toBeNull();
+  });
+});

--- a/client/apps/game/src/ui/features/world/components/armies/army-movement-readiness.ts
+++ b/client/apps/game/src/ui/features/world/components/armies/army-movement-readiness.ts
@@ -1,0 +1,134 @@
+import { useMemo } from "react";
+
+import { useCurrentArmiesTick, useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
+import {
+  computeExploreFoodCosts,
+  computeTravelFoodCosts,
+  configManager,
+  divideByPrecision,
+  ResourceManager,
+  StaminaManager,
+} from "@bibliothecadao/eternum";
+import { ClientComponents, getNeighborHexes, ResourcesIds, TroopType } from "@bibliothecadao/types";
+import { ComponentValue } from "@dojoengine/recs";
+import { getArmyMovementFoodRequirementWarnings, getArmyStaminaRequirementWarnings } from "./army-warning-copy";
+
+type ExplorerTroopsValue = ComponentValue<ClientComponents["ExplorerTroops"]["schema"]>;
+type ResourceValue = ComponentValue<ClientComponents["Resource"]["schema"]>;
+
+interface ArmyFoodCosts {
+  wheatPayAmount: number;
+  fishPayAmount: number;
+}
+
+/**
+ * The single source of truth for "can this army take a move action right
+ * now" — stamina and food together. The stamina bar's color and the
+ * readiness icons both render from this; nothing re-derives it locally.
+ */
+export interface ArmyMovementReadiness {
+  canTravel: boolean;
+  canExplore: boolean;
+  hasTravelStaminaWarning: boolean;
+  hasExploreStaminaWarning: boolean;
+  foodWarnings: ReturnType<typeof getArmyMovementFoodRequirementWarnings>;
+  minTravelStamina: number;
+  minExploreStamina: number;
+}
+
+export const deriveArmyMovementReadiness = ({
+  currentStamina,
+  minTravelStamina,
+  minExploreStamina,
+  travelFoodCosts,
+  exploreFoodCosts,
+  food,
+}: {
+  currentStamina: number;
+  minTravelStamina: number;
+  minExploreStamina: number;
+  travelFoodCosts: ArmyFoodCosts;
+  exploreFoodCosts: ArmyFoodCosts;
+  food: { wheat: number; fish: number };
+}): ArmyMovementReadiness => {
+  const foodWarnings = getArmyMovementFoodRequirementWarnings({ travelFoodCosts, exploreFoodCosts, food });
+  const { hasTravelStaminaWarning, hasExploreStaminaWarning } = getArmyStaminaRequirementWarnings({
+    currentStamina,
+    minTravelStamina,
+    minExploreStamina,
+  });
+
+  return {
+    canTravel: !hasTravelStaminaWarning && !foodWarnings.travel.hasWarning,
+    canExplore: !hasExploreStaminaWarning && !foodWarnings.explore.hasWarning,
+    hasTravelStaminaWarning,
+    hasExploreStaminaWarning,
+    foodWarnings,
+    minTravelStamina,
+    minExploreStamina,
+  };
+};
+
+export const useArmyMovementReadiness = (
+  army: ExplorerTroopsValue | null | undefined,
+  structureResources: ResourceValue | null | undefined,
+): ArmyMovementReadiness | null => {
+  const currentArmiesTick = useCurrentArmiesTick();
+  const currentDefaultTick = useCurrentDefaultTick();
+
+  return useMemo(() => {
+    if (!army) return null;
+
+    const movementFoodCosts = army.owner
+      ? { travel: computeTravelFoodCosts(army.troops), explore: computeExploreFoodCosts(army.troops) }
+      : {
+          travel: { wheatPayAmount: 0, fishPayAmount: 0 },
+          explore: { wheatPayAmount: 0, fishPayAmount: 0 },
+        };
+
+    return deriveArmyMovementReadiness({
+      currentStamina: Number(StaminaManager.getStamina(army.troops, currentArmiesTick).amount),
+      minTravelStamina: resolveCheapestNeighborTravelStamina(army),
+      minExploreStamina: configManager.getExploreStaminaCost(),
+      travelFoodCosts: movementFoodCosts.travel,
+      exploreFoodCosts: movementFoodCosts.explore,
+      food: resolveStructureFoodBalance(structureResources, currentDefaultTick),
+    });
+  }, [army, structureResources, currentArmiesTick, currentDefaultTick]);
+};
+
+// Cannot use an instantiated resource manager here: it reads RECS, which is
+// only synced for the local player's armies. An absent balance is treated as
+// unbounded — an unknown balance must never paint the army blocked.
+const resolveStructureFoodBalance = (
+  structureResources: ResourceValue | null | undefined,
+  currentDefaultTick: number,
+): { wheat: number; fish: number } => {
+  if (!structureResources) {
+    return { wheat: Number.POSITIVE_INFINITY, fish: Number.POSITIVE_INFINITY };
+  }
+
+  const { balance: wheat } = ResourceManager.balanceWithProduction(
+    structureResources,
+    currentDefaultTick,
+    ResourcesIds.Wheat,
+  );
+  const { balance: fish } = ResourceManager.balanceWithProduction(
+    structureResources,
+    currentDefaultTick,
+    ResourcesIds.Fish,
+  );
+
+  return { wheat: divideByPrecision(wheat), fish: divideByPrecision(fish) };
+};
+
+const resolveCheapestNeighborTravelStamina = (army: ExplorerTroopsValue): number => {
+  const neighbors = getNeighborHexes(army.coord.x, army.coord.y);
+  return neighbors.reduce((min, neighbor) => {
+    const staminaCost = configManager.getTravelStaminaCost(
+      configManager.getBiome(neighbor.col, neighbor.row),
+      army.troops.category as TroopType,
+    );
+    return min === 0 ? staminaCost : Math.min(min, staminaCost);
+  }, 0);
+};

--- a/client/apps/game/src/ui/features/world/components/armies/army-warning-copy.ts
+++ b/client/apps/game/src/ui/features/world/components/armies/army-warning-copy.ts
@@ -114,3 +114,29 @@ export const getArmyReadinessTitle = ({
 
   return "Ready to travel or explore";
 };
+
+/** Tooltip for a movement-blocked stamina bar; null when travel is possible. */
+export const formatTravelBlockedSummary = ({
+  staminaBlocked,
+  minTravelStamina,
+  missingWheat,
+  missingFish,
+  wheatLabel,
+  formatAmount,
+}: {
+  staminaBlocked: boolean;
+  minTravelStamina: number;
+  missingWheat: number;
+  missingFish: number;
+  wheatLabel: string;
+  formatAmount: (amount: number) => string;
+}): string | null => {
+  const requirements = [
+    staminaBlocked ? `${minTravelStamina}+ stamina` : null,
+    formatArmyFoodRequirement({ missingWheat, missingFish, wheatLabel, formatAmount }) || null,
+  ].filter(Boolean);
+
+  if (requirements.length === 0) return null;
+
+  return `Cannot travel — needs ${requirements.join(" and ")}`;
+};

--- a/client/apps/game/src/ui/features/world/components/armies/army-warning.tsx
+++ b/client/apps/game/src/ui/features/world/components/armies/army-warning.tsx
@@ -2,110 +2,24 @@ import Route from "lucide-react/dist/esm/icons/route";
 import Telescope from "lucide-react/dist/esm/icons/telescope";
 import Wheat from "lucide-react/dist/esm/icons/wheat";
 import type { ReactNode } from "react";
-import { useMemo } from "react";
 
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { useBlockTimestampStore } from "@/hooks/store/use-block-timestamp-store";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { formatNumber } from "@/ui/utils/utils";
-import { getBlockTimestamp } from "@bibliothecadao/eternum";
 
-import {
-  computeExploreFoodCosts,
-  computeTravelFoodCosts,
-  configManager,
-  divideByPrecision,
-  ResourceManager,
-  StaminaManager,
-} from "@bibliothecadao/eternum";
-import { ClientComponents, getNeighborHexes, ResourcesIds, TroopType } from "@bibliothecadao/types";
-import { ComponentValue } from "@dojoengine/recs";
-import {
-  formatArmyFoodRequirement,
-  getArmyMovementFoodRequirementWarnings,
-  getArmyFoodRequirementLabel,
-  getArmyReadinessTitle,
-  getArmyStaminaRequirementWarnings,
-} from "./army-warning-copy";
+import type { ArmyMovementReadiness } from "./army-movement-readiness";
+import { formatArmyFoodRequirement, getArmyFoodRequirementLabel, getArmyReadinessTitle } from "./army-warning-copy";
 
 interface ArmyWarningProps {
-  army: ComponentValue<ClientComponents["ExplorerTroops"]["schema"]>;
-  explorerResources: ComponentValue<ClientComponents["Resource"]["schema"]>;
-  structureResources: ComponentValue<ClientComponents["Resource"]["schema"]>;
-  currentArmiesTick?: number;
+  readiness: ArmyMovementReadiness;
 }
 
-export const ArmyWarning = ({
-  army,
-  explorerResources,
-  structureResources,
-  currentArmiesTick: currentArmiesTickProp,
-}: ArmyWarningProps) => {
+export const ArmyWarning = ({ readiness }: ArmyWarningProps) => {
   const gameMode = useGameModeConfig();
   const foodRequirementLabel = getArmyFoodRequirementLabel(gameMode.id);
 
-  const food = useMemo(() => {
-    // cannot use instantiated resource manager because it uses recs, which isn't synced for all armies (only yours)
-    const { balance: wheat } = ResourceManager.balanceWithProduction(
-      structureResources,
-      getBlockTimestamp().currentDefaultTick,
-      ResourcesIds.Wheat,
-    );
-    const { balance: fish } = ResourceManager.balanceWithProduction(
-      structureResources,
-      getBlockTimestamp().currentDefaultTick,
-      ResourcesIds.Fish,
-    );
-    return { wheat: divideByPrecision(wheat), fish: divideByPrecision(fish) };
-  }, [structureResources, army.owner]);
-
-  const movementFoodCosts = useMemo(
-    () =>
-      !army?.owner
-        ? {
-            travel: { wheatPayAmount: 0, fishPayAmount: 0 },
-            explore: { wheatPayAmount: 0, fishPayAmount: 0 },
-          }
-        : {
-            travel: computeTravelFoodCosts(army.troops),
-            explore: computeExploreFoodCosts(army.troops),
-          },
-    [army],
-  );
-
-  const foodWarnings = getArmyMovementFoodRequirementWarnings({
-    travelFoodCosts: movementFoodCosts.travel,
-    exploreFoodCosts: movementFoodCosts.explore,
-    food,
-  });
-
-  const storeArmiesTick = useBlockTimestampStore((state) => state.currentArmiesTick);
-  const currentArmiesTick = currentArmiesTickProp ?? storeArmiesTick;
-
-  const stamina = useMemo(() => {
-    return StaminaManager.getStamina(army.troops, currentArmiesTick);
-  }, [army, currentArmiesTick]);
-
-  const minStaminaNeeded = useMemo(() => {
-    const neighbors = getNeighborHexes(army.coord.x, army.coord.y);
-    return neighbors.reduce((min, neighbor) => {
-      const staminaCost = configManager.getTravelStaminaCost(
-        configManager.getBiome(neighbor.col, neighbor.row),
-        army.troops.category as TroopType,
-      );
-      return min === 0 ? staminaCost : Math.min(min, staminaCost);
-    }, 0);
-  }, [army.coord.x, army.coord.y, army.troops.category]);
-
-  const minStaminaNeededExplore = useMemo(() => {
-    return configManager.getExploreStaminaCost();
-  }, []);
-
-  const { hasTravelStaminaWarning, hasExploreStaminaWarning } = getArmyStaminaRequirementWarnings({
-    currentStamina: Number(stamina.amount),
-    minTravelStamina: minStaminaNeeded,
-    minExploreStamina: minStaminaNeededExplore,
-  });
+  const { hasTravelStaminaWarning, hasExploreStaminaWarning, foodWarnings, minTravelStamina, minExploreStamina } =
+    readiness;
 
   const hasTravelFoodWarning = foodWarnings.travel.hasWarning;
   const hasExploreFoodWarning = foodWarnings.explore.hasWarning;
@@ -124,7 +38,7 @@ export const ArmyWarning = ({
     label: "Travel",
     readyLabel: "Travel ready",
     requirements: [
-      hasTravelStaminaWarning ? `${minStaminaNeeded}+ stamina` : null,
+      hasTravelStaminaWarning ? `${minTravelStamina}+ stamina` : null,
       hasTravelFoodWarning ? missingTravelFoodText : null,
     ],
   });
@@ -132,7 +46,7 @@ export const ArmyWarning = ({
     label: "Explore",
     readyLabel: "Explore ready",
     requirements: [
-      hasExploreStaminaWarning ? `${minStaminaNeededExplore}+ stamina` : null,
+      hasExploreStaminaWarning ? `${minExploreStamina}+ stamina` : null,
       hasExploreFoodWarning ? missingExploreFoodText : null,
     ],
   });

--- a/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
+++ b/client/apps/game/src/ui/features/world/components/entities/banner/army-banner-entity-detail.tsx
@@ -17,10 +17,12 @@ import {
   STAMINA_RECHARGING_TRACK_CLASS,
 } from "@/ui/shared/lib/stamina-visuals";
 import { resolveStaminaDisplay } from "@/ui/shared/lib/stamina-display";
-import { configManager } from "@bibliothecadao/eternum";
-import { BiomeType, EntityType, ID, RelicRecipientType, TroopType } from "@bibliothecadao/types";
+import { formatNumber } from "@/ui/utils/utils";
+import { EntityType, ID, RelicRecipientType } from "@bibliothecadao/types";
 import { ActiveRelicEffects } from "../active-relic-effects";
+import { useArmyMovementReadiness } from "../../armies/army-movement-readiness";
 import { ArmyWarning } from "../../armies/army-warning";
+import { formatTravelBlockedSummary, getArmyFoodRequirementLabel } from "../../armies/army-warning-copy";
 import { buildDisplayItems, CompactEntityInventory, countDisplayItems } from "../compact-entity-inventory";
 import { useArmyEntityDetail } from "../hooks/use-army-entity-detail";
 import { EntityDetailLayoutVariant } from "../layout";
@@ -67,6 +69,7 @@ const ArmyBannerEntityDetailContent = memo(
     );
     const inventoryCounts = useMemo(() => countDisplayItems(inventoryItems), [inventoryItems]);
     const resolvedWorldMode = useResolvedWorldGameMode();
+    const movementReadiness = useArmyMovementReadiness(explorer, structureResources);
     const ownerUsername = derivedData?.addressName ?? null;
     const { data: ownerProfileByUsername } = usePlayerAvatarByUsername(ownerUsername);
     const ownerAvatarUrl = ownerProfileByUsername?.avatarUrl ?? null;
@@ -98,6 +101,17 @@ const ArmyBannerEntityDetailContent = memo(
       : "border-red-400/40 bg-red-400/15 text-red-200";
     const currentStamina = derivedData.staminaDisplay?.displayCurrent ?? Number(derivedData.stamina.amount);
     const maxStamina = derivedData.maxStamina;
+    const travelBlocked = movementReadiness ? !movementReadiness.canTravel : false;
+    const travelBlockedTitle = movementReadiness
+      ? formatTravelBlockedSummary({
+          staminaBlocked: movementReadiness.hasTravelStaminaWarning,
+          minTravelStamina: movementReadiness.minTravelStamina,
+          missingWheat: movementReadiness.foodWarnings.travel.missingWheat,
+          missingFish: movementReadiness.foodWarnings.travel.missingFish,
+          wheatLabel: getArmyFoodRequirementLabel(resolvedWorldMode),
+          formatAmount: (amount) => formatNumber(amount, 0),
+        })
+      : null;
     const showResourceInventoryInline = shouldShowArmyResourceInventoryTab(
       resolvedWorldMode,
       inventoryCounts.resources,
@@ -167,15 +181,9 @@ const ArmyBannerEntityDetailContent = memo(
               currentStamina={currentStamina}
               maxStamina={maxStamina}
               isRecharging={derivedData.staminaDisplay?.isRecharging}
-              rightAccessory={
-                hasWarnings && explorerResources && structureResources ? (
-                  <ArmyWarning
-                    army={explorer}
-                    explorerResources={explorerResources}
-                    structureResources={structureResources}
-                  />
-                ) : null
-              }
+              travelBlocked={travelBlocked}
+              travelBlockedTitle={travelBlockedTitle}
+              rightAccessory={hasWarnings && movementReadiness ? <ArmyWarning readiness={movementReadiness} /> : null}
             />
           ) : null}
           {showRelicsInline && (
@@ -253,11 +261,15 @@ const InlineStaminaBar = ({
   currentStamina,
   maxStamina,
   isRecharging,
+  travelBlocked,
+  travelBlockedTitle,
   rightAccessory,
 }: {
   currentStamina: number;
   maxStamina: number;
   isRecharging?: boolean | null;
+  travelBlocked?: boolean;
+  travelBlockedTitle?: string | null;
   rightAccessory?: ReactNode;
 }) => {
   if (maxStamina === 0) return null;
@@ -265,21 +277,22 @@ const InlineStaminaBar = ({
     current: currentStamina,
     max: maxStamina,
   });
-  const minTravelCost = configManager.getTravelStaminaCost(BiomeType.Ocean, TroopType.Crossbowman);
   const recharging = isRecharging ?? isStaminaRecharging(displayedCurrent, maxStamina);
 
-  let fillClass = "bg-progress-bar-danger";
-  if (displayedCurrent >= minTravelCost) {
-    fillClass =
-      displayPercentage > 66
-        ? "bg-progress-bar-good"
-        : displayPercentage > 33
-          ? "bg-progress-bar-medium"
-          : "bg-progress-bar-danger";
-  }
+  // Red exclusively means "this army cannot take its cheapest move right now"
+  // (stamina- or food-blocked); low-but-movable stamina renders amber so the
+  // blocked signal stays unambiguous. The readiness icons say why.
+  const fillClass = travelBlocked
+    ? "bg-progress-bar-danger"
+    : displayPercentage > 66
+      ? "bg-progress-bar-good"
+      : "bg-progress-bar-medium";
 
   return (
-    <div className="flex items-center gap-2 text-xxs text-gold/80">
+    <div
+      className="flex items-center gap-2 text-xxs text-gold/80"
+      title={travelBlocked ? (travelBlockedTitle ?? undefined) : undefined}
+    >
       <Lightning className={cn("h-3 w-3 fill-order-power", recharging && STAMINA_RECHARGING_TEXT_CLASS)} />
       <div
         className={cn(

--- a/packages/provider/src/classify-transaction-error.test.ts
+++ b/packages/provider/src/classify-transaction-error.test.ts
@@ -102,4 +102,52 @@ describe("extractErrorMessage", () => {
     );
     expect(extractErrorMessage({ weird: true }, "fallback")).toBe("fallback");
   });
+
+  // Shapes pinned from the Aug 19 playtest: the controller wraps katana's
+  // submission-time rejection as {code: 41, message: "An error occurred
+  // (TRANSACTION_EXECUTION_ERROR)", data: <Cairo trace>}. The wrapper must
+  // classify as generic or the extractor returns it and the real revert
+  // (which the automation resync predicate keys on) never surfaces.
+  describe("Cartridge 'An error occurred (<CODE>)' wrapper", () => {
+    const WRAPPER = "An error occurred (TRANSACTION_EXECUTION_ERROR)";
+    const REVERT = "Insufficient Balance: COPPER (id: 32230, balance: 210000000000) < 796000000000";
+    // data as the raw JSON text katana returns: \" and \n are escape
+    // sequences inside the string, exactly as they appear on the wire.
+    const RAW_JSON_TRACE =
+      'Transaction execution error: {"execution_error":"Transaction execution has failed:\\n' +
+      "0: Error in the called contract (contract address: 0x015b24, class hash: 0x0743c8, selector: 0x015d40):\\n" +
+      "Execution failed. Failure reason:\\n" +
+      "(0x617267656e742f6d756c746963616c6c2d6661696c6564 ('argent/multicall-failed'), 0x0 (''), " +
+      `\\"${REVERT}\\", 0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED')).\\n",` +
+      '"transaction_index":0}';
+
+    it("digs past the wrapper into a raw-JSON trace in data and skips the multicall frame", () => {
+      expect(extractErrorMessage({ code: 41, message: WRAPPER, data: RAW_JSON_TRACE })).toBe(REVERT);
+    });
+
+    it("digs past the wrapper into a parsed execution_error object in data", () => {
+      const parsedTrace = {
+        execution_error:
+          "Transaction execution has failed:\nExecution failed. Failure reason:\n" +
+          `(0x617267656e742f6d756c746963616c6c2d6661696c6564 ('argent/multicall-failed'), 0x0 (''), "${REVERT}", ` +
+          "0x454e545259504f494e545f4641494c4544 ('ENTRYPOINT_FAILED')).",
+      };
+      expect(extractErrorMessage({ code: 41, message: WRAPPER, data: parsedTrace })).toBe(REVERT);
+    });
+
+    it("returns the fallback, never the wrapper, when data carries no trace", () => {
+      expect(extractErrorMessage({ code: 41, message: WRAPPER }, "fallback")).toBe("fallback");
+    });
+
+    it("classifies the wrapped code-41 error as reverted with the real reason", () => {
+      const classified = classifyTransactionError({ code: 41, message: WRAPPER, data: RAW_JSON_TRACE });
+      expect(classified.kind).toBe("reverted");
+      expect(classified.reason).toBe(REVERT);
+    });
+
+    it("extracts the revert from a raw starknet.js estimateFee rejection (preflight abort path)", () => {
+      const estimateError = new Error(`RPC: starknet_estimateFee with params {}\n\n 41: ${RAW_JSON_TRACE}`);
+      expect(extractErrorMessage(estimateError)).toBe(REVERT);
+    });
+  });
 });

--- a/packages/provider/src/classify-transaction-error.ts
+++ b/packages/provider/src/classify-transaction-error.ts
@@ -25,6 +25,10 @@ const GENERIC_ERROR_MESSAGES = new Set([
   "reason",
 ]);
 const GENERIC_ERROR_PREFIXES = ["transaction execution error:", "rpc error:", "rpc:"];
+// Cartridge controller wraps failures as "An error occurred (<ERROR_CODE>)"
+// with the actual Cairo trace in `data`. The wrapper must classify as generic
+// or the extractor returns it and never descends into the trace.
+const CARTRIDGE_WRAPPER_PATTERN = /^an error occurred \([a-z0-9_ ]+\)$/;
 const WRAPPED_ERROR_PREFIXES = [
   "Transaction failed to submit:",
   "Transaction failed while waiting for confirmation:",
@@ -74,8 +78,7 @@ const asReasonCandidate = (value: string): string | null => {
     return null;
   }
 
-  const normalized = normalizeErrorKey(reason);
-  if (GENERIC_ERROR_MESSAGES.has(normalized) || isWrappedGenericErrorMessage(reason) || isProtocolErrorCode(reason)) {
+  if (isGenericErrorMessage(reason)) {
     return null;
   }
 
@@ -185,6 +188,7 @@ const isGenericErrorMessage = (message: string): boolean => {
   if (
     GENERIC_ERROR_MESSAGES.has(normalized) ||
     GENERIC_ERROR_PREFIXES.some((prefix) => normalized.startsWith(prefix)) ||
+    CARTRIDGE_WRAPPER_PATTERN.test(normalized) ||
     isProtocolErrorCode(message)
   ) {
     return true;

--- a/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
+++ b/packages/provider/src/execute-and-check-transaction.l2-gas.test.ts
@@ -406,8 +406,79 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
     expect(payload?.error).toBeUndefined();
   });
 
+  it("aborts the submit when the fee estimate proves a deterministic revert", async () => {
+    const provider = makeProvider();
+    const estimateError = {
+      code: 41,
+      message: "An error occurred (TRANSACTION_EXECUTION_ERROR)",
+      data: {
+        execution_error:
+          "Execution failed. Failure reason: 0x506f70756c6174696f6e2065786365656473206361706163697479 ('Population exceeds capacity').",
+      },
+    };
+
+    const signer = {
+      estimateInvokeFee: vi.fn().mockRejectedValue(estimateError),
+    };
+    const call: Call = {
+      contractAddress: "0x1",
+      entrypoint: "settle_realms",
+      calldata: [],
+    };
+
+    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBe(estimateError);
+
+    // The estimate already executed the calls and proved they revert — the
+    // doomed transaction must never reach the paymaster.
+    expect(provider.execute).not.toHaveBeenCalled();
+    expect(findTransactionFailedPayload(provider)).toMatchObject({
+      message: "Transaction failed to submit: Population exceeds capacity",
+      stage: "submit",
+      errorCode: 41,
+    });
+  });
+
+  it("keeps the default-details fallback for VRF multicalls whose estimate reverts", async () => {
+    const provider = makeProvider();
+    provider.VRF_PROVIDER_ADDRESS = "0x999";
+    const estimateError = {
+      code: 41,
+      message: "An error occurred (TRANSACTION_EXECUTION_ERROR)",
+      data: {
+        execution_error: "Execution failed. Failure reason: 0x0 ('Randomness not fulfilled').",
+      },
+    };
+
+    const signer = {
+      address: "0xabc",
+      estimateInvokeFee: vi.fn().mockRejectedValue(estimateError),
+    };
+    const calls: Call[] = [
+      {
+        contractAddress: "0x999",
+        entrypoint: "request_random",
+        calldata: ["0x123", 0, "0xabc"],
+      },
+      {
+        contractAddress: "0x123",
+        entrypoint: "open_chest",
+        calldata: [],
+      },
+    ];
+
+    // consume_random can revert at estimate time (no submit_random yet) and
+    // still succeed at execution once the VRF server front-runs it.
+    const result = await provider.executeAndCheckTransaction(signer, calls, undefined, {
+      waitForConfirmation: false,
+    });
+
+    expect(result).toMatchObject({ statusReceipt: "PENDING", transaction_hash: "0xabc" });
+    expect(provider.execute.mock.calls[0][3]).toEqual({ version: 3 });
+  });
+
   it("prefers a recent fee-estimate error when the submit error is uninformative", async () => {
     const provider = makeProvider();
+    provider.VRF_PROVIDER_ADDRESS = "0x999";
     const estimateError = {
       code: 41,
       message: "Transaction execution error",
@@ -419,17 +490,27 @@ describe("EternumProvider.executeAndCheckTransaction gas bounds", () => {
     provider.execute = vi.fn().mockRejectedValue({});
 
     const signer = {
+      address: "0xabc",
       estimateInvokeFee: vi.fn().mockRejectedValue(estimateError),
     };
-    const call: Call = {
-      contractAddress: "0x1",
-      entrypoint: "settle_realms",
-      calldata: [],
-    };
+    const calls: Call[] = [
+      {
+        contractAddress: "0x999",
+        entrypoint: "request_random",
+        calldata: ["0x123", 0, "0xabc"],
+      },
+      {
+        contractAddress: "0x123",
+        entrypoint: "open_chest",
+        calldata: [],
+      },
+    ];
 
-    await expect(provider.executeAndCheckTransaction(signer, call)).rejects.toBeDefined();
+    // The estimate error is thrown to callers, not only stashed in the
+    // payload: downstream revert classifiers key on its trace.
+    await expect(provider.executeAndCheckTransaction(signer, calls)).rejects.toBe(estimateError);
 
-    // Estimate failure must not block submission — execute still ran.
+    // VRF exemption: estimate failure must not block submission — execute ran.
     expect(provider.execute).toHaveBeenCalledTimes(1);
     expect(findTransactionFailedPayload(provider)).toMatchObject({
       message: "Transaction failed to submit: Unknown error",

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -684,12 +684,30 @@ export class EternumProvider extends EnhancedDojoProvider {
         resourceBounds,
       };
     } catch (error) {
+      if (this.shouldAbortSubmitAfterEstimateRevert(error, transactionDetails)) {
+        throw error;
+      }
       // Submission proceeds with default v3 details, but the estimate error is
       // the richest failure signal we get — stash it for the failure payload.
       this.lastEstimateError = { error, atMs: Date.now() };
       console.warn("[provider] Failed to estimate invoke fee, using default v3 tx details", error);
       return details;
     }
+  }
+
+  /**
+   * A fee estimate that failed with an execution revert has already run the
+   * calls and proven they fail deterministically — submitting anyway only
+   * lands a doomed transaction on the paymaster and buries the revert reason
+   * under the controller's generic wrapper. VRF multicalls are the one
+   * exception: their consume_random can revert at estimate time (no
+   * submit_random on chain yet) and still succeed at execution once the VRF
+   * server front-runs it. A marginal tx that would pass one block later is
+   * rejected too; callers retry (automation next tick, players re-click).
+   */
+  private shouldAbortSubmitAfterEstimateRevert(error: unknown, transactionDetails: AllowArray<Call>): boolean {
+    if (classifyTransactionError(error).kind !== "reverted") return false;
+    return this.getVrfRequestRandomCalls(transactionDetails).length === 0;
   }
 
   private takeRecentEstimateError(): unknown {
@@ -1009,6 +1027,10 @@ export class EternumProvider extends EnhancedDojoProvider {
             cacheKey: executionDetailsCacheKey,
           })
         : undefined;
+    // The prefetch can reject (preflight abort) before the guard/lock awaits
+    // below reach it; park a handler so the window never surfaces as an
+    // unhandled rejection. The await inside the try still observes the error.
+    executionDetailsPromise?.catch(() => {});
 
     await this.runTransactionSubmitGuard(signer, transactionMeta);
 
@@ -1026,15 +1048,17 @@ export class EternumProvider extends EnhancedDojoProvider {
       }
     }
 
-    const executionDetails = executionDetailsPromise
-      ? await executionDetailsPromise
-      : await this.getV3ExecutionDetails(signer, transactionDetails, {
-          cacheKey: executionDetailsCacheKey,
-        });
-
     let tx;
     let submitPromise: Promise<{ transaction_hash: string }> | undefined;
     try {
+      // Resolved inside the try so a preflight abort (the estimate proved a
+      // deterministic revert) rides the same failure emission and VRF-lock
+      // release as a submit failure.
+      const executionDetails = executionDetailsPromise
+        ? await executionDetailsPromise
+        : await this.getV3ExecutionDetails(signer, transactionDetails, {
+            cacheKey: executionDetailsCacheKey,
+          });
       submitPromise = this.submitTransaction(signer, transactionDetails, executionDetails, {
         executionDetailsCacheKey,
       });
@@ -1052,14 +1076,18 @@ export class EternumProvider extends EnhancedDojoProvider {
         releaseVrfExecutionLock?.();
         releaseVrfExecutionLock = undefined;
       }
+      // Throw the resolved error too: when the submit error decoded to
+      // nothing actionable, callers (automation's revert classifier, toasts)
+      // need the stashed estimate trace as much as the diagnostics do.
+      const resolvedError = this.resolveSubmitFailureError(error, message);
       this.emitTransactionFailure({
         ...transactionMeta,
         message: `Transaction failed to submit: ${message}`,
         stage: "submit",
         ...submitFailure,
-        ...buildFailureDiagnostics(this.resolveSubmitFailureError(error, message)),
+        ...buildFailureDiagnostics(resolvedError),
       });
-      throw error;
+      throw resolvedError;
     }
 
     // Emit immediately so UI can show pending state


### PR DESCRIPTION
Two changes, both shipped per owner ruling in this session.

## 1. Provider: surface real revert reasons and abort doomed submits

Tonight's playtest logs (Aug 19, 20:00–20:23 UTC) showed the BL-5 automation resync never firing: 32 identical `Insufficient Balance: COPPER` plan failures across 3 realms, zero projection-overshoot warns. The revert text was present in every failure — the provider was discarding it at three points, all fixed here:

1. **Classify the Cartridge wrapper as generic.** The controller wraps katana's submission-time rejection as `{code: 41, message: "An error occurred (TRANSACTION_EXECUTION_ERROR)", data: <Cairo trace>}`. `extractErrorMessage` returned `record.message` before descending into `data` because the wrapper string wasn't classified generic. `asReasonCandidate` had a partial copy of the generic checks (the wrapper also leaked through the JSON-serialize fallback), so it now shares the one classifier.

2. **Abort the submit when the estimate already proved a deterministic revert.** `estimateInvokeFee` executes the calls; when it fails with an execution revert, the tx is doomed — submitting anyway just landed 32 known-dead txs on the paymaster in 11 minutes from one player (feeds the relayer lock contention). VRF multicalls keep the fallback: their `consume_random` can revert at estimate time (no `submit_random` yet) and still succeed once the VRF server front-runs it. The details await moved inside the submit try so the abort rides the existing failure emission and VRF-lock release.

3. **Throw the resolved submit error.** The catch computed `resolveSubmitFailureError` (which prefers a stashed estimate trace when the submit error decodes to nothing) for diagnostics but threw the raw error — callers never saw the trace. Now diagnostics and throw share the resolved error.

Net effect: the automation resync predicate finally sees `insufficient balance:` and fires, toasts show the real revert instead of the wrapper, and doomed transactions stop hitting the paymaster.

## 2. Client: army tile stamina bar goes red when the army cannot move

The ARMY TILE panel computed "can this army move" twice, differently: the stamina bar colored by raw stamina against a hardcoded `(Ocean, Crossbowman)` travel cost, while the readiness icons recomputed real neighbor-min stamina plus travel/explore food costs. At 90/120 stamina with no wheat, the bar said "go" while the wheat icon said "blocked".

One resolver (`useArmyMovementReadiness`) now feeds both the bar color and the readiness icons; the heuristic and `ArmyWarning`'s duplicate cost math are deleted into it. The bar's red now means exactly one thing — "this army cannot take its cheapest move right now" (stamina- or food-blocked; travel-only trigger per owner ruling) — with fill width still true to stamina, amber for low-but-movable, and a tooltip naming what's missing ("Cannot travel — needs 25+ stamina and 1,240 wheat"). An unknown structure balance never paints the army blocked.

## Verification

- Provider vitest: 88/88, including new tests pinning the exact wrapper shape from tonight's log (raw-JSON trace in `data`, parsed `execution_error` object, trace-less wrapper → fallback), the preflight abort (execute never called, payload carries the real reason), the VRF exemption (fallback preserved, default v3 details), and the estimate-error throw-through. The prior test asserting "estimate failure must not block submission" for a plain call pinned exactly the removed behavior; re-pinned as VRF-shaped, where the fallback legitimately survives.
- Client: new unit tests for the readiness derivation (wheat-blocked at full stamina, explore-only-blocked keeps travel open, unknown balance never blocks) and the tooltip copy; `use-army-entity-detail.stamina-sync` still green; `tsc --noEmit` clean.
- `pnpm -w run build:packages`, `pnpm run format`, `pnpm run knip` all green.

## Non-goals

starknet v10 tip-estimator noise (192 ERROR lines/game), the `s2-resource_systems.approve` session-policy deprecation, the transfer-runner resync sibling, and adopting the readiness resolver in other army stamina bars (army-chip, armies panel) stay on the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)