### PR TITLE
ci: run contract tests on next and preset changes

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -1,9 +1,20 @@
 name: test-contracts
 
 on:
+  push:
+    branches:
+      - next
+    paths:
+      - "contracts/l3/game/**"
+      - "config/source/**"
+      - "config/deployer/clean/**"
+      - ".github/workflows/test-contracts.yml"
   pull_request:
     paths:
       - "contracts/l3/game/**"
+      - "config/source/**"
+      - "config/deployer/clean/**"
+      - ".github/workflows/test-contracts.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,6 +32,7 @@ jobs:
   test-various:
     needs: [setup-environment]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # strategy:
     #   matrix:
     #     # Only troop_management has active tests (40 tests)


### PR DESCRIPTION
Contract CI currently runs only for pull requests touching game contracts, so pushes to `next` and preset/calldata changes can miss it. Run the existing suite for those changes and limit the test job to 30 minutes.

Validation: the unchanged Cairo suite passes (173 tests). `pnpm run format` and `pnpm run knip` pass. The push trigger itself can only be verified after merge to `next`.

Audit item 1. No gameplay or test changes.
