### PR TITLE
Avoid redundant instance uploads and idle client updates

### DIFF
--- a/apps/game/src/hooks/store/use-realm-store.test.ts
+++ b/apps/game/src/hooks/store/use-realm-store.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 
+import { createStore } from "zustand/vanilla";
 import { describe, expect, it, vi } from "vitest";
 import { configManager } from "@bibliothecadao/eternum";
 import { UNDEFINED_STRUCTURE_ENTITY_ID } from "@/ui/constants";
@@ -135,4 +136,24 @@ describe("use-realm-store spectator lifecycle", () => {
     expect(next.isSpectating).toBe(false);
     expect(next.structureEntityId).toBe(444);
   });
+});
+
+it("publishes arrival badges only when their counts or ordered structure IDs change", () => {
+  const store = createStore<RealmStore>((set) => createRealmStoreSlice(set));
+  const listener = vi.fn();
+  store.subscribe(listener);
+  const setIndicators = store.getState().setArrivalIndicators;
+  for (let tick = 0; tick < 60; tick++) {
+    setIndicators({ arrivedArrivalsNumber: 0, pendingArrivalsNumber: 0, arrivedArrivalStructureIds: [] });
+  }
+  expect(listener).not.toHaveBeenCalled();
+  const indicators = { arrivedArrivalsNumber: 2, pendingArrivalsNumber: 1, arrivedArrivalStructureIds: [7, 8] };
+  setIndicators(indicators);
+  const committed = store.getState();
+  setIndicators({ ...indicators, arrivedArrivalStructureIds: [7, 8] });
+  expect(store.getState()).toBe(committed);
+  expect(listener).toHaveBeenCalledTimes(1);
+  setIndicators({ ...indicators, arrivedArrivalStructureIds: [8, 7] });
+  setIndicators({ ...indicators, pendingArrivalsNumber: 2 });
+  expect(listener).toHaveBeenCalledTimes(3);
 });

--- a/apps/game/src/hooks/store/use-realm-store.ts
+++ b/apps/game/src/hooks/store/use-realm-store.ts
@@ -205,7 +205,8 @@ export const createRealmStoreSlice = (
     }),
   arrivedArrivalsNumber: 0,
   arrivedArrivalStructureIds: [],
-  setArrivalIndicators: (indicators: Parameters<RealmStore["setArrivalIndicators"]>[0]) => set(indicators),
+  setArrivalIndicators: (indicators: Parameters<RealmStore["setArrivalIndicators"]>[0]) =>
+    set((state) => (haveSameArrivalIndicators(state, indicators) ? state : indicators)),
   pendingArrivalsNumber: 0,
   publicIncomingTroopArrivalsByStructure: {},
   setPublicIncomingTroopArrivalsByStructure: (
@@ -224,3 +225,15 @@ export const createRealmStoreSlice = (
   relicsRefreshNonce: 0,
   triggerRelicsRefresh: () => set((state: RealmStore) => ({ relicsRefreshNonce: state.relicsRefreshNonce + 1 })),
 });
+
+function haveSameArrivalIndicators(
+  current: RealmStore,
+  next: Parameters<RealmStore["setArrivalIndicators"]>[0],
+): boolean {
+  return (
+    current.arrivedArrivalsNumber === next.arrivedArrivalsNumber &&
+    current.pendingArrivalsNumber === next.pendingArrivalsNumber &&
+    current.arrivedArrivalStructureIds.length === next.arrivedArrivalStructureIds.length &&
+    current.arrivedArrivalStructureIds.every((id, index) => id === next.arrivedArrivalStructureIds[index])
+  );
+}

--- a/apps/game/src/three/combat/melee-impact-system.test.ts
+++ b/apps/game/src/three/combat/melee-impact-system.test.ts
@@ -1,5 +1,5 @@
 import { TroopTier } from "@bibliothecadao/types";
-import { Vector3 } from "three";
+import { InstancedMesh, Matrix4, Vector3 } from "three";
 import { describe, expect, it } from "vitest";
 
 import { MeleeImpactSystem } from "./melee-impact-system";
@@ -22,4 +22,54 @@ describe("melee impact system", () => {
     expect(system.getStats().activeCount).toBe(0);
     system.dispose();
   });
