### PR TITLE
Warm the local scene behind the held frame and hold chunk work during the flight

### DIFF
--- a/apps/game/src/three/flight-trace.ts
+++ b/apps/game/src/three/flight-trace.ts
@@ -27,6 +27,14 @@ const readFlightTraceFlag = (): boolean => {
 };
 
 export const FLIGHT_TRACE_ENABLED = readFlightTraceFlag();
+// The route change that starts a flight runs before flyOut, so commits and long tasks are watched from load.
+if (FLIGHT_TRACE_ENABLED) observeLongTasks();
+
+/** A moment worth a line: navigation, transition start, warm-up, the fade itself. */
+export function traceFlightMark(label: string): void {
+  if (!FLIGHT_TRACE_ENABLED) return;
+  console.log(`[flight] ${offset()} ${label}`);
+}
 
 export function beginFlightTrace(from: string | undefined, to: string): void {
   if (!FLIGHT_TRACE_ENABLED) return;
@@ -40,39 +48,8 @@ export function endFlightTrace(reason: string): void {
   console.log(`[flight] ${offset()} ${reason}`);
   const trace = activeTrace;
   window.setTimeout(() => {
-    if (activeTrace === trace) {
-      activeTrace = null;
-      longTaskObserver?.disconnect();
-      longTaskObserver = null;
-    }
+    if (activeTrace === trace) activeTrace = null;
   }, TRACE_TAIL_MS);
-}
-
-/** A React commit of the HUD during the flight: the route change re-renders it while the scene animates. */
-export function traceFlightCommit(id: string, phase: string, actualDurationMs: number): void {
-  if (!activeTrace || actualDurationMs <= FRAME_BUDGET_MS) return;
-  console.log(`[flight] ${offset()} react ${id} ${phase} ${actualDurationMs.toFixed(1)}ms`);
-}
-
-// Long tasks catch what no frame owner wraps: module loading, layout, garbage collection.
-function observeLongTasks(): void {
-  if (longTaskObserver || typeof PerformanceObserver === "undefined") return;
-  try {
-    longTaskObserver = new PerformanceObserver((list) => {
-      if (!activeTrace) return;
-      list.getEntries().forEach((entry) => {
-        const at = entry.startTime - (activeTrace?.startedAt ?? 0);
-        const source = (
-          entry as PerformanceEntry & { attribution?: { containerType?: string; containerSrc?: string }[] }
-        ).attribution?.[0];
-        const where = source ? ` in ${source.containerType ?? "?"} ${source.containerSrc ?? ""}`.trimEnd() : "";
-        console.log(`[flight] +${at.toFixed(0)}ms longtask ${entry.duration.toFixed(0)}ms${where}`);
-      });
-    });
-    longTaskObserver.observe({ entryTypes: ["longtask"] });
-  } catch {
-    longTaskObserver = null;
-  }
 }
 
 export function traceFlightFrame(durationMs: number, owner: { owner: string; maxCallMs: number } | null): void {
@@ -89,6 +66,32 @@ export function traceFlightPlanner(decision: Record<string, unknown>): void {
   console.log(`[flight] ${offset()} planner ${fields}`);
 }
 
+/** A React commit of the HUD over budget: the route change re-renders it before and during the flight. */
+export function traceFlightCommit(id: string, phase: string, actualDurationMs: number): void {
+  if (!FLIGHT_TRACE_ENABLED || actualDurationMs <= FRAME_BUDGET_MS) return;
+  console.log(`[flight] ${offset()} react ${id} ${phase} ${actualDurationMs.toFixed(1)}ms`);
+}
+
+// Long tasks catch what no frame owner wraps: module loading, layout, garbage collection.
+function observeLongTasks(): void {
+  if (longTaskObserver || typeof PerformanceObserver === "undefined") return;
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      list.getEntries().forEach((entry) => {
+        console.log(`[flight] ${offsetOf(entry.startTime)} longtask ${entry.duration.toFixed(0)}ms`);
+      });
+    });
+    longTaskObserver.observe({ entryTypes: ["longtask"] });
+  } catch {
+    longTaskObserver = null;
+  }
+}
+
+/** Relative to flyOut while a flight is traced; absolute otherwise, so lines before a flight still align. */
 function offset(): string {
-  return `+${(performance.now() - (activeTrace?.startedAt ?? 0)).toFixed(0)}ms`;
+  return offsetOf(performance.now());
+}
+
+function offsetOf(atMs: number): string {
+  return activeTrace ? `+${(atMs - activeTrace.startedAt).toFixed(0)}ms` : `@${atMs.toFixed(0)}ms`;
 }

