### PR TITLE
Local scene: only this realm's buildable ring, no pad tint on empty cells, greyer band

### DIFF
--- a/apps/game/src/index.css
+++ b/apps/game/src/index.css
@@ -340,6 +340,16 @@ body {
   }
 }
 
+/* A quick-feed row's exit: one linear fade the compositor runs on its own. */
+@keyframes quickFeedFade {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 /* One quick fill around a resource token each time its held amount changes. */
 @property --accrual-angle {
   syntax: "<angle>";

--- a/apps/game/src/three/scenes/hexception.tsx
+++ b/apps/game/src/three/scenes/hexception.tsx
@@ -1245,6 +1245,8 @@ export default class HexceptionScene extends HexagonScene {
           ];
           const neighbors = getNeighborHexes(this.centerColRow[0], this.centerColRow[1]);
           this.highlights = [];
+          // The buildable set belongs to this realm and its level; a previous realm's must not linger.
+          this.interactiveHexManager.clearHexes();
 
           // compute matrices to update biome models for each of the large hexes
           for (const center in centers) {
@@ -1299,6 +1301,14 @@ export default class HexceptionScene extends HexagonScene {
     const fallbackBiome = configManager.getBiome(this.centerColRow[0], this.centerColRow[1]);
     const cellsByKey = new Map<string, TerrainCellInput>();
     const worldPosition = new Vector3();
+    // Only a cell with a building gets the packed structure pad; an empty buildable cell keeps its ground.
+    const builtKeys = new Set(
+      this.buildings.map((building) => {
+        worldPosition.setFromMatrixPosition(building.matrix);
+        const coordinate = getHexForWorldPosition(worldPosition);
+        return `${coordinate.col}:${coordinate.row}`;
+      }),
+    );
 
     Object.entries(terrainMatricesByBiome).forEach(([biomeKey, matrices]) => {
       const biome = resolveHexceptionBiome(biomeKey, fallbackBiome);
@@ -1310,7 +1320,7 @@ export default class HexceptionScene extends HexagonScene {
           biome,
           col: coordinate.col,
           explored: true,
-          occupied: biomeKey === "Empty",
+          occupied: builtKeys.has(key),
           previewBiome: biome,
           row: coordinate.row,
         });

--- a/apps/game/src/three/shaders/border-hex-material.ts
+++ b/apps/game/src/three/shaders/border-hex-material.ts
@@ -1,10 +1,10 @@
 import * as THREE from "three";
 
-/** The buildable-hex band: a quiet parchment line that reads on every biome and never writes depth. */
+/** The buildable-hex band: the terrain grid's grey, a step more present, and it never writes depth. */
 export const interactiveHexMaterial = new THREE.MeshBasicMaterial({
-  color: 0xf6f1e5,
+  color: 0xc9c4b9,
   transparent: true,
-  opacity: 0.45,
+  opacity: 0.7,
   depthWrite: false,
   toneMapped: false,
 });

--- a/apps/game/src/ui/action-runners.tsx
+++ b/apps/game/src/ui/action-runners.tsx
@@ -5,6 +5,7 @@ import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
 import { useConnectionStore } from "@/hooks/store/use-connection-store";
 import { useUIStore } from "@/hooks/store/use-ui-store";
+import { shouldClaimSharePoints } from "@/ui/share-points-claim-policy";
 import { useWorldSlicesStore } from "@/hooks/store/use-world-slices-store";
 import { executeObservedClientTransaction } from "@/observability/observed-client-transaction";
 import { gameCallArgs, gameEntityKey, getGameNamespace } from "@/sync/game-scope";
@@ -26,6 +27,7 @@ import {
   shouldSkipAutomaticClaimSharePointsSubmission,
 } from "@/ui/utils/uncertain-transaction-registry";
 import {
+  getBlockTimestamp,
   getBuildingCount,
   getIsBlitz,
   getStructureName,
@@ -221,7 +223,7 @@ const ResourceArrivalAutoClaim = () => {
 
 const AUTO_REGISTER_POINTS_DEBUG = VERBOSE_LOGS_ENABLED;
 
-/** Registers unregistered shareholder points on completed hyperstructures on a slow timer. */
+/** Registers shareholder points on completed hyperstructures once they are worth a transaction, or in the endgame. */
 const AutoRegisterPoints = () => {
   const {
     account: { account },
@@ -261,8 +263,10 @@ const AutoRegisterPoints = () => {
       const registeredPoints = leaderboardManager.getPlayerRegisteredPoints(playerAddress);
       const unregisteredPoints = leaderboardManager.getPlayerHyperstructureUnregisteredShareholderPoints(playerAddress);
       log(`Registered: ${registeredPoints}, Unregistered: ${unregisteredPoints}`);
-      if (unregisteredPoints <= 0) {
-        log("Skipped: no unregistered points");
+      const gameEndAt = useUIStore.getState().gameEndAt;
+      const secondsToGameEnd = gameEndAt ? gameEndAt - getBlockTimestamp().currentBlockTimestamp : null;
+      if (!shouldClaimSharePoints({ registeredPoints, unregisteredPoints, secondsToGameEnd })) {
+        log("Skipped: unregistered points not worth a transaction yet");
         return;
       }
 

--- a/apps/game/src/ui/features/event-feed/feed-row-line.tsx
+++ b/apps/game/src/ui/features/event-feed/feed-row-line.tsx
@@ -1,7 +1,6 @@
 import { useNavigateToMapView } from "@/hooks/helpers/use-navigate";
 import { useWorldSlicesStore } from "@/hooks/store/use-world-slices-store";
 import { cn } from "@/ui/design-system/atoms/lib/utils";
-import { OVERLAY_SURFACE_BASE } from "@/ui/design-system/atoms/overlay-surface";
 import { Position } from "@bibliothecadao/eternum";
 import { useDojo } from "@bibliothecadao/react";
 import type { LucideIcon } from "lucide-react";
@@ -29,11 +28,10 @@ import { transferRowLabel } from "./event-feed-rows";
 import { formatFeedTime, type ImportantFeedRow } from "./important-feed-rows";
 import { resolveStoryEventPosition } from "./story-feed-row";
 
-/** One feed row on the shared solid surface: a fixed icon column, one line of text, the time flush right. */
-export const FEED_ROW_CLASS = cn(
-  "pointer-events-auto flex h-8 w-full items-center gap-2 rounded-md px-2.5 text-xs text-gold",
-  OVERLAY_SURFACE_BASE,
-);
+/** One feed row in the Log button's translucent black, not the panels' surface: a fixed icon column, one line of
+ *  text, the time flush right. */
+export const FEED_ROW_CLASS =
+  "pointer-events-auto flex h-8 w-full items-center gap-2 rounded-md bg-black/50 px-2.5 text-xs text-gold backdrop-blur-[2px]";
 const FEED_ROW_ICON_COLUMN_CLASS = "flex w-4 shrink-0 items-center justify-center";
 
 const HEADLINE_ICONS: Record<HeadlineType, LucideIcon> = {
@@ -74,7 +72,7 @@ export const FeedRowLine = ({ row, style }: { row: ImportantFeedRow; style?: CSS
     <button
       type="button"
       onClick={() => navigate(target)}
-      className={cn(FEED_ROW_CLASS, "font-sans normal-case tracking-normal hover:border-gold/50")}
+      className={cn(FEED_ROW_CLASS, "font-sans normal-case tracking-normal hover:bg-black/70")}
       style={style}
     >
       {content}

--- a/apps/game/src/ui/features/event-feed/quick-feed.tsx
+++ b/apps/game/src/ui/features/event-feed/quick-feed.tsx
@@ -52,11 +52,7 @@ export const QuickFeed = ({ logOpen, onLogToggle }: { logOpen: boolean; onLogTog
       </button>
       <FeedNotices pinned={pinned} />
       {visible.map((row) => (
-        <FeedRowLine
-          key={row.id}
-          row={row}
-          style={{ opacity: Math.min(1, (QUICK_FEED_WINDOW_MS - (nowMs - row.at)) / QUICK_FEED_FADE_MS) }}
-        />
+        <QuickFeedRow key={row.id} row={row} />
       ))}
       {logOpen && (
         <EventLogPanel
@@ -65,6 +61,18 @@ export const QuickFeed = ({ logOpen, onLogToggle }: { logOpen: boolean; onLogTog
         />
       )}
     </div>
+  );
+};
+
+/** A row fades out over its last seconds on the compositor: the delay is fixed at mount, so the once-a-second
+ *  clock that removes it never restarts or steps the fade. */
+const QuickFeedRow = ({ row }: { row: ImportantFeedRow }) => {
+  const [delayMs] = useState(() => Math.max(0, row.at + QUICK_FEED_WINDOW_MS - QUICK_FEED_FADE_MS - Date.now()));
+  return (
+    <FeedRowLine
+      row={row}
+      style={{ animation: `quickFeedFade ${QUICK_FEED_FADE_MS}ms linear ${delayMs}ms forwards` }}
+    />
   );
 };
 
@@ -100,7 +108,7 @@ export const FeedNotices = ({ pinned }: { pinned: Headline[] }) => (
   <>
     <OfflineRow />
     {pinned.map((headline) => (
-      <div key={headline.id} aria-label="Pinned event" className={cn(FEED_ROW_CLASS, "border-gold/60")}>
+      <div key={headline.id} aria-label="Pinned event" className={cn(FEED_ROW_CLASS, "border border-gold/60")}>
         <HeadlineIcon type={headline.type} />
         <span className="min-w-0 flex-1 truncate">{headline.description}</span>
       </div>
@@ -129,7 +137,7 @@ function OfflineRow() {
   );
   if (status !== "disconnected") return null;
   return (
-    <div aria-label="Offline" className={cn(FEED_ROW_CLASS, "border-danger/60 text-danger")}>
+    <div aria-label="Offline" className={cn(FEED_ROW_CLASS, "border border-danger/60 text-danger")}>
       <WifiOff className="h-4 w-4 shrink-0" />
       <span className="min-w-0 flex-1 truncate">Offline</span>
       <button

--- a/apps/game/src/ui/share-points-claim-policy.test.ts
+++ b/apps/game/src/ui/share-points-claim-policy.test.ts
@@ -1,0 +1,28 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { shouldClaimSharePoints } from "./share-points-claim-policy";
+
+describe("shouldClaimSharePoints", () => {
+  it("waits until the unregistered share is a tenth of what is registered", () => {
+    expect(shouldClaimSharePoints({ registeredPoints: 1000, unregisteredPoints: 50, secondsToGameEnd: 3600 })).toBe(
+      false,
+    );
+    expect(shouldClaimSharePoints({ registeredPoints: 1000, unregisteredPoints: 100, secondsToGameEnd: 3600 })).toBe(
+      true,
+    );
+  });
+
+  it("claims the first whole point when nothing is registered yet", () => {
+    expect(shouldClaimSharePoints({ registeredPoints: 0, unregisteredPoints: 0.4, secondsToGameEnd: null })).toBe(
+      false,
+    );
+    expect(shouldClaimSharePoints({ registeredPoints: 0, unregisteredPoints: 1, secondsToGameEnd: null })).toBe(true);
+  });
+
+  it("claims anything unregistered inside the endgame and nothing when there is nothing", () => {
+    expect(shouldClaimSharePoints({ registeredPoints: 1000, unregisteredPoints: 2, secondsToGameEnd: 600 })).toBe(true);
+    expect(shouldClaimSharePoints({ registeredPoints: 1000, unregisteredPoints: 0, secondsToGameEnd: 600 })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/game/src/ui/share-points-claim-policy.ts
+++ b/apps/game/src/ui/share-points-claim-policy.ts
@@ -1,0 +1,18 @@
+/** Unregistered shareholder points worth a transaction: a tenth of what is already registered. */
+export const CLAIM_SHARE_POINTS_GROWTH = 0.1;
+/** Inside the endgame every claim counts, so the runner claims whatever is unregistered. */
+export const CLAIM_SHARE_POINTS_ENDGAME_SECONDS = 15 * 60;
+
+/**
+ * Standings already show live shareholder points, so registering them on chain is worth a transaction only when
+ * the unregistered share has grown meaningfully, or when the game is about to end and the chain must hold them.
+ */
+export function shouldClaimSharePoints(input: {
+  registeredPoints: number;
+  unregisteredPoints: number;
+  secondsToGameEnd: number | null;
+}): boolean {
+  if (input.unregisteredPoints <= 0) return false;
+  if (input.secondsToGameEnd !== null && input.secondsToGameEnd <= CLAIM_SHARE_POINTS_ENDGAME_SECONDS) return true;
+  return input.unregisteredPoints >= Math.max(1, input.registeredPoints * CLAIM_SHARE_POINTS_GROWTH);
+}

--- a/apps/game/src/ui/share-points-claim-policy.ts
+++ b/apps/game/src/ui/share-points-claim-policy.ts
@@ -1,7 +1,7 @@
 /** Unregistered shareholder points worth a transaction: a tenth of what is already registered. */
-export const CLAIM_SHARE_POINTS_GROWTH = 0.1;
+const CLAIM_SHARE_POINTS_GROWTH = 0.1;
 /** Inside the endgame every claim counts, so the runner claims whatever is unregistered. */
-export const CLAIM_SHARE_POINTS_ENDGAME_SECONDS = 15 * 60;
+const CLAIM_SHARE_POINTS_ENDGAME_SECONDS = 15 * 60;
 
 /**
  * Standings already show live shareholder points, so registering them on chain is worth a transaction only when


### PR DESCRIPTION
- **Only the current realm's ring**: the interactive hex set was never cleared when entering another realm, so a larger realm visited earlier left its ring behind. It is cleared on every rebuild, so the outline is the level's ring set.
- **No shadow on empty cells**: every buildable cell was flagged as occupied, which laid the packed structure pad (flattening plus the darker disc) under empty ground. Only a cell with a building gets the pad now.
- **Band colour**: the terrain grid's grey, a step more present.

Verified: tsc, knip, scene and interactive-hex tests, and a headless capture of the local view.