+});
+
+it("does no drawing or buffer writes while idle, and packs surviving impacts into the drawn prefix", () => {
+  const system = new MeleeImpactSystem(4);
+  const meshes = system.group.children as InstancedMesh[];
+  const versions = meshes.map((mesh) => mesh.instanceMatrix.version);
+  for (let frame = 0; frame < 60; frame++) system.update(1 / 60);
+  expect(meshes.map((mesh) => mesh.count)).toEqual([0, 0]);
+  expect(meshes.map((mesh) => mesh.instanceMatrix.version)).toEqual(versions);
+  expect(meshes.every((mesh) => !mesh.visible)).toBe(true);
+
+  const spawn = (x: number) =>
+    system.spawn({ direction: new Vector3(0, 0, 1), target: new Vector3(x, 0, 0), tier: TroopTier.T1 });
+  spawn(1);
+  for (let frame = 0; frame < 3; frame++) system.update(0.1);
+  spawn(2);
+  system.update(0.1);
+  expect(meshes.map((mesh) => mesh.count)).toEqual([2, 2]);
+  for (const mesh of meshes) mesh.instanceMatrix.clearUpdateRanges();
+  system.update(0.1);
+  expect(system.getStats().activeCount).toBe(1);
+  for (const mesh of meshes) {
+    expect(mesh.count).toBe(1);
+    const transform = new Matrix4();
+    mesh.getMatrixAt(0, transform);
+    expect(transform.elements[12]).toBe(2);
+    expect(mesh.instanceMatrix.updateRanges).toEqual([{ start: 0, count: 16 }]);
+  }
+  system.reset();
+  expect(meshes.every((mesh) => !mesh.visible)).toBe(true);
+  expect(meshes.map((mesh) => mesh.count)).toEqual([0, 0]);
+  spawn(3);
+  system.update(0);
+  expect(meshes.every((mesh) => mesh.visible)).toBe(true);
+  expect(meshes.map((mesh) => mesh.count)).toEqual([1, 1]);
+  system.dispose();
+});
+
+it("keeps simulating while overview hides the group and never overrides that visibility", () => {
+  const system = new MeleeImpactSystem();
+  system.group.visible = false;
+  system.spawn({ direction: new Vector3(0, 0, 1), target: new Vector3(), tier: TroopTier.T1 });
+  system.update(0.1);
+  expect(system.group.visible).toBe(false);
+  expect(system.getStats().activeCount).toBe(1);
+  for (let frame = 0; frame < 4; frame++) system.update(0.1);
+  expect(system.getStats().activeCount).toBe(0);
+  system.group.visible = true;
+  expect((system.group.children as InstancedMesh[]).every((mesh) => mesh.count === 0 && !mesh.visible)).toBe(true);
+  system.dispose();
 });

--- a/apps/game/src/three/combat/melee-impact-system.ts
+++ b/apps/game/src/three/combat/melee-impact-system.ts
@@ -1,3 +1,4 @@
+import { queueInstanceUpdate } from "../utils/instance-update-ranges";
 import { createInstancedMesh } from "../utils/create-instanced-mesh";
 import { TroopTier } from "@bibliothecadao/types";
 import {
@@ -52,6 +53,7 @@ export class MeleeImpactSystem {
     transparent: true,
     opacity: 0.72,
     side: DoubleSide,
+    forceSinglePass: true,
     vertexColors: true,
   });
   private readonly slashMesh: InstancedMesh;
@@ -62,6 +64,7 @@ export class MeleeImpactSystem {
   private readonly spinQuaternion = new Quaternion();
   private readonly scale = new Vector3();
   private readonly color = new Color();
+  private activeCount = 0;
   private spawnedCount = 0;
   private droppedCount = 0;
   private disposed = false;
@@ -82,7 +85,7 @@ export class MeleeImpactSystem {
       tier: TroopTier.T1,
     }));
     this.group.add(this.slashMesh, this.impactMesh);
