### PR TITLE
fix(chat): apply the loopback origin rule to HTTP CORS, not only the socket

### DIFF
--- a/apps/realtime-server/src/config/security.test.ts
+++ b/apps/realtime-server/src/config/security.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isAllowedOrigin, readSecurityConfig } from "./security";
+import { isAllowedOrigin, readSecurityConfig, resolveAllowedOrigin } from "./security";
 
 describe("browser origin policy", () => {
   it("is closed by default and exact-match allowlisted", () => {
@@ -23,3 +23,11 @@ it.each([undefined, "null", "https://localhost.attacker.invalid", "ftp://localho
     expect(isAllowedOrigin(origin, readSecurityConfig({}).allowedOrigins)).toBe(false);
   },
 );
+
+it("echoes allowed and loopback origins for CORS and refuses the rest", () => {
+  const allowed = readSecurityConfig({ CORS_ORIGIN: "https://play.realms.test" }).allowedOrigins;
+  expect(resolveAllowedOrigin("https://play.realms.test", allowed)).toBe("https://play.realms.test");
+  expect(resolveAllowedOrigin("https://localhost:4183", allowed)).toBe("https://localhost:4183");
+  expect(resolveAllowedOrigin("https://evil.realms.test", allowed)).toBeNull();
+  expect(resolveAllowedOrigin(undefined, allowed)).toBeNull();
+});

--- a/apps/realtime-server/src/config/security.ts
+++ b/apps/realtime-server/src/config/security.ts
@@ -31,3 +31,7 @@ export const readSecurityConfig = (environment = process.env): SecurityConfig =>
 
 export const isAllowedOrigin = (origin: string | undefined, allowedOrigins: ReadonlySet<string>): boolean =>
   Boolean(origin && (allowedOrigins.has(origin) || isLoopbackOrigin(origin)));
+
+/** The one origin rule for HTTP CORS and the socket upgrade: echo an allowed origin, refuse everything else. */
+export const resolveAllowedOrigin = (origin: string | undefined, allowedOrigins: ReadonlySet<string>): string | null =>
+  origin !== undefined && isAllowedOrigin(origin, allowedOrigins) ? origin : null;

--- a/apps/realtime-server/src/server.ts
+++ b/apps/realtime-server/src/server.ts
@@ -25,7 +25,7 @@ import type { DirectMessageRecord, DirectMessageThreadRecord } from "./db/schema
 import { worldChatMessages, type WorldChatMessageRecord } from "./db/schema/world-chat";
 import { parseGameChannel } from "./channels/channel";
 import type { MembershipResolver } from "./channels/membership";
-import { isAllowedOrigin, readSecurityConfig, type SecurityConfig } from "./config/security";
+import { isAllowedOrigin, readSecurityConfig, resolveAllowedOrigin, type SecurityConfig } from "./config/security";
 import {
   createAttachPlayerSession,
   requirePlayerSession,
@@ -261,7 +261,7 @@ export const createRealtimeApp = ({ membership, sessions, security }: RealtimeDe
   app.use(
     "/api/*",
     cors({
-      origin: Array.from(security.allowedOrigins),
+      origin: (origin) => resolveAllowedOrigin(origin, security.allowedOrigins),
       allowHeaders: ["Content-Type"],
       allowMethods: ["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
       credentials: true,


### PR DESCRIPTION
PR #4923 added a loopback allowance to `isAllowedOrigin`, but only the websocket upgrade reads it. The Hono CORS middleware on `/api/*` still echoed the static `CORS_ORIGIN` list, so chat history and DM requests from a localhost client only worked because of the systemd drop-in on the box that appends localhost to that list.

This routes the CORS middleware through the same rule: `resolveAllowedOrigin` echoes an allowed or loopback origin and refuses everything else. Production origins are unchanged. After this deploys the drop-in can be deleted.

Verification: `pnpm test` and `pnpm typecheck` in apps/realtime-server, `pnpm run knip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtuqfAf5JA3UTBHGhYvdXF
