### PR TITLE
Desk theme pass: balances and production in the HUD face, tighter desk, sliders back

### DIFF
--- a/apps/game/src/ui/design-system/molecules/popover.tsx
+++ b/apps/game/src/ui/design-system/molecules/popover.tsx
@@ -39,7 +39,7 @@ const COMPACT_DRAWER_MAX_WIDTH = "min(100vw, 640px)";
  * fits the drawer exactly; Tailwind needs the class as a literal, so keep the three in step.
  */
 export const SURFACE_WORKSPACE_CLASS =
-  "w-[1320px] h-[calc(100dvh-7rem)] max-lg:w-screen max-lg:h-[85dvh] max-lg:landscape:w-[min(60vw,640px)] max-lg:landscape:h-[calc(100dvh-3.5rem-max(1rem,env(safe-area-inset-bottom)))]";
+  "w-[1180px] h-[calc(100dvh-9rem)] max-lg:w-screen max-lg:h-[85dvh] max-lg:landscape:w-[min(60vw,640px)] max-lg:landscape:h-[calc(100dvh-3.5rem-max(1rem,env(safe-area-inset-bottom)))]";
 
 type PopoverAlign = "start" | "end";
 

--- a/apps/game/src/ui/features/economy/resources/entity-resource-table/entity-resource-table-old.tsx
+++ b/apps/game/src/ui/features/economy/resources/entity-resource-table/entity-resource-table-old.tsx
@@ -2,7 +2,6 @@ import { useBlockTimestamp } from "@/hooks/helpers/use-block-timestamp";
 import { ResourceChip } from "@/ui/features/economy/resources";
 import {
   getBuildingCount,
-  getEntityIdFromKeys,
   getStructureArmyRelicEffects,
   getStructureRelicEffects,
   isMilitaryResource,
@@ -12,9 +11,9 @@ import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { useDojo, useResourceManager } from "@bibliothecadao/react";
 import { BuildingType, getBuildingFromResource, ID, ResourcesIds } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
-import clsx from "clsx";
-import ArrowDown from "lucide-react/dist/esm/icons/arrow-down";
-import ArrowUp from "lucide-react/dist/esm/icons/arrow-up";
+import { HUD_CUE, HUD_LABEL } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import ChevronDown from "lucide-react/dist/esm/icons/chevron-down";
 import React, { useCallback, useMemo, useState } from "react";
 import { ALWAYS_SHOW_RESOURCES, TIER_DISPLAY_NAMES } from "./utils";
 import { gameEntityKey } from "@/sync/game-scope";
@@ -85,69 +84,37 @@ export const EntityResourceTableOld = React.memo(
     }, []);
 
     return (
-      <div className="flex flex-col gap-4">
-        <div className="sticky top-0 z-20 -mx-2 -mt-2 px-2 pt-3 pb-2 border-b border-gold/20 bg-black/50 backdrop-blur">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="space-y-1">
-              <h4 className="text-sm font-semibold uppercase tracking-wide text-gold">Resources</h4>
-              <p className="text-[11px] text-gold/60">Entity #{entityId}</p>
-            </div>
-            <div className="flex flex-wrap items-center justify-end gap-2">
-              <label className="inline-flex items-center gap-2 rounded-full border border-gold/20 bg-gold/5 px-3 py-1 text-[11px] text-gold/70">
-                <span className={clsx(!showAllResources && "text-gold")}>Hide empty</span>
-                <div className="relative">
-                  <input
-                    type="checkbox"
-                    className="peer sr-only"
-                    checked={!showAllResources}
-                    onChange={() => setShowAllResources((prev) => !prev)}
-                  />
-                  <div className="h-5 w-9 rounded-full bg-brown/50 transition peer-checked:bg-gold/30">
-                    <div className="absolute top-[2px] left-[2px] h-4 w-4 rounded-full bg-gold transition peer-checked:translate-x-4" />
-                  </div>
-                </div>
-              </label>
-              <label className="inline-flex items-center gap-2 rounded-full border border-gold/20 bg-gold/5 px-3 py-1 text-[11px] text-gold/70">
-                <span className={clsx(showProductionOnly && "text-gold")}>Production only</span>
-                <div className="relative">
-                  <input
-                    type="checkbox"
-                    className="peer sr-only"
-                    checked={showProductionOnly}
-                    onChange={() => {
-                      const nextValue = !showProductionOnly;
-                      setShowProductionOnly(nextValue);
-                      localStorage.setItem("entityResourceTableShowProductionOnly", String(nextValue));
-                    }}
-                  />
-                  <div className="h-5 w-9 rounded-full bg-brown/50 transition peer-checked:bg-gold/30">
-                    <div className="absolute top-[2px] left-[2px] h-4 w-4 rounded-full bg-gold transition peer-checked:translate-x-4" />
-                  </div>
-                </div>
-              </label>
-              <label className="inline-flex items-center gap-2 rounded-full border border-gold/20 bg-gold/5 px-3 py-1 text-[11px] text-gold/70">
-                <span className={clsx(showMilitaryOnly && "text-gold")}>Military only</span>
-                <div className="relative">
-                  <input
-                    type="checkbox"
-                    className="peer sr-only"
-                    checked={showMilitaryOnly}
-                    onChange={() => {
-                      const nextValue = !showMilitaryOnly;
-                      setShowMilitaryOnly(nextValue);
-                      localStorage.setItem("entityResourceTableShowMilitaryOnly", String(nextValue));
-                    }}
-                  />
-                  <div className="h-5 w-9 rounded-full bg-brown/50 transition peer-checked:bg-gold/30">
-                    <div className="absolute top-[2px] left-[2px] h-4 w-4 rounded-full bg-gold transition peer-checked:translate-x-4" />
-                  </div>
-                </div>
-              </label>
-            </div>
+      <div className="flex flex-col gap-3">
+        <div className="sticky top-0 z-20 flex flex-wrap items-center justify-between gap-2 border-b border-gold/15 bg-[#101c23]/95 px-1 pb-2 pt-1 backdrop-blur">
+          <span className={HUD_LABEL}>Resources</span>
+          <div className="flex flex-wrap items-center gap-1.5">
+            <FilterToggle
+              label="Hide empty"
+              checked={!showAllResources}
+              onToggle={() => setShowAllResources((prev) => !prev)}
+            />
+            <FilterToggle
+              label="Producing"
+              checked={showProductionOnly}
+              onToggle={() => {
+                const nextValue = !showProductionOnly;
+                setShowProductionOnly(nextValue);
+                localStorage.setItem("entityResourceTableShowProductionOnly", String(nextValue));
+              }}
+            />
+            <FilterToggle
+              label="Military"
+              checked={showMilitaryOnly}
+              onToggle={() => {
+                const nextValue = !showMilitaryOnly;
+                setShowMilitaryOnly(nextValue);
+                localStorage.setItem("entityResourceTableShowMilitaryOnly", String(nextValue));
+              }}
+            />
           </div>
         </div>
 
-        <div className="space-y-4 pt-2">
+        <div className="space-y-3">
           {Object.entries(mode.resources.getTiers()).map(([tier, resourceIds]) => {
             const resourcesForTier = (resourceIds as ResourcesIds[]).filter((resourceId: ResourcesIds) => {
               const alwaysShow = ALWAYS_SHOW_RESOURCES.includes(resourceId);
@@ -190,21 +157,22 @@ export const EntityResourceTableOld = React.memo(
             const isCollapsed = collapsedTiers[tier] ?? false;
 
             return (
-              <div key={tier} className="pb-3">
+              <div key={tier}>
                 <button
                   type="button"
                   onClick={() => handleToggleTierVisibility(tier)}
-                  className="flex w-full items-center justify-between border-b border-gold/10 pb-1 text-left text-sm font-medium text-gold/80"
+                  aria-expanded={!isCollapsed}
+                  className="flex w-full items-center justify-between border-b border-gold/10 px-1 pb-1 text-left"
                 >
-                  <span>{TIER_DISPLAY_NAMES[tier]}</span>
-                  <span className="flex items-center gap-2 text-[11px] text-gold/60">
+                  <span className={HUD_LABEL}>{TIER_DISPLAY_NAMES[tier]}</span>
+                  <span className={cn(HUD_CUE, "flex items-center gap-1")}>
                     {resourcesForTier.length}
-                    {isCollapsed ? <ArrowDown className="h-3 w-3" /> : <ArrowUp className="h-3 w-3" />}
+                    <ChevronDown className={cn("h-3 w-3 transition-transform", isCollapsed && "-rotate-90")} />
                   </span>
                 </button>
 
                 {!isCollapsed && (
-                  <div className="mt-3 grid grid-cols-1 gap-2">
+                  <div className="mt-2 grid grid-cols-1 gap-1.5">
                     {resourcesForTier.map((resourceId) => {
                       const buildingType = getBuildingFromResource(resourceId);
                       const hasProductionBuilding =
@@ -241,4 +209,21 @@ export const EntityResourceTableOld = React.memo(
       </div>
     );
   },
+);
+
+/** One filter switch in the balances header: a small caps label that lights while it is on. */
+const FilterToggle = ({ label, checked, onToggle }: { label: string; checked: boolean; onToggle: () => void }) => (
+  <button
+    type="button"
+    role="switch"
+    aria-checked={checked}
+    onClick={onToggle}
+    className={cn(
+      "rounded-md border px-2 py-1 transition",
+      HUD_CUE,
+      checked ? "border-gold/60 bg-gold/15 text-gold" : "border-gold/15 bg-black/20 hover:border-gold/40",
+    )}
+  >
+    {label}
+  </button>
 );

--- a/apps/game/src/ui/features/economy/resources/resource-chip.tsx
+++ b/apps/game/src/ui/features/economy/resources/resource-chip.tsx
@@ -6,12 +6,13 @@ import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { ResourceTransferPopover } from "@/ui/features/economy/resources/resource-transfer-popover";
 import { ProductionModal } from "@/ui/features/settlement/production/production-modal";
 import { CountUpNumber } from "@/ui/shared";
+import { HUD_CUE, HUD_VALUE } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { currencyFormat, currencyIntlFormat } from "@/ui/utils/utils";
 import {
   configManager,
   divideByPrecision,
   formatTime,
-  getTotalResourceWeightKg,
   isRelic as isResourceRelic,
   relicsArmiesTicksLeft,
   ResourceManager,
@@ -30,8 +31,6 @@ import Factory from "lucide-react/dist/esm/icons/factory";
 import FlaskConical from "lucide-react/dist/esm/icons/flask-conical";
 import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import { getComponentValue } from "@dojoengine/recs";
-import { getEntityIdFromKeys } from "@bibliothecadao/eternum";
-import type { MouseEvent } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { gameEntityKey } from "@/sync/game-scope";
 
@@ -72,13 +71,11 @@ export const ResourceChip = ({
   const {
     setup: { components },
   } = useDojo();
-  const [showPerHour, setShowPerHour] = useState(true);
   const [balance, setBalance] = useState(0);
   const [amountProduced, setAmountProduced] = useState(0n);
   const [amountProducedLimited, setAmountProducedLimited] = useState(0n);
   const [hasReachedMaxCap, setHasReachedMaxCap] = useState(false);
   const [displayBalance, setDisplayBalance] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
 
   const storeDefaultTick = useBlockTimestampStore((state) => state.currentDefaultTick);
   const storeArmiesTick = useBlockTimestampStore((state) => state.currentArmiesTick);
@@ -139,95 +136,10 @@ export const ResourceChip = ({
   }, [resourceManager, resourceEnumId, currentTick, isProducing, hasReachedMaxCap]);
 
   const icon = useMemo(() => {
-    return (
-      <ResourceIcon
-        withTooltip={false}
-        resource={ResourcesIds[resourceId]}
-        size={size === "large" ? "md" : "sm"}
-        className=" self-center"
-      />
-    );
+    return <ResourceIcon withTooltip={false} resource={ResourcesIds[resourceId]} size="sm" className="self-center" />;
   }, [resourceId, size]);
 
-  const producedWeight = useMemo(() => {
-    return getTotalResourceWeightKg([{ resourceId, amount: Number(amountProduced) }]);
-  }, [amountProduced, resourceId]);
-
-  const handleMouseEnter = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      setIsHovered(true);
-      // const newDisplayBalance = Number(actualBalance || 0) + Number(amountProduced || 0n);
-      // setDisplayBalance(newDisplayBalance);
-
-      // setTooltip({
-      //   anchorElement: event.currentTarget,
-      //   position: "left",
-      //   content: (
-      //     <div className="space-y-1 max-w-72">
-      //       <div>
-      //         <span className="text-gold font-bold">Total available:</span>{" "}
-      //         <span className="text-gold">{currencyFormat(newDisplayBalance, 2)}</span>{" "}
-      //         {findResourceById(resourceId)?.trait}
-      //       </div>
-      //       {Number(amountProduced || 0n) > 0 && (
-      //         <>
-      //           <p>
-      //             You have{" "}
-      //             <span className={!isStorageFull ? "text-green" : "text-red"}>
-      //               {currencyFormat(Number(amountProduced || 0n), 2)}
-      //             </span>{" "}
-      //             {findResourceById(resourceId)?.trait} waiting to be stored.
-      //           </p>
-      //           <p>
-      //             Whenever you use this resource (building, trading, pause, production, etc.) the produced amount is
-      //             first moved into storage.
-      //             <br />
-      //             Only the portion that fits within your remaining capacity&nbsp;(
-      //             <span className="text-green">
-      //               {storageRemaining.toLocaleString(undefined, { maximumFractionDigits: 0 })}kg
-      //             </span>
-      //             ) will be saved; any excess&nbsp;(
-      //             <span className="text-red">
-      //               of{" "}
-      //               {divideByPrecision(producedWeight, false).toLocaleString(undefined, { maximumFractionDigits: 0 })}
-      //               kg
-      //             </span>
-      //             ) will be permanently burned.
-      //           </p>
-      //           <p>
-      //             {
-      //               // Calculate the net result of claiming all produced weight against remaining storage.
-      //               storageRemaining - divideByPrecision(producedWeight, false) >= 0 ? (
-      //                 <span className="text-green">All will fit if used right now.</span>
-      //               ) : (
-      //                 <>
-      //                   <span className="text-red">
-      //                     {Math.abs(storageRemaining - divideByPrecision(producedWeight, false)).toLocaleString(
-      //                       undefined,
-      //                       { maximumFractionDigits: 0 },
-      //                     )}
-      //                     kg&nbsp;
-      //                   </span>
-      //                   will be burnt if you claim it all.
-      //                 </>
-      //               )
-      //             }
-      //           </p>
-      //         </>
-      //       )}
-      //     </div>
-      //   ),
-      // });
-    },
-    [actualBalance, amountProduced, resourceId, setTooltip, producedWeight, setIsHovered, setDisplayBalance],
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    setIsHovered(false);
-    setTooltip(null);
-    setShowPerHour(true);
-    // setDisplayBalance(actualBalance ? Number(actualBalance) : 0);
-  }, [setTooltip, actualBalance, setShowPerHour, setIsHovered, setDisplayBalance]);
+  const handleMouseLeave = useCallback(() => setTooltip(null), [setTooltip]);
 
   const mode = useGameModeConfig();
 
@@ -307,101 +219,55 @@ export const ResourceChip = ({
   if (hideZeroBalance && balance <= 0 && !(isRelic && relicEffectActivated)) {
     return null;
   }
+  const ratePerHour = isProducing && !hasReachedMaxCap ? `+${currencyIntlFormat(productionRate * 60 * 60, 4)}/h` : null;
+  const timeLeft =
+    timeUntilValueReached > 0 && timeUntilValueReached <= 1_000_000_000 ? formatTime(timeUntilValueReached) : null;
+  const actionButton =
+    "rounded p-1 text-gold/80 transition hover:bg-gold/15 hover:text-gold disabled:cursor-not-allowed disabled:opacity-50";
+
   return (
     <div
       data-tooltip-anchor
-      className={`flex relative group items-center ${
-        size === "large" ? "text-base px-3 p-2" : "text-sm px-2 p-1.5"
-      } hover:bg-gold/5 ${
-        relicEffectActivated ? "bg-purple-500/20 border border-purple-500/50 rounded-lg animate-pulse" : ""
-      }`}
-      onMouseEnter={handleMouseEnter}
+      className={cn(
+        "group flex items-center gap-2 rounded-lg border border-gold/15 bg-black/25 transition hover:border-gold/35",
+        size === "large" ? "px-3 py-2" : "px-2 py-1.5",
+        relicEffectActivated && "animate-pulse border-purple-500/50 bg-purple-500/20",
+      )}
       onMouseLeave={handleMouseLeave}
     >
-      <div className="flex flex-wrap w-full items-center">
-        <div className={`self-center flex flex-wrap w-full gap-2 ${size === "large" ? "text-lg" : ""}`}>
-          <div className="flex items-center gap-2">
-            {icon}
-            <CountUpNumber
-              value={displayBalance}
-              format={(v) => currencyFormat(v, 2)}
-              className={`${isHovered ? "font-bold animate-pulse" : ""} ${
-                relicEffectActivated ? "text-relic font-semibold" : ""
-              }`}
-              highlightClassName="text-green font-bold scale-105"
-            />{" "}
-            {relicEffectActivated && (
-              <div className="flex items-center ml-1 gap-1">
-                <Sparkles className="h-3 w-3 text-relic2 animate-pulse" />
-                <span
-                  className="text-xs text-relic2 font-medium"
-                  onMouseEnter={(e) => {
-                    e.stopPropagation();
-                    setTooltip({
-                      anchorElement: e.currentTarget,
-                      position: "top",
-                      content: (
-                        <span className="text-sm">Relic effect expires in {formatTime(relicTimeRemaining)}</span>
-                      ),
-                    });
-                  }}
-                  onMouseLeave={(e) => {
-                    e.stopPropagation();
-                    setTooltip(null);
-                  }}
-                >
-                  {formatTime(relicTimeRemaining)}
-                </span>
-              </div>
-            )}
-          </div>
-
-          {amountProduced > 0n && (
-            <div className={` flex  gap-2 self-start text-xs text-gold/50`}>
-              [
-              {/* <span className={!isStorageFull ? "text-green" : "text-red"}>
-                {currencyFormat(Number(amountProduced || 0n), 2)}
-              </span> */}
-              <div className="flex  gap-4 w-full col-span-12">
-                {isProducing && !hasReachedMaxCap ? (
-                  <div className={`self-center flex ${size === "large" ? "text-base" : "text-xs"} justify-end`}>
-                    <div className="text-green">
-                      +
-                      {showPerHour
-                        ? `${currencyIntlFormat(productionRate * 60 * 60, 4)}/h`
-                        : `${currencyIntlFormat(productionRate, 4)}/s`}
-                    </div>
-                  </div>
-                ) : (
-                  <div
-                    className={`self-center col-span-5 text-right ${size === "large" ? "text-base" : "text-xs"} font-medium`}
-                  >
-                    {hasReachedMaxCap ? "Max" : ""}
-                  </div>
-                )}
-              </div>
-              ]
-            </div>
-          )}
-        </div>
-
-        {/* {producedWeight > 0 && (
-          <div className="text-xs text-gold/40 col-span-12 flex items-center">
-            {divideByPrecision(Number(producedWeight || 0n), false).toLocaleString(undefined, {
-              maximumFractionDigits: 0,
-            })}{" "}
-            kg produced
-          </div>
-        )} */}
-
-        <div className={`ml-2 text-xs text-gold/40  ${size === "large" ? "" : ""}`}>
-          {timeUntilValueReached > 1000000000
-            ? "∞"
-            : timeUntilValueReached !== 0
-              ? formatTime(timeUntilValueReached)
-              : ""}
-        </div>
-      </div>
+      {icon}
+      <CountUpNumber
+        value={displayBalance}
+        format={(v) => currencyFormat(v, 2)}
+        className={cn(HUD_VALUE, "tabular-nums", relicEffectActivated && "text-relic")}
+        highlightClassName="text-green font-bold scale-105"
+      />
+      {relicEffectActivated && (
+        <span
+          className="inline-flex items-center gap-1 text-[10px] font-semibold text-relic2"
+          onMouseEnter={(e) => {
+            e.stopPropagation();
+            setTooltip({
+              anchorElement: e.currentTarget,
+              position: "top",
+              content: <span className="text-sm">Relic effect expires in {formatTime(relicTimeRemaining)}</span>,
+            });
+          }}
+          onMouseLeave={(e) => {
+            e.stopPropagation();
+            setTooltip(null);
+          }}
+        >
+          <Sparkles className="h-3 w-3 animate-pulse" />
+          {formatTime(relicTimeRemaining)}
+        </span>
+      )}
+      {ratePerHour && <span className="text-[10px] font-semibold tabular-nums text-emerald-300">{ratePerHour}</span>}
+      {hasReachedMaxCap && amountProduced > 0n && (
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-300">Max</span>
+      )}
+      {timeLeft && <span className={cn(HUD_CUE, "tracking-normal")}>{timeLeft}</span>}
+      <span className="ml-auto" />
       {canShowProductionShortcut && (
         <button
           data-tooltip-anchor
@@ -418,9 +284,9 @@ export const ResourceChip = ({
           }
           onMouseLeave={() => setTooltip(null)}
           disabled={disableButtons}
-          className="ml-2 p-1 hover:bg-gold/20 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+          className={actionButton}
         >
-          <Factory className={`${size === "large" ? "h-6 w-6" : "h-5 w-5"} text-gold`} />
+          <Factory className="h-4 w-4" />
         </button>
       )}
       {canOpenCraftRelic && (
@@ -447,9 +313,9 @@ export const ResourceChip = ({
           disabled={disableButtons}
           title="Craft relic from research"
           aria-label="Craft relic from research"
-          className="ml-2 rounded border border-relic/35 bg-relic/10 p-1 text-relic2 transition hover:bg-relic/20 disabled:opacity-50 disabled:cursor-not-allowed"
+          className={cn(actionButton, "border border-relic/35 bg-relic/10 text-relic2 hover:bg-relic/20")}
         >
-          <FlaskConical className={`${size === "large" ? "h-6 w-6" : "h-5 w-5"} text-current`} />
+          <FlaskConical className="h-4 w-4" />
         </button>
       )}
       {showTransfer && (
@@ -463,11 +329,11 @@ export const ResourceChip = ({
                 toggle();
               }}
               disabled={disableButtons}
-              className="ml-2 p-1 hover:bg-gold/20 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+              className={actionButton}
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
-                className={`${size === "large" ? "h-6 w-6" : "h-5 w-5"} text-gold`}
+                className="h-4 w-4"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -513,9 +379,9 @@ export const ResourceChip = ({
             })
           }
           onMouseLeave={() => setTooltip(null)}
-          className="ml-2 p-1 hover:bg-gold/20 rounded disabled:opacity-50 disabled:cursor-not-allowed"
+          className={actionButton}
         >
-          <Sparkles className={`${size === "large" ? "h-6 w-6" : "h-5 w-5"} text-gold`} />
+          <Sparkles className="h-4 w-4" />
         </button>
       )}
     </div>

--- a/apps/game/src/ui/features/settlement/production/buildings-list.tsx
+++ b/apps/game/src/ui/features/settlement/production/buildings-list.tsx
@@ -1,4 +1,5 @@
-import { BUILDING_IMAGES_PATH } from "@/ui/config";
+import { HUD_BODY, HUD_BODY_MUTED, HUD_HEADLINE } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { useCoarseCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { ResourceChip } from "@/ui/features/economy/resources";
@@ -11,7 +12,7 @@ import {
   ResourceManager,
 } from "@bibliothecadao/eternum";
 import { useDojo, useResourceManager } from "@bibliothecadao/react";
-import { Building, BuildingType, RealmInfo, ResourcesIds } from "@bibliothecadao/types";
+import { Building, RealmInfo, ResourcesIds } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
 import { useMemo } from "react";
 import { gameEntityKey } from "@/sync/game-scope";
@@ -32,12 +33,7 @@ export const BuildingsList = ({
   const currentDefaultTick = useCoarseCurrentDefaultTick();
   // Guard against invalid realm data to prevent crashes
   if (!realm || !realm.position || !realm.entityId) {
-    return (
-      <div className="rounded-lg border border-gold/20 bg-black/30 p-3 h-[500px] overflow-y-auto">
-        <h3 className="text-3xl border-gold/20">Production Buildings</h3>
-        <p className="text-gold/70 pb-8 text-lg">Realm data is currently unavailable.</p>
-      </div>
-    );
+    return <p className={cn(HUD_BODY_MUTED, "p-3")}>Realm data is currently unavailable.</p>;
   }
 
   const { setup } = useDojo();
@@ -102,120 +98,78 @@ export const BuildingsList = ({
 
   if (selectedResource !== null) {
     if (!selectedProduction) {
-      return (
-        <div className="p-3">
-          <p className="text-sm text-gold/70">Loading production data…</p>
-        </div>
-      );
+      return <p className={cn(HUD_BODY_MUTED, "p-3")}>Loading production data…</p>;
     }
 
-    const bgImage = selectedProduction.isLabor
-      ? BUILDING_IMAGES_PATH[BuildingType.ResourceLabor as keyof typeof BUILDING_IMAGES_PATH]
-      : selectedProduction.buildings[0]?.category
-        ? BUILDING_IMAGES_PATH[selectedProduction.buildings[0].category as keyof typeof BUILDING_IMAGES_PATH]
-        : "";
-
     return (
-      <div
-        className="rounded-lg border border-gold/20 bg-black/30 relative min-h-28 p-3"
-        style={{
-          backgroundImage: `linear-gradient(rgba(20, 16, 13, 0.9), rgba(20, 16, 13, 0.9)), url(${bgImage})`,
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-        }}
-      >
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <ResourceIcon resource={ResourcesIds[selectedProduction.resource]} size="xl" />
-            <div>
-              <h4 className="text-xl font-semibold text-gold tracking-wide">
-                {ResourcesIds[selectedProduction.resource]}
-              </h4>
-              <span className="text-base text-gold/70 font-medium">
-                {selectedProduction.buildings.length} building
-                {selectedProduction.buildings.length !== 1 ? "s" : ""} producing
-              </span>
-            </div>
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-gold/15 bg-black/25 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <ResourceIcon resource={ResourcesIds[selectedProduction.resource]} size="md" />
+          <div className="min-w-0">
+            <h4 className={cn(HUD_HEADLINE, "truncate")}>{ResourcesIds[selectedProduction.resource]}</h4>
+            <span className={HUD_BODY}>
+              {selectedProduction.buildings.length} building{selectedProduction.buildings.length !== 1 ? "s" : ""}{" "}
+              producing
+            </span>
           </div>
-          <button
-            onClick={() => onSelectProduction(null)}
-            className="button button-ghost hover:button-ghost-hover w-full px-4 py-2 text-sm sm:w-auto"
-          >
-            Change Resource
-          </button>
         </div>
+        <button
+          type="button"
+          onClick={() => onSelectProduction(null)}
+          className="rounded-md border border-gold/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] text-gold/80 transition hover:border-gold/50 hover:text-gold"
+        >
+          Change resource
+        </button>
       </div>
     );
   }
 
   return (
-    <div className="h-full pt-6">
-      <div className="flex flex-col gap-3">
-        {productions.length === 0 ? (
-          <div className="rounded-lg border border-gold/20 bg-black/30 p-6 text-center">
-            <h4 className="mb-2 text-xl font-semibold text-gold">No Production Buildings</h4>
-            <p className="text-lg text-gold/70">
-              You need to create production buildings first to start producing resources.
-            </p>
-          </div>
-        ) : (
-          productions.map((production) => {
-            const bgImage = production.isLabor
-              ? BUILDING_IMAGES_PATH[BuildingType.ResourceLabor as keyof typeof BUILDING_IMAGES_PATH]
-              : production.buildings[0]?.category
-                ? BUILDING_IMAGES_PATH[production.buildings[0].category as keyof typeof BUILDING_IMAGES_PATH]
-                : "";
-
-            return (
-              <div
-                key={production.resource}
-                onClick={() => onSelectProduction(production.resource)}
-                role="button"
-                tabIndex={0}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    onSelectProduction(production.resource);
-                  }
-                }}
-                className="relative flex cursor-pointer flex-wrap items-center gap-4 rounded-lg border border-gold/25 bg-[rgba(20,16,13,0.85)] p-4 transition hover:border-gold/40 hover:bg-[rgba(42,34,28,0.9)] focus:outline-none focus:ring-2 focus:ring-gold/60"
-                style={{
-                  backgroundImage: `linear-gradient(rgba(20, 16, 13, 0.85), rgba(20, 16, 13, 0.85)), url(${bgImage})`,
-                  backgroundSize: "cover",
-                  backgroundPosition: "center",
-                }}
-              >
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                  <ResourceIcon resource={ResourcesIds[production.resource]} size="lg" />
-                  <div className="min-w-0">
-                    <h4 className="truncate text-xl font-semibold text-gold tracking-wide">
-                      {ResourcesIds[production.resource]}
-                    </h4>
-                    <span className="text-base font-medium text-gold/70">
-                      {production.buildings.length} building
-                      {production.buildings.length !== 1 ? "s" : ""}
-                    </span>
-                  </div>
-                </div>
-
-                <div className="w-full min-w-[200px] flex-1 sm:w-auto sm:flex-initial">
-                  <ResourceChip
-                    resourceId={production.resource}
-                    resourceManager={resourceManager}
-                    size="large"
-                    showTransfer={false}
-                    storageCapacity={realmInfo?.storehouses?.capacityKg}
-                    storageCapacityUsed={realmInfo?.storehouses?.capacityUsedKg}
-                    activeRelicEffects={activeRelicEffects}
-                    canOpenProduction={production.buildings.length > 0}
-                    onManageProduction={(resource) => onSelectProduction(resource)}
-                  />
+    <div className="flex flex-col gap-1.5">
+      {productions.length === 0 ? (
+        <p className={cn(HUD_BODY_MUTED, "p-3")}>Build production buildings first to start producing resources.</p>
+      ) : (
+        productions.map((production) => {
+          return (
+            <div
+              key={production.resource}
+              onClick={() => onSelectProduction(production.resource)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelectProduction(production.resource);
+                }
+              }}
+              className="flex cursor-pointer items-center gap-3 rounded-lg border border-gold/15 bg-black/25 px-3 py-2 transition hover:border-gold/40 focus:outline-none focus:ring-2 focus:ring-gold/60"
+            >
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <ResourceIcon resource={ResourcesIds[production.resource]} size="md" />
+                <div className="min-w-0">
+                  <h4 className={cn(HUD_HEADLINE, "truncate")}>{ResourcesIds[production.resource]}</h4>
+                  <span className={HUD_BODY}>
+                    {production.buildings.length} building{production.buildings.length !== 1 ? "s" : ""}
+                  </span>
                 </div>
               </div>
-            );
-          })
-        )}
-      </div>
+
+              <div className="w-[320px] max-w-[55%]">
+                <ResourceChip
+                  resourceId={production.resource}
+                  resourceManager={resourceManager}
+                  showTransfer={false}
+                  storageCapacity={realmInfo?.storehouses?.capacityKg}
+                  storageCapacityUsed={realmInfo?.storehouses?.capacityUsedKg}
+                  activeRelicEffects={activeRelicEffects}
+                  canOpenProduction={production.buildings.length > 0}
+                  onManageProduction={(resource) => onSelectProduction(resource)}
+                />
+              </div>
+            </div>
+          );
+        })
+      )}
     </div>
   );
 };

--- a/apps/game/src/ui/features/settlement/production/labor-resources-panel.tsx
+++ b/apps/game/src/ui/features/settlement/production/labor-resources-panel.tsx
@@ -1,4 +1,7 @@
 import { NumberInput } from "@/ui/design-system/atoms/number-input";
+import { HUD_LABEL, HUD_VALUE } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import Button from "@/ui/design-system/atoms/button";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { ResourcesIds } from "@bibliothecadao/types";
 
@@ -51,43 +54,30 @@ export const LaborResourcesPanel = ({
   };
 
   return (
-    <div className={`cursor-pointer`} onClick={onSelect}>
-      <div>
-        {laborInputResources?.map((input) => {
-          const balance = resourceBalances[input.resource] || 0;
-          return (
-            <div key={input.resource} className="flex items-center gap-3 my-1  transition-colors">
-              <ResourceIcon resource={ResourcesIds[input.resource]} size="lg" />
-              <div className="flex items-center justify-between w-full">
-                <span
-                  className={`text-xl font-bold ${
-                    resourceBalances[input.resource] <
-                    Math.round((input.amount * productionAmount) / resourceOutputPerInputResources)
-                      ? "text-order-giants"
-                      : "text-gold"
-                  }`}
-                >
-                  {balance.toLocaleString()}
-                </span>
-                <div className="w-2/3">
-                  <NumberInput
-                    value={Math.round((input.amount * productionAmount) / resourceOutputPerInputResources)}
-                    onChange={(value) => handleInputChange(value, input.resource)}
-                    min={0}
-                    className="rounded-md border-gold/30 hover:border-gold/50"
-                  />
-                </div>
-              </div>
-            </div>
-          );
-        })}
-        <button
-          onClick={handleMaxClick}
-          className="mt-2 px-3 py-1 text-sm bg-gold/20 hover:bg-gold/30 text-gold rounded"
-        >
-          MAX
-        </button>
-      </div>
+    <div className="cursor-pointer space-y-1" onClick={onSelect}>
+      <div className={HUD_LABEL}>Labor required</div>
+      {laborInputResources?.map((input) => {
+        const balance = resourceBalances[input.resource] || 0;
+        const needed = Math.round((input.amount * productionAmount) / resourceOutputPerInputResources);
+        const isShort = balance < needed;
+        return (
+          <div key={input.resource} className="flex items-center gap-2 py-0.5">
+            <ResourceIcon resource={ResourcesIds[input.resource]} size="sm" withTooltip={false} />
+            <span className={cn(HUD_VALUE, "w-24 shrink-0 tabular-nums", isShort && "text-red-300")}>
+              {balance.toLocaleString()}
+            </span>
+            <NumberInput
+              value={needed}
+              onChange={(value) => handleInputChange(value, input.resource)}
+              min={0}
+              className="h-8 flex-1 text-sm"
+            />
+          </div>
+        );
+      })}
+      <Button variant="outline" size="xs" onClick={handleMaxClick} className="mt-1">
+        Max
+      </Button>
     </div>
   );
 };

--- a/apps/game/src/ui/features/settlement/production/production-modal-content.tsx
+++ b/apps/game/src/ui/features/settlement/production/production-modal-content.tsx
@@ -82,8 +82,8 @@ const ProductionContainer = ({
   );
 
   return (
-    <div className="production-modal-selector grid h-full min-h-0 grid-cols-1 gap-4 overflow-hidden rounded-2xl bg-black/40 lg:grid-cols-12 lg:gap-0">
-      <div className="order-1 col-span-1 min-h-0 overflow-y-auto border-b border-gold/20 p-4 pb-4 border-r border-gold/25 lg:order-1 lg:col-span-4 lg:border-b-0 lg:border-r lg:border-gold/20">
+    <div className="production-modal-selector grid h-full min-h-0 grid-cols-1 overflow-hidden lg:grid-cols-12">
+      <div className="order-1 col-span-1 min-h-0 overflow-y-auto border-b border-gold/15 px-2 py-3 lg:order-1 lg:col-span-3 lg:border-b-0 lg:border-r">
         <Suspense fallback={<LoadingAnimation />}>
           {playerStructures.length > 0 && (
             <ProductionSidebar
@@ -95,7 +95,7 @@ const ProductionContainer = ({
           )}
         </Suspense>
       </div>
-      <div className="order-2 col-span-1 min-h-0 overflow-y-auto p-4 lg:order-2 lg:col-span-8 lg:p-6">
+      <div className="order-2 col-span-1 min-h-0 overflow-y-auto p-4 lg:order-2 lg:col-span-9">
         <Suspense fallback={<LoadingAnimation />}>
           {selectedRealm && (
             <ProductionBody

--- a/apps/game/src/ui/features/settlement/production/production-sidebar.tsx
+++ b/apps/game/src/ui/features/settlement/production/production-sidebar.tsx
@@ -7,7 +7,8 @@ import { getProducedResource, ID, RealmInfo, ResourcesIds } from "@bibliothecada
 import { useComponentValue } from "@dojoengine/react";
 import { HasValue, runQuery } from "@dojoengine/recs";
 import clsx from "clsx";
-import CheckCircle2Icon from "lucide-react/dist/esm/icons/check-circle-2";
+import { HUD_BODY, HUD_HEADLINE, HUD_LABEL, HUD_LABEL_BRIGHT } from "@/ui/design-system/atoms/hud-typography";
+import { OVERLAY_SURFACE_BASE } from "@/ui/design-system/atoms/overlay-surface";
 import SparklesIcon from "lucide-react/dist/esm/icons/sparkles";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import Button from "@/ui/design-system/atoms/button";
@@ -168,9 +169,10 @@ const SidebarRealm = ({
   return (
     <div
       className={clsx(
-        "rounded-lg bg-black/30 transition-all cursor-pointer border border-transparent",
-        "px-3 py-2",
-        isSelected ? "border-gold/70 bg-gold/5 shadow-[0_0_18px_rgba(255,204,102,0.45)]" : "hover:bg-gold/5",
+        "cursor-pointer rounded-xl px-2.5 py-2 transition",
+        isSelected
+          ? "border border-gold/65 ring-1 ring-gold/30 bg-gradient-to-b from-[#231913]/97 to-[#2c2018]/97 shadow-[0_0_18px_rgba(223,170,84,0.3),inset_0_1px_0_rgba(255,214,102,0.28)]"
+          : clsx(OVERLAY_SURFACE_BASE, "hover:border-gold/50"),
       )}
       onClick={onSelect}
       aria-selected={isSelected}
@@ -178,23 +180,14 @@ const SidebarRealm = ({
       <div className="flex flex-col gap-2">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <h3 className="text-lg font-bold text-gold">{mode.structure.getName(realm.structure).name}</h3>
-            <p className="text-xs text-gold/60">
+            <h3 className={clsx(HUD_HEADLINE, "truncate")}>{mode.structure.getName(realm.structure).name}</h3>
+            <p className={HUD_BODY}>
               {hasProduction
-                ? `${buildings.size} buildings • ${activeProductionBuildings}/${totalProductionBuildings} producing`
-                : `${buildings.size} buildings • no production`}
+                ? `${buildings.size} buildings · ${activeProductionBuildings}/${totalProductionBuildings} producing`
+                : `${buildings.size} buildings · no production`}
             </p>
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            {isSelected && (
-              <div
-                className="flex items-center gap-1 rounded bg-gold/20 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-gold shadow-[0_0_12px_rgba(255,204,102,0.25)]"
-                title="Selected structure"
-              >
-                <CheckCircle2Icon className="h-4 w-4" aria-hidden="true" />
-                <span>Selected</span>
-              </div>
-            )}
             {(hasActivatedWonderBonus || activeRelics.length > 0) && (
               <div className="flex gap-1 shrink-0">
                 {hasActivatedWonderBonus && (
@@ -215,7 +208,7 @@ const SidebarRealm = ({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2.5 px-1 pt-1">
           {hasProduction ? (
             resourceProductionSummary
               .toSorted((a, b) => {
@@ -254,13 +247,13 @@ const SidebarRealm = ({
                     isProducing={summary.isProducing}
                     timeRemainingSeconds={effectiveRemainingSeconds}
                     totalCount={summary.totalBuildings}
-                    size="sm"
+                    size="xs"
                     onClick={() => onSelectResource(realm.entityId, summary.resourceId)}
                   />
                 );
               })
           ) : (
-            <span className="text-xs text-gold/60">No production buildings</span>
+            <span className={HUD_BODY}>No production buildings</span>
           )}
         </div>
       </div>
@@ -418,9 +411,9 @@ export const ProductionSidebar = memo(
       : null;
 
     return (
-      <div className="space-y-4">
-        <div className="space-y-3">
-          <div className="flex gap-2">
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <div className="flex gap-1.5">
             {tabButtons.map((tab) => {
               const isActive = activeTab === tab.key;
               const disabled = tab.count === 0;
@@ -431,12 +424,13 @@ export const ProductionSidebar = memo(
                   disabled={disabled}
                   onClick={() => handleChangeTab(tab.key)}
                   className={clsx(
-                    "rounded border px-4 py-2 text-xs font-semibold uppercase tracking-wide transition",
+                    "rounded-md border px-2.5 py-1 transition",
+                    HUD_LABEL_BRIGHT,
                     disabled
                       ? "cursor-not-allowed border-gold/10 text-gold/30"
                       : isActive
-                        ? "border-gold/60 bg-black/25 text-gold shadow-[0_0_10px_rgba(255,204,102,0.25)]"
-                        : "border-gold/20 text-gold/60 hover:border-gold/40 hover:text-gold",
+                        ? "border-gold/60 bg-gold/15 text-gold"
+                        : "border-gold/15 bg-black/20 text-gold/65 hover:border-gold/40 hover:text-gold",
                   )}
                 >
                   {tab.label} ({tab.count})
@@ -446,11 +440,9 @@ export const ProductionSidebar = memo(
           </div>
 
           {activeStructures.length > 0 && (
-            <div className="space-y-2 rounded border border-gold/15 bg-black/10 p-3">
-              <div className="text-[10px] uppercase tracking-wide text-gold/50">
-                Apply preset to all {activeLabel.toLowerCase()}
-              </div>
-              <div className="flex flex-wrap gap-2">
+            <div className="space-y-1.5 rounded-lg border border-gold/15 bg-black/20 px-2.5 py-2">
+              <div className={HUD_LABEL}>Apply preset to all {activeLabel.toLowerCase()}</div>
+              <div className="flex flex-wrap gap-1.5">
                 {REALM_PRESETS.filter((preset) => preset.id !== "custom").map((preset) => {
                   const isPending =
                     pendingPreset?.presetId === preset.id && pendingPreset?.tab === activeTab && !!pendingPreset;
@@ -460,7 +452,7 @@ export const ProductionSidebar = memo(
                       type="button"
                       onClick={() => handleStagePreset(preset.id)}
                       className={clsx(
-                        "rounded border px-3 py-1 text-xs transition-colors",
+                        "rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors",
                         activeStructures.length === 0
                           ? "cursor-not-allowed border-gold/10 text-gold/30"
                           : isPending
@@ -476,8 +468,8 @@ export const ProductionSidebar = memo(
                 })}
               </div>
               {pendingPreset && pendingPreset.tab === activeTab && (
-                <div className="flex flex-wrap items-center gap-2 rounded border border-gold/20 bg-black/20 px-3 py-2">
-                  <span className="text-xs text-gold/70">
+                <div className="flex flex-wrap items-center gap-2 rounded-md border border-gold/20 bg-black/20 px-2 py-1.5">
+                  <span className={HUD_BODY}>
                     Pending {pendingPresetLabel} for {pendingPreset.realmIds.length} {activeLabel.toLowerCase()}.
                   </span>
                   <div className="flex gap-2">
@@ -495,7 +487,7 @@ export const ProductionSidebar = memo(
         </div>
 
         {activeStructures.length === 0 ? (
-          <div className="rounded-lg border border-gold/20 bg-black/15 p-4 text-sm text-gold/70">
+          <div className={clsx(HUD_BODY, "rounded-lg border border-gold/15 bg-black/20 p-3")}>
             {activeTab === "realm"
               ? `You do not control any ${mode.labels.realms.toLowerCase()} yet.`
               : `You do not control any ${mode.labels.villages.toLowerCase()} yet.`}

--- a/apps/game/src/ui/features/settlement/production/production-workflows.tsx
+++ b/apps/game/src/ui/features/settlement/production/production-workflows.tsx
@@ -4,6 +4,7 @@ import Hammer from "lucide-react/dist/esm/icons/hammer";
 import { useEffect, useRef, useState } from "react";
 
 import { Tabs } from "@/ui/design-system/atoms";
+import { HUD_BODY_MUTED } from "@/ui/design-system/atoms/hud-typography";
 import { isVillageLikeStructureCategory } from "@/ui/lib/structure-capabilities";
 
 import { BuildingsList } from "./buildings-list";
@@ -52,14 +53,9 @@ export const ProductionWorkflows = ({
       description: "Direct control over buildings and output",
       icon: Hammer,
       content: (
-        <div className="space-y-4">
+        <div className="space-y-3">
           {!selectedResource && (
-            <div className="flex items-start gap-3 rounded-lg border border-gold/30 bg-dark-brown/70 px-4 py-3 text-sm text-gold/80">
-              <span className="font-semibold text-gold">Select a building</span>
-              <span className="text-left">
-                Choose any resource card below to inspect its buildings and manage production.
-              </span>
-            </div>
+            <p className={HUD_BODY_MUTED}>Pick a resource below to inspect its buildings and start production.</p>
           )}
 
           <BuildingsList
@@ -92,14 +88,14 @@ export const ProductionWorkflows = ({
   return (
     <section className="space-y-3">
       <Tabs selectedIndex={activeTab} onChange={handleTabChange} className="w-full" variant="default">
-        <Tabs.List className="flex flex-row items-stretch gap-1 rounded-lg border border-gold/25 bg-dark-brown/80 p-1">
+        <Tabs.List className="flex flex-row items-stretch gap-1 rounded-lg border border-gold/15 bg-black/25 p-1">
           {workflows.map((workflow, index) => {
             const Icon = workflow.icon;
             const isActive = activeTab === index;
             const tabClass = `flex flex-1 items-center justify-center gap-2 rounded-md border !space-x-0 ${
               isActive
                 ? "border-gold/60 bg-gold/15 text-gold"
-                : "border-transparent bg-dark-brown/90 text-gold/75 hover:border-gold/40 hover:text-gold"
+                : "border-transparent text-gold/65 hover:border-gold/40 hover:text-gold"
             } !px-3 !py-1.5 text-center !transition-none`;
             return (
               <Tabs.Tab key={workflow.label} className={tabClass} title={workflow.description}>
@@ -110,9 +106,9 @@ export const ProductionWorkflows = ({
           })}
         </Tabs.List>
 
-        <Tabs.Panels className="mt-4">
+        <Tabs.Panels className="mt-3">
           {workflows.map((workflow) => (
-            <Tabs.Panel key={workflow.label} className="flex flex-col gap-4">
+            <Tabs.Panel key={workflow.label} className="flex flex-col gap-3">
               {workflow.content}
             </Tabs.Panel>
           ))}

--- a/apps/game/src/ui/features/settlement/production/raw-resources-panel.tsx
+++ b/apps/game/src/ui/features/settlement/production/raw-resources-panel.tsx
@@ -1,4 +1,7 @@
 import { NumberInput } from "@/ui/design-system/atoms/number-input";
+import { HUD_LABEL, HUD_VALUE } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import Button from "@/ui/design-system/atoms/button";
 import { ResourceIcon } from "@/ui/design-system/molecules/resource-icon";
 import { configManager } from "@bibliothecadao/eternum";
 import { ResourcesIds } from "@bibliothecadao/types";
@@ -57,42 +60,29 @@ export const RawResourcesPanel = ({
   };
 
   return (
-    <div className={`cursor-pointer`} onClick={onSelect}>
-      <div className="">
-        <h4 className="text-sm font-semibold text-gold/80 mb-2">Resources Required:</h4>
-        {rawInputResources?.map((input) => {
-          const balance = resourceBalances[input.resource] || 0;
-          return (
-            <div key={input.resource} className="flex items-center gap-3 my-1  transition-colors">
-              <ResourceIcon resource={ResourcesIds[input.resource]} size="lg" />
-              <div className="flex items-center justify-between w-full">
-                <span
-                  className={`text-xl font-medium ${
-                    resourceBalances[input.resource] < input.amount * productionAmount
-                      ? "text-order-giants"
-                      : "text-gold"
-                  }`}
-                >
-                  {balance.toLocaleString()}
-                </span>
-                <div>
-                  <NumberInput
-                    value={Math.round(input.amount * productionAmount)}
-                    onChange={(value) => handleInputChange(value, input.resource)}
-                    min={0}
-                  />
-                </div>
-              </div>
-            </div>
-          );
-        })}
-        <button
-          onClick={handleMaxClick}
-          className="mt-2 px-3 py-1 text-sm bg-gold/20 hover:bg-gold/30 text-gold rounded"
-        >
-          MAX
-        </button>
-      </div>
+    <div className="cursor-pointer space-y-1" onClick={onSelect}>
+      <div className={HUD_LABEL}>Resources required</div>
+      {rawInputResources?.map((input) => {
+        const balance = resourceBalances[input.resource] || 0;
+        const isShort = balance < input.amount * productionAmount;
+        return (
+          <div key={input.resource} className="flex items-center gap-2 py-0.5">
+            <ResourceIcon resource={ResourcesIds[input.resource]} size="sm" withTooltip={false} />
+            <span className={cn(HUD_VALUE, "w-24 shrink-0 tabular-nums", isShort && "text-red-300")}>
+              {balance.toLocaleString()}
+            </span>
+            <NumberInput
+              value={Math.round(input.amount * productionAmount)}
+              onChange={(value) => handleInputChange(value, input.resource)}
+              min={0}
+              className="h-8 flex-1 text-sm"
+            />
+          </div>
+        );
+      })}
+      <Button variant="outline" size="xs" onClick={handleMaxClick} className="mt-1">
+        Max
+      </Button>
     </div>
   );
 };

--- a/apps/game/src/ui/features/settlement/production/realm-automation-panel.test.tsx
+++ b/apps/game/src/ui/features/settlement/production/realm-automation-panel.test.tsx
@@ -33,14 +33,13 @@ beforeEach(() => {
 afterEach(async () => {
   await act(async () => root.unmount());
 });
-it("shows sliders only when Custom is selected and saves through the existing store", async () => {
+it("keeps the sliders in reach under every preset and saves through the existing store", async () => {
   await act(async () =>
     root.render(<RealmAutomationPanel realmEntityId="5" producedResources={[ResourcesIds.Wood]} />),
   );
-  expect(container.querySelector('input[type="range"]')).toBeNull();
+  expect(container.querySelectorAll('input[type="range"]').length).toBeGreaterThan(0);
   const custom = [...container.querySelectorAll("button")].find((button) => button.textContent === "Custom")!;
   await act(async () => custom.click());
-  expect(container.querySelectorAll('input[type="range"]').length).toBeGreaterThan(0);
   const save = [...container.querySelectorAll("button")].find((button) => button.textContent === "Save Changes")!;
   await act(async () => save.click());
   expect(useAutomationStore.getState().realms["5"].presetId).toBe("custom");

--- a/apps/game/src/ui/features/settlement/production/realm-automation-panel.tsx
+++ b/apps/game/src/ui/features/settlement/production/realm-automation-panel.tsx
@@ -12,6 +12,7 @@ import Button from "@/ui/design-system/atoms/button";
 import { aggregateConsumptionPerSecond, configManager } from "@bibliothecadao/eternum";
 import { ResourcesIds } from "@bibliothecadao/types";
 import clsx from "clsx";
+import { HUD_BODY_MUTED, HUD_HEADLINE, HUD_LABEL } from "@/ui/design-system/atoms/hud-typography";
 import { useCallback, useEffect, useMemo, useState, type ChangeEvent } from "react";
 import { REALM_PRESETS, RealmPresetId, calculatePresetAllocations, inferRealmPreset } from "@/utils/automation-presets";
 
@@ -519,8 +520,8 @@ export const RealmAutomationPanel = ({
       <header className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <div>
-            <h4 className="text-lg font-semibold text-gold">Production Automation</h4>
-            <p className="text-xs text-gold/60">Adjust sliders or apply a preset, then save to commit your changes.</p>
+            <h4 className={HUD_HEADLINE}>Production automation</h4>
+            <p className={HUD_BODY_MUTED}>Move a slider or apply a preset, then save.</p>
           </div>
           <div className="flex flex-wrap gap-2">
             <Button
@@ -587,7 +588,7 @@ export const RealmAutomationPanel = ({
       </header>
 
       <section className="space-y-2">
-        <h5 className="text-sm font-semibold text-gold">Resource Usage</h5>
+        <h5 className={HUD_LABEL}>Resource usage</h5>
         {usageDisplayList.length === 0 ? (
           <p className="text-xs text-gold/60">No resources allocated yet.</p>
         ) : (
@@ -625,8 +626,9 @@ export const RealmAutomationPanel = ({
         )}
       </section>
 
-      {activePresetId === "custom" && (
-        <section aria-label="Custom automation allocations" className="grid grid-cols-4 gap-3">
+      {/* The sliders are always in reach: moving one turns the preset into Custom. */}
+      {
+        <section aria-label="Automation allocations" className="grid grid-cols-4 gap-3">
           {automationRows.map(({ resourceId, percentages, complexInputs, simpleInputs }) => {
             const label = resolveResourceLabel(resourceId);
             const complexImpacted = gatherImpactedResources(complexInputs.map((input) => input.resource));
@@ -747,7 +749,7 @@ export const RealmAutomationPanel = ({
             );
           })}
         </section>
-      )}
+      }
     </div>
   );
 };

--- a/apps/game/src/ui/features/settlement/production/resource-production-controls.tsx
+++ b/apps/game/src/ui/features/settlement/production/resource-production-controls.tsx
@@ -4,6 +4,8 @@ import { useCurrentDefaultTick } from "@/hooks/helpers/use-block-timestamp";
 import { useComponentValue } from "@dojoengine/react";
 import { gameEntityKey } from "@/sync/game-scope";
 import { Button, NumberInput, Tabs } from "@/ui/design-system/atoms";
+import { HUD_BODY_MUTED, HUD_CUE, HUD_HEADLINE, HUD_LABEL, HUD_VALUE } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
 import { ResourceIcon } from "@/ui/design-system/molecules";
 import { isVillageLikeStructureCategory } from "@/ui/lib/structure-capabilities";
 import { configManager, divideByPrecision, formatTime, getBuildingQuantity } from "@bibliothecadao/eternum";
@@ -280,27 +282,25 @@ export const ResourceProductionControls = ({
       </section>
     );
 
+  const timeRequired = ticks
+    ? formatTime(Math.floor((ticks / buildingCount) * (isVillageLikeStructureCategory(realm.category) ? 2 : 1)))
+    : "0s";
+
   return (
-    <div className="p-6 rounded-lg border border-gold/20 bg-black/30">
-      <div className={`grid ${canUseLabor ? "grid-cols-2" : "grid-cols-1"} gap-4`}>
-        <div className="grid grid-cols-1 gap-4">
-          <div className="mb-4">
-            <h3 className="text-2xl font-bold mb-4">Start Production - {ResourcesIds[selectedResource]}</h3>
-            <p className="text-xl text-gold/80 mb-4">
-              You can input the output here and it will be automatically calculated.
-            </p>
-            <div className="flex items-center gap-4 mb-4 w-72">
-              <div className="flex items-center gap-2">
-                <ResourceIcon resource={ResourcesIds[selectedResource]} size="xl" />
-              </div>
-              <NumberInput
-                value={Math.round(productionAmount)}
-                onChange={(value) => setProductionAmount(value)}
-                min={1}
-                className="rounded-md border-gold/30 hover:border-gold/50"
-              />
-            </div>
+    <div className="space-y-3 rounded-lg border border-gold/15 bg-black/25 p-4">
+      <div className={cn("grid gap-4", canUseLabor ? "grid-cols-2" : "grid-cols-1")}>
+        <div className="space-y-2">
+          <h3 className={HUD_HEADLINE}>Start production · {ResourcesIds[selectedResource]}</h3>
+          <div className="flex items-center gap-2">
+            <ResourceIcon resource={ResourcesIds[selectedResource]} size="md" />
+            <NumberInput
+              value={Math.round(productionAmount)}
+              onChange={(value) => setProductionAmount(value)}
+              min={1}
+              className="h-9 w-52 text-sm"
+            />
           </div>
+          <p className={HUD_BODY_MUTED}>Type the output; the inputs follow.</p>
         </div>
         {selectableTabs.length > 1 ? (
           <Tabs
@@ -309,13 +309,13 @@ export const ResourceProductionControls = ({
               setUseRawResources(selectableTabs[index].isRaw);
             }}
           >
-            <Tabs.List className="p-2 w-full">
+            <Tabs.List className="w-full">
               {selectableTabs.map((tab, index) => (
                 <Tabs.Tab key={index}>{tab.label}</Tabs.Tab>
               ))}
             </Tabs.List>
 
-            <Tabs.Panels className="overflow-hidden">
+            <Tabs.Panels className="overflow-hidden pt-2">
               {selectableTabs.map((tab, index) => (
                 <Tabs.Panel key={index}>{tab.component}</Tabs.Panel>
               ))}
@@ -332,54 +332,34 @@ export const ResourceProductionControls = ({
               onSelect={() => setUseRawResources(true)}
               outputResourceAmount={outputResourceAmountWithBonus}
             />
-            <div className="text-sm text-gold/70 mt-2">
-              <span>
-                Only standard production is available for this resource. Simple production is not unlocked or not
-                available yet.
-              </span>
-            </div>
+            <p className={HUD_BODY_MUTED}>Only standard production is available for this resource.</p>
           </div>
         )}
       </div>
 
-      {error && <p role="status">{error}</p>}
-      {/* Output */}
-      <div className="flex flex-col gap-2">
-        <div className="flex justify-between gap-2">
-          <div>
-            <h2 className="flex items-center gap-2 mt-4">
-              {Math.round(productionAmount).toLocaleString()} {ResourcesIds[selectedResource]}
-              <ResourceIcon resource={ResourcesIds[selectedResource]} size="sm" /> to produce
-              {bonus > 1 && (
-                <span className="text-relic-activated text-lg font-semibold animate-pulse">
-                  (+{Math.round((bonus - 1) * 100)}% bonus)
-                </span>
-              )}
-            </h2>
-          </div>
-          <h4 className="flex items-center gap-2">
-            <span className="text-gold/80">Time Required:</span>
-            <span>
-              {ticks
-                ? formatTime(
-                    Math.floor((ticks / buildingCount) * (isVillageLikeStructureCategory(realm.category) ? 2 : 1)),
-                  )
-                : "0s"}
-            </span>
-          </h4>
-        </div>
-
-        <Button
-          onClick={useRawResources ? handleRawResourcesProduce : handleLaborResourcesProduce}
-          disabled={!ordersAllowed || isDisabled || isLoading}
-          isLoading={isLoading}
-          variant={isDisabled ? "default" : "gold"}
-          className="px-8 py-2"
-          size="lg"
-        >
-          {isDisabled ? "Not enough resources" : "Start Production"}
-        </Button>
+      {error && (
+        <p role="status" className="text-xs text-danger">
+          {error}
+        </p>
+      )}
+      <div className="flex items-center justify-between gap-3 border-t border-gold/15 pt-3">
+        <span className={cn(HUD_VALUE, "flex items-center gap-1.5")}>
+          {Math.round(productionAmount).toLocaleString()} {ResourcesIds[selectedResource]}
+          <ResourceIcon resource={ResourcesIds[selectedResource]} size="xs" withTooltip={false} />
+          {bonus > 1 && <span className="text-relic-activated">+{Math.round((bonus - 1) * 100)}% bonus</span>}
+        </span>
+        <span className={HUD_CUE}>Time required {timeRequired}</span>
       </div>
+      <Button
+        onClick={useRawResources ? handleRawResourcesProduce : handleLaborResourcesProduce}
+        disabled={!ordersAllowed || isDisabled || isLoading}
+        isLoading={isLoading}
+        variant={isDisabled ? "outline" : "gold"}
+        className="w-full"
+        size="md"
+      >
+        {isDisabled ? "Not enough resources" : "Start production"}
+      </Button>
     </div>
   );
 };

--- a/apps/game/src/ui/features/world/containers/logistics-view.tsx
+++ b/apps/game/src/ui/features/world/containers/logistics-view.tsx
@@ -1,4 +1,3 @@
-import { useGameModeConfig } from "@/config/game-modes/use-game-mode-config";
 import { useUIStore } from "@/hooks/store/use-ui-store";
 import { Tabs } from "@/ui/design-system/atoms/tab";
 import { EntityResourceTable } from "@/ui/features/economy/resources";
@@ -6,7 +5,10 @@ import { ResourceArrivals } from "@/ui/features/economy/trading";
 import { TransferAutomationAdvancedModal } from "@/ui/features/economy/transfers/transfer-automation-modal";
 import { TransferAutomationPanel } from "@/ui/features/economy/transfers/transfer-automation-panel";
 import clsx from "clsx";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
+import { HUD_BODY_MUTED } from "@/ui/design-system/atoms/hud-typography";
+import { cn } from "@/ui/design-system/atoms/lib/utils";
+import { StructureSidebar } from "@/ui/features/world/containers/structure-sidebar";
 
 const TAB_KEYS = ["arrivals", "transfer", "automation", "balances"] as const;
 type LogisticsTab = (typeof TAB_KEYS)[number];
@@ -19,7 +21,7 @@ const TAB_INDEX_BY_KEY: Record<LogisticsTab, number> = {
 };
 
 const tabClass =
-  "!mx-0 flex items-center justify-center rounded-md border border-gold/30 bg-black/30 px-3 py-1.5 text-center text-[11px] font-semibold uppercase tracking-wide text-gold transition hover:bg-gold/15";
+  "!mx-0 flex items-center justify-center rounded-md border border-gold/20 bg-black/25 px-3 py-1.5 text-center text-[11px] font-semibold uppercase tracking-[0.14em] text-gold/75 transition hover:border-gold/40 hover:text-gold";
 
 interface LogisticsViewProps {
   hasArrivals: boolean;
@@ -86,7 +88,7 @@ export const LogisticsView = ({ hasArrivals }: LogisticsViewProps) => {
           <Tabs.Panel className="h-full overflow-y-auto">
             <TransferAutomationAdvancedModal />
           </Tabs.Panel>
-          <Tabs.Panel className="h-full overflow-y-auto">
+          <Tabs.Panel className="h-full overflow-hidden">
             <AllRealmsBalanceTab structures={playerStructures} />
           </Tabs.Panel>
         </Tabs.Panels>
@@ -99,8 +101,8 @@ interface AllRealmsBalanceTabProps {
   structures: Array<{ entityId: number; structure?: unknown }>;
 }
 
+/** The balances tab: the shared structure switcher on the left, the chosen structure's balances on the right. */
 const AllRealmsBalanceTab = ({ structures }: AllRealmsBalanceTabProps) => {
-  const mode = useGameModeConfig();
   const [selectedId, setSelectedId] = useState<number | null>(structures[0]?.entityId ?? null);
 
   useEffect(() => {
@@ -108,48 +110,25 @@ const AllRealmsBalanceTab = ({ structures }: AllRealmsBalanceTabProps) => {
     setSelectedId(structures[0]?.entityId ?? null);
   }, [selectedId, structures]);
 
-  const options = useMemo(
-    () =>
-      structures.map((structure) => ({
-        id: structure.entityId,
-        // The mode.structure.getName signature expects the Structure component value;
-        // legacy callers pass the wrapper or raw value depending on context.
-        name: mode.structure.getName((structure.structure ?? structure) as Parameters<typeof mode.structure.getName>[0])
-          .name,
-      })),
-    [mode.structure, structures],
-  );
-
-  const selected = options.find((option) => option.id === selectedId) ?? options[0];
-
-  if (!options.length) {
-    return <div className="p-4 text-sm text-gold/70">No realms available.</div>;
+  if (!structures.length) {
+    return <p className={cn(HUD_BODY_MUTED, "p-4")}>No structures yet.</p>;
   }
 
   return (
-    <div className="flex gap-3 p-1">
-      <div className="w-40 flex-shrink-0 space-y-1">
-        {options.map((option) => (
-          <button
-            key={option.id}
-            type="button"
-            className={clsx(
-              "w-full rounded border px-2 py-1.5 text-left text-xs transition",
-              selected?.id === option.id
-                ? "border-gold/50 bg-gold/10 text-gold"
-                : "border-gold/20 bg-dark/40 text-gold/80 hover:border-gold/40 hover:bg-dark/60",
-            )}
-            onClick={() => setSelectedId(option.id)}
-          >
-            {option.name}
-          </button>
-        ))}
+    <div className="grid h-full min-h-0 grid-cols-12">
+      <div className="col-span-3 min-h-0 border-r border-gold/15">
+        <StructureSidebar
+          selectedEntityId={selectedId ?? 0}
+          onSelectStructure={setSelectedId}
+          title="Your structures"
+          enableCategoryFilter
+        />
       </div>
-      <div className="flex-1 min-w-0 rounded-lg border border-gold/20 bg-black/40 p-2">
-        {selected ? (
-          <EntityResourceTable entityId={selected.id} />
+      <div className="col-span-9 min-h-0 overflow-y-auto px-3 py-2">
+        {selectedId ? (
+          <EntityResourceTable entityId={selectedId} />
         ) : (
-          <div className="p-4 text-sm text-gold/70">Select a realm to view balances.</div>
+          <p className={HUD_BODY_MUTED}>Select a structure.</p>
         )}
       </div>
     </div>

--- a/apps/game/src/ui/features/world/containers/top-header/identity-chip.tsx
+++ b/apps/game/src/ui/features/world/containers/top-header/identity-chip.tsx
@@ -10,7 +10,7 @@ import { BuildingThumbs } from "@/ui/config";
 import Button from "@/ui/design-system/atoms/button";
 import { HUD_BODY, HUD_BODY_MUTED, HUD_HEADLINE } from "@/ui/design-system/atoms/hud-typography";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
-import { Popover, SurfaceFrame } from "@/ui/design-system/molecules/popover";
+import { Popover, SURFACE_WORKSPACE_CLASS, SurfaceFrame } from "@/ui/design-system/molecules/popover";
 import { normalizeLeaderboardAddress } from "@/ui/features/social/player/finalized-blitz-leaderboard";
 import { useInGameLeaderboard } from "@/ui/features/social/player/use-in-game-leaderboard";
 import { IdentityLogin } from "@/ui/modules/identity/identity-login";
@@ -78,7 +78,7 @@ const LeaderboardSurface = () => (
     title="Leaderboard"
     icon={Trophy}
     onClose={() => usePopoverStore.getState().close(LEADERBOARD_POPOVER_ID)}
-    className="w-[1000px]"
+    className={SURFACE_WORKSPACE_CLASS}
   >
     <SocialBoard focusOwnPlayer />
   </SurfaceFrame>


### PR DESCRIPTION
From the latest notes on the Build, Logistics and Production desks.

- **Desk size**: the workspace desk is narrower and shorter, and the leaderboard opens at the same size.
- **Automation sliders**: always shown. Moving one turns the preset into Custom, as it already did; they no longer hide behind the Custom button.
- **Balances**: the single-structure view uses the HUD typography with compact filter switches and small-caps tier headers. The resource row is one compact line (icon, amount, hourly rate, time left, action icons) shared with the production list. The balances tab picks its structure through the shared structure sidebar. Dead commented-out tooltip code in the row is deleted.
- **Production**: realm cards match the structure rows, list rows drop the building photos, and the start-production panel is one compact form with held-versus-needed recipe rows. The desk splits like the Military desk.

Verified: tsc, knip, `pnpm test` (707 files green). The views need a signed-in look; none of these render in spectate.