-    this.hideInactiveInstances();
+    this.setRenderCount(0);
   }
 
   public spawn(input: MeleeImpactSpawn): boolean {
@@ -92,6 +95,7 @@ export class MeleeImpactSystem {
       this.droppedCount += 1;
       return false;
     }
+    this.activeCount++;
     entry.active = true;
     entry.elapsedSeconds = 0;
     entry.position.copy(input.target);
@@ -105,18 +109,23 @@ export class MeleeImpactSystem {
   }
 
   public update(deltaSeconds: number): void {
-    if (this.disposed) return;
+    if (this.disposed || this.activeCount === 0) return;
     const elapsed = Number.isFinite(deltaSeconds) ? Math.min(Math.max(0, deltaSeconds), 0.1) : 0;
-    this.entries.forEach((entry, index) => this.updateEntry(entry, index, elapsed));
-    this.slashMesh.instanceMatrix.needsUpdate = true;
-    this.impactMesh.instanceMatrix.needsUpdate = true;
-    if (this.slashMesh.instanceColor) this.slashMesh.instanceColor.needsUpdate = true;
-    if (this.impactMesh.instanceColor) this.impactMesh.instanceColor.needsUpdate = true;
+    let renderCount = 0;
+    for (const entry of this.entries) {
+      if (this.updateEntry(entry, renderCount, elapsed)) renderCount++;
+    }
+    this.setRenderCount(renderCount);
+    if (renderCount === 0) return;
+    for (const mesh of [this.slashMesh, this.impactMesh]) {
+      queueInstanceUpdate(mesh.instanceMatrix, 0, renderCount);
+      if (mesh.instanceColor) queueInstanceUpdate(mesh.instanceColor, 0, renderCount);
+    }
   }
 
   public getStats(): MeleeImpactSystemStats {
     return {
-      activeCount: this.entries.filter(({ active }) => active).length,
+      activeCount: this.activeCount,
       capacity: this.capacity,
       droppedCount: this.droppedCount,
       spawnedCount: this.spawnedCount,
@@ -128,14 +137,17 @@ export class MeleeImpactSystem {
       entry.active = false;
       entry.elapsedSeconds = 0;
     });
+    this.activeCount = 0;
     this.spawnedCount = 0;
     this.droppedCount = 0;
-    this.hideInactiveInstances();
+    this.setRenderCount(0);
   }
 
   public dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.slashMesh.dispose();
+    this.impactMesh.dispose();
     this.slashGeometry.dispose();
     this.impactGeometry.dispose();
     this.slashMaterial.dispose();
@@ -144,14 +156,14 @@ export class MeleeImpactSystem {
     this.group.removeFromParent();
   }
 
-  private updateEntry(entry: MeleeImpactEntry, index: number, deltaSeconds: number): void {
-    if (!entry.active) return;
+  private updateEntry(entry: MeleeImpactEntry, index: number, deltaSeconds: number): boolean {
+    if (!entry.active) return false;
     entry.elapsedSeconds += deltaSeconds;
     const progress = Math.min(1, entry.elapsedSeconds / IMPACT_SECONDS);
     if (progress >= 1) {
       entry.active = false;
-      this.hideInstance(index);
-      return;
+      this.activeCount--;
+      return false;
     }
 
     const intensity = 1 - progress;
@@ -166,19 +178,14 @@ export class MeleeImpactSystem {
     this.color.copy(resolveTierColor(entry.tier)).multiplyScalar(Math.max(0.08, intensity));
     this.slashMesh.setColorAt(index, this.color);
     this.impactMesh.setColorAt(index, this.color);
+    return true;
   }
 
-  private hideInactiveInstances(): void {
-    this.entries.forEach((_entry, index) => this.hideInstance(index));
-    this.slashMesh.instanceMatrix.needsUpdate = true;
-    this.impactMesh.instanceMatrix.needsUpdate = true;
-  }
-
-  private hideInstance(index: number): void {
-    this.scale.setScalar(0);
-    this.matrix.compose(this.group.position, this.group.quaternion, this.scale);
-    this.slashMesh.setMatrixAt(index, this.matrix);
-    this.impactMesh.setMatrixAt(index, this.matrix);
+  private setRenderCount(count: number): void {
+    this.slashMesh.count = count;
+    this.impactMesh.count = count;
+    this.slashMesh.visible = count > 0;
+    this.impactMesh.visible = count > 0;
   }
 }
 

--- a/apps/game/src/three/debug/procedural-terrain-debug-renderer.ts
+++ b/apps/game/src/three/debug/procedural-terrain-debug-renderer.ts
@@ -494,7 +494,6 @@ async function createSettlementRealmModel(
     model.setMatrixAt(index, matrix);
   });
   model.setCount(TERRAIN_SETTLEMENT_REGROWTH_SITES.length);
-  model.needsUpdate();
   return model;
 }
 

--- a/apps/game/src/three/debug/terrain-lab-interaction.ts
+++ b/apps/game/src/three/debug/terrain-lab-interaction.ts
@@ -104,7 +104,7 @@ export class TerrainLabInteraction {
         getArmyGroundOffset(this.army.instancedMeshes, this.armyType === "none" ? undefined : this.armyType),
       );
       this.army.setMatrixAt(0, this.matrix, this.armyPosition.y);
-      this.army.needsUpdate();
+      this.army.refreshBounds();
     }
     this.army.updateAnimations(delta);
   }