--- a/apps/game/src/three/flight-trace.ts
+++ b/apps/game/src/three/flight-trace.ts
@@ -11,6 +11,9 @@ interface ActiveFlightTrace {
 }
 
 let activeTrace: ActiveFlightTrace | null = null;
+let longTaskObserver: PerformanceObserver | null = null;
+// The post-reveal frame compiles what the reveal could not; keep listening that long after fadeIn.
+const TRACE_TAIL_MS = 4_000;
 
 const TRACE_STORAGE_KEY = "eternum:trace";
 
@@ -23,18 +26,53 @@ const readFlightTraceFlag = (): boolean => {
   return (requested ?? window.sessionStorage.getItem(TRACE_STORAGE_KEY)) === "flight";
 };
 
-const FLIGHT_TRACE_ENABLED = readFlightTraceFlag();
+export const FLIGHT_TRACE_ENABLED = readFlightTraceFlag();
 
 export function beginFlightTrace(from: string | undefined, to: string): void {
   if (!FLIGHT_TRACE_ENABLED) return;
   activeTrace = { startedAt: performance.now(), label: `${from ?? "?"}→${to}` };
   console.log(`[flight] flyOut ${activeTrace.label} at ${activeTrace.startedAt.toFixed(0)}ms`);
+  observeLongTasks();
 }
 
 export function endFlightTrace(reason: string): void {
   if (!activeTrace) return;
   console.log(`[flight] ${offset()} ${reason}`);
-  activeTrace = null;
+  const trace = activeTrace;
+  window.setTimeout(() => {
+    if (activeTrace === trace) {
+      activeTrace = null;
+      longTaskObserver?.disconnect();
+      longTaskObserver = null;
+    }
+  }, TRACE_TAIL_MS);
+}
+
+/** A React commit of the HUD during the flight: the route change re-renders it while the scene animates. */
+export function traceFlightCommit(id: string, phase: string, actualDurationMs: number): void {
+  if (!activeTrace || actualDurationMs <= FRAME_BUDGET_MS) return;
+  console.log(`[flight] ${offset()} react ${id} ${phase} ${actualDurationMs.toFixed(1)}ms`);
+}
+
+// Long tasks catch what no frame owner wraps: module loading, layout, garbage collection.
+function observeLongTasks(): void {
+  if (longTaskObserver || typeof PerformanceObserver === "undefined") return;
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      if (!activeTrace) return;
+      list.getEntries().forEach((entry) => {
+        const at = entry.startTime - (activeTrace?.startedAt ?? 0);
+        const source = (
+          entry as PerformanceEntry & { attribution?: { containerType?: string; containerSrc?: string }[] }
+        ).attribution?.[0];
+        const where = source ? ` in ${source.containerType ?? "?"} ${source.containerSrc ?? ""}`.trimEnd() : "";
+        console.log(`[flight] +${at.toFixed(0)}ms longtask ${entry.duration.toFixed(0)}ms${where}`);
+      });
+    });
+    longTaskObserver.observe({ entryTypes: ["longtask"] });
+  } catch {
+    longTaskObserver = null;
+  }
 }
 
 export function traceFlightFrame(durationMs: number, owner: { owner: string; maxCallMs: number } | null): void {

--- a/apps/game/src/three/frame-budget-work-queue.test.ts
+++ b/apps/game/src/three/frame-budget-work-queue.test.ts
@@ -184,3 +184,35 @@ describe("FrameBudgetWorkQueue", () => {
     expect(harness.frameCount()).toBe(0);
   });
 });
