### PR TITLE
Restore client startup with the configured Alchemy RPC

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -3,7 +3,7 @@ name: Deploy Client
 # Ships the game client to play.realms.party as a Cloudflare Pages project
 # (project name in vars.CLOUDFLARE_PAGES_PROJECT; the custom domain is attached
 # in the Pages dashboard once). Manual dispatch keeps deploys deliberate; the
-# build reads the committed .env.production and stamps the version from the ref.
+# build reads .env.production plus the identity RPC secret and stamps the version from the ref.
 on:
   workflow_dispatch:
     inputs:
@@ -22,7 +22,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      VITE_PUBLIC_IDENTITY_RPC_URL: ${{ secrets.CLIENT_IDENTITY_RPC_URL }}
+      VITE_PUBLIC_CONTROLLER_RPC_URL: ${{ secrets.CLIENT_IDENTITY_RPC_URL }}
     steps:
+      - name: Validate identity RPC configuration
+        run: |
+          if [ -z "$VITE_PUBLIC_IDENTITY_RPC_URL" ]; then
+            echo "::error::CLIENT_IDENTITY_RPC_URL is required"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/apps/game/.env.production
+++ b/apps/game/.env.production
@@ -5,7 +5,7 @@ VITE_PUBLIC_CHAIN=madara
 VITE_PUBLIC_NODE_URL=https://rpc.realms.party
 VITE_PUBLIC_IDENTITY_ORIGIN=https://app.realms.party
 # Identity RPC is a public mainnet node the browser calls directly (SIWS signature verification), not proxied.
-VITE_PUBLIC_IDENTITY_RPC_URL=https://rpc.starknet.lava.build/rpc/v0_9
+# VITE_PUBLIC_IDENTITY_RPC_URL is supplied by the CLIENT_IDENTITY_RPC_URL deployment secret.
 
 # Madara devnet fee token and gameplay-account contracts (from .lab/gameplay-contracts.json).
 VITE_PUBLIC_FEE_TOKEN_ADDRESS=0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -34,6 +34,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 // are surfaced in the What's New popup.
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-09-07",
+    title: "Reliable Identity RPC",
+    description:
+      "Wallet initialization uses Alchemy’s mainnet RPC, restoring client startup after the previous endpoint stopped serving requests.",
+    type: "fix",
+  },
+  {
     date: "2026-09-06",
     title: "Clearer Terrain And Daylight",
     type: "improvement",


### PR DESCRIPTION
Lava's mainnet endpoint returns HTTP 410 to browser preflight requests, which prevents Controller initialization and crashes client startup. Supply the identity and Controller RPC from the configured Alchemy endpoint through `CLIENT_IDENTITY_RPC_URL`, and fail deployment early when that secret is absent.

The credential is not committed. Alchemy returned the expected mainnet chain ID. Format and Knip pass in the combined client checkout; local Spectate reaches world-interactive with Alchemy requests and no browser errors. Production deployment run 34121275931 succeeded from this branch.