--- a/apps/game/src/three/managers/instanced-model.material-semantics.test.ts
+++ b/apps/game/src/three/managers/instanced-model.material-semantics.test.ts
@@ -183,4 +183,22 @@ describe("InstancedModel material semantics", () => {
     expect(readInstanceMatrix(chestMesh, 1).elements).toEqual(hiddenMatrix.elements);
     expect(model.getMatricesAndCount().count).toBe(1);
   });
+  it("queues only changed structure slots and does not upload matrices for a count-only update", async () => {
+    const { default: InstancedModel } = await import("./instanced-model");
+    const model = new InstancedModel(createInstancedModelTestGltf(new MeshStandardMaterial()), 1000);
+    const mesh = model.instancedMeshes[0];
+    mesh.instanceMatrix.clearUpdateRanges();
+    const version = mesh.instanceMatrix.version;
+    model.setCount(4);
+    expect(mesh.instanceMatrix.version).toBe(version);
+    model.setMatrixAt(3, new Matrix4().makeTranslation(3, 2, 1));
+    expect(mesh.instanceMatrix.updateRanges).toEqual([{ start: 48, count: 16 }]);
+    model.setCount(4);
+    expect(mesh.instanceMatrix.updateRanges).toEqual([{ start: 48, count: 16 }]);
+    mesh.instanceMatrix.clearUpdateRanges();
+    model.removeInstance(3);
+    expect(mesh.instanceMatrix.updateRanges).toEqual([{ start: 48, count: 16 }]);
+    expect(readInstanceMatrix(mesh, 3).elements).toEqual(new Matrix4().makeScale(0, 0, 0).elements);
+    model.dispose();
+  });
 });

--- a/apps/game/src/three/managers/instanced-model.tsx
+++ b/apps/game/src/three/managers/instanced-model.tsx
@@ -1,3 +1,4 @@
+import { queueInstanceUpdate } from "../utils/instance-update-ranges";
 import { createInstancedMesh } from "../utils/create-instanced-mesh";
 import { MinesMaterialsParams, PREVIEW_BUILD_COLOR_INVALID } from "@/three/constants";
 import { ResourcesIds, StructureType } from "@bibliothecadao/types";
@@ -55,6 +56,7 @@ function resolveRenderedInstanceCount(mesh: InstancedMesh, logicalCount: number)
 function hideUnusedRenderedInstances(mesh: InstancedMesh, logicalCount: number, renderedCount: number): void {
   for (let index = logicalCount; index < renderedCount; index++) {
     mesh.setMatrixAt(index, zeroMatrix);
+    queueInstanceUpdate(mesh.instanceMatrix, index, 1);
   }
 }
 
@@ -295,7 +297,7 @@ export default class InstancedModel {
         targetArray.set(sourceArray.subarray(0, floatsToCopy));
       }
       applyRenderedInstanceCount(mesh, finalCount);
-      mesh.instanceMatrix.needsUpdate = true;
+      if (finalCount > 0) queueInstanceUpdate(mesh.instanceMatrix, 0, finalCount);
       resolvedCount = Math.min(resolvedCount, finalCount);
     });
     this.count = resolvedCount;
@@ -307,7 +309,7 @@ export default class InstancedModel {
     }
     this.instancedMeshes.forEach((child) => {
       child.setMatrixAt(index, matrix);
-      child.instanceMatrix.needsUpdate = true;
+      queueInstanceUpdate(child.instanceMatrix, index, 1);
     });
 
     if (this.contactShadowMesh) {
@@ -323,7 +325,7 @@ export default class InstancedModel {
         );
         this.contactShadowMesh.setMatrixAt(index, this.contactShadowMatrix);
       }
-      this.contactShadowMesh.instanceMatrix.needsUpdate = true;
+      queueInstanceUpdate(this.contactShadowMesh.instanceMatrix, index, 1);
     }
   }
 
@@ -334,7 +336,7 @@ export default class InstancedModel {
     this.instancedMeshes.forEach((mesh) => {
       mesh.setColorAt(index, color);
       if (mesh.instanceColor) {
-        mesh.instanceColor.needsUpdate = true;
+        queueInstanceUpdate(mesh.instanceColor, index, 1);
       }
     });
   }
