### PR TITLE
Fix missing client chunks receiving cached HTML

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -50,40 +50,23 @@ jobs:
       - name: Build packages
         run: pnpm run build:packages
 
+      - name: Test deployment verification and chunk recovery
+        run: |
+          node --test apps/game/scripts/verify-client-deployment.test.mjs
+          pnpm --dir apps/game test src/utils/chunk-load-recovery.test.ts
+
       - name: Build client
         env:
           VITE_PUBLIC_GAME_VERSION: ${{ github.event.inputs.version || github.sha }}
           VITE_PUBLIC_SENTRY_DSN: ${{ secrets.CLIENT_SENTRY_DSN }}
         run: pnpm --dir apps/game build
 
-      - name: Write cache headers
+      - name: Remove public sourcemaps
         working-directory: apps/game
         run: |
           set -euo pipefail
           # Never ship sourcemaps publicly.
           find dist -name "*.js.map" -delete
-          # Three cache tiers, as a Pages _headers file. Only Vite's content-hashed
-          # assets/ may be immutable: a stable-path file cached immutable is
-          # unfixable in a browser for a year (the corrupt /basis/ wasm proved it).
-          # HTML + service-worker files revalidate every request — a stale sw.js is
-          # the one file that can pin testers to an old build. Everything else
-          # (public/ passthrough: models, basis, images, sounds) revalidates after
-          # 5 minutes. Pages deploys are atomic and invalidate its cache, so no
-          # purge step is needed.
-          cat > dist/_headers <<'EOF'
-          /assets/*
-            Cache-Control: public, max-age=31536000, immutable
-          /*.html
-            Cache-Control: public, max-age=0, must-revalidate
-          /sw.js
-            Cache-Control: public, max-age=0, must-revalidate
-          /registerSW.js
-            Cache-Control: public, max-age=0, must-revalidate
-          /manifest.webmanifest
-            Cache-Control: public, max-age=0, must-revalidate
-          /*
-            Cache-Control: public, max-age=300, must-revalidate
-          EOF
 
       # wrangler-action@v3 auto-installs wrangler with `pnpm add`, which pnpm refuses at a workspace root
       # (ERR_PNPM_ADDING_TO_ROOT). Run wrangler with `pnpm dlx` instead — isolated, no workspace mutation.
@@ -95,3 +78,15 @@ jobs:
           pnpm dlx wrangler@3 pages deploy apps/game/dist \
             --project-name="${{ vars.CLOUDFLARE_PAGES_PROJECT }}" \
             --branch=main --commit-hash="${{ github.sha }}"
+
+      - name: Verify published client modules and routes
+        run:
+          node apps/game/scripts/verify-client-deployment.mjs apps/game/dist https://play.realms.party
+          client-deployment-check.json
+
+      - name: Upload deployment verification
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-deployment-check
+          path: client-deployment-check.json

--- a/apps/game/public/404.html
+++ b/apps/game/public/404.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html lang="en">
+  <meta charset="utf-8" />
+  <title>Not found</title>
+  <p>This page or asset is unavailable. <a href="/">Return to Eternum</a>.</p>
+</html>

--- a/apps/game/public/_headers
+++ b/apps/game/public/_headers
@@ -1,0 +1,17 @@
+# Use Pages' default ETag revalidation for assets. Overlapping Cache-Control
+# rules are concatenated, and an asset wildcard also matches missing chunks.
+# Extensionless navigation must always obtain the current deployment's shell.
+/
+  Cache-Control: no-cache
+/index.html
+  Cache-Control: no-cache
+/play/*
+  Cache-Control: no-cache
+/enter/*
+  Cache-Control: no-cache
+/biome-lab
+  Cache-Control: no-cache
+/local-lab
+  Cache-Control: no-cache
+/debug/*
+  Cache-Control: no-cache

--- a/apps/game/public/_redirects
+++ b/apps/game/public/_redirects
@@ -1,0 +1,14 @@
+# Only application routes use the SPA shell. Missing assets must remain 404s.
+/biome-lab / 200
+/local-lab / 200
+/learn / 200
+/news / 200
+/factory / 200
+/profile / 200
+/markets / 200
+/amm / 200
+/leaderboard / 200
+/enter/* / 200
+/play/* / 200
+/factory/* / 200
+/debug/* / 200

--- a/apps/game/scripts/verify-client-deployment.mjs
+++ b/apps/game/scripts/verify-client-deployment.mjs
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
+
+export async function verifyClientDeployment(dist, origin) {
+  const checks = await checkPublishedAssets(dist, origin);
+  const modules = checks.length;
+  const entry = await readModuleEntry(dist);
+  for (const route of [
+    "/",
+    "/play/madara/deployment-check/map?spectate=true",
+    "/biome-lab",
+    "/local-lab",
+    "/factory/v2",
+  ]) {
+    checks.push(await checkPublishedRoute(origin, route, entry));
+  }
+  checks.push(await checkMissingAsset(origin));
+  return { origin, ok: checks.every((check) => check.ok), modules, checks };
+}
+
+async function checkPublishedAssets(dist, origin) {
+  const files = (await readdir(join(dist, "assets"))).filter((name) => /\.(js|css)$/.test(name));
+  if (!files.length) throw new Error("Build has no client modules");
+  const checks = [];
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: 6 }, async () => {
+      while (next < files.length) {
+        const file = files[next++];
+        checks.push(await checkPublishedAsset(dist, origin, file));
+      }
+    }),
+  );
+  return checks;
+}
+
+async function readModuleEntry(dist) {
+  const html = await readFile(join(dist, "index.html"), "utf8");
+  const entry = html.match(/src="(\/assets\/[^" ]+\.js)"/)?.[1];
+  if (!entry) throw new Error("Build HTML has no module entry");
+  return entry;
+}
+
+async function fetchResponse(origin, path) {
+  return fetch(new URL(path, origin), { signal: AbortSignal.timeout(30_000) });
+}
+
+async function checkPublishedAsset(dist, origin, file) {
+  const path = `/assets/${file}`;
+  try {
+    const response = await fetchResponse(origin, path);
+    const type = response.headers.get("content-type") ?? "";
+    const expectedType = file.endsWith(".js") ? /(?:javascript|ecmascript)/i : /text\/css/i;
+    const expected = await readFile(join(dist, "assets", file));
+    const actual = Buffer.from(await response.arrayBuffer());
+    return {
+      path,
+      status: response.status,
+      type,
+      bytes: actual.length,
+      ok: response.status === 200 && expectedType.test(type) && digest(actual) === digest(expected),
+    };
+  } catch (error) {
+    return { path, ok: false, error: error.message };
+  }
+}
+
+async function checkPublishedRoute(origin, path, entry) {
+  try {
+    const response = await fetchResponse(origin, path);
+    const cache = response.headers.get("cache-control") ?? "";
+    const html = await response.text();
+    return {
+      path,
+      status: response.status,
+      cache,
+      ok:
+        response.status === 200 &&
+        html.includes(entry) &&
+        /no-cache|max-age=0\b/.test(cache) &&
+        !cache.includes("immutable"),
+    };
+  } catch (error) {
+    return { path, ok: false, error: error.message };
+  }
+}
+
+async function checkMissingAsset(origin) {
+  const path = `/assets/deployment-check-missing-${Date.now()}.js`;
+  try {
+    const response = await fetchResponse(origin, path);
+    const cache = response.headers.get("cache-control") ?? "";
+    await response.arrayBuffer();
+    return { path, status: response.status, cache, ok: response.status === 404 && !cache.includes("immutable") };
+  } catch (error) {
+    return { path, ok: false, error: error.message };
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const [dist, origin, reportPath = "client-deployment-check.json"] = process.argv.slice(2);
+  if (!dist || !origin) throw new Error("Usage: verify-client-deployment.mjs <dist> <origin> [report.json]");
+  const result = await verifyClientDeployment(dist, origin);
+  await writeFile(reportPath, JSON.stringify(result, null, 2));
+  console.log(
+    JSON.stringify(
+      { origin, ok: result.ok, modules: result.modules, failures: result.checks.filter((check) => !check.ok) },
+      null,
+      2,
+    ),
+  );
+  if (!result.ok) process.exitCode = 1;
+}

--- a/apps/game/scripts/verify-client-deployment.mjs
+++ b/apps/game/scripts/verify-client-deployment.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { readFile, readdir, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { setTimeout } from "node:timers/promises";
 
 const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
 
@@ -104,14 +105,28 @@ async function checkMissingAsset(origin) {
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
   const [dist, origin, reportPath = "client-deployment-check.json"] = process.argv.slice(2);
   if (!dist || !origin) throw new Error("Usage: verify-client-deployment.mjs <dist> <origin> [report.json]");
-  const result = await verifyClientDeployment(dist, origin);
-  await writeFile(reportPath, JSON.stringify(result, null, 2));
-  console.log(
-    JSON.stringify(
-      { origin, ok: result.ok, modules: result.modules, failures: result.checks.filter((check) => !check.ok) },
-      null,
-      2,
-    ),
-  );
-  if (!result.ok) process.exitCode = 1;
+  const attempts = [];
+  // Pages can publish the shell before every edge can resolve its new chunks.
+  // Keep the failed attempts as evidence; success still requires the full build.
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const result = await verifyClientDeployment(dist, origin);
+    attempts.push(result);
+    await writeFile(reportPath, JSON.stringify({ ...result, attempts }, null, 2));
+    console.log(
+      JSON.stringify(
+        {
+          attempt,
+          origin,
+          ok: result.ok,
+          modules: result.modules,
+          failures: result.checks.filter((check) => !check.ok),
+        },
+        null,
+        2,
+      ),
+    );
+    if (result.ok) break;
+    if (attempt < 5) await setTimeout(15_000);
+  }
+  if (!attempts.at(-1).ok) process.exitCode = 1;
 }

--- a/apps/game/scripts/verify-client-deployment.test.mjs
+++ b/apps/game/scripts/verify-client-deployment.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { verifyClientDeployment } from "./verify-client-deployment.mjs";
+
+test("deployment gate rejects HTML modules, stale bytes and cached shells", async () => {
+  const dist = await mkdtemp(join(tmpdir(), "client-deploy-test-"));
+  const html = '<script type="module" src="/assets/main-abc.js"></script>';
+  const js = 'console.log("current build");';
+  await mkdir(join(dist, "assets"));
+  await writeFile(join(dist, "index.html"), html);
+  await writeFile(join(dist, "assets/main-abc.js"), js);
+  let mode = "healthy";
+  const server = createServer((request, response) => {
+    response.setHeader("Cache-Control", mode === "cached-shell" ? "public, max-age=300" : "no-cache");
+    if (request.url.startsWith("/assets/deployment-check-missing")) {
+      response.statusCode = mode === "spa-fallback" ? 200 : 404;
+      response.end(html);
+    } else if (request.url === "/assets/main-abc.js") {
+      response.setHeader("Content-Type", mode === "html-module" ? "text/html" : "application/javascript");
+      response.end(mode === "stale-module" ? 'console.log("old build");' : mode === "html-module" ? html : js);
+    } else {
+      response.setHeader("Content-Type", "text/html");
+      response.end(html);
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  try {
+    assert.equal((await verifyClientDeployment(dist, origin)).ok, true);
+    for (mode of ["html-module", "stale-module", "cached-shell", "spa-fallback"]) {
+      assert.equal((await verifyClientDeployment(dist, origin)).ok, false, mode);
+    }
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(dist, { recursive: true, force: true });
+  }
+});

--- a/apps/game/src/main.tsx
+++ b/apps/game/src/main.tsx
@@ -6,6 +6,7 @@ import ReactDOM from "react-dom/client";
 import * as Sentry from "@sentry/react";
 
 import App from "./app";
+import { recoverChunkLoad } from "./utils/chunk-load-recovery";
 import { resolveSentryRuntimeOptions } from "./sentry-config";
 import { BootLoaderCrashFallback, markBootMilestone, setBootDocumentState } from "./ui/modules/boot-loader";
 
@@ -16,6 +17,10 @@ declare global {
 }
 
 window.Buffer = Buffer;
+
+window.addEventListener("vite:preloadError", (event) => {
+  recoverChunkLoad(event, import.meta.env.VITE_PUBLIC_GAME_VERSION || "development");
+});
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-07",
+    title: "Recover After Client Updates",
+    description: "An outdated client refreshes once if a game module is no longer available after an update.",
+    type: "fix",
+  },
+  {
+    date: "2026-09-07",
     title: "A Glimpse Beneath",
     description:
       "Preview Ethereal’s flat, textured floor under fixed moonlight in the World Biome Lab, with tile selection, armies and buildings. Dark unexplored tiles carry visible hints of its flowing energy and dissolve in uneven wisps as explorers advance.",

--- a/apps/game/src/utils/chunk-load-recovery.test.ts
+++ b/apps/game/src/utils/chunk-load-recovery.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { recoverChunkLoad } from "./chunk-load-recovery";
+
+function createBrowser() {
+  const values = new Map<string, string>();
+  return {
+    navigator: { onLine: true },
+    location: { reload: vi.fn() },
+    sessionStorage: {
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    },
+  };
+}
+
+describe("deployment chunk recovery", () => {
+  it("reloads once per version and leaves repeated failures to the crash UI", () => {
+    const browser = createBrowser();
+    const first = new Event("vite:preloadError", { cancelable: true });
+    recoverChunkLoad(first, "release-a", browser as unknown as Window);
+    const repeat = new Event("vite:preloadError", { cancelable: true });
+    recoverChunkLoad(repeat, "release-a", browser as unknown as Window);
+    expect(browser.location.reload).toHaveBeenCalledTimes(1);
+    expect(first.defaultPrevented).toBe(true);
+    expect(repeat.defaultPrevented).toBe(false);
+    recoverChunkLoad(new Event("vite:preloadError"), "release-b", browser as unknown as Window);
+    expect(browser.location.reload).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reload offline or when storage is unavailable", () => {
+    const browser = createBrowser();
+    browser.navigator.onLine = false;
+    recoverChunkLoad(new Event("vite:preloadError"), "release", browser as unknown as Window);
+    expect(browser.sessionStorage.setItem).not.toHaveBeenCalled();
+    browser.navigator.onLine = true;
+    browser.sessionStorage.setItem.mockImplementation(() => {
+      throw new Error("Storage denied");
+    });
+    recoverChunkLoad(new Event("vite:preloadError"), "release", browser as unknown as Window);
+    expect(browser.location.reload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/game/src/utils/chunk-load-recovery.ts
+++ b/apps/game/src/utils/chunk-load-recovery.ts
@@ -1,0 +1,18 @@
+const RECOVERY_KEY = "eternum:chunk-load-recovery";
+
+/** A tab open across a deployment may still request a retired lazy chunk. */
+export function recoverChunkLoad(event: Event, version: string, browser: Window = window): void {
+  if (!browser.navigator.onLine) return;
+
+  try {
+    // Persist before navigating so a broken deployment cannot cause a reload loop.
+    if (browser.sessionStorage.getItem(RECOVERY_KEY) === version) return;
+    browser.sessionStorage.setItem(RECOVERY_KEY, version);
+  } catch {
+    // Without a durable guard, let the existing crash UI offer manual recovery.
+    return;
+  }
+
+  event.preventDefault();
+  browser.location.reload();
+}


