### PR TITLE
fix(herald): treat a delete for a row the fold never held as a no-op

### DIFF
--- a/apps/herald/src/world-fold.test.ts
+++ b/apps/herald/src/world-fold.test.ts
@@ -179,6 +179,25 @@ describe("WorldFold", () => {
     expect(fold.snapshot(7, 12).models[0].rows).toEqual([]);
   });
 
+  it("treats a delete for a row it never held as a chain-legal no-op", () => {
+    const fold = new WorldFold(registry);
+    fold.apply(
+      decodeRequired(
+        registry,
+        rawEvent(WORLD_EVENT_SELECTORS.set, "0x101", ["0x2", "0x7", "0x2", "0x5", "0x3", "0x1", "0x4", "0x5", "0x2"]),
+      ),
+    );
+    const unknownRow = rawEvent(WORLD_EVENT_SELECTORS.delete, "0x101", []);
+    unknownRow.keys[2] = "0xfee";
+
+    expect(fold.apply(decodeRequired(registry, unknownRow))).toBeUndefined();
+    expect(fold.snapshot(7, 12).models[0].rows.map(({ key }) => key)).toEqual(["0xabc"]);
+
+    const overlay = new WorldFold(registry, fold);
+    expect(overlay.apply(decodeRequired(registry, unknownRow))).toBeUndefined();
+    expect(overlay.snapshot(7, 12).models[0].rows.map(({ key }) => key)).toEqual(["0xabc"]);
+  });
+
   it("decodes event messages without retaining them in the state fold", () => {
     const event = decodeRequired(
       registry,

--- a/apps/herald/src/world-fold.ts
+++ b/apps/herald/src/world-fold.ts
@@ -141,6 +141,10 @@ export class WorldFold {
     if (!rows) throw new Error(`Store event ${event.model.name} is not a persistent sync model`);
 
     const existing = this.storedRow(event.model.name, event.entityId);
+    // Dojo's erase_model emits StoreDelRecord whether or not the row was ever written (ResourceArrival
+    // is erased when an arrival day settles to zero, initialized or not), so a delete for a row this
+    // fold never held is chain-legal: nothing to remove, nothing to broadcast.
+    if (event.kind === "delete" && !existing) return undefined;
     const gameId = event.model.s2Scope === "game" ? this.eventGameId(event, existing) : undefined;
 
     if (event.kind === "set") {


### PR DESCRIPTION
Herald on the lab box has been crash-looping since 20:24 UTC today. The fold throws `delete for ResourceArrival:0x3895c4… has no preceding StoreSetRecord`, and every systemd restart replays from the 20:22 checkpoint (block 344156) straight into the same event. Result: `herald.realms.party` returns 502 on every route and clients lose their game socket.

The chain is allowed to emit that event. `ResourceArrivalImpl::delete` (`contracts/l3/game/src/systems/utils/resource.cairo:729`) calls `erase_model` unconditionally when an arrival day settles to zero, and Dojo emits `StoreDelRecord` whether or not the row was ever written. The fold's delete branch already tolerated a missing row; it was the game-id lookup for the outgoing diff that demanded a prior `StoreSetRecord` and threw.

A delete for a row neither the fold nor its parent overlay holds now returns no change. Update and member events without a prior row still throw, since they cannot be applied without the row's key fields.

Verification: new fold test covers the base fold and an overlay; `apps/herald` suite and typecheck pass. `pnpm run knip` reports pre-existing unused enum members in `packages/types`, none in Herald.

Recovery on the box: `world-fold.ts` is identical between the box's checkout (`client-scale-96p` @ `37b2c1e6c70`) and `next`, so this single commit cherry-picks cleanly there, followed by `sudo systemctl restart herald`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcynR9YYAEgM9y7vDKq1i2