### PR TITLE
Publish the sequencer clock off the pre-confirmed block

### DIFF
--- a/apps/game/src/sync/herald-game-sync-session.test.ts
+++ b/apps/game/src/sync/herald-game-sync-session.test.ts
@@ -60,9 +60,32 @@ it("records confirmed heads even when provisional row evidence has advanced the 
   const previousBlock = useConnectionStore.getState().lastConfirmedBlock;
   try {
     useChainTimeStore.setState({ lastHeartbeat: { timestamp: 200_000, source: "row-evidence" } });
-    session.onHead?.({ block: 13, timestamp: 100 });
+    session.onHead?.({ block: 13, preconfirmed: false, timestamp: 100 });
     expect(useConnectionStore.getState().lastConfirmedBlock).toBe(13);
     expect(useChainTimeStore.getState().lastHeartbeat?.timestamp).toBe(200_000);
+  } finally {
+    useChainTimeStore.setState(previous);
+    useConnectionStore.setState({ lastConfirmedBlock: previousBlock });
+  }
+});
+
+it("a pre-confirmed clock advances the heartbeat without moving the confirmed head", () => {
+  const session = createHeraldGameSyncSession({
+    baseUrl: "https://herald.realms.test",
+    chain: "madara",
+    entityModels: [],
+    eventModels: [],
+    gameId: 54,
+    setup: { network: { contractComponents: {} } } as never,
+  });
+  const previous = useChainTimeStore.getState();
+  const previousBlock = useConnectionStore.getState().lastConfirmedBlock;
+  try {
+    useConnectionStore.setState({ lastConfirmedBlock: 13 });
+    useChainTimeStore.setState({ lastHeartbeat: { timestamp: 100_000, source: "herald-head" } });
+    session.onHead?.({ block: 14, preconfirmed: true, timestamp: 103 });
+    expect(useConnectionStore.getState().lastConfirmedBlock).toBe(13);
+    expect(useChainTimeStore.getState().lastHeartbeat?.timestamp).toBe(103_000);
   } finally {
     useChainTimeStore.setState(previous);
     useConnectionStore.setState({ lastConfirmedBlock: previousBlock });

--- a/apps/game/src/sync/herald-game-sync-session.ts
+++ b/apps/game/src/sync/herald-game-sync-session.ts
@@ -66,10 +66,10 @@ export function createHeraldGameSyncSession(input: CreateHeraldGameSyncSessionIn
     onTransactionEntitiesReceived: recordClientActionDiffReceived,
     onSubscriptionActive: input.onSubscriptionActive,
     onHead: (head) => {
-      useConnectionStore.getState().recordConfirmedHead(head.block);
+      if (!head.preconfirmed) useConnectionStore.getState().recordConfirmedHead(head.block);
       useChainTimeStore.getState().setHeartbeat({
         blockNumber: head.block,
-        source: "herald-head",
+        source: head.preconfirmed ? "herald-clock" : "herald-head",
         timestamp: head.timestamp * 1_000,
       });
     },

--- a/apps/herald/src/game-stream.ts
+++ b/apps/herald/src/game-stream.ts
@@ -120,8 +120,9 @@ export class GameStreamHub {
     this.publish(gameId, { ...input, type: "tx" });
   }
 
-  public publishHead(gameId: string, block: number, timestamp: number): void {
-    this.publish(gameId, { block, timestamp, type: "head" });
+  /** A confirmed head, or with `preconfirmed` the sequencer clock read off the pre-confirmed block. */
+  public publishHead(gameId: string, block: number, timestamp: number, preconfirmed = false): void {
+    this.publish(gameId, { block, preconfirmed, timestamp, type: "head" });
   }
 
   private publish(gameId: string, body: PublishBody<PublishedMessage>): void {

--- a/apps/herald/src/live-world.test.ts
+++ b/apps/herald/src/live-world.test.ts
@@ -105,6 +105,7 @@ const rpcFixture = (block: RpcBlockWithReceipts, confirmedEvents: RawWorldEvent[
   ({
     blockNumber: async () => 12,
     getBlockWithReceipts: async () => block,
+    getPreconfirmedHeader: async () => ({ block_number: block.block_number, timestamp: block.timestamp + 3 }),
     getEvents: async function* () {
       if (confirmedEvents.length > 0) yield { events: confirmedEvents, page: 1 };
     },
@@ -220,6 +221,15 @@ describe("LiveWorld", () => {
     releaseCommit();
     await advancing;
     expect(socket.messages).toContainEqual(expect.objectContaining({ type: "head", block: 13 }));
+  });
+
+  it("publishes the pre-confirmed clock as a head only while it advances", async () => {
+    const { live } = liveFixture();
+    const socket = attachResumed(live);
+    await live.publishChainClock();
+    await live.publishChainClock();
+    const clocks = socket.messages.filter((message) => message.type === "head" && message.preconfirmed === true);
+    expect(clocks).toEqual([expect.objectContaining({ block: 13, preconfirmed: true, timestamp: 103 })]);
   });
 
   it("advances history completeness through confirmed blocks without history events", async () => {

--- a/apps/herald/src/live-world.ts
+++ b/apps/herald/src/live-world.ts
@@ -77,6 +77,7 @@ export class LiveWorld {
   private overlayFold: WorldFold;
   private confirmedBlockValue: number;
   private preconfirmedBlockValue: number | null = null;
+  private lastClockTimestamp = 0;
   private lastCheckpointBlock: number;
   private checkpointFailure?: Error;
   private checkpointInFlight = false;
@@ -148,6 +149,18 @@ export class LiveWorld {
 
   public detach(session: GameStreamSession): void {
     this.hub.detach(session);
+  }
+
+  /**
+   * The sequencer clock: the pre-confirmed block's timestamp, published whenever it moves. Clients project
+   * production at the newest chain-written time, so this keeps a MAX within a poll of what the chain accepts.
+   */
+  public async publishChainClock(): Promise<void> {
+    if (this.knownGames.size === 0) return;
+    const header = await this.input.rpc.getPreconfirmedHeader();
+    if (header.timestamp <= this.lastClockTimestamp) return;
+    this.lastClockTimestamp = header.timestamp;
+    for (const gameId of this.knownGames) this.hub.publishHead(gameId, header.block_number, header.timestamp, true);
   }
 
   public async acceptSubscribedHead(head: RpcHead): Promise<void> {
@@ -253,6 +266,7 @@ export class LiveWorld {
     await this.rebuildOverlay();
     this.publishOverlayReverts();
     this.diffLatency.record("confirmed", performance.now() - startedAt);
+    this.lastClockTimestamp = Math.max(this.lastClockTimestamp, head.timestamp);
     for (const gameId of this.knownGames) this.hub.publishHead(gameId, head.block_number, head.timestamp);
     this.checkpointIfDue();
   }

--- a/apps/herald/src/madara-rpc.ts
+++ b/apps/herald/src/madara-rpc.ts
@@ -1,4 +1,4 @@
-import type { Felt, RawWorldEvent, RpcBlockWithReceipts } from "./types";
+import type { Felt, RawWorldEvent, RpcBlockWithReceipts, RpcHead } from "./types";
 
 interface JsonRpcSuccess<Result> {
   jsonrpc: "2.0";
@@ -38,6 +38,11 @@ export class MadaraRpc {
 
   public blockNumber(): Promise<number> {
     return this.request<number>("starknet_blockNumber", []);
+  }
+
+  /** The pre-confirmed block's header: its timestamp is the sequencer clock a transaction executes against. */
+  public getPreconfirmedHeader(): Promise<RpcHead> {
+    return this.request<RpcHead>("starknet_getBlockWithTxHashes", ["pre_confirmed"]);
   }
 
   public getBlockWithReceipts(block: number | "pre_confirmed"): Promise<RpcBlockWithReceipts> {

--- a/apps/herald/src/server.ts
+++ b/apps/herald/src/server.ts
@@ -14,6 +14,8 @@ import { backfillHistory } from "./history-backfill";
 import { HistoryStore } from "./history-store";
 
 const CHECKPOINT_EVERY_BLOCKS = 100;
+/** How often Herald reads the sequencer clock off the pre-confirmed block. */
+const CHAIN_CLOCK_INTERVAL_MS = 500;
 
 interface HeraldConfig {
   chain: string;
@@ -129,9 +131,16 @@ const main = async (): Promise<void> => {
     onTransaction: (transaction) => live.acceptTransaction(transaction),
   });
 
+  const chainClock = setInterval(() => {
+    live.publishChainClock().catch((error: Error) => {
+      console.warn(JSON.stringify({ error: error.message, event: "herald_chain_clock_failed" }));
+    });
+  }, CHAIN_CLOCK_INTERVAL_MS);
+
   const shutdown = async (exitCode: number): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
+    clearInterval(chainClock);
     subscriptions.stop();
     server?.stop();
     try {

--- a/apps/herald/src/stream-protocol.ts
+++ b/apps/herald/src/stream-protocol.ts
@@ -31,7 +31,7 @@ export type HeraldStreamMessage =
       block: number | null;
       revert_reason?: string;
     })
-  | (StreamMessageBase & { type: "head"; block: number; timestamp: number });
+  | (StreamMessageBase & { type: "head"; block: number; timestamp: number; preconfirmed: boolean });
 
 export interface ResumeRequest {
   type: "resume";

--- a/packages/core/src/sync/game-sync-types.ts
+++ b/packages/core/src/sync/game-sync-types.ts
@@ -54,6 +54,8 @@ export interface GameSyncTransport {
 
 export interface GameSyncHead {
   block: number;
+  /** The sequencer clock read off the pre-confirmed block, not a confirmed block. */
+  preconfirmed: boolean;
   timestamp: number;
 }
 

--- a/packages/core/src/sync/herald-game-sync-transport.test.ts
+++ b/packages/core/src/sync/herald-game-sync-transport.test.ts
@@ -255,7 +255,7 @@ describe("HeraldGameSyncTransport", () => {
       { hashed_keys: "0xbeef", models: { BattleEvent: { game_id: "0x36", timestamp: "0x7" } } },
     ]);
     expect(harness.transactions).toEqual([{ block: null, hash: "0xabc", status: "PRE_CONFIRMED" }]);
-    expect(harness.heads).toEqual([{ block: 13, timestamp: 100 }]);
+    expect(harness.heads).toEqual([{ block: 13, preconfirmed: false, timestamp: 100 }]);
   });
 
   it("preserves the pre-confirmed transaction boundary for atomic ingest", async () => {

--- a/packages/core/src/sync/herald-game-sync-transport.ts
+++ b/packages/core/src/sync/herald-game-sync-transport.ts
@@ -52,7 +52,7 @@ type HeraldMessage =
       block: number | null;
       revert_reason?: string;
     })
-  | (HeraldMessageBase & { type: "head"; block: number; timestamp: number });
+  | (HeraldMessageBase & { type: "head"; block: number; timestamp: number; preconfirmed?: boolean });
 
 export interface HeraldSocket {
   close(): void;
@@ -394,7 +394,11 @@ export class HeraldGameSyncTransport implements GameSyncTransport {
   }
 
   private acceptHead(message: Extract<HeraldMessage, { type: "head" }>): void {
-    const head: GameSyncHead = { block: message.block, timestamp: message.timestamp };
+    const head: GameSyncHead = {
+      block: message.block,
+      preconfirmed: message.preconfirmed === true,
+      timestamp: message.timestamp,
+    };
     this.handlers?.onHead?.(head);
   }
 


### PR DESCRIPTION
Follow-up to #4940. There the client started projecting production at the newest chain-written timestamp it holds, which was a closed head: 2 to 4 seconds behind the sequencer clock on the lab chain, and a MAX left that much production unspent.

**Herald** now reads the pre-confirmed block's header twice a second (one `starknet_getBlockWithTxHashes` call) and publishes its timestamp as a head flagged `preconfirmed` whenever it advances. Confirmed heads are unchanged.

**Client** takes the flagged head as a heartbeat like any chain-written timestamp, and moves its confirmed block only on confirmed heads. Older Herald builds without the flag keep working as before.

Verified: Herald typecheck and tests (12 files), core sync tests, client sync and clock tests, format and knip. Needs a Herald redeploy on the box to take effect.