### PR TITLE
Project production at chain-proven time so a MAX never outruns the chain

### DIFF
--- a/apps/game/src/ui/shared/components/chain-time-poller.test.tsx
+++ b/apps/game/src/ui/shared/components/chain-time-poller.test.tsx
@@ -1,0 +1,34 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+vi.mock("@bibliothecadao/eternum", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@bibliothecadao/eternum")>();
+  return { ...actual, configManager: { ...actual.configManager, getTick: () => 1 } };
+});
+
+import { getBlockTimestamp } from "@bibliothecadao/eternum";
+import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
+import { ChainTimePoller } from "./chain-time-poller";
+
+const HEAD_SECONDS = 1_787_000_000;
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  root = createRoot(container);
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+});
+
+it("projects production at the newest chain-written timestamp while the clock runs on the estimate", async () => {
+  await act(async () => root.render(<ChainTimePoller />));
+  act(() => useChainTimeStore.getState().setHeartbeat({ timestamp: HEAD_SECONDS * 1000, source: "herald-head" }));
+
+  const { currentBlockTimestamp, currentDefaultTick } = getBlockTimestamp();
+  expect(currentDefaultTick).toBe(HEAD_SECONDS);
+  expect(currentBlockTimestamp).toBeGreaterThanOrEqual(HEAD_SECONDS);
+});