+
+describe("hold", () => {
+  it("keeps queued work while held and drains it on release", async () => {
+    const harness = createHarness();
+    const ran: string[] = [];
+    harness.queue.setHeld(true);
+    const done = harness.queue.schedule("critical", () => void ran.push("terrain"), "terrain:present:page");
+    expect(harness.frameCount()).toBe(0);
+    await harness.flushFrame();
+    expect(ran).toEqual([]);
+    harness.queue.setHeld(false);
+    expect(harness.frameCount()).toBe(1);
+    await harness.flushFrame();
+    await done;
+    expect(ran).toEqual(["terrain"]);
+  });
+
+  it("stops a running drain at the next task when held mid-frame", async () => {
+    const harness = createHarness();
+    const ran: string[] = [];
+    void harness.queue.schedule("critical", () => {
+      ran.push("first");
+      harness.queue.setHeld(true);
+    });
+    void harness.queue.schedule("critical", () => void ran.push("second"));
+    await harness.flushFrame();
+    expect(ran).toEqual(["first"]);
+    harness.queue.setHeld(false);
+    await harness.flushFrame();
+    expect(ran).toEqual(["first", "second"]);
+  });
+});

--- a/apps/game/src/three/frame-budget-work-queue.ts
+++ b/apps/game/src/three/frame-budget-work-queue.ts
@@ -81,6 +81,7 @@ export class FrameBudgetWorkQueue implements FrameBudgetWorkScheduler {
   private cancelDrainRequest: (() => void) | null = null;
   private isDraining = false;
   private isDisposed = false;
+  private isHeld = false;
   private consecutiveCriticalTasks = 0;
   private consecutiveVisibleTasks = 0;
 
@@ -117,6 +118,13 @@ export class FrameBudgetWorkQueue implements FrameBudgetWorkScheduler {
     return result;
   }
 
+  /** Held, the queue keeps its work but drains nothing; releasing it drains on the next frame. */
+  setHeld(held: boolean): void {
+    if (this.isHeld === held) return;
+    this.isHeld = held;
+    if (!held) this.requestDrain();
+  }
+
   dispose(): void {
     if (this.isDisposed) {
       return;
@@ -135,7 +143,13 @@ export class FrameBudgetWorkQueue implements FrameBudgetWorkScheduler {
   }
 
   private requestDrain(): void {
-    if (this.isDisposed || this.isDraining || this.cancelDrainRequest !== null || !this.hasPendingWork()) {
+    if (
+      this.isDisposed ||
+      this.isHeld ||
+      this.isDraining ||
+      this.cancelDrainRequest !== null ||
+      !this.hasPendingWork()
+    ) {
       return;
     }
 
@@ -155,7 +169,7 @@ export class FrameBudgetWorkQueue implements FrameBudgetWorkScheduler {
     const frameBudgetMs = this.isLoading() ? this.loadingFrameBudgetMs : this.frameBudgetMs;
 
     try {
-      while (!this.isDisposed) {
+      while (!this.isDisposed && !this.isHeld) {
         const work = this.takeNextWork();
         if (!work) {
           break;

--- a/apps/game/src/three/managers/scene-flight.ts
+++ b/apps/game/src/three/managers/scene-flight.ts
@@ -1,4 +1,5 @@
 import { Vector3 } from "three";
+import { traceFlightMark } from "../flight-trace";
 import type { HexagonScene } from "../scenes/hexagon-scene";
 import { SceneName } from "../types";
 
@@ -67,6 +68,7 @@ export class SceneFlight {
         const factor = this.destination === SceneName.Hexception ? 1.15 : 0.85;
         incoming.getCamera().position.copy(target).add(settled.clone().sub(target).multiplyScalar(factor));
         incoming.cameraAnimate(settled, target, 0.3);
+        traceFlightMark("reveal: incoming scene presentable, frame fades on its next render");
         this.revealPending = true;
       });
   }

--- a/apps/game/src/three/renderer-scene-bootstrap.test.ts
+++ b/apps/game/src/three/renderer-scene-bootstrap.test.ts
@@ -46,11 +46,14 @@ describe("createRendererSceneRegistry", () => {
     const worldmapScene = createScene("map");
     const fastTravelScene = createScene("travel");
     const surface = document.createElement("canvas");
+    const compilePipelines = vi.fn(async () => {});
+    const createHexceptionScene = vi.fn(() => hexceptionScene as never);
 
     const registry = createRendererSceneRegistry({
+      compilePipelines,
       controls: { id: "controls" } as never,
       createFastTravelScene: vi.fn(() => fastTravelScene as never),
-      createHexceptionScene: vi.fn(() => hexceptionScene as never),
+      createHexceptionScene,
       createSceneManager: vi.fn(() => sceneManager as never),
       createTransitionManager: vi.fn(() => transitionManager as never),
       createWorldmapScene: vi.fn(() => worldmapScene as never),
@@ -61,6 +64,8 @@ describe("createRendererSceneRegistry", () => {
       raycaster: { id: "raycaster" } as never,
     });
 
+    // Both hex scenes warm their pipelines through the one renderer compiler.
+    expect(createHexceptionScene).toHaveBeenCalledWith(expect.objectContaining({ compilePipelines }));
     expect(registry.transitionManager).toBe(transitionManager);
     expect(registry.sceneManager).toBe(sceneManager);
     expect(registry.fastTravelScene).toBe(fastTravelScene);

--- a/apps/game/src/three/renderer-scene-bootstrap.ts
+++ b/apps/game/src/three/renderer-scene-bootstrap.ts
@@ -52,6 +52,7 @@ interface CreateRendererSceneRegistryInput<
     sceneManager: TSceneManager;
   }) => TFastTravelScene;
   createHexceptionScene: (input: {
+    compilePipelines: PipelineCompiler;
     controls: TControls;
     dojo: TDojo;
     mouse: TMouse;
@@ -118,6 +119,7 @@ export function createRendererSceneRegistry<
   const transitionManager = input.createTransitionManager();
   const sceneManager = input.createSceneManager(transitionManager);
   const hexceptionScene = input.createHexceptionScene({
+    compilePipelines: input.compilePipelines ?? (async () => {}),
     controls: input.controls,
     dojo: input.dojo,
     mouse: input.mouse,
@@ -176,8 +178,8 @@ export function createGameRendererSceneRegistry(input: {
     controls: input.controls,
     createFastTravelScene: ({ controls, dojo, mouse, raycaster, sceneManager }) =>
       new FastTravelScene(dojo, raycaster, controls, mouse, sceneManager),
-    createHexceptionScene: ({ controls, dojo, mouse, raycaster, sceneManager }) =>
-      new HexceptionScene(controls, dojo, mouse, raycaster, sceneManager),
+    createHexceptionScene: ({ compilePipelines, controls, dojo, mouse, raycaster, sceneManager }) =>
+      new HexceptionScene(controls, dojo, mouse, raycaster, sceneManager, compilePipelines),
     createSceneManager: (transitionManager) => new SceneManager(transitionManager),
     createTransitionManager: () => new TransitionManager(),
     createWorldmapScene: ({ compilePipelines, controls, dojo, markLabelsDirty, mouse, raycaster, sceneManager }) =>

--- a/apps/game/src/three/scene-manager.ts
+++ b/apps/game/src/three/scene-manager.ts
@@ -1,6 +1,7 @@
 import { TransitionManager } from "@/three/managers/transition-manager";
 import { HexagonScene, type SceneSetupContext } from "@/three/scenes/hexagon-scene";
 import { runWithFrameWorkOwner } from "@/three/frame-work-owner";
+import { traceFlightMark } from "@/three/flight-trace";
 import { formatReadableErrorForConsole } from "@/utils/error-message";
 import {
   resolvePendingTransitionStart,
@@ -47,6 +48,7 @@ export class SceneManager {
   }
 
   switchScene(sceneName: SceneName) {
+    traceFlightMark(`switchScene ${sceneName} requested`);
     const scene = this.scenes.get(sceneName);
     const decision = resolveSceneSwitchRequest({
       requestedSceneName: sceneName,

--- a/apps/game/src/three/scenes/hexception.tsx
+++ b/apps/game/src/three/scenes/hexception.tsx
@@ -13,6 +13,8 @@ import { resolveStoredLocalCameraDistance, useCameraZoomStore } from "@/hooks/st
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { isVillageLikeStructureCategory } from "@/lib/structure-type-utils";
 import { resolvePlayRouteTarget } from "@/play/navigation/play-route-target";
+import type { PipelineCompiler } from "@/three/pipeline-compiler";
+import { awaitLocalScenePresentable } from "./local-scene-presentation";
 import { getGameModeConfig } from "@/config/game-modes";
 import type { GameModeConfig } from "@/config/game-modes";
 import {
@@ -178,6 +180,7 @@ export default class HexceptionScene extends HexagonScene {
   private lastRealmKey?: string;
   private activeRealmGeneration = 0;
   private localGridBuilt: Promise<void> = Promise.resolve();
+  private groundTexturesReady: Promise<void> = Promise.resolve();
   // Store Zustand unsubscribe functions to clean up on destroy
   private storeUnsubscribes: (() => void)[] = [];
   // True from setup until switch-off. Store subscriptions fire in every scene, so a grid rebuild (and the
@@ -199,6 +202,7 @@ export default class HexceptionScene extends HexagonScene {
     mouse: Vector2,
     raycaster: Raycaster,
     sceneManager: SceneManager,
+    private readonly compilePipelines: PipelineCompiler = async () => {},
   ) {
     super(SceneName.Hexception, controls, dojo, mouse, raycaster, sceneManager);
 
@@ -530,7 +534,7 @@ export default class HexceptionScene extends HexagonScene {
     void this.proceduralTerrain.loadProps().catch((error) => {
       console.warn("[Hexception] Optional procedural terrain props failed to load", error);
     });
-    void this.proceduralTerrain.loadGroundTextures().catch((error) => {
+    this.groundTexturesReady = this.proceduralTerrain.loadGroundTextures().catch((error) => {
       console.warn("[Hexception] Procedural ground textures failed; retaining flat terrain", error);
     });
     this.loadBuildingModels();
@@ -1118,9 +1122,16 @@ export default class HexceptionScene extends HexagonScene {
     });
   }
 
-  /** The first local frame is empty until the grid build presents terrain and buildings. */
+  /**
+   * The first local frame is empty until the grid build presents terrain and buildings, and slow until the
+   * renderer has compiled their pipelines; both happen behind the held world frame.
+   */
   public override whenPresentable(): Promise<void> {
-    return this.localGridBuilt;
+    return awaitLocalScenePresentable({
+      gridBuilt: this.localGridBuilt,
+      groundTextures: this.groundTexturesReady,
+      compile: () => this.compilePipelines(this.scene, this.scene),
+    });
   }
 
   private advanceRealmGeneration(): number {

--- a/apps/game/src/three/scenes/hexception.tsx
+++ b/apps/game/src/three/scenes/hexception.tsx
@@ -15,6 +15,7 @@ import { isVillageLikeStructureCategory } from "@/lib/structure-type-utils";
 import { resolvePlayRouteTarget } from "@/play/navigation/play-route-target";
 import type { PipelineCompiler } from "@/three/pipeline-compiler";
 import { awaitLocalScenePresentable } from "./local-scene-presentation";
+import { traceFlightMark } from "../flight-trace";
 import { getGameModeConfig } from "@/config/game-modes";
 import type { GameModeConfig } from "@/config/game-modes";
 import {
@@ -1130,7 +1131,11 @@ export default class HexceptionScene extends HexagonScene {
     return awaitLocalScenePresentable({
       gridBuilt: this.localGridBuilt,
       groundTextures: this.groundTexturesReady,
-      compile: () => this.compilePipelines(this.scene, this.scene),
+      compile: async () => {
+        traceFlightMark("warm-up: compiling local scene pipelines");
+        await this.compilePipelines(this.scene, this.scene);
+        traceFlightMark("warm-up: pipelines compiled");
+      },
     });
   }
 

--- a/apps/game/src/three/scenes/local-scene-presentation.test.ts
+++ b/apps/game/src/three/scenes/local-scene-presentation.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { awaitLocalScenePresentable } from "./local-scene-presentation";
+
+afterEach(() => vi.restoreAllMocks());
+
+it("compiles only once the grid and ground textures have settled, then resolves", async () => {
+  const order: string[] = [];
+  let buildGrid!: () => void;
+  const gridBuilt = new Promise<void>((resolve) => (buildGrid = resolve)).then(() => void order.push("grid"));
+  const groundTextures = Promise.reject(new Error("textures offline")).catch(() => void order.push("textures"));
+  const compile = vi.fn(async () => void order.push("compile"));
+  const presentable = awaitLocalScenePresentable({ gridBuilt, groundTextures, compile });
+  await Promise.resolve();
+  expect(compile).not.toHaveBeenCalled();
+  buildGrid();
+  await presentable;
+  expect(order).toEqual(["textures", "grid", "compile"]);
+});
+
+it("still resolves when the warm-up itself fails", async () => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  await expect(
+    awaitLocalScenePresentable({
+      gridBuilt: Promise.resolve(),
+      groundTextures: Promise.resolve(),
+      compile: async () => {
+        throw new Error("device lost");
+      },
+    }),
+  ).resolves.toBeUndefined();
+  expect(console.warn).toHaveBeenCalledOnce();
+});

--- a/apps/game/src/three/scenes/local-scene-presentation.ts
+++ b/apps/game/src/three/scenes/local-scene-presentation.ts
@@ -1,0 +1,17 @@
+/**
+ * When the local scene may be revealed: after its grid is built and its ground textures have settled, and after
+ * the renderer has compiled every pipeline the first frame would otherwise compile on screen. A failed warm-up
+ * still reveals: an uncompiled first frame is a hitch, a frozen snapshot is a bug.
+ */
+export async function awaitLocalScenePresentable(input: {
+  gridBuilt: Promise<void>;
+  groundTextures: Promise<void>;
+  compile: () => Promise<void>;
+}): Promise<void> {
+  await Promise.allSettled([input.gridBuilt, input.groundTextures]);
+  try {
+    await input.compile();
+  } catch (error) {
+    console.warn("[Hexception] pipeline warm-up failed; the first frame compiles on screen", error);
+  }
+}

--- a/apps/game/src/three/scenes/worldmap-flight-hold.source.test.ts
+++ b/apps/game/src/three/scenes/worldmap-flight-hold.source.test.ts
@@ -1,0 +1,9 @@
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { expect, it } from "vitest";
+
+it("holds the world map's chunk work while the flight owns the camera", () => {
+  const worldmap = readFileSync("src/three/scenes/worldmap.tsx", "utf8");
+  expect(worldmap).toContain("public override setCameraOwnedByFlight(owned: boolean): void {");
+  expect(worldmap).toContain("this.chunkWorkQueue.setHeld(owned);");
+});

--- a/apps/game/src/three/scenes/worldmap.tsx
+++ b/apps/game/src/three/scenes/worldmap.tsx
@@ -3705,6 +3705,12 @@ export default class WorldmapScene extends WarpTravel {
     if (setupContext.isCurrent()) this.redrawHeldSelection();
   }
 
+  /** The flight owns the camera: no chunk work (terrain pages, composites, refreshes) draws on its way out. */
+  public override setCameraOwnedByFlight(owned: boolean): void {
+    super.setCameraOwnedByFlight(owned);
+    this.chunkWorkQueue.setHeld(owned);
+  }
+
   private redrawHeldSelection(): void {
     const selectedHex = this.state.selectedHex;
     if (!selectedHex) return;

--- a/apps/game/src/three/utils/navigation.ts
+++ b/apps/game/src/three/utils/navigation.ts
@@ -1,3 +1,4 @@
+import { traceFlightMark } from "../flight-trace";
 import { Position } from "@bibliothecadao/eternum";
 import { getGameModeId } from "@/config/game-modes";
 import { buildPlayHref, parsePlayRoute } from "@/play/navigation/play-route";
@@ -40,8 +41,10 @@ function buildSceneLocationUrl(col: number, row: number, targetScene: SceneName)
 }
 
 function dispatchSceneNavigation(navigationUrl: string): void {
+  traceFlightMark(`navigate ${navigationUrl}`);
   window.history.pushState({}, "", navigationUrl);
   window.dispatchEvent(new Event("urlChanged"));
+  traceFlightMark("urlChanged listeners done");
 }
 
 /**

--- a/apps/game/src/ui/layouts/world.tsx
+++ b/apps/game/src/ui/layouts/world.tsx
@@ -24,6 +24,8 @@ import { ChainTimePoller } from "../shared/components/chain-time-poller";
 import { ActionRunners } from "../action-runners";
 import { RelicCrateOpenings } from "../features/military/chest/relic-crate-openings";
 import { RecsStoreBridge } from "./recs-store-bridge";
+import { FLIGHT_TRACE_ENABLED, traceFlightCommit } from "@/three/flight-trace";
+import { Profiler } from "react";
 import { PlayOverlayManager } from "./play-overlay-manager";
 
 export const World = ({ backgroundImage }: { backgroundImage: string }) => {
@@ -47,7 +49,13 @@ export const World = ({ backgroundImage }: { backgroundImage: string }) => {
         <ActionInfo />
 
         {/* HUD (heads-up display) elements */}
-        <HUD />
+        {FLIGHT_TRACE_ENABLED ? (
+          <Profiler id="hud" onRender={(id, phase, actualDuration) => traceFlightCommit(id, phase, actualDuration)}>
+            <HUD />
+          </Profiler>
+        ) : (
+          <HUD />
+        )}
 
         {/* Utility overlays */}
         <Leva hidden={!DEV_MODE_ENABLED} collapsed titleBar={{ position: { x: 0, y: 50 } }} />


### PR DESCRIPTION
Follow-ups from the owner's hardware trace of one World to Local flight (WebGPU, dev build) and the testing session around it.

Flight:
1. **2.2 s right after the reveal**: the renderer compiled every building material on the local scene's first visible frame (422 bind groups, 36 pipelines, 47 programs, 24 texture uploads). The local scene now receives the renderer's pipeline compiler and `whenPresentable` resolves after the grid is built, the ground textures have settled and `compileAsync` has run, behind the captured world frame, with a 1.5 s budget so a slow asynchronous compile never holds the frame (the WebGPU lane took twelve seconds).
2. **62 and 89 ms frames mid-flight**: terrain pages queued before `flyOut` were still presented. The world map holds its frame-budget work queue while the flight owns the camera.
3. **The route-change hitch** at flight start: the `?trace=flight` trace now logs HUD React commits and long tasks whenever the flag is on, with marks at the switch request, the warm-up and the real fade; the second hardware capture shows it as five HUD commits (170 ms) plus long tasks during the zoom, not one frame.

Names and crates, found while testing:
4. Structure map labels decoded AddressName themselves; they use the player resolver now.
5. The core story formatter named owners from the chain alone; it takes the client's resolver and names every owner through one path (zero address reads Neutral). Battle lab, faith leaderboard rows and the prize panel stop shortening addresses themselves.
6. Nothing renders the context menu state, so the crate's right-click menu never appeared; the right-click opens the crate directly. The structure right-click menu has the same problem and is left for its own change.

Verified: work-queue hold, bootstrap, presentation helper, flight, scene-manager, formatter and structure-manager suites, typecheck, prettier; full apps/game suite run before merge.