### PR DESCRIPTION
Spectate failed because a game-route dependency (`MapControls-vOf9X73R.js`) returned HTTP 200 HTML as a JavaScript module. Pages' implicit SPA fallback and overlapping cache rules allowed missing chunk responses to be cached as immutable.

Use explicit application rewrites and a real 404 for missing assets, remove conflicting asset cache overrides, and revalidate navigation HTML. Tabs running an older release refresh once on Vite preload failure; a session guard prevents reload loops. Deployment now checks every published JS/CSS file's MIME type and SHA-256 against the build, navigation entry freshness, and missing-asset behavior. Bounded retries allow edge propagation, with every attempt retained in the JSON artifact.

Validation:

- Production TypeScript/Vite build, repository formatting and Knip pass.
- Chunk recovery tests pass; deployment verifier regression test rejects HTML modules, stale bytes, cached HTML and SPA fallback.
- Browser fault injection recovers after exactly one reload; persistent failure does not loop.
- Production deployment 34130683453 passes the complete published-module check.
- Fresh headed Brave confirms deployed commit 369fd13e1af, interactive Spectate in bltz-clash-538 and the Ethereal lab, with no page errors.

Local Wrangler parsed the hosting rules but its runtime stalled on requests; it is not counted as a hosting pass. Public deployment verification and the real browser checks above passed. No auth behavior or chunk restructuring changes are included.