--- a/apps/game/src/ui/shared/components/chain-time-poller.tsx
+++ b/apps/game/src/ui/shared/components/chain-time-poller.tsx
@@ -1,4 +1,8 @@
-import { setBlockTimestampSource, setChainTimestampEvidenceSink } from "@bibliothecadao/eternum";
+import {
+  setBlockTimestampSource,
+  setChainProvenTimestampSource,
+  setChainTimestampEvidenceSink,
+} from "@bibliothecadao/eternum";
 import { useEffect } from "react";
 
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
@@ -33,6 +37,11 @@ const bindRowEvidenceSink = () => {
 export const ChainTimePoller = () => {
   useEffect(() => {
     setBlockTimestampSource(() => useChainTimeStore.getState().getNowSeconds());
+    // Heartbeats are chain-written timestamps (closed heads and row evidence), the floor a transaction executes at.
+    setChainProvenTimestampSource(() => {
+      const heartbeat = useChainTimeStore.getState().lastHeartbeat;
+      return heartbeat ? Math.floor(heartbeat.timestamp / 1000) : null;
+    });
     bindRowEvidenceSink();
     logChainTimeDebug("source_bound", {
       source: "herald head + row-evidence sink",
@@ -41,6 +50,7 @@ export const ChainTimePoller = () => {
 
     return () => {
       setBlockTimestampSource(null);
+      setChainProvenTimestampSource(null);
       setChainTimestampEvidenceSink(null);
     };
   }, []);

--- a/packages/core/src/utils/timestamp.test.ts
+++ b/packages/core/src/utils/timestamp.test.ts
@@ -4,28 +4,40 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   getAutomationProjectionTick,
   getBlockTimestamp,
-  getConservativeBlockTimestamp,
   setBlockTimestampSource,
+  setChainProvenTimestampSource,
 } from "./timestamp";
 
 // getTick(Default) is a fixed 1s, so ticks equal source seconds and the
 // buffers are directly observable as tick differences.
 const SOURCE_SECONDS = 1_787_000_000;
 
-afterEach(() => setBlockTimestampSource(null));
+afterEach(() => {
+  setBlockTimestampSource(null);
+  setChainProvenTimestampSource(null);
+});
 
-describe("tick buffers", () => {
-  it("holds the automation projection 3s behind the clock — jitter belt under the revert-resync chokepoint", () => {
-    setBlockTimestampSource(() => SOURCE_SECONDS);
-    const { currentDefaultTick } = getBlockTimestamp();
+describe("chain time", () => {
+  it("projects production at chain-proven time while clocks keep the estimate", () => {
+    setBlockTimestampSource(() => SOURCE_SECONDS + 4);
+    setChainProvenTimestampSource(() => SOURCE_SECONDS);
 
-    expect(getAutomationProjectionTick().currentDefaultTick).toBe(currentDefaultTick - 3);
+    const { currentBlockTimestamp, currentDefaultTick } = getBlockTimestamp();
+    expect(currentBlockTimestamp).toBe(SOURCE_SECONDS + 4);
+    expect(currentDefaultTick).toBe(SOURCE_SECONDS);
   });
 
-  it("keeps the UI validation buffer at 1s — only automation gets the deep buffer", () => {
+  it("falls back to the estimate until the chain has written a timestamp", () => {
     setBlockTimestampSource(() => SOURCE_SECONDS);
-    const { currentDefaultTick } = getBlockTimestamp();
+    setChainProvenTimestampSource(() => null);
 
-    expect(getConservativeBlockTimestamp().currentDefaultTick).toBe(currentDefaultTick - 1);
+    expect(getBlockTimestamp().currentDefaultTick).toBe(SOURCE_SECONDS);
+  });
+
+  it("holds the automation projection 3s behind the proven tick — jitter belt under the revert-resync chokepoint", () => {
+    setBlockTimestampSource(() => SOURCE_SECONDS + 4);
+    setChainProvenTimestampSource(() => SOURCE_SECONDS);
+
+    expect(getAutomationProjectionTick().currentDefaultTick).toBe(SOURCE_SECONDS - 3);
   });
 });

--- a/packages/core/src/utils/timestamp.ts
+++ b/packages/core/src/utils/timestamp.ts
@@ -7,12 +7,10 @@ import { configManager } from "../managers/config-manager";
 type TimestampSource = () => number;
 
 const defaultTimestampSource: TimestampSource = () => Math.floor(Date.now() / 1000);
+/** The client's running estimate of chain time: clocks, cooldowns and stamina read it. */
 let timestampSource: TimestampSource = defaultTimestampSource;
-
-// Conservative buffer in ticks to account for client-chain clock desync.
-// This ensures validation uses a tick slightly behind the displayed tick,
-// preventing tx failures when client clock is ahead of chain.
-const CONSERVATIVE_TICK_BUFFER = 1;
+/** The newest timestamp the chain itself has written (a closed head or a row). Null until one is known. */
+let chainProvenTimestampSource: (() => number | null) | null = null;
 
 // Small extra buffer for automation projections — clock-jitter insurance only.
 // The Aug 19 playtest proved buffer depth cannot fix automation reverts: with
@@ -25,6 +23,15 @@ const CONSERVATIVE_TICK_BUFFER_AUTOMATION = 3;
 
 export const setBlockTimestampSource = (source: TimestampSource | null) => {
   timestampSource = source ? () => Math.floor(source()) : defaultTimestampSource;
+};
+
+/**
+ * Production is projected at chain-proven time, never at the estimate. A transaction executes at or after the
+ * newest chain-written timestamp, so a balance projected there is a floor on what the chain will hold; the
+ * estimate can lead the executing block by seconds and a MAX taken from it reverts.
+ */
+export const setChainProvenTimestampSource = (source: (() => number | null) | null) => {
+  chainProvenTimestampSource = source;
 };
 
 // A chain-written timestamp ahead of the local chain-time estimate is proof the
@@ -45,35 +52,20 @@ export const reportObservedChainTimestamp = (timestampSeconds: number) => {
 
 export const getBlockTimestamp = () => {
   const timestamp = timestampSource();
+  const provenTimestamp = chainProvenTimestampSource?.() ?? timestamp;
   const tickConfigArmies = configManager.getTick(TickIds.Armies);
   const tickConfigDefault = configManager.getTick(TickIds.Default);
 
   // Config not hydrated yet reads as interval 0; report tick 0 (not Infinity) until it lands.
-  const tickOrZero = (interval: number) =>
-    Number.isFinite(interval) && interval > 0 ? Math.floor(timestamp / interval) : 0;
-  const currentDefaultTick = tickOrZero(Number(tickConfigDefault));
-  const currentArmiesTick = tickOrZero(Number(tickConfigArmies));
+  const tickOrZero = (seconds: number, interval: number) =>
+    Number.isFinite(interval) && interval > 0 ? Math.floor(seconds / interval) : 0;
+  const currentDefaultTick = tickOrZero(provenTimestamp, Number(tickConfigDefault));
+  const currentArmiesTick = tickOrZero(timestamp, Number(tickConfigArmies));
 
   return {
     currentBlockTimestamp: timestamp,
     currentDefaultTick,
     currentArmiesTick,
-  };
-};
-
-/**
- * Returns conservative tick values for transaction validation.
- * Subtracts a buffer from the current tick to account for potential
- * client-chain clock desync, ensuring resources are validated against
- * a slightly earlier tick to prevent tx failures.
- */
-export const getConservativeBlockTimestamp = () => {
-  const { currentBlockTimestamp, currentDefaultTick, currentArmiesTick } = getBlockTimestamp();
-
-  return {
-    currentBlockTimestamp,
-    currentDefaultTick: Math.max(0, currentDefaultTick - CONSERVATIVE_TICK_BUFFER),
-    currentArmiesTick: Math.max(0, currentArmiesTick - CONSERVATIVE_TICK_BUFFER),
   };
 };
 


### PR DESCRIPTION
Fixes the "Insufficient Balance: T1 PALADIN 34530 < 34580" revert from today's playtest.

**Cause.** The client projects production between chain updates with its own chain-time estimate. That estimate starts from the browser clock, only ever ratchets up, and its 5 second lead cap is measured against Herald heads, which are closed blocks that lag the sequencer's pre-confirmed clock by 2 to 4 seconds (sampled live on the lab chain). So the client can sit a few seconds ahead of the timestamp its transaction executes with. Blitz produces troops every second, and MAX offered troops the chain had not minted yet.

**Fix.** Production is projected at chain-proven time: the newest timestamp the chain itself has written, which the client already tracks as its heartbeat (closed heads plus row evidence). A transaction executes at or after that moment, so a balance projected there is a floor on what the chain will hold. Only the default tick moves onto it; block timestamp and armies tick keep the estimate, so clocks, cooldowns and stamina are unchanged. Every balance, affordability check and MAX already reads the default tick, so display and submit agree without touching call sites.

**Cost.** A MAX leaves up to one head lag of production unspent, 2 to 4 seconds on the lab chain. Herald could tighten that to under a second by publishing the pre-confirmed block timestamp it already fetches; not done here.

**Deleted.** The conservative one-tick helper that nothing called. Automation keeps its 3 second belt on top of the proven tick by the earlier ruling; it is now redundant and could go in a follow-up.

Verified: core suite (30 files) and client suite (708 files) green, tsc, knip. New tests cover the split between proven tick and estimate and the poller wiring.