@@ -348,7 +350,7 @@ export default class InstancedModel {
     if (this.contactShadowMesh) {
       this.contactShadowMesh.count = drawCount;
     }
-    this.needsUpdate();
+    this.refreshBounds();
   }
 
   removeInstance(index: number) {
@@ -356,19 +358,7 @@ export default class InstancedModel {
     this.refreshBounds();
   }
 
-  needsUpdate() {
-    this.instancedMeshes.forEach((mesh) => {
-      mesh.instanceMatrix.needsUpdate = true;
-    });
-
-    if (this.contactShadowMesh) {
-      this.contactShadowMesh.instanceMatrix.needsUpdate = true;
-    }
-
-    this.refreshBounds();
-  }
-
-  private refreshBounds(): void {
+  refreshBounds(): void {
     this.instancedMeshes.forEach((mesh) => {
       if (this.worldBounds) {
         this.applyWorldBounds(mesh);
@@ -583,15 +573,12 @@ export default class InstancedModel {
 
     // Wonder rotation with its own frame limiting
     if (this.name === "wonder" && now - this.lastWonderUpdate >= this.wonderUpdateInterval) {
-      const rotationSpeed = 1; // Adjust speed as needed
+      rotationMatrix.makeRotationY(deltaTime);
 
       this.instancedMeshes.forEach((mesh) => {
         for (let i = 0; i < mesh.count; i++) {
           // Get the current instance matrix
           mesh.getMatrixAt(i, instanceMatrix);
-
-          // Create a rotation matrix around Y axis
-          rotationMatrix.makeRotationY(rotationSpeed * deltaTime);
 
           // Apply rotation to the instance matrix
           instanceMatrix.multiply(rotationMatrix);
@@ -600,7 +587,7 @@ export default class InstancedModel {
           mesh.setMatrixAt(i, instanceMatrix);
         }
 
-        mesh.instanceMatrix.needsUpdate = true;
+        if (mesh.count > 0) queueInstanceUpdate(mesh.instanceMatrix, 0, mesh.count);
       });
 
       this.lastWonderUpdate = now;

--- a/apps/game/src/three/managers/reserved-hyperstructure-manager.ts
+++ b/apps/game/src/three/managers/reserved-hyperstructure-manager.ts
@@ -131,7 +131,6 @@ export class ReservedHyperstructureManager {
     }
 
     reservedHyperstructureModel.setCount(entries.length);
-    reservedHyperstructureModel.needsUpdate();
   }
 
   private getReservedHyperstructureHexes(): HexPosition[] {

--- a/apps/game/src/three/utils/create-instanced-mesh.ts
+++ b/apps/game/src/three/utils/create-instanced-mesh.ts
@@ -1,12 +1,12 @@
-import { DynamicDrawUsage, InstancedMesh, type BufferGeometry, type Material } from "three";
+import { InstancedMesh, type BufferGeometry, type Material } from "three";
 import { StorageInstancedBufferAttribute } from "three/webgpu";
 
 /**
  * Keep native WebGPU transforms out of per-draw uniform uploads.
  * Ordinary instance matrices below the uniform limit are uploaded at full
  * capacity on every draw. Storage attributes upload only when needsUpdate is
- * set and honor dirty ranges. WebGL keeps its native instance attributes:
- * three's storage-matrix fallback does not render correctly on that backend.
+ * set and honor dirty ranges. The Three patch keeps WebGL on native instance
+ * attributes at every capacity; its uniform path otherwise uploads every draw.
  */
 export function createInstancedMesh<G extends BufferGeometry, M extends Material | Material[]>(
   geometry: G,
@@ -24,10 +24,6 @@ export function createInstancedMesh<G extends BufferGeometry, M extends Material
       const matrices = new StorageInstancedBufferAttribute(mesh.instanceMatrix.array, 16);
       matrices.name = mesh.instanceMatrix.name;
       mesh.instanceMatrix = matrices;
-    } else {
-      // The WebGL matrix wrapper synchronizes its version after attribute
-      // uploads. Dynamic usage makes a changed transform visible this frame.
-      mesh.instanceMatrix.setUsage(DynamicDrawUsage);
     }
     mesh.onBeforeRender = beforeRender;
     beforeRender.call(this, renderer, ...args);

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-10",
+    title: "Lighter Map and Combat Updates",
+    type: "improvement",
+    description:
+      "The map does less background rendering work, idle combat effects stop consuming frame time, and arrival badges update only when their contents change.",
+  },
+  {
+    date: "2026-09-10",
     title: "Clearer Terrain and Smoother Storms",
     type: "improvement",
     description:

--- a/patches/three@0.185.1.patch
+++ b/patches/three@0.185.1.patch
@@ -1,0 +1,205 @@
+diff --git a/build/three.webgpu.js b/build/three.webgpu.js
+index 2e490796d4d4aa9479b04a5c46ddbf31cc05b1a1..25c348fe44c8286525c47df68dac10514586bb8a 100644
+--- a/build/three.webgpu.js
++++ b/build/three.webgpu.js
+@@ -18297,6 +18297,15 @@ const _matrixBuffers = /*@__PURE__*/ new WeakMap();
+ const _colorBuffers = /*@__PURE__*/ new WeakMap();
+ const _previousInstanceMatrices = /*@__PURE__*/ new WeakMap();
+ 
++// The WebGL uniform path uploads the entire matrix array on every draw, even
++// for unchanged instances. Vertex attributes honor versions and dirty ranges.
++function useUniformInstanceMatrices( builder, matrices ) {
++
++	return builder.renderer.backend.isWebGLBackend !== true &&
++		Math.max( matrices.count, 1 ) * 16 * 4 <= builder.getUniformBufferLimit();
++
++}
++
+ /**
+  * Creates the appropriate node for instanced matrix transformations.
+  * Depending on buffer limits and storage capability, returns either a storage, buffer, or instanced interleaved attribute node.
+@@ -18318,9 +18327,7 @@ function createInstanceMatrixNode( builder, instanceMatrix ) {
+ 
+ 	} else {
+ 
+-		const uniformBufferSize = matrixCount * 16 * 4;
+-
+-		if ( uniformBufferSize <= builder.getUniformBufferLimit() ) {
++		if ( useUniformInstanceMatrices( builder, instanceMatrix ) ) {
+ 
+ 			instanceMatrixNode = buffer( instanceMatrix.array, 'mat4', matrixCount ).element( instanceIndex );
+ 
+@@ -18412,9 +18419,7 @@ const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder ) => {
+ 
+ 	if ( ! isStorageMatrix ) {
+ 
+-		const uniformBufferSize = Math.max( matrices.count, 1 ) * 16 * 4;
+-
+-		if ( uniformBufferSize > builder.getUniformBufferLimit() ) {
++		if ( ! useUniformInstanceMatrices( builder, matrices ) ) {
+ 
+ 			interleavedMatrix = _matrixBuffers.get( matrices );
+ 
+@@ -18437,7 +18442,7 @@ const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder ) => {
+ 
+ 			if ( ! bufferAttribute ) {
+ 
+-				bufferAttribute = new InstancedBufferAttribute( colors.array, 3 );
++				bufferAttribute = new InstancedInterleavedBuffer( colors.array, 3, 1 );
+ 				_colorBuffers.set( colors, bufferAttribute );
+ 
+ 			}
+@@ -18452,34 +18457,27 @@ const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder ) => {
+ 
+ 	}
+ 
+-	// Synchronization of dynamic buffer updates per frame
++	// Synchronize before geometry uploads; consuming dirty spans keeps later
++	// writes small and makes a changed transform/color visible in this draw.
+ 	if ( interleavedMatrix !== null || interleavedColor !== null ) {
+ 
+-		OnFrameUpdate( () => {
++		OnBeforeObjectUpdate( () => {
+ 
+-			if ( interleavedMatrix !== null ) {
++			if ( interleavedMatrix !== null && matrices.version !== interleavedMatrix.version ) {
+ 
+ 				interleavedMatrix.clearUpdateRanges();
+ 				interleavedMatrix.updateRanges.push( ...matrices.updateRanges );
+-
+-				if ( matrices.version !== interleavedMatrix.version ) {
+-
+-					interleavedMatrix.version = matrices.version;
+-
+-				}
++				matrices.clearUpdateRanges();
++				interleavedMatrix.version = matrices.version;
+ 
+ 			}
+ 
+-			if ( colors && interleavedColor !== null ) {
++			if ( colors && interleavedColor !== null && colors.version !== interleavedColor.version ) {
+ 
+ 				interleavedColor.clearUpdateRanges();
+ 				interleavedColor.updateRanges.push( ...colors.updateRanges );
+-
+-				if ( colors.version !== interleavedColor.version ) {
+-
+-					interleavedColor.version = colors.version;
+-
+-				}
++				colors.clearUpdateRanges();
++				interleavedColor.version = colors.version;
+ 
+ 			}
+ 
+diff --git a/src/nodes/accessors/Instance.js b/src/nodes/accessors/Instance.js
+index b89834b9166c75fd946ade24db265bf8c367d244..5f4775ba77e44ab58439d0fc57275ec6e4909ff7 100644
+--- a/src/nodes/accessors/Instance.js
++++ b/src/nodes/accessors/Instance.js
+@@ -1,6 +1,6 @@
+ 
+ import { vec3, mat4, Fn } from '../tsl/TSLBase.js';
+-import { OnFrameUpdate, OnObjectUpdate } from '../utils/EventNode.js';
++import { OnBeforeObjectUpdate, OnObjectUpdate } from '../utils/EventNode.js';
+ import { normalLocal, transformNormal } from './Normal.js';
+ import { positionLocal, positionPrevious } from './Position.js';
+ import { varyingProperty } from '../core/PropertyNode.js';
+@@ -10,13 +10,21 @@ import { storage } from './StorageBufferNode.js';
+ import { instanceIndex } from '../core/IndexNode.js';
+ 
+ import { InstancedInterleavedBuffer } from '../../core/InstancedInterleavedBuffer.js';
+-import { InstancedBufferAttribute } from '../../core/InstancedBufferAttribute.js';
+ import { DynamicDrawUsage } from '../../constants.js';
+ 
+ const _matrixBuffers = /*@__PURE__*/ new WeakMap();
+ const _colorBuffers = /*@__PURE__*/ new WeakMap();
+ const _previousInstanceMatrices = /*@__PURE__*/ new WeakMap();
+ 
++// The WebGL uniform path uploads the entire matrix array on every draw, even
++// for unchanged instances. Vertex attributes honor versions and dirty ranges.
++function useUniformInstanceMatrices( builder, matrices ) {
++
++	return builder.renderer.backend.isWebGLBackend !== true &&
++		Math.max( matrices.count, 1 ) * 16 * 4 <= builder.getUniformBufferLimit();
++
++}
++
+ /**
+  * Creates the appropriate node for instanced matrix transformations.
+  * Depending on buffer limits and storage capability, returns either a storage, buffer, or instanced interleaved attribute node.
+@@ -38,9 +46,7 @@ function createInstanceMatrixNode( builder, instanceMatrix ) {
+ 
+ 	} else {
+ 
+-		const uniformBufferSize = matrixCount * 16 * 4;
+-
+-		if ( uniformBufferSize <= builder.getUniformBufferLimit() ) {
++		if ( useUniformInstanceMatrices( builder, instanceMatrix ) ) {
+ 
+ 			instanceMatrixNode = buffer( instanceMatrix.array, 'mat4', matrixCount ).element( instanceIndex );
+ 
+@@ -132,9 +138,7 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
+ 
+ 	if ( ! isStorageMatrix ) {
+ 
+-		const uniformBufferSize = Math.max( matrices.count, 1 ) * 16 * 4;
+-
+-		if ( uniformBufferSize > builder.getUniformBufferLimit() ) {
++		if ( ! useUniformInstanceMatrices( builder, matrices ) ) {
+ 
+ 			interleavedMatrix = _matrixBuffers.get( matrices );
+ 
+@@ -157,7 +161,7 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
+ 
+ 			if ( ! bufferAttribute ) {
+ 
+-				bufferAttribute = new InstancedBufferAttribute( colors.array, 3 );
++				bufferAttribute = new InstancedInterleavedBuffer( colors.array, 3, 1 );
+ 				_colorBuffers.set( colors, bufferAttribute );
+ 
+ 			}
+@@ -172,34 +176,27 @@ export const instance = /*@__PURE__*/ Fn( ( [ matrices, colors = null ], builder
+ 
+ 	}
+ 
+-	// Synchronization of dynamic buffer updates per frame
++	// Synchronize before geometry uploads; consuming dirty spans keeps later
++	// writes small and makes a changed transform/color visible in this draw.
+ 	if ( interleavedMatrix !== null || interleavedColor !== null ) {
+ 
+-		OnFrameUpdate( () => {
++		OnBeforeObjectUpdate( () => {
+ 
+-			if ( interleavedMatrix !== null ) {
++			if ( interleavedMatrix !== null && matrices.version !== interleavedMatrix.version ) {
+ 
+ 				interleavedMatrix.clearUpdateRanges();
+ 				interleavedMatrix.updateRanges.push( ...matrices.updateRanges );
+-
+-				if ( matrices.version !== interleavedMatrix.version ) {
+-
+-					interleavedMatrix.version = matrices.version;
+-
+-				}
++				matrices.clearUpdateRanges();
++				interleavedMatrix.version = matrices.version;
+ 
+ 			}
+ 
+-			if ( colors && interleavedColor !== null ) {
++			if ( colors && interleavedColor !== null && colors.version !== interleavedColor.version ) {
+ 
+ 				interleavedColor.clearUpdateRanges();
+ 				interleavedColor.updateRanges.push( ...colors.updateRanges );
+-
+-				if ( colors.version !== interleavedColor.version ) {
+-
+-					interleavedColor.version = colors.version;
+-
+-				}
++				colors.clearUpdateRanges();
++				interleavedColor.version = colors.version;
+ 
+ 			}
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-2XhCmL8hTN3oqYW8jQHF2j7T7zZfCdxiCgOiQlYn6rU=
 
+patchedDependencies:
+  three@0.185.1:
+    hash: 92f09167c58a4b5699768c631f1b079bf5baaf9e499ffbb3a3dfdbd41cb9205e
+    path: patches/three@0.185.1.patch
+
 importers:
 
   .:
@@ -419,7 +424,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.9.0))
       three:
         specifier: ^0.185.1
-        version: 0.185.1
+        version: 0.185.1(patch_hash=92f09167c58a4b5699768c631f1b079bf5baaf9e499ffbb3a3dfdbd41cb9205e)
       type-fest:
         specifier: catalog:game
         version: 2.19.0
@@ -35022,7 +35027,7 @@ snapshots:
 
   three@0.174.0: {}
 
-  three@0.185.1: {}
+  three@0.185.1(patch_hash=92f09167c58a4b5699768c631f1b079bf5baaf9e499ffbb3a3dfdbd41cb9205e): {}
 
   timeout-abort-controller@3.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,3 +63,6 @@ catalogs:
     viem: ^2.55.19
     vite: ^7.3.1
     zod: ^4.3.6
+
+patchedDependencies:
+  three@0.185.1: patches/three@0.185.1.patch


### PR DESCRIPTION
The idle map repeatedly uploaded full instance-transform buffers, drew empty melee pools, and republished unchanged arrival badges. This pass removes that work at the renderer, model, effect-pool, and store boundaries.

Stacks on #4936; the lighting and weather changes are reviewed there.

- Patch Three 0.185.1's WebGL instancing path to use vertex attributes at every capacity. Synchronize matrix/color wrappers before geometry uploads and consume their dirty ranges. This also fixes the late synchronization that required our unconditional dynamic-upload workaround, which is now deleted. The patch covers the package's exported WebGPU bundle and source module.
- Use the shared dirty-range helper for structure transforms, colors, contact shadows, restored matrices, and wonder animation. Count-only changes no longer force uploads; remove the redundant `needsUpdate()` API and calls.
- Pack active melee effects into the drawn prefix, skip idle updates, and release both instance meshes on disposal. Effects continue aging when overview hides their group. Flat contact rings use one pass.
- Suppress unchanged arrival indicators at the store setter, preserving immediate notification when counts or ordered structure IDs change.

Evidence from the browser's software WebGL2 fallback:

| Case | Before | After |
| --- | --- | --- |
| Unchanged 1,000-slot transform buffer | 64,000 bytes uploaded each draw | No attribute upload across 10 idle draws |
| Move and recolor one instance | Whole transform buffer | 64 transform bytes + 12 color bytes, visible on the next draw |
| Idle melee pool | 128 inactive slots in each of two meshes, with repeated writes | Zero drawn instances and no buffer writes |
| Unchanged arrival badge | 56 notifications in the initial live capture | Zero in the follow-up capture; 60 repeated updates also covered in a regression test |

The fresh live-map capture no longer shows recurring 64 KB uploads after asset loading settles. This is a reduction in submitted work, not a hardware FPS claim.

Validation: 2,252 tests passed across 443 rendering/store test files, followed by 19 passing combat/store tests after the overview-visibility correction; production WebGPU build (including typecheck); root format and knip. Browser checks cover immediate transform/color changes, consumed dirty ranges, and live scene uploads.

Remaining findings: the 12-second critical-manager loading timeout still reproduces in the software renderer. Sparse army slots and broad structure batches also submit substantial geometry; this pass leaves their visibility/slot ownership intact. Native hardware WebGPU performance remains unmeasured.
