### PR TITLE
Reduce terrain placement work and redundant world render passes

### DIFF
--- a/apps/game/src/three/terrain/terrain-field.test.ts
+++ b/apps/game/src/three/terrain/terrain-field.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { findNearestTerrainHex, terrainHexToWorld } from "./terrain-coordinates";
 import { TerrainField } from "./terrain-field";
 import type { TerrainCellInput, TerrainPageRequest } from "./terrain-types";
+import { isTerrainWaterBiome, isTerrainWaterCovered, TERRAIN_WATER_LEVEL } from "./terrain-water";
 
 describe("TerrainField", () => {
   it("is deterministic and keeps projected biome authoritative at cell centers", () => {
@@ -21,6 +22,36 @@ describe("TerrainField", () => {
     const field = new TerrainField(createRequest([cell(0, 0, BiomeType.DeepOcean)]));
     expect(field.sampleVertex(0, 0).height).toBeLessThan(-0.055);
     expect(field.sampleSurface(0, 0)).toMatchObject({ height: -0.055, normal: [0, 1, 0] });
+  });
+
+  it("matches generated terrain geometry for placement across biomes, boundaries and structure pads", () => {
+    const biomes = Object.values(BiomeType).filter((biome) => biome !== BiomeType.None);
+    const cells = biomes.map((biome, index) =>
+      cell((index % 5) - 2, Math.floor(index / 5) - 2, biome, index % 3 === 0),
+    );
+    const field = new TerrainField(createRequest(cells));
+    const offsets = [
+      [0, 0],
+      [0.5, -0.4],
+      [-0.86, 0.5],
+      [Math.sqrt(3) / 2, 0],
+      [20, 20],
+    ];
+
+    for (const owner of cells) {
+      const center = terrainHexToWorld(owner.col, owner.row);
+      for (const [offsetX, offsetZ] of offsets) {
+        const x = center.x + offsetX;
+        const z = center.z + offsetZ;
+        const vertex = field.sampleVertex(x, z);
+        const water = isTerrainWaterCovered(vertex.height) && (isTerrainWaterBiome(vertex.biome) || vertex.shore > 0);
+        expect(field.sampleSurface(x, z)).toEqual({
+          biome: vertex.biome,
+          height: water ? TERRAIN_WATER_LEVEL : vertex.height,
+          normal: water ? [0, 1, 0] : vertex.normal,
+        });
+      }
+    }
   });
 
   it("keeps material brightness consistent inside a uniform biome", () => {

--- a/apps/game/src/three/terrain/terrain-field.ts
+++ b/apps/game/src/three/terrain/terrain-field.ts
@@ -82,6 +82,7 @@ export interface TerrainVisualSample extends TerrainSurfaceSample {
 }
 
 const NORMAL_SAMPLE_DISTANCE = 0.035;
+const TERRAIN_BLEND_RADIUS_SQUARED = 4;
 const PAD_INNER_RADIUS = 0.5;
 const PAD_OUTER_RADIUS = 0.82;
 const PROP_CLEARANCE_INNER_RADIUS = 0.68;
@@ -185,13 +186,12 @@ export class TerrainField {
     candidates: readonly CellFieldSample[],
     explored = 1,
   ): TerrainVisualSample {
-    if (candidates.length === 0) return createUnknownSample();
+    const dominant = findDominantTerrainCandidate(worldX, worldZ, candidates);
+    if (!dominant) return createUnknownSample();
 
     let totalWeight = 0;
     let visualWeightSum = 0;
-    const nearestDistanceSquared = Math.min(
-      ...candidates.map((candidate) => (candidate.centerX - worldX) ** 2 + (candidate.centerZ - worldZ) ** 2),
-    );
+    const nearestDistanceSquared = (dominant.centerX - worldX) ** 2 + (dominant.centerZ - worldZ) ** 2;
     let height = 0;
     let roughness = 0;
     let red = 0;
@@ -201,9 +201,7 @@ export class TerrainField {
     let macroTintStrength = 0;
     let shoreWetness = 0;
     const groundWeights = Array.from({ length: 8 }, () => 0);
-    let strongestWeight = -1;
-    let strongestBiome = candidates[0].biome;
-    let strongestBiomeId = candidates[0].biomeId;
+    const strongestBiome = dominant.biome;
     const macroMaterial = this.noise.sample(worldX * 0.42, worldZ * 0.42, "terrain-color-v1");
     const colorMix = 0.18 + macroMaterial * 0.28;
 
@@ -224,12 +222,6 @@ export class TerrainField {
       red += (candidate.primary[0] + (candidate.secondary[0] - candidate.primary[0]) * colorMix) * visualWeight;
       green += (candidate.primary[1] + (candidate.secondary[1] - candidate.primary[1]) * colorMix) * visualWeight;
       blue += (candidate.primary[2] + (candidate.secondary[2] - candidate.primary[2]) * colorMix) * visualWeight;
-
-      if (weight > strongestWeight) {
-        strongestWeight = weight;
-        strongestBiome = candidate.biome;
-        strongestBiomeId = candidate.biomeId;
-      }
     }
 
     if (totalWeight === 0) return createUnknownSample();
@@ -261,7 +253,7 @@ export class TerrainField {
 
     return {
       biome: strongestBiome,
-      biomeId: strongestBiomeId,
+      biomeId: dominant.biomeId,
       color: [
         (baseColor[0] + (TERRAIN_DISTURBED_GROUND_COLOR.r - baseColor[0]) * disturbedColorBlend) *
           albedoFactor *
@@ -290,11 +282,23 @@ export class TerrainField {
   }
 
   sampleSurface(worldX: number, worldZ: number): TerrainSurfaceSample {
-    const sample = this.sampleVertex(worldX, worldZ);
-    if (isTerrainWaterCovered(sample.height) && (isTerrainWaterBiome(sample.biome) || sample.shore > 0)) {
-      return { biome: sample.biome, height: TERRAIN_WATER_LEVEL, normal: [0, 1, 0] };
+    const owner = findNearestTerrainHex(worldX, worldZ);
+    const candidates = this.resolveExploredCandidates(owner.col, owner.row);
+    const dominant = findDominantTerrainCandidate(worldX, worldZ, candidates);
+    if (!dominant) {
+      return { biome: null, height: TERRAIN_BIOME_DESCRIPTORS[BiomeType.None].baseHeight, normal: [0, 1, 0] };
     }
-    return sample;
+
+    // Model placement needs geometry only; material and vegetation sampling belongs to page generation.
+    const height = this.sampleHeightFromCandidates(worldX, worldZ, candidates);
+    const biome = dominant.biome;
+    if (
+      isTerrainWaterCovered(height) &&
+      (isTerrainWaterBiome(biome) || this.sampleShoreProximity(worldX, worldZ, candidates) > 0)
+    ) {
+      return { biome, height: TERRAIN_WATER_LEVEL, normal: [0, 1, 0] };
+    }
+    return { biome, height, normal: this.sampleNormalFromCandidates(worldX, worldZ, candidates) };
   }
 
   samplePropDensityContext(
@@ -832,9 +836,27 @@ function clampUnit(value: number): number {
   return Math.min(1, Math.max(0, value));
 }
 
+/** Blend weight decreases with distance; retain canonical candidate order at an exact hex boundary. */
+function findDominantTerrainCandidate(
+  worldX: number,
+  worldZ: number,
+  candidates: readonly CellFieldSample[],
+): CellFieldSample | null {
+  let nearest: CellFieldSample | null = null;
+  let nearestDistanceSquared = TERRAIN_BLEND_RADIUS_SQUARED;
+  for (const candidate of candidates) {
+    const distanceSquared = (candidate.centerX - worldX) ** 2 + (candidate.centerZ - worldZ) ** 2;
+    if (distanceSquared < nearestDistanceSquared) {
+      nearest = candidate;
+      nearestDistanceSquared = distanceSquared;
+    }
+  }
+  return nearest;
+}
+
 function terrainBlendWeight(distanceSquared: number): number {
-  if (distanceSquared >= 4) return 0;
-  const support = 1 - distanceSquared / 4;
+  if (distanceSquared >= TERRAIN_BLEND_RADIUS_SQUARED) return 0;
+  const support = 1 - distanceSquared / TERRAIN_BLEND_RADIUS_SQUARED;
   return (support * support * support * support) / (0.04 + distanceSquared * distanceSquared);
 }
 

--- a/apps/game/src/three/webgpu-renderer-backend.test.ts
+++ b/apps/game/src/three/webgpu-renderer-backend.test.ts
@@ -635,6 +635,8 @@ describe("createWebGPURendererBackend", () => {
 
   it("owns quality, resize, frame rendering, and disposal once initialized", async () => {
     const renderer = createRendererSurface();
+    const clearPolicies: boolean[] = [];
+    renderer.render.mockImplementation(() => clearPolicies.push(renderer.autoClear));
     const backend = createWebGPURendererBackend(
       {
         isMobileDevice: false,
@@ -679,7 +681,9 @@ describe("createWebGPURendererBackend", () => {
     expect(renderer.setSize).toHaveBeenNthCalledWith(2, 640, 360);
     expect(renderer.setSize).toHaveBeenNthCalledWith(3, 800, 450);
     expect(renderer.info.reset).toHaveBeenCalledTimes(1);
-    expect(renderer.clear).toHaveBeenCalledTimes(1);
+    expect(renderer.clear).not.toHaveBeenCalled();
+    expect(clearPolicies).toEqual([true, false]);
+    expect(renderer.autoClear).toBe(false);
     expect(renderer.clearDepth).toHaveBeenCalledTimes(1);
     expect(renderer.render).toHaveBeenCalledTimes(2);
     expect(renderer.dispose).toHaveBeenCalledTimes(1);
@@ -688,12 +692,14 @@ describe("createWebGPURendererBackend", () => {
 
   it("recovers from a transient webgpu depth texture frame failure by resizing and retrying once", async () => {
     const renderer = createRendererSurface();
+    const clearPolicies: boolean[] = [];
     renderer.render = vi
       .fn()
       .mockImplementationOnce(() => {
+        clearPolicies.push(renderer.autoClear);
         throw new TypeError("Cannot read properties of null (reading 'depthTexture')");
       })
-      .mockImplementation(() => {});
+      .mockImplementation(() => clearPolicies.push(renderer.autoClear));
     const backend = createWebGPURendererBackend(
       {
         isMobileDevice: false,
@@ -722,7 +728,37 @@ describe("createWebGPURendererBackend", () => {
 
     expect(renderer.setSize).toHaveBeenCalledWith(window.innerWidth, window.innerHeight);
     expect(renderer.render).toHaveBeenCalledTimes(2);
+    expect(clearPolicies).toEqual([true, true]);
+    expect(renderer.autoClear).toBe(false);
+    expect(renderer.clear).not.toHaveBeenCalled();
   });
+
+  it.each(["webgpu", "webgl2-fallback"] as const)(
+    "restores the %s clear policy when a frame cannot be recovered",
+    async (activeMode) => {
+      const renderer = createRendererSurface(activeMode);
+      const failure = new Error("Frame failed");
+      renderer.render.mockImplementation(() => {
+        expect(renderer.autoClear).toBe(true);
+        throw failure;
+      });
+      const backend = createWebGPURendererBackend(
+        { isMobileDevice: false, pixelRatio: 1, requestedMode: "webgpu-auto" },
+        {
+          createRenderer: vi.fn(async () => ({
+            activeMode,
+            renderer: Object.assign(renderer, { init: vi.fn(async () => {}) }),
+          })),
+          now: vi.fn(() => 0),
+        },
+      );
+      await backend.initialize();
+
+      expect(() => backend.renderFrame?.({ mainCamera: {} as never, mainScene: {} as never })).toThrow(failure);
+      expect(renderer.autoClear).toBe(false);
+      expect(renderer.clear).not.toHaveBeenCalled();
+    },
+  );
 
   it("resolves neutral tone mapping to NeutralToneMapping, distinct from aces-filmic", async () => {
     const renderer = createRendererSurface();

--- a/apps/game/src/three/webgpu-renderer-backend.ts
+++ b/apps/game/src/three/webgpu-renderer-backend.ts
@@ -352,10 +352,9 @@ async function waitForWebGpuBackendStartup(input: {
 
 function renderMainFrameWithRecovery(renderer: RendererSurfaceLike, pipeline: RendererFramePipeline): void {
   renderer.info.reset();
-  renderer.clear();
 
   try {
-    renderer.render(pipeline.mainScene, pipeline.mainCamera);
+    renderClearedMainScene(renderer, pipeline);
     return;
   } catch (error) {
     if (!isRecoverableWebGpuFrameError(error)) {
@@ -365,13 +364,24 @@ function renderMainFrameWithRecovery(renderer: RendererSurfaceLike, pipeline: Re
     recordRendererDiagnosticUncapturedError((error as TypeError).message);
     logRecoverableWebGpuFrameError(error as TypeError);
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.clear();
 
     try {
-      renderer.render(pipeline.mainScene, pipeline.mainCamera);
+      renderClearedMainScene(renderer, pipeline);
     } catch (retryError) {
       recordRendererDiagnosticUncapturedError(retryError instanceof Error ? retryError.message : String(retryError));
     }
+  }
+}
+
+function renderClearedMainScene(renderer: RendererSurfaceLike, pipeline: RendererFramePipeline): void {
+  const previousAutoClear = renderer.autoClear;
+  // A manual clear also presents Three.js's output target. Clear inside the main
+  // render pass instead, then restore the overlay policy even when rendering fails.
+  renderer.autoClear = true;
+  try {
+    renderer.render(pipeline.mainScene, pipeline.mainCamera);
+  } finally {
+    renderer.autoClear = previousAutoClear;
   }
 }
 

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-06",
+    title: "Lighter Terrain Placement",
+    type: "improvement",
+    description: "Reduced terrain sampling work when positioning armies and buildings on world tiles.",
+  },
+  {
+    date: "2026-09-06",
     title: "Choose Your Frame Limit",
     type: "improvement",
     description:

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-06",
+    title: "Lighter World Rendering",
+    type: "improvement",
+    description: "Removed redundant screen passes while preserving world detail and selection overlays.",
+  },
+  {
+    date: "2026-09-06",
     title: "Lighter Terrain Placement",
     type: "improvement",
     description: "Reduced terrain sampling work when positioning armies and buildings on world tiles.",


### PR DESCRIPTION
Terrain placement calculated material colors and vegetation data even though callers only need surface geometry. World rendering also manually cleared the framebuffer before drawing; Three.js presents that cleared output target, adding two GPU passes and submissions per frame.

Sample only geometry for placement, preserving height, normal and biome results. Clear within the main render pass and restore the previous clear policy before overlays, including after a failed render or retry. Scene detail stays unchanged.

Validation:
- 6,912 placement queries: median about 58ms → 10.5ms. All 1,728 placement samples and 1,728 complete visual samples match the prior implementation.
- Native WebGPU Spectate with fixed world lighting and 1,962 props: idle passes/submissions 8 → 6; panning 9 → 7. Before/after screenshots remain visually consistent. WebGL Spectate also passes without page or GPU errors.
- Average panning FPS remains about 58. This reduces specific CPU/GPU work; it does not establish improved overall FPS or eliminate long frames. In the paired native run, the worst frame was 69ms before and 88ms after.
- Placement: 207 terrain tests passed. Frame clear: 22 backend/overlay tests passed. Production TypeScript/Vite build, root format and Knip passed.

Benchmark correction: older captures froze the renderer's cycle input but not the separate world-lighting store. The frame-clear comparison fixes the world debug override at 50; earlier timing comparisons have that limitation.
