### PR TITLE
fix(identity): trust loopback origins so a local client can sign in

### DIFF
--- a/apps/realms/server/api-cors.test.ts
+++ b/apps/realms/server/api-cors.test.ts
@@ -27,6 +27,22 @@ describe("handleApiCors", () => {
     expect(response.headers.get("access-control-allow-origin")).toBe("https://play.realms.party");
   });
 
+  it.each(["http://localhost:5173", "https://127.0.0.1:3000", "http://[::1]:8080"])(
+    "echoes the loopback origin %s so a local client can sign in",
+    async (origin) => {
+      const response = await handleApiCors(request("POST", origin), () => Response.json({ session: true }));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    },
+  );
+
+  it("rejects a non-loopback host that merely contains localhost", async () => {
+    const response = await handleApiCors(request("POST", "https://localhost.attacker.invalid"), () => new Response());
+
+    expect(response.status).toBe(403);
+  });
+
   it("rejects an untrusted cross-origin request", async () => {
     const response = await handleApiCors(request("POST", "https://attacker.invalid"), () => new Response());
 

--- a/apps/realms/server/api-cors.ts
+++ b/apps/realms/server/api-cors.ts
@@ -1,4 +1,5 @@
 import { serverEnv } from "./env";
+import { isLoopbackOrigin } from "./loopback-origins";
 
 type ApiHandler = () => Promise<Response> | Response;
 
@@ -9,7 +10,7 @@ const ALLOWED_ORIGINS = new Set([
 
 export async function handleApiCors(request: Request, handler: ApiHandler): Promise<Response> {
   const origin = request.headers.get("origin");
-  if (origin !== null && !ALLOWED_ORIGINS.has(origin)) {
+  if (origin !== null && !isAllowedOrigin(origin)) {
     return Response.json({ error: "origin_not_allowed" }, { status: 403 });
   }
 
@@ -19,6 +20,8 @@ export async function handleApiCors(request: Request, handler: ApiHandler): Prom
 
   return withCorsHeaders(await handler(), origin);
 }
+
+const isAllowedOrigin = (origin: string): boolean => ALLOWED_ORIGINS.has(origin) || isLoopbackOrigin(origin);
 
 function withCorsHeaders(response: Response, origin: string | null): Response {
   response.headers.set("access-control-allow-credentials", "true");

--- a/apps/realms/server/auth.ts
+++ b/apps/realms/server/auth.ts
@@ -5,6 +5,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@realms-world/db/client";
 
 import { serverEnv } from "./env";
+import { LOOPBACK_ORIGIN_PATTERNS } from "./loopback-origins";
 import { nameRuleViolation } from "./name-rules";
 import { isNameTaken } from "./names";
 import { siws } from "./siws-plugin";
@@ -18,13 +19,19 @@ const PORTRAIT_PATTERN = /^(0[1-9]|1[0-2])$/;
  * (including better-auth's own /update-user); the functional unique index on
  * lower(name) remains the race-proof guarantee.
  */
+const secureCookies = serverEnv.VITE_BASE_URL.startsWith("https:");
+
 export const auth = betterAuth({
   secret: serverEnv.BETTER_AUTH_SECRET,
   baseURL: serverEnv.VITE_BASE_URL,
   basePath: "/api/auth",
-  trustedOrigins: [serverEnv.VITE_BASE_URL, serverEnv.VITE_PUBLIC_GAME_ORIGIN],
+  trustedOrigins: [serverEnv.VITE_BASE_URL, serverEnv.VITE_PUBLIC_GAME_ORIGIN, ...LOOPBACK_ORIGIN_PATTERNS],
   advanced: {
-    useSecureCookies: serverEnv.VITE_BASE_URL.startsWith("https:"),
+    useSecureCookies: secureCookies,
+    // A loopback client is cross-site to the identity host, and a Lax cookie never travels
+    // cross-site, so the session cookie is None wherever Secure allows it. The API's origin
+    // allowlist and better-auth's origin check keep state-changing requests first-party.
+    defaultCookieAttributes: secureCookies ? { sameSite: "none" } : {},
     crossSubDomainCookies: {
       enabled: true,
       domain: serverEnv.IDENTITY_COOKIE_DOMAIN,

--- a/apps/realms/server/loopback-origins.ts
+++ b/apps/realms/server/loopback-origins.ts
@@ -1,0 +1,20 @@
+// A game client served from a developer's machine signs in against the live identity service, so
+// loopback origins on any port are trusted alongside the configured ones. Browsers set the Origin
+// header themselves; a page cannot claim a loopback origin it is not served from.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+export const isLoopbackHost = (host: string | undefined): boolean => host !== undefined && LOOPBACK_HOSTS.has(host);
+
+export const isLoopbackOrigin = (origin: string): boolean => {
+  try {
+    return isLoopbackHost(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
+};
+
+/** The same set as better-auth `trustedOrigins` patterns (matched against the request origin). */
+export const LOOPBACK_ORIGIN_PATTERNS = ["localhost", "127.0.0.1", "[::1]"].flatMap((host) => [
+  `http://${host}:*`,
+  `https://${host}:*`,
+]);

--- a/apps/realms/server/siws-plugin.ts
+++ b/apps/realms/server/siws-plugin.ts
@@ -14,6 +14,7 @@ import { normalizeStarknetAddress, parseSiwsTypedData } from "@realms-world/iden
 import { RpcProvider, verifyMessageInStarknet } from "starknet";
 
 import { serverEnv } from "./env";
+import { isLoopbackHost } from "./loopback-origins";
 import { authorizeSiwsNonce, SiwsVerificationError } from "./siws-verification";
 
 interface SIWSPluginOptions {
@@ -45,9 +46,8 @@ function getHostname(value?: string | null) {
 
 function isEquivalentHost(a?: string, b?: string) {
   if (!a || !b) return false;
-  const loopbacks = new Set(["localhost", "127.0.0.1", "::1"]);
   if (a === b) return true;
-  return loopbacks.has(a) && loopbacks.has(b);
+  return isLoopbackHost(a) && isLoopbackHost(b);
 }
 
 const resolveIdentityRpcUrl = () =>


### PR DESCRIPTION
A game client served from a developer's machine signs in against the live identity service, but the API's CORS allowlist and better-auth's `trustedOrigins` only knew the two configured hosts, so every local sign-in died on `origin_not_allowed` before reaching SIWS.

Loopback origins (`localhost`, `127.0.0.1`, `::1`, any port, http or https) are now trusted in both places from one module, `server/loopback-origins.ts`, which also replaces the SIWS plugin's private loopback set. better-auth 1.5 matches `http://localhost:*`-style patterns against the request origin, so the same list feeds `trustedOrigins`.

The session cookie becomes `SameSite=None` where Secure allows it. A loopback page is cross-site to `app.realms.party`, and a Lax cookie never travels cross-site, so without this the verify call would succeed and the follow-up `get-session` would come back empty. The API origin allowlist and better-auth's origin check on non-GET requests keep state-changing calls first-party; `play.realms.party` is same-site and unaffected.

Tests: CORS echoes loopback origins on three hosts and still rejects `localhost.attacker.invalid`; `apps/realms` server suite and typecheck pass.

Local testing note: the browser must allow third-party cookies for the localhost site (Brave shields down on it), since the cookie belongs to `.realms.party`. With Deploy Box in place this lands on the box on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcynR9YYAEgM9y7vDKq1i2