### PR TITLE
Let players choose uncapped or 60 FPS rendering

### DIFF
--- a/apps/game/src/three/characters/collision/procedural-collision-profile.ts
+++ b/apps/game/src/three/characters/collision/procedural-collision-profile.ts
@@ -75,10 +75,7 @@ export function createProceduralCollisionProfile(kind: ProceduralUnitKind, world
   };
 }
 
-export function createProceduralCollisionBudget(mode: "battery" | "benchmark" | "quality"): ProceduralCollisionBudget {
-  if (mode === "battery") {
-    return { maxActivePresentationBodies: 64, maxActiveRagdolls: 4, maxNeighborsPerBody: 8, maxPairResolutions: 512 };
-  }
+export function createProceduralCollisionBudget(mode: "benchmark" | "quality"): ProceduralCollisionBudget {
   if (mode === "benchmark") {
     return {
       maxActivePresentationBodies: 100,

--- a/apps/game/src/three/characters/procedural-army-character-layer.ts
+++ b/apps/game/src/three/characters/procedural-army-character-layer.ts
@@ -128,12 +128,15 @@ export class ProceduralArmyCharacterLayer {
   private readonly hitTargetGeometry = new BoxGeometry(1, 1, 1);
   private readonly hitTargetMaterial = new MeshBasicMaterial({ colorWrite: false, depthWrite: false });
   private readonly raycastHits: Intersection[] = [];
-  private readonly separationSimulation = new ProceduralSeparationSimulation();
+  private readonly collisionBudget: ProceduralCollisionBudget = createProceduralCollisionBudget("quality");
+  private readonly separationSimulation = new ProceduralSeparationSimulation({
+    maxNeighborsPerBody: this.collisionBudget.maxNeighborsPerBody,
+    maxPairResolutions: this.collisionBudget.maxPairResolutions,
+  });
   private readonly impactRegistry = new CombatImpactRegistry();
   private readonly expectedProjectileImpacts = new Map<number, number>();
   private readonly collisionCandidates: ProceduralArmyCharacterPresentation[] = [];
   private readonly separationInputs: ProceduralSeparationInput[] = [];
-  private collisionBudget: ProceduralCollisionBudget = createProceduralCollisionBudget("quality");
   private readonly projectileTargetCenter = new Vector3();
   private readonly projectileHitPoint = new Vector3();
   private readonly projectileImpactDirection = new Vector3();
@@ -334,18 +337,6 @@ export class ProceduralArmyCharacterLayer {
         [...this.actors.values()].filter(({ actor }) => actor.mode === "sinking").length +
         this.defeatedActors.filter(({ actor }) => actor.mode === "sinking").length,
     };
-  }
-
-  public setCollisionBudget(budget: ProceduralCollisionBudget): void {
-    this.collisionBudget = { ...budget };
-    this.separationSimulation.updateConfig({
-      maxNeighborsPerBody: budget.maxNeighborsPerBody,
-      maxPairResolutions: budget.maxPairResolutions,
-    });
-    while (this.defeatedActors.length > Math.max(1, budget.maxActiveRagdolls)) {
-      const defeated = this.defeatedActors.shift();
-      if (defeated) this.disposeDefeatedActor(defeated);
-    }
   }
 
   public getCollisionSnapshots(): ProceduralSeparationBodySnapshot[] {

--- a/apps/game/src/three/game-renderer.backend.test.ts
+++ b/apps/game/src/three/game-renderer.backend.test.ts
@@ -270,7 +270,7 @@ describe("GameRenderer backend seam", () => {
     };
     subject.camera = "camera";
     subject.lastTime = performance.now() - 16;
-    subject.getTargetFps = vi.fn(() => null);
+    subject.lastFrameTime = subject.lastTime;
     subject.updateWeatherPostProcessing = vi.fn();
     subject.supportRuntimeRegistry = {
       getEffectsBridge: vi.fn(() => undefined),

--- a/apps/game/src/three/game-renderer.runtime.test.ts
+++ b/apps/game/src/three/game-renderer.runtime.test.ts
@@ -163,7 +163,6 @@ describe("GameRenderer runtime harness", () => {
       .spyOn(window, "requestAnimationFrame")
       .mockImplementation((callback) => pendingFrames.push(callback));
     vi.spyOn(console, "error").mockImplementation(() => {});
-    subject.getTargetFps = vi.fn(() => null);
     harness.backend.renderFrame.mockImplementation(() => {
       throw frameError;
     });
@@ -231,12 +230,14 @@ describe("GameRenderer runtime harness", () => {
     subject.isRecoveringFromDeviceLoss = true;
     subject.isRendererRecoveryPaused = true;
     subject.lastTime = 100;
+    subject.lastFrameTime = 104;
 
     subject.handleDeviceLossFallbackFailure(new Error("fallback init failed"), "webgpu");
 
     expect(subject.isRecoveringFromDeviceLoss).toBe(false);
     expect(subject.isRendererRecoveryPaused).toBe(false);
     expect(subject.lastTime).toBe(0);
+    expect(subject.lastFrameTime).toBe(0);
     expect(animate).toHaveBeenCalledTimes(1);
     expect(sentry.captureException).toHaveBeenCalledWith(
       expect.any(Error),
@@ -255,7 +256,6 @@ describe("GameRenderer runtime harness", () => {
     const pendingFrames: FrameRequestCallback[] = [];
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => pendingFrames.push(callback));
-    subject.getTargetFps = vi.fn(() => null);
 
     harness.sceneManager.switchScene(SceneName.WorldMap);
     await vi.waitFor(() => expect(harness.worldmapScene.activateInputSurface).toHaveBeenCalledOnce());

--- a/apps/game/src/three/game-renderer.ts
+++ b/apps/game/src/three/game-renderer.ts
@@ -11,7 +11,6 @@ import { configureGltfTextureSupport, transitionDB } from "./utils/";
 import { trackGuiFolder, type TrackableGuiFolder } from "./utils/gui-folder-lifecycle";
 import {
   createRendererFrameFailureCircuit,
-  resolveRendererPacedFps,
   runRendererAnimationTick,
   type RendererFrameFailureCircuit,
 } from "./renderer-animation-runtime";
@@ -91,9 +90,9 @@ export default class GameRenderer {
   private hudScene!: HUDScene;
 
   private lastTime: number = 0;
+  private lastFrameTime: number = 0;
   private animationFrameHandle: number | null = null;
   private isAnimationLoopRunning = false;
-  private lastInteractionTime = performance.now();
   private dojo: SetupResult;
   private sceneManager!: SceneManager;
   private cleanupIntervals: NodeJS.Timeout[] = [];
@@ -147,10 +146,8 @@ export default class GameRenderer {
     const foundationRuntime = createRendererFoundationRuntime({
       isMobileDevice: this.isMobileDevice,
       onControlsChange: () => {
-        this.markRendererInteraction();
         this.supportRuntimeRegistry.getControlBridge().handleInteractionChange();
       },
-      onInteraction: () => this.markRendererInteraction(),
       warn: (message, error) => console.warn(message, error),
     });
 
@@ -320,6 +317,7 @@ export default class GameRenderer {
     this.isRecoveringFromDeviceLoss = false;
     this.isRendererRecoveryPaused = false;
     this.lastTime = 0;
+    this.lastFrameTime = 0;
 
     if (this.hasPreparedRendererScenes()) {
       this.animate();
@@ -330,6 +328,7 @@ export default class GameRenderer {
     this.isRecoveringFromDeviceLoss = false;
     this.isRendererRecoveryPaused = false;
     this.lastTime = 0;
+    this.lastFrameTime = 0;
     reportRendererRecoveryFailure(error, lostMode);
 
     if (!this.isDestroyed && this.hasPreparedRendererScenes()) {
@@ -463,18 +462,6 @@ export default class GameRenderer {
     return Math.min(pixelRatio, resolveRendererPixelRatioCap());
   }
 
-  private markRendererInteraction(): void {
-    this.lastInteractionTime = performance.now();
-  }
-
-  private getTargetFps(): number | null {
-    return resolveRendererPacedFps({
-      currentTime: performance.now(),
-      lastInteractionTime: this.lastInteractionTime,
-      profile: renderProfile,
-    });
-  }
-
   handleKeyEvent(event: KeyboardEvent): void {
     const { key } = event;
 
@@ -519,12 +506,13 @@ export default class GameRenderer {
       startGpuBackendFrame();
     }
 
-    this.lastTime = runRendererAnimationTick({
+    const timing = runRendererAnimationTick({
       getCurrentTime: () => performance.now(),
       getCycleProgress: () => useUIStore.getState().cycleProgress || 0,
       isDestroyed: shouldStopAnimationLoop,
       isLabelRuntimeReady: this.labelRuntime?.isReady() ?? false,
       lastTime: this.lastTime,
+      lastFrameTime: this.lastFrameTime,
       logDestroyed: (message) => {
         if (this.isDestroyed) {
           console.warn(message);
@@ -552,12 +540,14 @@ export default class GameRenderer {
         return rendered;
       },
       requestNextFrame: () => this.scheduleNextAnimationFrame(),
-      targetFPS: this.getTargetFps(),
+      targetFPS: renderProfile.maxFps,
       updateControls: () => {
         this.controls?.update();
       },
       updateStatsPanel: () => this.sessionRuntime.updateStatsPanel(),
     });
+    this.lastTime = timing.lastTime;
+    this.lastFrameTime = timing.lastFrameTime;
 
     if (shouldStopAnimationLoop) {
       this.stopAnimationLoop();

--- a/apps/game/src/three/managers/army-manager.ts
+++ b/apps/game/src/three/managers/army-manager.ts
@@ -4,8 +4,6 @@ import { gameWorkerManager } from "@/managers/game-worker-manager";
 import type { ProceduralMeleeContactEvent, ProceduralRangedReleaseEvent } from "@/three/characters";
 import type { ArrowImpactEvent } from "@/three/projectiles/arrow-projectile-system";
 import type { ProceduralImpactAuthority } from "@/three/characters/collision/procedural-impact";
-import { createProceduralCollisionBudget } from "@/three/characters/collision/procedural-collision-profile";
-import type { RenderMode } from "@/three/render-profile";
 import type { ProjectileSweepHit, ProjectileSweepRequest } from "@/three/projectiles/projectile-hit-query";
 import {
   ProceduralArmyCharacterLayer,
@@ -2228,10 +2226,6 @@ export class ArmyManager {
       fallbackRepresentationCount: Math.max(0, visibleArmyCount - this.activeProceduralArmyEntityIds.size),
       visibleArmyCount,
     };
-  }
-
-  public setProceduralCollisionMode(mode: RenderMode): void {
-    this.proceduralArmyCharacterLayer.setCollisionBudget(createProceduralCollisionBudget(mode));
   }
 
   public async startProceduralCharacterRagdoll(): Promise<void> {

--- a/apps/game/src/three/render-profile.test.ts
+++ b/apps/game/src/three/render-profile.test.ts
@@ -8,29 +8,16 @@ import {
 } from "./render-profile";
 
 describe("render profile", () => {
-  it("keeps Quality and Battery pixels identical", () => {
-    expect(createRenderProfile("battery").visuals).toEqual(createRenderProfile("quality").visuals);
+  it("changes only the frame limit between modes", () => {
+    const uncapped = createRenderProfile("uncapped");
+    const capped = createRenderProfile("capped");
+    expect(uncapped.maxFps).toBeNull();
+    expect(capped.maxFps).toBe(60);
+    expect(capped.visuals).toEqual(uncapped.visuals);
+    expect(uncapped.visuals.pixelRatio).toBe(RENDERER_PIXEL_RATIO_CAP);
   });
 
-  it("uses the renderer pixel-ratio cap as the visual profile value", () => {
-    expect(createRenderProfile("quality").visuals.pixelRatio).toBe(RENDERER_PIXEL_RATIO_CAP);
-    expect(RENDERER_PIXEL_RATIO_CAP).toBe(1.25);
-  });
-
-  it("changes only temporal pacing knobs in Battery", () => {
-    const quality = createRenderProfile("quality");
-    const battery = createRenderProfile("battery");
-
-    expect(quality.pacing.idleFps).toBeNull();
-    expect(battery.pacing.idleFps).toBe(30);
-    expect(quality.pacing.maxFps).toBe(60);
-    expect(battery.pacing.maxFps).toBe(60);
-    expect(battery.animation.distantIntervalMultiplier).toBeGreaterThan(quality.animation.distantIntervalMultiplier);
-    expect(battery.prefetch.sideRadiusLimit).toBeLessThan(quality.prefetch.sideRadiusLimit);
-    expect(battery.shadows.minimumRefreshIntervalMs).toBeGreaterThan(quality.shadows.minimumRefreshIntervalMs);
-  });
-
-  it("migrates every retired tier to Quality and removes the old keys", () => {
+  it("migrates every retired tier to Uncapped and removes the old keys", () => {
     const values = new Map<string, string>([[["GRAPHICS", "SETTING"].join("_"), "LOW"]]);
     const storage = {
       getItem: vi.fn((key: string) => values.get(key) ?? null),
@@ -38,18 +25,31 @@ describe("render profile", () => {
       setItem: vi.fn((key: string, value: string) => values.set(key, value)),
     };
 
-    expect(readRenderMode(storage)).toBe("quality");
-    expect(values.get(RENDER_MODE_STORAGE_KEY)).toBe("quality");
+    expect(readRenderMode(storage)).toBe("uncapped");
+    expect(values.get(RENDER_MODE_STORAGE_KEY)).toBe("uncapped");
     expect(values.has(["GRAPHICS", "SETTING"].join("_"))).toBe(false);
+  });
+
+  it.each(["uncapped", "capped"] as const)("retains an explicit %s choice", (mode) => {
+    const storage = { getItem: () => mode, removeItem: vi.fn(), setItem: vi.fn() };
+    expect(readRenderMode(storage)).toBe(mode);
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("migrates the former Quality mode to Uncapped", () => {
+    const storage = { getItem: () => "quality", removeItem: vi.fn(), setItem: vi.fn() };
+    expect(readRenderMode(storage)).toBe("uncapped");
+    expect(storage.setItem).toHaveBeenCalledWith(RENDER_MODE_STORAGE_KEY, "uncapped");
+    expect(readRenderMode(null)).toBe("uncapped");
   });
 
   it("persists an explicit mode choice", () => {
     const setItem = vi.fn();
-    writeRenderMode({ setItem }, "battery");
-    expect(setItem).toHaveBeenCalledWith(RENDER_MODE_STORAGE_KEY, "battery");
+    writeRenderMode({ setItem }, "capped");
+    expect(setItem).toHaveBeenCalledWith(RENDER_MODE_STORAGE_KEY, "capped");
   });
 
-  it("cleans retired preferences without replacing an explicit Battery choice", () => {
+  it("migrates Battery to the 60 FPS limit and removes retired preferences", () => {
     const removeItem = vi.fn();
     const storage = {
       getItem: vi.fn((key: string) => (key === RENDER_MODE_STORAGE_KEY ? "battery" : "HIGH")),
@@ -57,8 +57,8 @@ describe("render profile", () => {
       setItem: vi.fn(),
     };
 
-    expect(readRenderMode(storage)).toBe("battery");
+    expect(readRenderMode(storage)).toBe("capped");
     expect(removeItem).toHaveBeenCalledWith(["GRAPHICS", "SETTING"].join("_"));
-    expect(storage.setItem).not.toHaveBeenCalled();
+    expect(storage.setItem).toHaveBeenCalledWith(RENDER_MODE_STORAGE_KEY, "capped");
   });
 });

--- a/apps/game/src/three/render-profile.ts
+++ b/apps/game/src/three/render-profile.ts
@@ -1,4 +1,4 @@
-export type RenderMode = "quality" | "battery";
+export type RenderMode = "uncapped" | "capped";
 
 export interface RenderVisualProfile {
   animationCullDistance: number;
@@ -14,29 +14,19 @@ export interface RenderVisualProfile {
   vignette: boolean;
 }
 
-export interface RenderProfile {
-  animation: {
-    distantBucketStrideMultiplier: number;
-    distantIntervalMultiplier: number;
-  };
+interface RenderProfile {
   mode: RenderMode;
-  pacing: {
-    idleAfterMs: number;
-    idleFps: number | null;
-    maxFps: number;
-  };
-  prefetch: {
-    areaBoundaryLookaheadLimit: number;
-    forwardDepthLimit: number;
-    maxAheadLimit: number;
-    maxConcurrentLimit: number;
-    sideRadiusLimit: number;
-  };
-  shadows: {
-    minimumRefreshIntervalMs: number;
-  };
+  maxFps: number | null;
   visuals: RenderVisualProfile;
 }
+
+export const RENDER_MODE_OPTIONS: ReadonlyArray<{ label: string; mode: RenderMode }> = [
+  { label: "Uncapped", mode: "uncapped" },
+  { label: "60 FPS", mode: "capped" },
+];
+
+export const RENDER_MODE_DESCRIPTION =
+  "Choose display refresh or a 60 FPS limit. Visual detail stays the same. Changing mode reloads the page.";
 
 export const RENDER_MODE_STORAGE_KEY = "RENDER_MODE";
 export const RENDERER_PIXEL_RATIO_CAP = 1.25;
@@ -59,7 +49,7 @@ const QUALITY_VISUALS: RenderVisualProfile = {
 
 export function readRenderMode(storage: Pick<Storage, "getItem" | "removeItem" | "setItem"> | null): RenderMode {
   if (!storage) {
-    return "quality";
+    return "uncapped";
   }
 
   // Read once before deletion so old clients complete the migration even when
@@ -70,14 +60,14 @@ export function readRenderMode(storage: Pick<Storage, "getItem" | "removeItem" |
   storage.removeItem(LEGACY_DEVICE_CHECK_STORAGE_KEY);
 
   const storedMode = storage.getItem(RENDER_MODE_STORAGE_KEY);
-  if (storedMode === "quality" || storedMode === "battery") {
+  if (storedMode === "uncapped" || storedMode === "capped") {
     return storedMode;
   }
 
-  // Every retired tier maps to Quality. The migration is deliberately one-way:
-  // Battery is an explicit player choice, never a hardware recommendation.
-  storage.setItem(RENDER_MODE_STORAGE_KEY, "quality");
-  return "quality";
+  // Preserve a frame limit for players who previously chose Battery.
+  const mode = storedMode === "battery" ? "capped" : "uncapped";
+  storage.setItem(RENDER_MODE_STORAGE_KEY, mode);
+  return mode;
 }
 
 export function writeRenderMode(storage: Pick<Storage, "setItem"> | null, mode: RenderMode): void {
@@ -85,35 +75,7 @@ export function writeRenderMode(storage: Pick<Storage, "setItem"> | null, mode: 
 }
 
 export function createRenderProfile(mode: RenderMode): RenderProfile {
-  const isBattery = mode === "battery";
-  const unlimited = Number.POSITIVE_INFINITY;
-
-  return {
-    animation: {
-      distantBucketStrideMultiplier: isBattery ? 2 : 1,
-      distantIntervalMultiplier: isBattery ? 2 : 1,
-    },
-    mode,
-    pacing: {
-      idleAfterMs: 2_000,
-      idleFps: isBattery ? 30 : null,
-      // Both modes cap at 60: above that, high-refresh displays spend the
-      // whole frame budget re-rendering and starve streaming/compile work,
-      // which reads as unsteady fps rather than extra smoothness.
-      maxFps: 60,
-    },
-    prefetch: {
-      areaBoundaryLookaheadLimit: isBattery ? 1 : unlimited,
-      forwardDepthLimit: isBattery ? 1 : unlimited,
-      maxAheadLimit: isBattery ? 2 : unlimited,
-      maxConcurrentLimit: isBattery ? 1 : unlimited,
-      sideRadiusLimit: isBattery ? 0 : unlimited,
-    },
-    shadows: {
-      minimumRefreshIntervalMs: isBattery ? 250 : 100,
-    },
-    visuals: QUALITY_VISUALS,
-  };
+  return { mode, maxFps: mode === "uncapped" ? null : 60, visuals: QUALITY_VISUALS };
 }
 
 const browserStorage = typeof globalThis.localStorage === "undefined" ? null : globalThis.localStorage;

--- a/apps/game/src/three/renderer-animation-runtime.test.ts
+++ b/apps/game/src/three/renderer-animation-runtime.test.ts
@@ -1,23 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { createRendererFrameFailureCircuit, resolveRendererPacedFps, runRendererAnimationTick } =
-  await import("./renderer-animation-runtime");
-
-describe("resolveRendererPacedFps", () => {
-  it("caps every mode at 60fps and drops idle Battery to 30", () => {
-    const quality = { pacing: { idleAfterMs: 2_000, idleFps: null, maxFps: 60 } };
-    const battery = { pacing: { idleAfterMs: 2_000, idleFps: 30, maxFps: 60 } };
-
-    expect(resolveRendererPacedFps({ currentTime: 10_000, lastInteractionTime: 0, profile: quality })).toBe(60);
-    expect(resolveRendererPacedFps({ currentTime: 1_999, lastInteractionTime: 0, profile: battery })).toBe(60);
-    expect(resolveRendererPacedFps({ currentTime: 2_000, lastInteractionTime: 0, profile: battery })).toBe(30);
-    expect(resolveRendererPacedFps({ currentTime: 2_001, lastInteractionTime: 2_000, profile: battery })).toBe(60);
-  });
-});
+const { createRendererFrameFailureCircuit, runRendererAnimationTick } = await import("./renderer-animation-runtime");
 
 describe("runRendererAnimationTick", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it.each(
+    [60, 120, 144, 165].flatMap((refreshRate) => [30, 60, null].map((targetFPS) => ({ refreshRate, targetFPS }))),
+  )("preserves elapsed animation time at $targetFPS FPS on a $refreshRate Hz display", ({ targetFPS, refreshRate }) => {
+    let timing = { lastTime: 100, lastFrameTime: 100 };
+    let elapsed = 0;
+    let frames = 0;
+    let renderedAt = 100;
+    for (let tick = 1; tick <= refreshRate * 10; tick++) {
+      const now = 100 + (tick * 1000) / refreshRate;
+      timing = runRendererAnimationTick({
+        getCurrentTime: () => now,
+        getCycleProgress: () => 0.5,
+        isDestroyed: false,
+        isLabelRuntimeReady: true,
+        ...timing,
+        targetFPS,
+        requestNextFrame: () => {},
+        renderFrame: ({ deltaTime }) => {
+          elapsed += deltaTime;
+          renderedAt = now;
+          frames++;
+          return true;
+        },
+      });
+    }
+    expect(frames).toBeGreaterThanOrEqual((targetFPS ?? refreshRate) * 10 - 1);
+    expect(frames).toBeLessThanOrEqual((targetFPS ?? refreshRate) * 10);
+    expect(elapsed).toBeCloseTo((renderedAt - 100) / 1000, 8);
   });
 
   it("stops the loop immediately when the renderer is destroyed", () => {
@@ -31,13 +48,14 @@ describe("runRendererAnimationTick", () => {
       isDestroyed: true,
       isLabelRuntimeReady: true,
       lastTime: 42,
+      lastFrameTime: 42,
       logDestroyed,
       renderFrame,
       requestNextFrame,
       targetFPS: null,
     });
 
-    expect(lastTime).toBe(42);
+    expect(lastTime.lastTime).toBe(42);
     expect(logDestroyed).toHaveBeenCalledWith("GameRenderer destroyed, stopping animation loop");
     expect(renderFrame).not.toHaveBeenCalled();
     expect(requestNextFrame).not.toHaveBeenCalled();
@@ -53,12 +71,13 @@ describe("runRendererAnimationTick", () => {
       isDestroyed: false,
       isLabelRuntimeReady: false,
       lastTime: 25,
+      lastFrameTime: 25,
       renderFrame,
       requestNextFrame,
       targetFPS: null,
     });
 
-    expect(lastTime).toBe(25);
+    expect(lastTime.lastTime).toBe(25);
     expect(renderFrame).not.toHaveBeenCalled();
     expect(requestNextFrame).toHaveBeenCalledTimes(1);
   });
@@ -73,12 +92,13 @@ describe("runRendererAnimationTick", () => {
       isDestroyed: false,
       isLabelRuntimeReady: true,
       lastTime: 0,
+      lastFrameTime: 0,
       renderFrame,
       requestNextFrame,
       targetFPS: 30,
     });
 
-    expect(lastTime).toBe(100);
+    expect(lastTime.lastTime).toBe(100);
     expect(renderFrame).not.toHaveBeenCalled();
     expect(requestNextFrame).toHaveBeenCalledTimes(1);
   });
@@ -96,6 +116,7 @@ describe("runRendererAnimationTick", () => {
       isDestroyed: false,
       isLabelRuntimeReady: true,
       lastTime: 100,
+      lastFrameTime: 100,
       onFrameSuccess,
       renderFrame,
       requestNextFrame,
@@ -104,7 +125,7 @@ describe("runRendererAnimationTick", () => {
       updateStatsPanel,
     });
 
-    expect(lastTime).toBe(116);
+    expect(lastTime.lastTime).toBe(116);
     expect(updateStatsPanel).toHaveBeenCalledTimes(1);
     expect(updateControls).toHaveBeenCalledTimes(1);
     expect(renderFrame).toHaveBeenCalledWith({
@@ -128,6 +149,7 @@ describe("runRendererAnimationTick", () => {
       isDestroyed: false,
       isLabelRuntimeReady: true,
       lastTime: 100,
+      lastFrameTime: 100,
       onFrameError,
       onFrameSuccess,
       renderFrame: vi.fn(() => {
@@ -137,7 +159,7 @@ describe("runRendererAnimationTick", () => {
       targetFPS: null,
     });
 
-    expect(lastTime).toBe(116);
+    expect(lastTime.lastTime).toBe(116);
     expect(onFrameError).toHaveBeenCalledWith(frameError);
     expect(onFrameSuccess).not.toHaveBeenCalled();
     expect(requestNextFrame).toHaveBeenCalledTimes(1);
@@ -153,6 +175,7 @@ describe("runRendererAnimationTick", () => {
       isDestroyed: false,
       isLabelRuntimeReady: true,
       lastTime: 100,
+      lastFrameTime: 100,
       onFrameError: () => {
         throw new Error("reporter failed");
       },
@@ -163,7 +186,7 @@ describe("runRendererAnimationTick", () => {
       targetFPS: null,
     });
 
-    expect(lastTime).toBe(116);
+    expect(lastTime.lastTime).toBe(116);
     expect(requestNextFrame).toHaveBeenCalledOnce();
     expect(errorSpy).toHaveBeenCalledWith("[GameRenderer] Failed to report renderer frame error", expect.any(Error));
   });

--- a/apps/game/src/three/renderer-animation-runtime.ts
+++ b/apps/game/src/three/renderer-animation-runtime.ts
@@ -1,11 +1,10 @@
-import type { RenderProfile } from "./render-profile";
-
 interface RunRendererAnimationTickInput {
   getCurrentTime: () => number;
   getCycleProgress: () => number;
   isDestroyed: boolean;
   isLabelRuntimeReady: boolean;
   lastTime: number;
+  lastFrameTime: number;
   logDestroyed?: (message: string) => void;
   onFrameError?: (error: unknown) => void;
   onFrameSuccess?: () => void;
@@ -20,6 +19,7 @@ interface RendererAnimationFrameState {
   currentTime: number;
   deltaTime: number;
   lastTime: number;
+  lastFrameTime: number;
   shouldSkipFrame: boolean;
 }
 
@@ -34,24 +34,27 @@ export interface RendererFrameFailureCircuit {
 export const RENDERER_FRAME_FAILURE_REPORT_INTERVAL = 60;
 const RENDERER_FRAME_FAILURE_MAX_REPORT_INTERVAL = 3_600;
 
-export function runRendererAnimationTick(input: RunRendererAnimationTickInput): number {
+export function runRendererAnimationTick(input: RunRendererAnimationTickInput): {
+  lastTime: number;
+  lastFrameTime: number;
+} {
+  const timing = { lastTime: input.lastTime, lastFrameTime: input.lastFrameTime };
   if (shouldStopRendererAnimation(input)) {
     input.logDestroyed?.("GameRenderer destroyed, stopping animation loop");
-    return input.lastTime;
+    return timing;
   }
 
   if (shouldWaitForRendererLabels(input)) {
     input.requestNextFrame();
-    return input.lastTime;
+    return timing;
   }
-
-  let nextLastTime = input.lastTime;
 
   try {
     const frameState = resolveRendererAnimationFrameState(input);
-    nextLastTime = frameState.lastTime;
+    timing.lastTime = frameState.lastTime;
+    timing.lastFrameTime = frameState.lastFrameTime;
     if (frameState.shouldSkipFrame) {
-      return nextLastTime;
+      return timing;
     }
 
     input.updateStatsPanel?.();
@@ -77,7 +80,7 @@ export function runRendererAnimationTick(input: RunRendererAnimationTickInput): 
     input.requestNextFrame();
   }
 
-  return nextLastTime;
+  return timing;
 }
 
 export function createRendererFrameFailureCircuit(): RendererFrameFailureCircuit {
@@ -129,18 +132,6 @@ function createRendererFrameFailureFingerprint(error: unknown): string {
   return `${typeof error}:${String(error)}`;
 }
 
-export function resolveRendererPacedFps(input: {
-  currentTime: number;
-  lastInteractionTime: number;
-  profile: Pick<RenderProfile, "pacing">;
-}): number | null {
-  const { idleFps, idleAfterMs, maxFps } = input.profile.pacing;
-  if (!idleFps || input.currentTime - input.lastInteractionTime < idleAfterMs) {
-    return maxFps;
-  }
-  return Math.min(idleFps, maxFps);
-}
-
 function shouldStopRendererAnimation(input: Pick<RunRendererAnimationTickInput, "isDestroyed">): boolean {
   return input.isDestroyed;
 }
@@ -150,42 +141,34 @@ function shouldWaitForRendererLabels(input: Pick<RunRendererAnimationTickInput, 
 }
 
 function resolveRendererAnimationFrameState(
-  input: Pick<RunRendererAnimationTickInput, "getCurrentTime" | "lastTime" | "targetFPS">,
+  input: Pick<RunRendererAnimationTickInput, "getCurrentTime" | "lastTime" | "lastFrameTime" | "targetFPS">,
 ): RendererAnimationFrameState {
   const currentTime = input.getCurrentTime();
   const baselineTime = input.lastTime === 0 ? currentTime : input.lastTime;
+  const previousFrameTime = input.lastFrameTime === 0 ? currentTime : input.lastFrameTime;
 
-  if (shouldThrottleRendererAnimationFrame({ currentTime, lastTime: baselineTime, targetFPS: input.targetFPS })) {
+  const frameTime = input.targetFPS ? 1000 / input.targetFPS : 0;
+  // Absorb floating-point rounding at exact refresh boundaries (for example 60 FPS on 60 Hz).
+  const completedIntervals = frameTime > 0 ? Math.floor((currentTime - baselineTime + 0.000001) / frameTime) : 0;
+  if (frameTime > 0 && completedIntervals === 0) {
     return {
       currentTime,
       deltaTime: 0,
       lastTime: baselineTime,
+      lastFrameTime: previousFrameTime,
       shouldSkipFrame: true,
     };
   }
 
-  const frameTime = input.targetFPS ? 1000 / input.targetFPS : 0;
-
   return {
     currentTime,
-    deltaTime: (currentTime - baselineTime) / 1000,
+    // Animation time follows actual frame intervals, never the pacing remainder.
+    deltaTime: (currentTime - previousFrameTime) / 1000,
+    lastFrameTime: currentTime,
     // Carry the sub-frame remainder: snapping lastTime to currentTime makes
     // the cap beat against the display refresh and quantises 60 down to
     // 30/40/41 fps on 60/120/165 Hz monitors.
-    lastTime: frameTime > 0 ? currentTime - ((currentTime - baselineTime) % frameTime) : currentTime,
+    lastTime: frameTime > 0 ? baselineTime + completedIntervals * frameTime : currentTime,
     shouldSkipFrame: false,
   };
-}
-
-function shouldThrottleRendererAnimationFrame(input: {
-  currentTime: number;
-  lastTime: number;
-  targetFPS: number | null;
-}): boolean {
-  if (!input.targetFPS) {
-    return false;
-  }
-
-  const frameTime = 1000 / input.targetFPS;
-  return input.currentTime - input.lastTime < frameTime;
 }

--- a/apps/game/src/three/renderer-effects-bridge-runtime.test.ts
+++ b/apps/game/src/three/renderer-effects-bridge-runtime.test.ts
@@ -8,7 +8,7 @@ describe("renderer effects bridge runtime", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("creates the effects runtime lazily and delegates setup, environment, and profile calls", () => {
-    const renderVisuals = createRenderProfile("quality").visuals;
+    const renderVisuals = createRenderProfile("uncapped").visuals;
     const effectsRuntime = createEffectsRuntimeStub();
     const createEffectsRuntime = vi.fn(() => effectsRuntime);
     const runtime = createRendererEffectsBridgeRuntime({
@@ -33,7 +33,7 @@ describe("renderer effects bridge runtime", () => {
     const createEffectsRuntime = vi.fn(() => effectsRuntime);
     const runtime = createRendererEffectsBridgeRuntime({
       createEffectsRuntime,
-      resolveRenderVisualProfile: () => createRenderProfile("quality").visuals,
+      resolveRenderVisualProfile: () => createRenderProfile("uncapped").visuals,
       resolveWeatherState: () => weatherState,
     });
 

--- a/apps/game/src/three/renderer-effects-runtime.test.ts
+++ b/apps/game/src/three/renderer-effects-runtime.test.ts
@@ -31,8 +31,8 @@ describe("renderer effects runtime", () => {
     const runtime = createRuntime(backend, scenes);
 
     await runtime.applyEnvironment();
-    runtime.setupPostProcessingEffects(createRenderProfile("quality").visuals);
-    runtime.applyRenderVisualProfile(createRenderProfile("battery").visuals);
+    runtime.setupPostProcessingEffects(createRenderProfile("uncapped").visuals);
+    runtime.applyRenderVisualProfile(createRenderProfile("capped").visuals);
 
     expect(backend.applyEnvironment).toHaveBeenCalledWith({
       fastTravelScene: scenes.fastTravelScene,

--- a/apps/game/src/three/renderer-foundation-runtime.test.ts
+++ b/apps/game/src/three/renderer-foundation-runtime.test.ts
@@ -31,7 +31,6 @@ describe("createRendererFoundationRuntime", () => {
     const runtime = createRendererFoundationRuntime({
       isMobileDevice: false,
       onControlsChange: vi.fn(),
-      onInteraction: vi.fn(),
       warn,
     });
 
@@ -65,7 +64,6 @@ describe("createRendererFoundationRuntime", () => {
     createRendererFoundationRuntime({
       isMobileDevice: true,
       onControlsChange: vi.fn(),
-      onInteraction: vi.fn(),
       warn,
     });
 

--- a/apps/game/src/three/renderer-foundation-runtime.ts
+++ b/apps/game/src/three/renderer-foundation-runtime.ts
@@ -12,7 +12,6 @@ export interface RendererFoundationRuntime {
 interface CreateRendererFoundationRuntimeInput {
   isMobileDevice: boolean;
   onControlsChange: () => void;
-  onInteraction: () => void;
   warn: (message: string, error: unknown) => void;
 }
 
@@ -21,7 +20,6 @@ export function createRendererFoundationRuntime(
 ): RendererFoundationRuntime {
   const interactionRuntime = createRendererInteractionRuntime({
     onControlsChange: input.onControlsChange,
-    onInteraction: input.onInteraction,
   });
   const labelRuntime = createRendererLabelRuntime({
     isMobileDevice: input.isMobileDevice,

--- a/apps/game/src/three/renderer-interaction-runtime.test.ts
+++ b/apps/game/src/three/renderer-interaction-runtime.test.ts
@@ -75,10 +75,8 @@ describe("createRendererInteractionRuntime", () => {
 
   it("configures shared camera, picking primitives, and control change wiring", () => {
     const onControlsChange = vi.fn();
-    const onInteraction = vi.fn();
     const runtime = createRendererInteractionRuntime({
       onControlsChange,
-      onInteraction,
     });
 
     const surface = document.createElement("canvas");
@@ -98,8 +96,6 @@ describe("createRendererInteractionRuntime", () => {
 
     controls?.fireChange();
     expect(onControlsChange).toHaveBeenCalledTimes(1);
-    surface.dispatchEvent(new PointerEvent("pointerdown"));
-    expect(onInteraction).toHaveBeenCalledTimes(1);
   });
 
   it("removes document listeners and disposes controls once", () => {
@@ -107,7 +103,6 @@ describe("createRendererInteractionRuntime", () => {
     const removeDocumentListenerSpy = vi.spyOn(document, "removeEventListener");
     const runtime = createRendererInteractionRuntime({
       onControlsChange: vi.fn(),
-      onInteraction: vi.fn(),
     });
 
     runtime.attachSurface(document.createElement("canvas"));

--- a/apps/game/src/three/renderer-interaction-runtime.ts
+++ b/apps/game/src/three/renderer-interaction-runtime.ts
@@ -13,7 +13,6 @@ export interface RendererInteractionRuntime {
 
 interface CreateRendererInteractionRuntimeInput {
   onControlsChange: () => void;
-  onInteraction: () => void;
 }
 
 export function createRendererInteractionRuntime(
@@ -28,8 +27,6 @@ class GameRendererInteractionRuntime implements RendererInteractionRuntime {
   public readonly pointer = new Vector2();
   public controls?: MapControls;
   private hasDocumentKeyboardLifecycle = false;
-  private inputSurface?: HTMLElement;
-  private readonly handleSurfaceInteraction = () => this.input.onInteraction();
 
   private readonly handleDocumentFocus = (event: FocusEvent) => {
     if (event.target instanceof HTMLInputElement && this.controls) {
@@ -47,7 +44,6 @@ class GameRendererInteractionRuntime implements RendererInteractionRuntime {
 
   public attachSurface(surface: HTMLElement): void {
     this.disposeControls();
-    this.attachInteractionListeners(surface);
     this.controls = createConfiguredMapControls({
       camera: this.camera,
       onControlsChange: this.input.onControlsChange,
@@ -61,8 +57,6 @@ class GameRendererInteractionRuntime implements RendererInteractionRuntime {
   }
 
   private disposeControls(): void {
-    this.detachInteractionListeners();
-
     if (this.hasDocumentKeyboardLifecycle) {
       document.removeEventListener("focus", this.handleDocumentFocus, true);
       document.removeEventListener("blur", this.handleDocumentBlur, true);
@@ -71,20 +65,6 @@ class GameRendererInteractionRuntime implements RendererInteractionRuntime {
 
     this.controls?.dispose();
     this.controls = undefined;
-  }
-
-  private attachInteractionListeners(surface: HTMLElement): void {
-    this.inputSurface = surface;
-    surface.addEventListener("pointerdown", this.handleSurfaceInteraction, { passive: true });
-    surface.addEventListener("pointermove", this.handleSurfaceInteraction, { passive: true });
-    surface.addEventListener("wheel", this.handleSurfaceInteraction, { passive: true });
-  }
-
-  private detachInteractionListeners(): void {
-    this.inputSurface?.removeEventListener("pointerdown", this.handleSurfaceInteraction);
-    this.inputSurface?.removeEventListener("pointermove", this.handleSurfaceInteraction);
-    this.inputSurface?.removeEventListener("wheel", this.handleSurfaceInteraction);
-    this.inputSurface = undefined;
   }
 
   private registerDocumentKeyboardLifecycle(): void {

--- a/apps/game/src/three/scenes/hexagon-scene.ts
+++ b/apps/game/src/three/scenes/hexagon-scene.ts
@@ -975,7 +975,7 @@ export abstract class HexagonScene {
       position.y - target.position.y,
       position.z - target.position.z,
     ]);
-    if (this.shadowRefreshPolicy.consumeRefresh(deltaTime * 1000, renderProfile.shadows.minimumRefreshIntervalMs)) {
+    if (this.shadowRefreshPolicy.consumeRefresh(deltaTime * 1000)) {
       this.mainDirectionalLight.shadow.needsUpdate = true;
     }
   }

--- a/apps/game/src/three/scenes/worldmap-chunk-policy.ts
+++ b/apps/game/src/three/scenes/worldmap-chunk-policy.ts
@@ -1,5 +1,4 @@
 import { WORLD_CHUNK_CONFIG } from "../constants/world-chunk-config";
-import { renderProfile } from "../render-profile";
 
 interface WorldmapChunkPolicy {
   chunkSize: number;
@@ -84,16 +83,7 @@ export function createWorldmapChunkPolicy(config: WorldChunkPolicyInput = WORLD_
       rowsBehind: config.pinRadius,
       colsEachSide: config.pinRadius,
     },
-    prefetch: {
-      forwardDepthStrides: Math.min(config.prefetch.forwardDepthStrides, renderProfile.prefetch.forwardDepthLimit),
-      sideRadiusStrides: Math.min(config.prefetch.sideRadiusStrides, renderProfile.prefetch.sideRadiusLimit),
-      areaBoundaryLookaheadStrides: Math.min(
-        config.prefetch.areaBoundaryLookaheadStrides,
-        renderProfile.prefetch.areaBoundaryLookaheadLimit,
-      ),
-      maxAhead: Math.min(config.prefetch.maxAhead, renderProfile.prefetch.maxAheadLimit),
-      maxConcurrent: Math.min(config.prefetch.maxConcurrent, renderProfile.prefetch.maxConcurrentLimit),
-    },
+    prefetch: { ...config.prefetch },
     visualPresentation: {
       maxCompositeChunks: config.visualPresentation.maxCompositeChunks,
       rollingWindowEnabled: config.visualPresentation.rollingWindowEnabled,

--- a/apps/game/src/three/scenes/worldmap.tsx
+++ b/apps/game/src/three/scenes/worldmap.tsx
@@ -38,7 +38,7 @@ import { SceneManager } from "@/three/scene-manager";
 import { CameraView } from "@/three/scenes/camera-view";
 import { CAMERA_CONFIG } from "@/three/constants";
 import { type SceneSetupContext } from "@/three/scenes/hexagon-scene";
-import { renderProfile, type RenderVisualProfile } from "@/three/render-profile";
+import { type RenderVisualProfile } from "@/three/render-profile";
 import { WorldmapPerfSimulation } from "@/three/scenes/worldmap-perf-simulation";
 import { playResourceSound } from "@/three/sound/utils";
 import { LeftView } from "@/types";
@@ -1136,7 +1136,6 @@ export default class WorldmapScene extends WarpTravel {
       this.chunkWorkQueue,
       this.compilePipelines,
     );
-    this.armyManager.setProceduralCollisionMode(renderProfile.mode);
     this.combatPresentation = new CombatPresentationCoordinator(this.scene, {
       projectileHitQuery: {
         hasTarget: (entityId) => this.armyManager.hasProceduralProjectileTarget(entityId),

--- a/apps/game/src/three/shadow-refresh-policy.ts
+++ b/apps/game/src/three/shadow-refresh-policy.ts
@@ -27,7 +27,7 @@ export class ShadowRefreshPolicy {
     this.dirty = true;
   }
 
-  consumeRefresh(deltaMs: number, minimumIntervalMs: number): boolean {
+  consumeRefresh(deltaMs: number, minimumIntervalMs = 100): boolean {
     this.elapsedSinceRefreshMs += deltaMs;
     if (!this.dirty || this.elapsedSinceRefreshMs < minimumIntervalMs) {
       return false;

--- a/apps/game/src/ui/features/landing/components/landing-settings.tsx
+++ b/apps/game/src/ui/features/landing/components/landing-settings.tsx
@@ -1,13 +1,14 @@
 import { AudioCategory, useAudio, useMusicPlayer, ScrollingTrackName } from "@/audio";
-import { renderProfile, type RenderMode, writeRenderMode } from "@/three/render-profile";
+import {
+  RENDER_MODE_OPTIONS,
+  RENDER_MODE_DESCRIPTION,
+  renderProfile,
+  type RenderMode,
+  writeRenderMode,
+} from "@/three/render-profile";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { Maximize2, Minimize2, Monitor, Music, Volume2, VolumeX, X } from "lucide-react";
 import { useEffect, useState } from "react";
-
-const RENDER_MODE_OPTIONS: { label: string; mode: RenderMode }[] = [
-  { label: "Quality", mode: "quality" },
-  { label: "Battery", mode: "battery" },
-];
 
 interface DocumentWithFullscreen extends HTMLDocument {
   mozFullScreenElement?: Element;
@@ -290,6 +291,7 @@ export const LandingSettings = ({ onClose, className }: LandingSettingsProps) =>
                 <button
                   key={mode}
                   type="button"
+                  aria-pressed={isActive}
                   disabled={isActive}
                   onClick={() => handleRenderModeChange(mode)}
                   className={cn(
@@ -304,9 +306,7 @@ export const LandingSettings = ({ onClose, className }: LandingSettingsProps) =>
               );
             })}
           </div>
-          <p className="text-xs leading-relaxed text-gold/42">
-            Battery reduces idle work without changing visual detail. Changing mode reloads the page.
-          </p>
+          <p className="text-xs leading-relaxed text-gold/42">{RENDER_MODE_DESCRIPTION}</p>
         </LandingSettingsSection>
       </div>
 

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -37,7 +37,8 @@ const allLatestFeatures: LatestFeature[] = [
     date: "2026-09-06",
     title: "Choose Your Frame Limit",
     type: "improvement",
-    description: "Choose Uncapped or a 60 FPS limit in landing and in-game settings, with the same visual detail in both modes.",
+    description:
+      "Choose Uncapped or a 60 FPS limit in landing and in-game settings, with the same visual detail in both modes.",
   },
   {
     date: "2026-09-05",

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -34,6 +34,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 // are surfaced in the What's New popup.
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-09-06",
+    title: "Choose Your Frame Limit",
+    type: "improvement",
+    description: "Choose Uncapped or a 60 FPS limit in landing and in-game settings, with the same visual detail in both modes.",
+  },
+  {
     date: "2026-09-05",
     title: "Reliable Terrain Updates",
     description:

--- a/apps/game/src/ui/modules/settings/settings.tsx
+++ b/apps/game/src/ui/modules/settings/settings.tsx
@@ -10,7 +10,7 @@ import { LOCAL_CAMERA_ZOOM } from "@/three/constants";
 import { WORLDMAP_CAMERA_ZOOM } from "@/three/scenes/worldmap-camera-view-profile";
 import { RendererDebugControl } from "@/ui/debug/renderer-debug-control";
 import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
-import { renderProfile, type RenderMode, writeRenderMode } from "@/three/render-profile";
+import { RENDER_MODE_OPTIONS, RENDER_MODE_DESCRIPTION, renderProfile, writeRenderMode } from "@/three/render-profile";
 import { Avatar, Button, Checkbox, RangeInput } from "@/ui/design-system/atoms";
 import { Headline } from "@/ui/design-system/molecules";
 import { redirectToLandingWorldSelection } from "@/ui/features/world-selector";
@@ -21,11 +21,6 @@ import { addressToNumber } from "@/ui/utils/utils";
 import { useDojo, useScreenOrientation } from "@bibliothecadao/react";
 import { useState } from "react";
 import { toast } from "@/ui/features/event-feed/notify";
-
-const RENDER_MODE_OPTIONS: { label: string; mode: RenderMode }[] = [
-  { label: "Quality", mode: "quality" },
-  { label: "Battery", mode: "battery" },
-];
 
 export const SETTINGS_POPOVER_ID = "settings";
 
@@ -158,9 +153,10 @@ const SettingsSections = ({ onViewShortcuts }: { onViewShortcuts: () => void }) 
             {RENDER_MODE_OPTIONS.map(({ label, mode: nextMode }) => (
               <Button
                 key={nextMode}
-                disabled={renderProfile.mode === nextMode}
+                aria-pressed={renderProfile.mode === nextMode}
                 variant={renderProfile.mode === nextMode ? "success" : "outline"}
                 onClick={() => {
+                  if (renderProfile.mode === nextMode) return;
                   writeRenderMode(localStorage, nextMode);
                   window.location.reload();
                 }}
@@ -169,9 +165,7 @@ const SettingsSections = ({ onViewShortcuts }: { onViewShortcuts: () => void }) 
               </Button>
             ))}
           </div>
-          <p className="text-xs leading-relaxed text-gray-gold/70">
-            Battery reduces idle and distant update frequency without changing visual detail.
-          </p>
+          <p className="text-xs leading-relaxed text-gray-gold/70">{RENDER_MODE_DESCRIPTION}</p>
           <RendererDebugControl className="border-0 bg-transparent px-0 py-0 backdrop-blur-none" />
         </section>
 


### PR DESCRIPTION
Players can choose Uncapped or a 60 FPS limit in landing and in-game settings, with identical visual detail in both modes. This removes Battery mode and its separate idle, prefetch, collision, and shadow policies; saved Battery preferences migrate to the capped option.

The animation loop now measures simulation time separately from frame pacing. The previous calculation advanced 11.945 seconds during a 10-second run capped at 60 FPS on a 165 Hz display; pacing tests cover 60/120/144/165 Hz and preserve elapsed time.

Validation: 85 targeted tests passed; production client build, root `pnpm run format`, and `pnpm run knip` passed. Headed WebGPU checks of these changes on the development branch verified both settings surfaces and persistence, with about 59 FPS capped and 153–160 FPS uncapped in the sampled idle/pointer scenarios. Those numbers are not a panning benchmark or a claim of steady 60 FPS across the world map.

CI note: the terrain gallery currently fails because the forced-WebGL full-screen benchmark does not complete before its timeout. The same three failure reasons are present in the upstream #4908 run: https://github.com/BibliothecaDAO/eternum/actions/runs/33936560029. Local hardware-backed checks above pass; this CI check is not green.
