### PR TITLE
fix(hud): selected hex outline uses the hover colour

### DIFF
--- a/apps/game/src/three/managers/selected-hex-manager.test.ts
+++ b/apps/game/src/three/managers/selected-hex-manager.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
+import * as THREE from "three";
 
+import { HoverHexManager } from "./hover-hex-manager";
 import { SelectedHexManager } from "./selected-hex-manager";
+import { resolveHoverVisualPalette } from "./worldmap-interaction-palette";
 
 describe("SelectedHexManager", () => {
-  it("holds the hover outline while a selection exists and releases it on dispose", () => {
+  it("draws the hover palette as an outline so selection and hover share one colour", () => {
+    const apply = vi.spyOn(HoverHexManager.prototype, "applyHoverPalette");
+    new SelectedHexManager(new THREE.Scene());
+    const palette = apply.mock.calls[0][0];
+    expect(palette).toEqual(resolveHoverVisualPalette({ hasSelection: false, preserveOutlineOnly: true }));
+    expect(palette.visualMode).toBe("outline");
+    expect(palette.rimColor).toBe(resolveHoverVisualPalette({ hasSelection: false }).rimColor);
+    apply.mockRestore();
+  });
+
+  it("holds the outline while a selection exists and releases it on dispose", () => {
     const subject = Object.create(SelectedHexManager.prototype) as SelectedHexManager;
     const outline = { showHover: vi.fn(), hideHover: vi.fn(), update: vi.fn(), dispose: vi.fn() };
     Reflect.set(subject as object, "outline", outline);

--- a/apps/game/src/three/managers/selected-hex-manager.ts
+++ b/apps/game/src/three/managers/selected-hex-manager.ts
@@ -1,4 +1,5 @@
 import { HoverHexManager } from "@/three/managers/hover-hex-manager";
+import { resolveHoverVisualPalette } from "@/three/managers/worldmap-interaction-palette";
 import { FLAT_TERRAIN_SURFACE, type TerrainSurface } from "@/three/terrain/terrain-surface";
 import * as THREE from "three";
 
@@ -8,7 +9,8 @@ export class SelectedHexManager {
 
   constructor(scene: THREE.Scene, terrainSurface: TerrainSurface = FLAT_TERRAIN_SURFACE) {
     this.outline = new HoverHexManager(scene, terrainSurface);
-    this.outline.setVisualMode("outline");
+    // The same colour the hover ring draws, outline only, so the selection reads as the hover that stayed.
+    this.outline.applyHoverPalette(resolveHoverVisualPalette({ hasSelection: false, preserveOutlineOnly: true }));
   }
 
   setPosition(x: number, z: number) {

--- a/apps/game/src/three/scenes/worldmap-selection-outline.source.test.ts
+++ b/apps/game/src/three/scenes/worldmap-selection-outline.source.test.ts
@@ -4,7 +4,7 @@ import { expect, it } from "vitest";
 
 it("keeps the selected hex outlined, independent of hover, across a local flight", () => {
   const manager = readFileSync("src/three/managers/selected-hex-manager.ts", "utf8");
-  expect(manager).toContain('this.outline.setVisualMode("outline")');
+  expect(manager).toContain("preserveOutlineOnly: true");
   expect(manager).not.toContain("Particles");
 
   const worldmap = readFileSync("src/three/scenes/worldmap.tsx", "utf8");


### PR DESCRIPTION
The held selection outline rendered white while the hover ring is pink. The selection's HoverHexManager never received the hover palette and kept the class default rim. It now applies the same generic hover palette, outline only, so the purple hex that persists is the same purple you hovered.

Verified: selected-hex-manager, hover-hex-manager and the worldmap selection source tests, tsc, prettier on the touched files. Not verified on hardware; the unit test pins the palette equality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgVMisnq5Gd2Z8CWH1zTj8