### PR TITLE
ci(box): redeploy host services from next on every push

### DIFF
--- a/.github/workflows/deploy-box.yml
+++ b/.github/workflows/deploy-box.yml
@@ -1,0 +1,83 @@
+name: Deploy Box
+
+# Keeps the lab box's host services (herald, identity, launch, chat) on `next`. Every push to `next`
+# that touches one of them runs deploy/madara-lab/scripts/deploy-box.sh over SSH; the script decides
+# which units to restart and prints one JSON result line, surfaced in the step summary.
+# Needs: secret BOX_SSH_PRIVATE_KEY (a key in ubuntu's authorized_keys on the box) and variables
+# BOX_SSH_HOST (the box IP) and BOX_SSH_HOST_KEY (its `ssh-keyscan -t ed25519` line).
+on:
+  push:
+    branches: [next]
+    paths:
+      - "apps/herald/**"
+      - "apps/realms/**"
+      - "apps/launch-service/**"
+      - "apps/realtime-server/**"
+      - "packages/**"
+      - "pnpm-lock.yaml"
+      - "deploy/madara-lab/scripts/deploy-box.sh"
+      - ".github/workflows/deploy-box.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-box
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BOX_SSH_HOST: ${{ vars.BOX_SSH_HOST }}
+    steps:
+      - name: Validate box access configuration
+        env:
+          BOX_SSH_PRIVATE_KEY: ${{ secrets.BOX_SSH_PRIVATE_KEY }}
+          BOX_SSH_HOST_KEY: ${{ vars.BOX_SSH_HOST_KEY }}
+        run: |
+          for name in BOX_SSH_HOST BOX_SSH_HOST_KEY BOX_SSH_PRIVATE_KEY; do
+            if [ -z "${!name}" ]; then echo "::error::$name is required"; exit 1; fi
+          done
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare SSH
+        env:
+          BOX_SSH_PRIVATE_KEY: ${{ secrets.BOX_SSH_PRIVATE_KEY }}
+          BOX_SSH_HOST_KEY: ${{ vars.BOX_SSH_HOST_KEY }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$BOX_SSH_PRIVATE_KEY" > ~/.ssh/box && chmod 600 ~/.ssh/box
+          printf '%s\n' "$BOX_SSH_HOST_KEY" > ~/.ssh/known_hosts
+
+      # The script is copied from this checkout rather than run from the box's own tree, so a box
+      # sitting on an old branch still runs the current recipe on its first deploy.
+      - name: Redeploy host services from next
+        run: |
+          set -o pipefail
+          scp -i ~/.ssh/box -o BatchMode=yes deploy/madara-lab/scripts/deploy-box.sh "ubuntu@$BOX_SSH_HOST:/tmp/deploy-box.sh"
+          ssh -i ~/.ssh/box -o BatchMode=yes "ubuntu@$BOX_SSH_HOST" "sudo DEPLOY_BRANCH=next bash /tmp/deploy-box.sh" | tee deploy-box.log
+
+      - name: Publish deploy result
+        if: always()
+        run: |
+          result=$(tail -n 1 deploy-box.log 2>/dev/null || echo '{"event":"box_deploy","status":"unknown"}')
+          {
+            echo "## Box deploy"
+            echo
+            echo '```json'
+            echo "$result"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload deploy log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-box
+          path: deploy-box.log
+          if-no-files-found: warn

--- a/deploy/madara-lab/README.md
+++ b/deploy/madara-lab/README.md
@@ -604,7 +604,7 @@ realms-lab` (prints the `TUNNEL_ID` and writes `~/.cloudflared/<id>.json`), then
 On the box, as root, fresh Ubuntu 24.04:
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/BibliothecaDAO/eternum/feat/madara-lab/deploy/madara-lab/scripts/bootstrap-server.sh
+curl -fsSLO https://raw.githubusercontent.com/BibliothecaDAO/eternum/next/deploy/madara-lab/scripts/bootstrap-server.sh
 LAB_DOMAIN=lab.example.com TUNNEL_ID=<uuid> bash bootstrap-server.sh
 ```
 
@@ -632,8 +632,7 @@ curl -s https://app.<LAB_DOMAIN>/health
 curl -s https://launch.<LAB_DOMAIN>/health
 ```
 
-Identity redeploys are
-`git pull && pnpm install && pnpm run build:packages && DATABASE_SSL=false pnpm --filter @realms-world/db push && pnpm --filter @realms-world/realms build && sudo systemctl restart realms-identity`.
+Redeploys of every host service go through `scripts/deploy-box.sh` (as root on the box), which `.github/workflows/deploy-box.yml` runs on each push to `next` that touches a service: it fast-forwards the checkout, installs, builds shared packages, rebuilds the identity SPA and pushes its schema when identity changed, restarts only the units whose inputs changed, waits for their `/health`, and prints one `box_deploy` JSON line. A box left on an old branch is carried onto `next` by the same run, provided its worktree is clean.
 On a box provisioned before `realms-identity.service` replaced `web.service`, switch the units once:
 
 ```bash
@@ -643,7 +642,7 @@ sudo systemctl disable --now web.service
 sudo systemctl enable --now realms-identity.service
 ```
 
-Herald redeploys remain `git pull && pnpm run build:packages && sudo systemctl restart herald`. The harness runs on the box (`pnpm lab:harness`) — driver-on-box for now; the
+The harness runs on the box (`pnpm lab:harness`) — driver-on-box for now; the
 driver-off-box variant (E.1) is the laptop against `rpc.<LAB_DOMAIN>` and is a separate measurement. Record the
 `cloudflared` image digest here at first `up` (pin discipline). Cloudflare's proxy has a 100 s per-request limit and
 WebSockets pass through; the herald stream and the RPC are both fine with that.
@@ -659,6 +658,7 @@ deploy/madara-lab/
   scripts/issue-certs.sh   wildcard certificate from the shared mkcert root into .lab/certs/
   scripts/deploy-world.sh  sozo build + migrate with the Madara-specific flags
   scripts/bootstrap-game.sh  gameplay contracts + ChainConfig + preset 1
+  scripts/deploy-box.sh    redeploy host services from next; run by .github/workflows/deploy-box.yml
   scripts/deploy-gameplay-contracts.ts  idempotent class declaration and registry deployment
   scripts/probe-deploy-account.ts  fee-free deploy_account proof + timings
   scripts/block-stats.sh   aggregates Madara's per-block JSON log

--- a/deploy/madara-lab/scripts/bootstrap-server.sh
+++ b/deploy/madara-lab/scripts/bootstrap-server.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 : "${TUNNEL_ID:?set TUNNEL_ID (from cloudflared tunnel create)}"
 CREDENTIALS_JSON="${CREDENTIALS_JSON:-/root/credentials.json}"
 REPO_URL="${REPO_URL:-https://github.com/BibliothecaDAO/eternum.git}"
-REPO_BRANCH="${REPO_BRANCH:-feat/madara-lab}"
+REPO_BRANCH="${REPO_BRANCH:-next}"
 REPO_DIR=/opt/realms/eternum
 LAB_DIR="$REPO_DIR/deploy/madara-lab"
 PNPM_VERSION=10.25.0   # package.json "packageManager"

--- a/deploy/madara-lab/scripts/deploy-box.sh
+++ b/deploy/madara-lab/scripts/deploy-box.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Redeploy the box's host services (herald, identity, launch, chat) from the deploy branch.
+#
+# This is the one redeploy recipe: the systemd units and the README point here instead of each
+# carrying its own. `.github/workflows/deploy-box.yml` runs it on every push to `next` that
+# touches a service; it can also be run by hand on the box as root:
+#
+#   sudo bash deploy/madara-lab/scripts/deploy-box.sh
+#
+# Only services whose inputs changed are restarted, because a herald restart drops every live game
+# socket. The last line of output is one JSON result (event=box_deploy) that says what moved, what
+# restarted, and what each health probe answered.
+set -euo pipefail
+
+REPO_DIR=/opt/realms/eternum
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-next}"
+REALMS_PATH=/home/realms/.bun/bin:/usr/local/bin:/usr/bin:/bin
+HEALTH_TIMEOUT_SECONDS=120
+
+declare -A SERVICE_PORT=([herald]=3003 [realms-identity]=3000 [realms-launch]=3006 [realms-chat]=3005)
+declare -A SERVICE_INPUTS=(
+  [herald]='^(apps/herald/|packages/|pnpm-lock\.yaml$)'
+  [realms-identity]='^(apps/realms/|packages/|pnpm-lock\.yaml$)'
+  [realms-launch]='^(apps/launch-service/|packages/|pnpm-lock\.yaml$)'
+  [realms-chat]='^(apps/realtime-server/|pnpm-lock\.yaml$)'
+)
+
+main() {
+  require_root
+  fetch_deploy_branch
+  local from to
+  from=$(repo rev-parse HEAD)
+  to=$(repo rev-parse "origin/$DEPLOY_BRANCH")
+  require_clean_worktree "$from"
+
+  if [ "$from" = "$to" ]; then
+    emit_result noop "$from" "$to" "" "" "$(probe_all_services)"
+    return 0
+  fi
+
+  local changed
+  changed=$(repo diff --name-only "$from" "$to")
+  local services
+  services=$(select_services_to_restart "$changed")
+
+  checkout_deploy_branch
+  install_workspace
+  build_shared_packages
+  for service in $services; do prepare_service "$service"; done
+  for service in $services; do systemctl restart "$service"; done
+
+  local health
+  health=$(await_services_healthy "$services")
+  local status
+  status=$(restart_outcome "$services")
+  emit_result "$status" "$from" "$to" "$changed" "$services" "$health"
+  [ "$status" = ok ]
+}
+
+require_root() {
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "deploy-box.sh must run as root (it restarts systemd units)" >&2
+    exit 1
+  fi
+}
+
+as_realms() { sudo -u realms env PATH="$REALMS_PATH" "$@"; }
+repo() { as_realms git -C "$REPO_DIR" "$@"; }
+
+fetch_deploy_branch() { repo fetch --quiet origin "$DEPLOY_BRANCH"; }
+
+require_clean_worktree() {
+  local dirty
+  dirty=$(repo status --porcelain --untracked-files=no)
+  if [ -n "$dirty" ]; then
+    emit_result failed "$1" "$1" "" "" '{}' "worktree has local modifications: $(echo "$dirty" | head -3 | tr '\n' ' ')"
+    exit 1
+  fi
+}
+
+# `checkout -B` moves the local branch onto origin, which also carries a box left on an old branch
+# over to the deploy branch. The clean-worktree check above is what makes that safe.
+checkout_deploy_branch() { repo checkout --quiet -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"; }
+
+install_workspace() { as_realms pnpm --dir "$REPO_DIR" install --frozen-lockfile --silent; }
+
+build_shared_packages() { as_realms pnpm --dir "$REPO_DIR" run build:packages >/dev/null; }
+
+select_services_to_restart() {
+  local changed=$1
+  for service in herald realms-identity realms-launch realms-chat; do
+    if echo "$changed" | grep -Eq "${SERVICE_INPUTS[$service]}"; then echo "$service"; fi
+  done
+}
+
+# Identity is the one unit with build steps of its own: the SPA bundle and the session schema.
+prepare_service() {
+  if [ "$1" = realms-identity ]; then
+    as_realms env DATABASE_SSL=false pnpm --dir "$REPO_DIR" --filter @realms-world/db push >/dev/null
+    as_realms pnpm --dir "$REPO_DIR" --filter @realms-world/realms build >/dev/null
+  fi
+}
+
+probe_service() { curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${SERVICE_PORT[$1]}/health" || true; }
+
+probe_all_services() {
+  local health=""
+  for service in herald realms-identity realms-launch realms-chat; do
+    health="$health,\"$service\":$(probe_service "$service" | sed 's/^$/0/')"
+  done
+  echo "{${health#,}}"
+}
+
+# Herald replays from its checkpoint before it listens, so a restart needs a real wait.
+await_services_healthy() {
+  local services=$1 deadline=$((SECONDS + HEALTH_TIMEOUT_SECONDS))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    local pending=0
+    for service in $services; do [ "$(probe_service "$service")" = 200 ] || pending=1; done
+    [ "$pending" -eq 0 ] && break
+    sleep 3
+  done
+  probe_all_services
+}
+
+# Only the units this run restarted decide the outcome; the other probes are informational.
+restart_outcome() {
+  for service in $1; do [ "$(probe_service "$service")" = 200 ] || { echo failed; return; }; done
+  echo ok
+}
+
+json_array() { printf '%s' "$1" | awk 'NF { printf "%s\"%s\"", (n++ ? "," : ""), $0 }' | sed 's/^/[/; s/$/]/'; }
+
+emit_result() {
+  local status=$1 from=$2 to=$3 changed=$4 restarted=$5 health=$6 error=${7:-}
+  printf '{"event":"box_deploy","status":"%s","branch":"%s","from":"%s","to":"%s","changed":%s,"restarted":%s,"health":%s,"error":"%s"}\n' \
+    "$status" "$DEPLOY_BRANCH" "${from:0:12}" "${to:0:12}" "$(json_array "$changed")" "$(json_array "$restarted")" "$health" "$error"
+}
+
+main "$@"

--- a/deploy/madara-lab/systemd/herald.service
+++ b/deploy/madara-lab/systemd/herald.service
@@ -1,6 +1,6 @@
 # herald: the game's real-time read path (apps/herald), on the host next to the compose stack.
 # Installed by scripts/bootstrap-server.sh into /etc/systemd/system/herald.service.
-# Redeploy: git pull && pnpm run build:packages && sudo systemctl restart herald
+# Redeploy: scripts/deploy-box.sh (run by .github/workflows/deploy-box.yml on push to next).
 [Unit]
 Description=Realms herald (fold of the Madara sequencer, WS + HTTP on :3003)
 After=network-online.target docker.service

--- a/deploy/madara-lab/systemd/realms-chat.service
+++ b/deploy/madara-lab/systemd/realms-chat.service
@@ -1,6 +1,6 @@
 # apps/realtime-server: the dev realtime chat (world chat, DMs, presence) on the box.
 # Installed by scripts/bootstrap-server.sh into /etc/systemd/system/realms-chat.service.
-# Redeploy: git pull && pnpm install && sudo systemctl restart realms-chat.
+# Redeploy: scripts/deploy-box.sh (run by .github/workflows/deploy-box.yml on push to next).
 # Env is inline (local dev creds, not secrets); the chat has its own eternum_realtime DB so its
 # drizzle-kit push can never collide with herald/identity in the shared realms DB.
 [Unit]

--- a/deploy/madara-lab/systemd/realms-identity.service
+++ b/deploy/madara-lab/systemd/realms-identity.service
@@ -1,6 +1,6 @@
 # apps/realms serves the identity SPA and its API from one process on the box.
 # Installed by scripts/bootstrap-server.sh into /etc/systemd/system/realms-identity.service.
-# Redeploy: build apps/realms, then sudo systemctl restart realms-identity.
+# Redeploy: scripts/deploy-box.sh (run by .github/workflows/deploy-box.yml on push to next).
 [Unit]
 Description=Realms identity (SPA + /api, :3000)
 After=network-online.target docker.service herald.service


### PR DESCRIPTION
The lab box's checkout was still on `client-scale-96p`, deleted from origin on Sept 5. Its redeploy recipe was four `git pull && restart` comments spread over the systemd units and the README, each relying on whatever branch the checkout tracked, so nothing moved it for three days and tonight's Herald fix had to be cherry-picked by hand.

**`deploy/madara-lab/scripts/deploy-box.sh`** is now the one recipe, run as root on the box. It fetches the deploy branch, refuses a dirty worktree, moves the checkout onto `origin/next` (which carries an old branch over on the first run), installs with a frozen lockfile, builds shared packages, rebuilds the identity SPA and pushes its schema when identity changed, restarts only the units whose inputs changed, waits for their `/health`, and prints one `box_deploy` JSON line. Restart selection matters: a Herald restart drops every live game socket, so a chat-only change must not touch it.

**`.github/workflows/deploy-box.yml`** runs the script over SSH on every push to `next` touching `apps/herald`, `apps/realms`, `apps/launch-service`, `apps/realtime-server`, `packages/**`, or the lockfile, plus manual dispatch. The script is copied from the workflow checkout so a stale box runs the current recipe. The JSON result goes to the step summary and the full log is an artifact.

The unit comments and the README point at the script instead of carrying recipes; `bootstrap-server.sh` defaults to `next`.

**Owner setup before the first run** (secret + two variables): `BOX_SSH_PRIVATE_KEY` (a dedicated key added to `ubuntu`'s `authorized_keys` on the box), `BOX_SSH_HOST` (`206.223.228.189`), `BOX_SSH_HOST_KEY` (the `ssh-keyscan -t ed25519` line).

Verification: `bash -n` on the script; prettier on the workflow and README. Not exercised against the box yet, since that needs the deploy key. Unit files under `deploy/madara-lab/systemd` are not reinstalled by the script; that stays a bootstrap step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcynR9YYAEgM9y7vDKq1i2