### PR TITLE
ci: deploy the client on every push to next that touches it

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -2,9 +2,18 @@ name: Deploy Client
 
 # Ships the game client to play.realms.party as a Cloudflare Pages project
 # (project name in vars.CLOUDFLARE_PAGES_PROJECT; the custom domain is attached
-# in the Pages dashboard once). Manual dispatch keeps deploys deliberate; the
-# build reads .env.production plus the identity RPC secret and stamps the version from the ref.
+# in the Pages dashboard once). Every push to next that touches the client's inputs
+# deploys, like the box services; manual dispatch remains for a redeploy or a version label.
+# The build reads .env.production plus the identity RPC secret and stamps the version from the ref.
 on:
+  push:
+    branches: [next]
+    paths:
+      - "apps/game/**"
+      - "packages/**"
+      - "config/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/deploy-client.yml"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
The client deploy was manual-only, so `next` ran ahead of play.realms.party until someone dispatched it. This adds a push trigger on `next` filtered to the client's inputs (`apps/game`, `packages`, `config`, the lockfile, the workflow itself), matching the box services' rule. Dispatch stays for a redeploy or a custom version label; on push the label falls back to the SHA as before. The existing concurrency group keeps runs sequential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2mqD7gbiGvPN44Ftxrqfe