### PR TITLE
feat(runtime): support Eternum launches and operator lifecycle checks

### DIFF
--- a/apps/herald/src/game-directory.test.ts
+++ b/apps/herald/src/game-directory.test.ts
@@ -15,7 +15,6 @@ const registry = {
   start_main_at: "0xc8",
   end_at: "0x12c",
   end_grace_seconds: "0x3c",
-  registration_grace_seconds: "0x78",
 };
 
 const worldConfig = {
@@ -73,7 +72,6 @@ describe("Herald game directory", () => {
           clock: {
             end_at: 300,
             end_grace_seconds: 60,
-            registration_grace_seconds: 120,
             start_main_at: 200,
             start_settling_at: 100,
           },

--- a/apps/herald/src/game-directory.ts
+++ b/apps/herald/src/game-directory.ts
@@ -123,10 +123,6 @@ const buildGameEntry = (
     clock: {
       end_at: asNumber(registry.end_at, "GameRegistry.end_at"),
       end_grace_seconds: asNumber(registry.end_grace_seconds, "GameRegistry.end_grace_seconds"),
-      registration_grace_seconds: asNumber(
-        registry.registration_grace_seconds,
-        "GameRegistry.registration_grace_seconds",
-      ),
       start_main_at: asNumber(registry.start_main_at, "GameRegistry.start_main_at"),
       start_settling_at: asNumber(registry.start_settling_at, "GameRegistry.start_settling_at"),
     },

--- a/apps/herald/src/http.test.ts
+++ b/apps/herald/src/http.test.ts
@@ -23,6 +23,7 @@ const snapshot: GameSnapshot = {
 const handler = createHeraldRequestHandler({
   chain: "madara",
   confirmedBlock: () => 12,
+  chainTimestamp: () => 100,
   decodedModelCount: 50,
   fold: {
     modelRows: (model) => {
@@ -40,7 +41,6 @@ const handler = createHeraldRequestHandler({
               start_main_at: "0x2",
               end_at: "0x3",
               end_grace_seconds: "0x4",
-              registration_grace_seconds: "0x5",
             },
           },
         ];
@@ -139,6 +139,7 @@ it("passes a battle-only history filter to the store before pagination", async (
   const battleHandler = createHeraldRequestHandler({
     chain: "madara",
     confirmedBlock: () => 12,
+    chainTimestamp: () => 100,
     decodedModelCount: 0,
     metrics,
     fold: { modelRows: () => [], snapshot: () => snapshot },

--- a/apps/herald/src/http.ts
+++ b/apps/herald/src/http.ts
@@ -1,3 +1,4 @@
+import { buildLiveLeaderboard } from "./live-leaderboard";
 import { buildGameDirectory } from "./game-directory";
 import type { FoldRow, GameSnapshot, ReplayMetrics } from "./types";
 import type { HistoryQuery, HistoryStore } from "./history-store";
@@ -10,6 +11,7 @@ interface SnapshotSource {
 interface HeraldHttpState {
   chain: string;
   confirmedBlock: () => number;
+  chainTimestamp: () => number;
   decodedModelCount: number;
   fold: SnapshotSource;
   metrics: ReplayMetrics;
@@ -117,9 +119,16 @@ export const createHeraldRequestHandler = (state: HeraldHttpState): ((request: R
 
     const leaderboardMatch = request.method === "GET" ? leaderboardPath.exec(url.pathname) : null;
     if (leaderboardMatch) {
-      if (!state.history) return jsonResponse({ error: "history_unavailable" }, 503);
-      const leaderboard = state.history.leaderboard(leaderboardMatch[1]);
-      return leaderboard ? jsonResponse(leaderboard) : jsonResponse({ error: "leaderboard_warming_up" }, 503);
+      try {
+        const gameId = leaderboardMatch[1];
+        const timestamp = state.chainTimestamp();
+        if (timestamp <= 0) return jsonResponse({ error: "chain_clock_unavailable" }, 503);
+        return jsonResponse(
+          buildLiveLeaderboard(state.fold.modelRows, gameId, timestamp, state.history?.leaderboard(gameId) ?? null),
+        );
+      } catch (error) {
+        return jsonResponse({ error: error instanceof Error ? error.message : String(error) }, 503);
+      }
     }
 
     const historyMatch = request.method === "GET" ? historyPath.exec(url.pathname) : null;

--- a/apps/herald/src/live-leaderboard.test.ts
+++ b/apps/herald/src/live-leaderboard.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "vitest";
+import { buildLiveLeaderboard } from "./live-leaderboard";
+import { createEmptyActivityBreakdown } from "@bibliothecadao/eternum/game-sync";
+import type { FoldRow } from "./types";
+
+it("uses registered plus elapsed shares, independent of story totals and other games", () => {
+  const models: Record<string, Record<string, unknown>[]> = {
+    GameRegistry: [{ game_id: 1, preset_id: 1, end_at: 200 }],
+    PresetConfig: [{ preset_id: 1, victory_points_grant_config: { hyp_points_per_second: 1_000_000 } }],
+    Hyperstructure: [{ game_id: 1, hyperstructure_id: 7, points_multiplier: 2 }],
+    HyperstructureShareholders: [
+      {
+        game_id: 1,
+        hyperstructure_id: 7,
+        start_at: 100,
+        shareholders: [
+          ["0xa", 5000],
+          ["0xb", 5000],
+        ],
+      },
+    ],
+    PlayerRegisteredPoints: [
+      { game_id: 1, address: "0xa", registered_points: 5_000_000 },
+      { game_id: 2, address: "0xa", registered_points: 999_000_000 },
+    ],
+  };
+  const rows = (model: string): FoldRow[] =>
+    (models[model] ?? []).map((value) => ({ key: "0x1", value: value as FoldRow["value"] }));
+  const activityBreakdown = createEmptyActivityBreakdown();
+  const history = { game_id: "1", entries: [{ address: "0xa", totalPoints: 999, rank: 1, activityBreakdown }] };
+  expect(
+    buildLiveLeaderboard(rows, "1", 300, history).entries.map(({ address, totalPoints }) => [address, totalPoints]),
+  ).toEqual([
+    ["0xa", 105],
+    ["0xb", 100],
+  ]);
+  models.PlayerRegisteredPoints = [];
+  expect(buildLiveLeaderboard(rows, "1", 300, null).entries.map((entry) => entry.rank)).toEqual([1, 1]);
+});

--- a/apps/herald/src/live-leaderboard.ts
+++ b/apps/herald/src/live-leaderboard.ts
@@ -1,0 +1,56 @@
+import {
+  calculateUnregisteredShareholderPoints,
+  createEmptyActivityBreakdown,
+  type HeraldLeaderboard,
+} from "@bibliothecadao/eternum/game-sync";
+import type { FoldRow } from "./types";
+
+/** Current scores come from the fold; history contributes only activity counts and breakdowns. */
+export function buildLiveLeaderboard(
+  modelRows: (model: string) => FoldRow[],
+  gameId: string,
+  timestamp: number,
+  history: HeraldLeaderboard | null,
+): HeraldLeaderboard {
+  const id = BigInt(gameId);
+  const rows = (model: string) => modelRows(model).map((row) => row.value);
+  const gameRows = (model: string) => rows(model).filter((row) => BigInt(row.game_id as string) === id);
+  const live = calculateUnregisteredShareholderPoints(
+    {
+      gameRegistry: gameRows("GameRegistry"),
+      hyperstructures: gameRows("Hyperstructure"),
+      presets: rows("PresetConfig"),
+      shareholders: gameRows("HyperstructureShareholders"),
+    },
+    id,
+    timestamp,
+  );
+  const points = new Map(live);
+  for (const row of gameRows("PlayerRegisteredPoints")) {
+    const address = normalizedAddress(row.address);
+    points.set(address, (live.get(address) ?? 0) + Number(BigInt(row.registered_points as string)) / 1_000_000);
+  }
+  for (const row of gameRows("BlitzSettlement")) {
+    const address = normalizedAddress(row.player);
+    if (!points.has(address)) points.set(address, 0);
+  }
+  const activity = new Map(
+    history?.entries.map((entry) => [normalizedAddress(entry.address), entry.activityBreakdown]),
+  );
+  const entries = [...points]
+    .map(([address, totalPoints]) => ({
+      address,
+      totalPoints,
+      rank: 0,
+      activityBreakdown: activity.get(address) ?? createEmptyActivityBreakdown(),
+    }))
+    .sort((left, right) => right.totalPoints - left.totalPoints || left.address.localeCompare(right.address));
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    entry.rank =
+      index > 0 && entry.totalPoints === entries[index - 1].totalPoints ? entries[index - 1].rank : index + 1;
+  }
+  return { game_id: id.toString(), entries };
+}
+
+const normalizedAddress = (address: unknown): string => `0x${BigInt(address as string).toString(16)}`;

--- a/apps/herald/src/live-world.ts
+++ b/apps/herald/src/live-world.ts
@@ -106,6 +106,10 @@ export class LiveWorld {
     return this.confirmedBlockValue;
   }
 
+  public get chainTimestamp(): number {
+    return this.lastClockTimestamp;
+  }
+
   public get preconfirmedBlock(): number | null {
     return this.preconfirmedBlockValue;
   }

--- a/apps/herald/src/server.ts
+++ b/apps/herald/src/server.ts
@@ -156,6 +156,7 @@ const main = async (): Promise<void> => {
   const http = createHeraldRequestHandler({
     chain: config.chain,
     confirmedBlock: () => live.confirmedBlock,
+    chainTimestamp: () => live.chainTimestamp,
     decodedModelCount: registry.bySelector.size,
     fold: {
       modelRows: (model) => live.modelRows(model),

--- a/apps/launch-service/src/app.ts
+++ b/apps/launch-service/src/app.ts
@@ -1,3 +1,4 @@
+import { isGameEnvironmentId, type GameEnvironmentId } from "../../../config/shared/game-environments";
 import { Effect, Result, Schema } from "effect";
 import { Hono, type Context, type MiddlewareHandler } from "hono";
 import { cors } from "hono/cors";
@@ -60,8 +61,8 @@ const decodeBody = async <A>(context: Context, schema: Schema.ConstraintDecoder<
   return Effect.runPromise(Schema.decodeUnknownEffect(schema)(payload));
 };
 
-const readEnvironment = (value: string | undefined): "madara.blitz" => {
-  if (value !== "madara.blitz") throw new Error('environment must be "madara.blitz"');
+const readEnvironment = (value: string | undefined): GameEnvironmentId => {
+  if (!value || !isGameEnvironmentId(value)) throw new Error("Unsupported game environment");
   return value;
 };
 

--- a/apps/launch-service/src/model.ts
+++ b/apps/launch-service/src/model.ts
@@ -1,3 +1,4 @@
+import type { GameEnvironmentId } from "../../../config/shared/game-environments";
 import type {
   LaunchGameSummary,
   LaunchRotationSummary,
@@ -11,7 +12,7 @@ export type LaunchSummary = LaunchGameSummary | LaunchSeriesSummary | LaunchRota
 export interface LaunchRun {
   id: string;
   kind: LaunchKind;
-  environment: "madara.blitz";
+  environment: GameEnvironmentId;
   name: string;
   request: LaunchJobRequest;
   status: LaunchJobStatus;

--- a/apps/launch-service/src/rotation.ts
+++ b/apps/launch-service/src/rotation.ts
@@ -9,7 +9,7 @@ import type { CreateRotationRequest } from "./schemas";
 import { PostgresLaunchStore } from "./store";
 
 const toRotationJobRequest = (request: LaunchRotationRequest): CreateRotationRequest => ({
-  environment: "madara.blitz",
+  environment: request.environmentId,
   rotationName: request.rotationName,
   firstGameStartTime: String(request.firstGameStartTime),
   gameIntervalMinutes: request.gameIntervalMinutes,
@@ -35,8 +35,8 @@ const toRotationJobRequest = (request: LaunchRotationRequest): CreateRotationReq
 const loadRotationRequest = (configPath: string, rpcUrl: string): CreateRotationRequest => {
   const args = resolveLaunchRequestArgs({ "config-path": configPath, "rpc-url": rpcUrl });
   const request = buildLaunchRequest(args);
-  if (request.launchKind !== "rotation" || request.environmentId !== "madara.blitz") {
-    throw new Error(`${configPath} must describe a madara.blitz rotation`);
+  if (request.launchKind !== "rotation") {
+    throw new Error(`${configPath} must describe a game rotation`);
   }
   return toRotationJobRequest(request);
 };

--- a/apps/launch-service/src/schemas.test.ts
+++ b/apps/launch-service/src/schemas.test.ts
@@ -27,3 +27,10 @@ describe("applyDurableLaunchDefaults", () => {
     expect(applyDurableLaunchDefaults("game", gameRequest(false, "9")).version).toBe("9");
   });
 });
+
+it("selects the Eternum preset and rejects cross-mode presets", () => {
+  const request: CreateGameRequest = { environment: "madara.eternum", gameName: "eternum-test", devModeOn: false };
+  expect(applyDurableLaunchDefaults("game", request).version).toBe("10");
+  expect(() => applyDurableLaunchDefaults("game", { ...request, version: "8" })).toThrow();
+  expect(() => applyDurableLaunchDefaults("game", { ...gameRequest(), version: "10" })).toThrow();
+});

--- a/apps/launch-service/src/schemas.ts
+++ b/apps/launch-service/src/schemas.ts
@@ -1,3 +1,4 @@
+import { defaultPresetForEnvironment } from "../../../config/deployer/clean/constants";
 import { Schema } from "effect";
 import type { LaunchRotationWeekday } from "../../../config/deployer/clean/types";
 
@@ -5,11 +6,9 @@ const NonEmptyString = Schema.NonEmptyString;
 const OptionalNumberRecord = Schema.optional(Schema.Record(Schema.String, Schema.Number));
 
 const SharedOptions = {
-  environment: Schema.Literal("madara.blitz"),
-  // The offered registrar presets: 8 = Regular Fast, 9 = Duel (6/7 retired —
-  // they baked 24-tick spawn immunity). The client's preset catalog is the
-  // authority on which one a launch uses.
-  version: Schema.optional(Schema.Literals(["8", "9"])),
+  environment: Schema.Literals(["madara.blitz", "madara.eternum"]),
+  // Registrar presets: 8 = Regular Fast, 9 = Duel, 10 = Eternum.
+  version: Schema.optional(Schema.Literals(["8", "9", "10"])),
   devModeOn: Schema.optional(Schema.Boolean),
   twoPlayerMode: Schema.optional(Schema.Boolean),
   singleRealmMode: Schema.optional(Schema.Boolean),
@@ -66,8 +65,8 @@ export const CreateRotationRequestSchema = Schema.Struct({
 });
 
 interface SharedLaunchOptions {
-  environment: "madara.blitz";
-  version?: "8" | "9";
+  environment: "madara.blitz" | "madara.eternum";
+  version?: "8" | "9" | "10";
   devModeOn?: boolean;
   twoPlayerMode?: boolean;
   singleRealmMode?: boolean;
@@ -121,10 +120,11 @@ export const applyDurableLaunchDefaults = (
   request: LaunchJobRequest,
   now = Date.now(),
 ): LaunchJobRequest => {
-  // Request values are honored, never overwritten — the client's preset is the
-  // authority (devModeOn: Sandbox on, real games off; version: 6 = Regular Fast,
-  // 7 = Duel). Defaults here only fill absent fields, once, before persistence.
-  const shared = { ...request, version: request.version ?? ("8" as const) };
+  const version = request.version ?? (defaultPresetForEnvironment(request.environment) as "8" | "10");
+  if ((request.environment === "madara.eternum") !== (version === "10")) {
+    throw new Error("Preset does not match the requested game format");
+  }
+  const shared = { ...request, version };
   if (kind === "game" && "gameName" in shared) {
     return { ...shared, gameStartTime: shared.gameStartTime ?? new Date(now + 15 * 60_000).toISOString() };
   }

--- a/apps/launch-service/src/store.ts
+++ b/apps/launch-service/src/store.ts
@@ -1,3 +1,4 @@
+import type { GameEnvironmentId } from "../../../config/shared/game-environments";
 import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { Context, Effect, Layer } from "effect";
@@ -17,7 +18,7 @@ const migrationUrl = new URL("../migrations/0001_launch_runs.sql", import.meta.u
 interface LaunchRunRow extends QueryResultRow {
   id: string;
   kind: LaunchKind;
-  environment: "madara.blitz";
+  environment: GameEnvironmentId;
   name: string;
   request: LaunchJobRequest;
   status: LaunchRun["status"];
@@ -35,15 +36,15 @@ export interface LaunchServiceStore extends LaunchRunStore {
   initialize(): Promise<void>;
   close(): Promise<void>;
   enqueue(kind: LaunchKind, request: LaunchJobRequest): Promise<LaunchRun>;
-  list(environment: "madara.blitz", kind?: LaunchKind): Promise<LaunchRun[]>;
-  find(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<LaunchRun | null>;
+  list(environment: GameEnvironmentId, kind?: LaunchKind): Promise<LaunchRun[]>;
+  find(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<LaunchRun | null>;
   claim(leaseMs: number): Promise<ClaimedLaunchRun | null>;
   heartbeat(runId: string, leaseToken: string, leaseMs: number): Promise<boolean>;
   complete(runId: string, leaseToken: string, summary: LaunchSummary): Promise<LaunchRun>;
   retry(runId: string, leaseToken: string, errorMessage: string, retryDelayMs: number): Promise<void>;
   fail(runId: string, leaseToken: string, errorMessage: string): Promise<void>;
-  cancel(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<boolean>;
-  delete(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<boolean>;
+  cancel(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<boolean>;
+  delete(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<boolean>;
 }
 
 export class LaunchDatabase extends Context.Service<LaunchDatabase, LaunchServiceStore>()("launch/LaunchDatabase") {}
@@ -118,7 +119,7 @@ export class PostgresLaunchStore implements LaunchServiceStore {
     return run;
   }
 
-  async list(environment: "madara.blitz", kind?: LaunchKind): Promise<LaunchRun[]> {
+  async list(environment: GameEnvironmentId, kind?: LaunchKind): Promise<LaunchRun[]> {
     const result = kind
       ? await this.pool.query<LaunchRunRow>(
           "SELECT * FROM launch_runs WHERE environment = $1 AND kind = $2 ORDER BY updated_at DESC",
@@ -131,7 +132,7 @@ export class PostgresLaunchStore implements LaunchServiceStore {
     return result.rows.map(toRun);
   }
 
-  async find(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<LaunchRun | null> {
+  async find(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<LaunchRun | null> {
     const result = await this.pool.query<LaunchRunRow>(
       "SELECT * FROM launch_runs WHERE kind = $1 AND environment = $2 AND name = $3",
       [kind, environment, name],
@@ -214,7 +215,7 @@ export class PostgresLaunchStore implements LaunchServiceStore {
     );
   }
 
-  async cancel(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<boolean> {
+  async cancel(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<boolean> {
     const result = await this.pool.query(
       `UPDATE launch_runs SET status = 'cancelled', claimed_until = NULL, lease_token = NULL, updated_at = now()
        WHERE kind = $1 AND environment = $2 AND name = $3 AND status <> 'running'`,
@@ -223,7 +224,7 @@ export class PostgresLaunchStore implements LaunchServiceStore {
     return result.rowCount === 1;
   }
 
-  async delete(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<boolean> {
+  async delete(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<boolean> {
     const result = await this.pool.query(
       "DELETE FROM launch_runs WHERE kind = $1 AND environment = $2 AND name = $3 AND status <> 'running'",
       [kind, environment, name],

--- a/apps/launch-service/src/test-store.ts
+++ b/apps/launch-service/src/test-store.ts
@@ -1,3 +1,4 @@
+import type { GameEnvironmentId } from "../../../config/shared/game-environments";
 import { randomUUID } from "node:crypto";
 import type {
   LaunchGameSummary,
@@ -37,13 +38,13 @@ export class InMemoryLaunchStore implements LaunchServiceStore {
     return run;
   }
 
-  async list(environment: "madara.blitz", kind?: LaunchKind): Promise<LaunchRun[]> {
+  async list(environment: GameEnvironmentId, kind?: LaunchKind): Promise<LaunchRun[]> {
     return Array.from(this.runs.values()).filter(
       (run) => run.environment === environment && (kind === undefined || run.kind === kind),
     );
   }
 
-  async find(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<LaunchRun | null> {
+  async find(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<LaunchRun | null> {
     return this.runs.get(this.key(kind, environment, name)) ?? null;
   }
 
@@ -114,7 +115,7 @@ export class InMemoryLaunchStore implements LaunchServiceStore {
     });
   }
 
-  async cancel(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<boolean> {
+  async cancel(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<boolean> {
     const key = this.key(kind, environment, name);
     const run = this.runs.get(key);
     if (!run || run.status === "running") return false;
@@ -122,19 +123,19 @@ export class InMemoryLaunchStore implements LaunchServiceStore {
     return true;
   }
 
-  async delete(kind: LaunchKind, environment: "madara.blitz", name: string): Promise<boolean> {
+  async delete(kind: LaunchKind, environment: GameEnvironmentId, name: string): Promise<boolean> {
     const key = this.key(kind, environment, name);
     const run = this.runs.get(key);
     return !run || run.status === "running" ? false : this.runs.delete(key);
   }
 
   async loadGame(environment: LaunchGameSummary["environment"], gameName: string): Promise<LaunchGameSummary | null> {
-    const summary = (await this.find("game", environment as "madara.blitz", gameName))?.summary;
+    const summary = (await this.find("game", environment as GameEnvironmentId, gameName))?.summary;
     return summary && "gameName" in summary ? summary : null;
   }
 
   async saveGame(summary: LaunchGameSummary): Promise<LaunchGameSummary> {
-    const environment = summary.environment as "madara.blitz";
+    const environment = summary.environment as GameEnvironmentId;
     if (this.runs.has(this.key("game", environment, summary.gameName))) {
       await this.attachSummary("game", environment, summary.gameName, summary);
       return summary;
@@ -148,12 +149,12 @@ export class InMemoryLaunchStore implements LaunchServiceStore {
     environment: LaunchSeriesSummary["environment"],
     seriesName: string,
   ): Promise<LaunchSeriesSummary | null> {
-    const summary = (await this.find("series", environment as "madara.blitz", seriesName))?.summary;
+    const summary = (await this.find("series", environment as GameEnvironmentId, seriesName))?.summary;
     return summary && "seriesName" in summary && !("rotationName" in summary) ? summary : null;
   }
 
   async saveSeries(summary: LaunchSeriesSummary): Promise<LaunchSeriesSummary> {
-    await this.attachSummary("series", summary.environment as "madara.blitz", summary.seriesName, summary);
+    await this.attachSummary("series", summary.environment as GameEnvironmentId, summary.seriesName, summary);
     return summary;
   }
 
@@ -161,18 +162,18 @@ export class InMemoryLaunchStore implements LaunchServiceStore {
     environment: LaunchRotationSummary["environment"],
     rotationName: string,
   ): Promise<LaunchRotationSummary | null> {
-    const summary = (await this.find("rotation", environment as "madara.blitz", rotationName))?.summary;
+    const summary = (await this.find("rotation", environment as GameEnvironmentId, rotationName))?.summary;
     return summary && "rotationName" in summary ? summary : null;
   }
 
   async saveRotation(summary: LaunchRotationSummary): Promise<LaunchRotationSummary> {
-    await this.attachSummary("rotation", summary.environment as "madara.blitz", summary.rotationName, summary);
+    await this.attachSummary("rotation", summary.environment as GameEnvironmentId, summary.rotationName, summary);
     return summary;
   }
 
   private async attachSummary(
     kind: LaunchKind,
-    environment: "madara.blitz",
+    environment: GameEnvironmentId,
     name: string,
     summary: LaunchSummary,
   ): Promise<void> {
@@ -182,7 +183,7 @@ export class InMemoryLaunchStore implements LaunchServiceStore {
     this.runs.set(key, { ...run, summary });
   }
 
-  private findParentRun(environment: "madara.blitz", gameName: string): LaunchRun | undefined {
+  private findParentRun(environment: GameEnvironmentId, gameName: string): LaunchRun | undefined {
     return Array.from(this.runs.values()).find(
       (run) =>
         run.environment === environment &&

--- a/deploy/madara-lab/harness/driver.ts
+++ b/deploy/madara-lab/harness/driver.ts
@@ -1,6 +1,9 @@
 import { setTimeout as sleep } from "node:timers/promises";
 import { CallData, shortString, type Account, type Call, type RpcProvider } from "starknet";
-import { buildBlitzSettleCalls } from "../../../apps/game/src/services/blitz/blitz-settlement-calls";
+import {
+  buildBlitzSettleCalls,
+  buildEternumSettleCalls,
+} from "../../../apps/game/src/services/blitz/blitz-settlement-calls";
 import { resolveGameTransactionResourceBounds } from "../../../packages/core/src/account/transaction-resource-bounds";
 import { Biome } from "../../../packages/core/src/utils/biome/biome";
 import { BiomeType } from "../../../packages/types/src/constants/hex";
@@ -63,6 +66,8 @@ export interface TrackedTransaction {
 }
 
 export interface HarnessSystemAddresses {
+  realm: string;
+  registrar: string;
   blitzRealm: string;
   prizeDistribution: string;
   production: string;
@@ -123,6 +128,7 @@ interface ExplorerPriority {
 }
 
 interface PrepareHarnessBotsOptions {
+  gameType?: "blitz" | "eternum";
   accounts: HarnessAccount[];
   beforeProvision?: () => Promise<void>;
   gameId: number;
@@ -314,6 +320,7 @@ const STEADY_ACTION_PATTERN: readonly WorkloadActionKind[] = [
 ];
 
 export async function prepareHarnessBots({
+  gameType = "blitz",
   accounts,
   beforeProvision,
   gameId,
@@ -327,7 +334,7 @@ export async function prepareHarnessBots({
   const mapCenter = await readMapCenter(heraldObserver, gameId);
 
   await mapWithConcurrency(accounts, setupConcurrency, async (harnessAccount) => {
-    const settle = await settleBot({ harnessAccount, gameId, provider, systems });
+    const settle = await settleBot({ harnessAccount, gameId, gameType, provider, systems });
     setupTransactions.push(settle);
     assertCompleted(settle);
   });
@@ -338,16 +345,18 @@ export async function prepareHarnessBots({
     const structureIds = await readSettlementStructureIds(heraldObserver, gameId, harnessAccount.address);
     const structures = await readStructures(heraldObserver, gameId, structureIds, mapCenter);
 
-    const provision = await provisionBot({
-      account: harnessAccount.account,
-      botId: harnessAccount.botId,
-      gameId,
-      provider,
-      structureIds,
-      systems,
-    });
-    setupTransactions.push(provision);
-    assertCompleted(provision);
+    if (gameType === "blitz") {
+      const provision = await provisionBot({
+        account: harnessAccount.account,
+        botId: harnessAccount.botId,
+        gameId,
+        provider,
+        structureIds,
+        systems,
+      });
+      setupTransactions.push(provision);
+      assertCompleted(provision);
+    }
 
     const troopTypes = await readStartingTroopTypes(heraldObserver, gameId, structureIds);
 
@@ -559,24 +568,34 @@ export function prioritizeExplorer<T extends ExplorerPriority>(
 }
 
 async function settleBot({
+  gameType,
   harnessAccount,
   gameId,
   provider,
   systems,
 }: {
+  gameType: "blitz" | "eternum";
   harnessAccount: HarnessAccount;
   gameId: number;
   provider: RpcProvider;
   systems: HarnessSystemAddresses;
 }): Promise<TrackedTransaction> {
   const usernameFelt = shortString.encodeShortString(`bot-${harnessAccount.botId.toString().padStart(3, "0")}`);
-  const calls = buildBlitzSettleCalls({
-    blitzSystemsAddress: systems.blitzRealm,
-    signerAddress: harnessAccount.address,
-    usernameFelt,
-    gameId,
-    cosmeticTokenIds: [],
-  });
+  const calls =
+    gameType === "eternum"
+      ? buildEternumSettleCalls({
+          realmSystemsAddress: systems.realm,
+          signerAddress: harnessAccount.address,
+          usernameFelt,
+          gameId,
+        })
+      : buildBlitzSettleCalls({
+          blitzSystemsAddress: systems.blitzRealm,
+          signerAddress: harnessAccount.address,
+          usernameFelt,
+          gameId,
+          cosmeticTokenIds: [],
+        });
 
   return trackTransaction({
     account: harnessAccount.account,
@@ -854,9 +873,7 @@ function planExplorerAction(
         ].join(",")}`,
     )
     .join("; ");
-  throw new HarnessPathingError(
-    `No collision-free ${kind} route is available for bot ${bot.botId}: ${routeState}`,
-  );
+  throw new HarnessPathingError(`No collision-free ${kind} route is available for bot ${bot.botId}: ${routeState}`);
 }
 
 function chooseExploreDirections(explorer: ExplorerState, structures: StructureState[]): number[] {

--- a/deploy/madara-lab/harness/harness.test.ts
+++ b/deploy/madara-lab/harness/harness.test.ts
@@ -28,15 +28,20 @@ import {
   summarizeRpcMetrics,
 } from "./report";
 import { createHarnessProvider, parseHarnessArgs } from "./run";
-import {
-  parseLedgerBotIdentities,
-  rankPlayersByRegisteredPoints,
-  toHarnessGameplayIdentities,
-} from "./ledger-mode";
+import { parseLedgerBotIdentities, rankPlayersByRegisteredPoints, toHarnessGameplayIdentities } from "./ledger-mode";
 import { BlockTag } from "starknet";
 import { HeraldObserver } from "./herald-observer";
 
 describe("Madara harness workload", () => {
+  it("selects Eternum and rejects incompatible ledger registration", () => {
+    expect(parseHarnessArgs([]).gameType).toBe("blitz");
+    expect(parseHarnessArgs(["--game-type", "eternum"]).gameType).toBe("eternum");
+    expect(() => parseHarnessArgs(["--game-type", "unknown"])).toThrow("--game-type must be blitz or eternum");
+    expect(() => parseHarnessArgs(["--game-type", "eternum", "--ledger"])).toThrow(
+      "The ledger harness currently registers Blitz passes only",
+    );
+  });
+
   it("separates the requested mix from completed outcomes", () => {
     const actions = [
       { kind: "move", outcome: "completed" },
@@ -138,6 +143,8 @@ describe("Madara harness workload", () => {
       minutes: 0.001,
       provider: provider as never,
       systems: {
+        registrar: "0x9",
+        realm: "0xa",
         blitzRealm: "0x1",
         prizeDistribution: "0x5",
         production: "0x2",
@@ -349,9 +356,7 @@ describe("Madara harness Herald observer", () => {
     try {
       const observer = new HeraldObserver(`http://127.0.0.1:${server.port}`, "madara", 5);
       const before = await observer.readResource(7, "11");
-      await expect(observer.waitForResource(7, "11", before, 12, 20)).rejects.toThrow(
-        "did not show a labor or wood",
-      );
+      await expect(observer.waitForResource(7, "11", before, 12, 20)).rejects.toThrow("did not show a labor or wood");
     } finally {
       server.stop(true);
     }

--- a/deploy/madara-lab/harness/ledger-mode.ts
+++ b/deploy/madara-lab/harness/ledger-mode.ts
@@ -1,23 +1,12 @@
+import { executeMadaraAndWait } from "./transactions";
 import { randomBytes } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { setTimeout as sleep } from "node:timers/promises";
-import {
-  Account,
-  CallData,
-  RpcProvider,
-  ec,
-  uint256,
-  validateAndParseAddress,
-  type Call,
-} from "starknet";
+import { Account, CallData, RpcProvider, ec, uint256, validateAndParseAddress, type Call } from "starknet";
 import { assertProviderChain } from "../../../packages/chain/chain-guard.js";
-import { resolveGameTransactionResourceBounds } from "../../../packages/core/src/account/transaction-resource-bounds";
+
 import { decodeGameLedgerGame } from "../../../packages/core/src/data/abi/GameLedger";
-import {
-  mapWithConcurrency,
-  type HarnessAccount,
-  type HarnessGameplayIdentity,
-} from "./account-factory";
+import { mapWithConcurrency, type HarnessAccount, type HarnessGameplayIdentity } from "./account-factory";
 import { HeraldObserver } from "./herald-observer";
 import {
   estimateLedgerStrkFeeFloor,
@@ -117,7 +106,7 @@ interface FinalizeLedgerGameOptions {
   mainnetRpcUrl: string;
   ledgerAddress: string;
   provider: RpcProvider;
-  rankingSystemAddress: string;
+  registrarSystemAddress: string;
   registrations: readonly LedgerRegistrationRuntime[];
   sweepManifestPath: string;
   lordsAddress: string;
@@ -131,8 +120,6 @@ interface LedgerPresetCosts {
   swordPrice: bigint;
 }
 
-const MADARA_RESOURCE_BOUNDS = resolveGameTransactionResourceBounds("madara");
-const MADARA_RECEIPT_POLL_MS = 50;
 const FUNDING_BATCH_SIZE = 12;
 const BINDING_BATCH_SIZE = 24;
 const RELAY_TIMEOUT_MS = 15 * 60 * 1_000;
@@ -150,7 +137,10 @@ export function parseLedgerBotIdentities(parsed: unknown, expectedCount: number)
   }
 
   const identities = parsed.map((value, index) => parseLedgerBotIdentity(value, index));
-  assertUnique(identities.map(({ mainnetAddress }) => mainnetAddress), "mainnet address");
+  assertUnique(
+    identities.map(({ mainnetAddress }) => mainnetAddress),
+    "mainnet address",
+  );
   assertUnique(
     identities.map(({ gameplayPrivateKey }) => ec.starkCurve.getStarkKey(gameplayPrivateKey)),
     "gameplay public key",
@@ -158,9 +148,7 @@ export function parseLedgerBotIdentities(parsed: unknown, expectedCount: number)
   return identities;
 }
 
-export function toHarnessGameplayIdentities(
-  identities: readonly LedgerBotIdentity[],
-): HarnessGameplayIdentity[] {
+export function toHarnessGameplayIdentities(identities: readonly LedgerBotIdentity[]): HarnessGameplayIdentity[] {
   return identities.map(({ gameplayPrivateKey, mainnetAddress }) => ({
     owner: mainnetAddress,
     privateKey: gameplayPrivateKey,
@@ -307,14 +295,20 @@ export async function waitForRelayedLedgerRegistrations(
           .filter((row) => truthyFelt(row.registered))
           .map((row) => normalizeFelt(row.owner)),
       );
-      return relayedOwners.size === expectedOwners.size && [...expectedOwners].every((owner) => relayedOwners.has(owner));
+      return (
+        relayedOwners.size === expectedOwners.size && [...expectedOwners].every((owner) => relayedOwners.has(owner))
+      );
     },
     RELAY_TIMEOUT_MS,
   );
 }
 
 export async function waitForGameStart(provider: RpcProvider, startAt: number): Promise<void> {
-  await waitForChainTimestamp(provider, startAt, Math.max(120_000, (startAt - Math.floor(Date.now() / 1_000)) * 1_000 + 120_000));
+  await waitForChainTimestamp(
+    provider,
+    startAt,
+    Math.max(120_000, (startAt - Math.floor(Date.now() / 1_000)) * 1_000 + 120_000),
+  );
 }
 
 export async function finalizeLedgerGame(options: FinalizeLedgerGameOptions): Promise<LedgerFinalizationEvidence> {
@@ -325,10 +319,11 @@ export async function finalizeLedgerGame(options: FinalizeLedgerGameOptions): Pr
   const schedule = await readGameSchedule(observer, options.gameId);
   await waitForChainTimestamp(
     options.provider,
-    schedule.endAt + schedule.registrationGraceSeconds + 1,
-    Math.max(120_000, (schedule.endAt + schedule.registrationGraceSeconds - Math.floor(Date.now() / 1_000)) * 1_000 + 120_000),
+    schedule.endAt + 1,
+    Math.max(120_000, (schedule.endAt - Math.floor(Date.now() / 1_000)) * 1_000 + 120_000),
   );
 
+  await checkpointGameShares(observer, options, schedule.endAt);
   const players = await readRankedPlayers(observer, options.gameId);
   if (players.length !== options.registrations.length) {
     throw new Error(
@@ -339,8 +334,8 @@ export async function finalizeLedgerGame(options: FinalizeLedgerGameOptions): Pr
   const rankingTransactionHash = await executeMadaraAndWait(
     options.account,
     {
-      contractAddress: options.rankingSystemAddress,
-      entrypoint: "blitz_prize_player_rank",
+      contractAddress: options.registrarSystemAddress,
+      entrypoint: "rank_players",
       calldata: [
         options.gameId.toString(),
         trialId.toString(),
@@ -459,8 +454,14 @@ async function prepareRegistrationAccounts(
   const baselineByOwner = new Map(baselines.map((baseline) => [normalizeFelt(baseline.owner), baseline]));
   return mapWithConcurrency(options.identities, options.concurrency, async (identity) => {
     await provider.getClassHashAt(identity.mainnetAddress);
-    const registered = await readLedgerRegistration(provider, options.ledgerAddress, options.gameId, identity.mainnetAddress);
-    if (registered) throw new Error(`Owner ${identity.mainnetAddress} is already registered for game ${options.gameId}`);
+    const registered = await readLedgerRegistration(
+      provider,
+      options.ledgerAddress,
+      options.gameId,
+      identity.mainnetAddress,
+    );
+    if (registered)
+      throw new Error(`Owner ${identity.mainnetAddress} is already registered for game ${options.gameId}`);
     const payment =
       costs.entryFee + (identity.sword ? costs.swordPrice : 0n) + (identity.shield ? costs.shieldPrice : 0n);
     const baseline = baselineByOwner.get(normalizeFelt(identity.mainnetAddress));
@@ -516,14 +517,7 @@ async function submitRegistrations(
   concurrency: number,
 ): Promise<string[]> {
   return mapWithConcurrency(registrations, concurrency, async ({ account, identity, payment }) => {
-    const calls = buildRegistrationCalls(
-      ledgerAddress,
-      lordsAddress,
-      gameId,
-      payment,
-      identity.sword,
-      identity.shield,
-    );
+    const calls = buildRegistrationCalls(ledgerAddress, lordsAddress, gameId, payment, identity.sword, identity.shield);
     return executeMainnetAndWait(account, calls, `register ${identity.mainnetAddress} for ledger game ${gameId}`);
   });
 }
@@ -615,11 +609,47 @@ async function readGameSchedule(observer: HeraldObserver, gameId: number) {
   if (!game) throw new Error(`GameRegistry ${gameId} is absent from Herald`);
   return {
     endAt: safeNumber(game.end_at, "GameRegistry.end_at"),
-    registrationGraceSeconds: safeNumber(
-      game.registration_grace_seconds,
-      "GameRegistry.registration_grace_seconds",
-    ),
   };
+}
+
+async function checkpointGameShares(
+  observer: HeraldObserver,
+  options: { account: Account; gameId: number; registrarSystemAddress: string },
+  cutoff: number,
+): Promise<void> {
+  const models = await observer.readModelRows(options.gameId, ["HyperstructureGlobals"]);
+  const globals = models.get("HyperstructureGlobals")![0];
+  const count = globals ? safeNumber(globals.completed_count, "HyperstructureGlobals.completed_count") : 0;
+  for (let start = 0; start < count; start += 16) {
+    await executeMadaraAndWait(
+      options.account,
+      {
+        contractAddress: options.registrarSystemAddress,
+        entrypoint: "checkpoint_share_points",
+        calldata: [options.gameId.toString(), start.toString(), Math.min(16, count - start).toString()],
+      },
+      `checkpoint completed hyperstructures ${start}–${Math.min(start + 16, count)}`,
+    );
+  }
+  if (count === 0) return;
+  await observer.waitForModelRows(
+    options.gameId,
+    ["CompletedHyperstructure", "HyperstructureShareholders"],
+    (rows) => {
+      const completed = rows.get("CompletedHyperstructure")!;
+      const shares = new Map(
+        rows.get("HyperstructureShareholders")!.map((row) => [String(row.hyperstructure_id), row]),
+      );
+      return (
+        completed.length === count &&
+        completed.every((row) => {
+          const share = shares.get(String(row.hyperstructure_id));
+          return share && safeNumber(share.start_at, "HyperstructureShareholders.start_at") >= cutoff;
+        })
+      );
+    },
+    120_000,
+  );
 }
 
 async function readRankedPlayers(observer: HeraldObserver, gameId: number): Promise<string[]> {
@@ -672,24 +702,6 @@ async function waitForChainTimestamp(provider: RpcProvider, target: number, time
     await sleep(1_000);
   }
   throw new Error(`Chain timestamp did not reach ${target} within ${Math.ceil(timeoutMs / 1_000)} seconds`);
-}
-
-async function executeMadaraAndWait(account: Account, calls: Call | Call[], label: string): Promise<string> {
-  const transaction = await account.execute(calls, { resourceBounds: MADARA_RESOURCE_BOUNDS, tip: 0 });
-  return waitForSuccessfulTransaction(account, transaction.transaction_hash, label, MADARA_RECEIPT_POLL_MS);
-}
-
-async function waitForSuccessfulTransaction(
-  account: Account,
-  transactionHash: string,
-  label: string,
-  retryInterval: number,
-): Promise<string> {
-  const receipt = await account.waitForTransaction(transactionHash, { retryInterval });
-  const status = receipt as { execution_status?: string; isSuccess?: () => boolean };
-  const succeeded = typeof status.isSuccess === "function" ? status.isSuccess() : status.execution_status === "SUCCEEDED";
-  if (!succeeded) throw new Error(`${label} failed for transaction ${transactionHash}`);
-  return transactionHash;
 }
 
 function readUint256(values: readonly string[], index: number): bigint {

--- a/deploy/madara-lab/harness/report.ts
+++ b/deploy/madara-lab/harness/report.ts
@@ -1,3 +1,4 @@
+import type { SeasonFinalizationEvidence } from "./season-lifecycle";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { HarnessAccount } from "./account-factory";
@@ -85,6 +86,7 @@ export interface HarnessReportInput {
   heraldUrl: string;
   workload: WorkloadResult;
   valuePlane?: LedgerHarnessEvidence;
+  seasonFinalizations?: SeasonFinalizationEvidence[];
 }
 
 interface PercentileSummary {
@@ -168,6 +170,7 @@ function analyzeHarnessResult(input: HarnessReportInput) {
     thresholdEligibleActions: thresholdEligibleActions >= input.minimumThresholdActions,
     preConfirmedP95: passesLatency(percentiles.preConfirmedMs.p95, PRECONFIRMED_P95_LIMIT_MS),
     setup: setupFailures.length === 0,
+    seasonsClosed: input.seasonFinalizations?.every((result) => result.status === "closed") ?? true,
     zeroBlockingFailures: blockingFailures.length === 0,
     zeroBlockingReverts: blockingReverts.length === 0,
   };
@@ -219,7 +222,8 @@ function buildHarnessManifest(
       executionModel: "single_process",
       instances: input.games,
     },
-    valuePlane: input.valuePlane ?? { mode: "dev" },
+    valuePlane: input.valuePlane ?? { mode: "open-entry" },
+    seasonFinalizations: input.seasonFinalizations ?? [],
     workload: {
       bots: input.botCount,
       minutes: input.minutes,
@@ -323,9 +327,7 @@ export function summarizeRevertReasons(actions: readonly Pick<TrackedTransaction
   return counts;
 }
 
-export function isThresholdBlockingFailure(
-  action: Pick<TrackedTransaction, "outcome" | "revertReason">,
-): boolean {
+export function isThresholdBlockingFailure(action: Pick<TrackedTransaction, "outcome" | "revertReason">): boolean {
   if (action.outcome === "completed") return false;
   const isRevert = action.outcome === "reverted" || action.outcome === "rejected";
   return !isRevert || action.revertReason !== "tile_contention";
@@ -443,7 +445,9 @@ async function captureBlockStats(since: string, until: string): Promise<BlockSta
     }
     return { ...summary, window: { since, until } };
   } catch (error) {
-    console.warn(`Block stats unavailable (${since}..${until}): ${error instanceof Error ? error.message : String(error)}`);
+    console.warn(
+      `Block stats unavailable (${since}..${until}): ${error instanceof Error ? error.message : String(error)}`,
+    );
     return null;
   }
 }

--- a/deploy/madara-lab/harness/run.ts
+++ b/deploy/madara-lab/harness/run.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+import { closeHarnessSeason } from "./season-lifecycle";
+import { defaultPresetForEnvironment } from "../../../config/deployer/clean/constants";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { Account, BlockTag, logger, RpcProvider } from "starknet";
@@ -18,14 +20,11 @@ import {
   type LedgerHarnessEvidence,
   type LedgerRegistrationRuntime,
 } from "./ledger-mode";
-import {
-  readLedgerSweepManifest,
-  sweepLedgerBalances,
-  writeLedgerSweepReceipt,
-} from "./ledger-money";
+import { readLedgerSweepManifest, sweepLedgerBalances, writeLedgerSweepReceipt } from "./ledger-money";
 import { collectHarnessEvidenceBeforeRun, finishHarnessEvidence, writeHarnessReport } from "./report";
 
 interface HarnessCliOptions {
+  gameType: "blitz" | "eternum";
   bots: number;
   gameId?: number;
   gameName?: string;
@@ -107,15 +106,19 @@ export function parseHarnessArgs(args: string[]): HarnessCliOptions {
   const gameId = values["game-id"] === undefined ? undefined : positiveInteger(values["game-id"], "game-id");
   const games = positiveInteger(values.games ?? "1", "games");
   const ledger = values.ledger === "true";
+  const gameType = values["game-type"] ?? "blitz";
+  if (gameType !== "blitz" && gameType !== "eternum") throw new Error("--game-type must be blitz or eternum");
+  if (ledger && gameType === "eternum") throw new Error("The ledger harness currently registers Blitz passes only");
   const sweepOnlyManifestPath = values["sweep-only"];
   const ledgerStartDelaySeconds = positiveInteger(
     values["ledger-start-delay-seconds"] ?? "900",
     "ledger-start-delay-seconds",
   );
 
-  if (bots > 96) throw new Error(`The Madara Blitz preset supports at most 96 bots, received ${bots}`);
+  if (bots > 96) throw new Error(`The harness supports at most 96 bots, received ${bots}`);
   if (gameId !== undefined && games !== 1) throw new Error("--game-id can only be used with --games 1");
-  if (ledger && gameId !== undefined) throw new Error("--ledger always creates a fresh game; --game-id is not supported");
+  if (ledger && gameId !== undefined)
+    throw new Error("--ledger always creates a fresh game; --game-id is not supported");
   if (ledger && games !== 1) throw new Error("--ledger supports one game per run");
   if (ledger && sweepOnlyManifestPath) throw new Error("--ledger and --sweep-only are separate modes");
   if ((ledger || sweepOnlyManifestPath) && !values["ledger-accounts"]) {
@@ -132,6 +135,7 @@ export function parseHarnessArgs(args: string[]): HarnessCliOptions {
   }
 
   return {
+    gameType,
     bots,
     gameId,
     gameName: values["game-name"],
@@ -207,6 +211,21 @@ async function main(): Promise<void> {
     heraldUrl: options.heraldUrl,
   });
 
+  const seasonFinalizations = [];
+  if (options.gameType === "eternum") {
+    for (const run of gameRuns) {
+      seasonFinalizations.push(
+        await closeHarnessSeason({
+          accounts: run.accounts,
+          gameId: run.game.gameId,
+          heraldUrl: options.heraldUrl,
+          provider,
+          seasonSystemAddress: requireContract(manifest, "s2-season_systems"),
+        }),
+      );
+    }
+  }
+
   const valuePlane = await finalizeValuePlaneRun({
     gameRuns,
     ledgerEnvironment,
@@ -231,6 +250,7 @@ async function main(): Promise<void> {
     heraldUrl: options.heraldUrl,
     workload,
     valuePlane,
+    seasonFinalizations,
   });
 
   console.log(`${report.passed ? "PASS" : "FAIL"}: ${report.path}`);
@@ -255,18 +275,17 @@ async function resolveHarnessGames(
     const startAt = Math.floor(Date.now() / 1_000) + (options.ledger ? options.ledgerStartDelaySeconds : 60);
     const summary = await launchGame({
       accountAddress: process.env.DOJO_ACCOUNT_ADDRESS ?? MADARA_ADMIN_ADDRESS,
-      devModeOn: !options.ledger,
+      devModeOn: options.gameType === "blitz" && !options.ledger,
       durationSeconds: Math.ceil(options.minutes * 60) + (options.ledger ? 300 : 3_600),
-      environmentId: "madara.blitz",
+      environmentId: options.gameType === "eternum" ? "madara.eternum" : "madara.blitz",
       gameName,
       ledgerAddress: ledgerEnvironment?.ledgerAddress,
       ledgerRpcUrl: ledgerEnvironment?.mainnetRpcUrl,
       lordsAddress: ledgerEnvironment?.lordsAddress,
-      pointRegistrationGraceSeconds: options.ledger ? 5 : undefined,
       privateKey: process.env.DOJO_PRIVATE_KEY ?? MADARA_ADMIN_PRIVATE_KEY,
       rpcUrl: options.rpcUrl,
       startTime: startAt,
-      version: "6", // preset 6 (official-60) — the lab default we play; 96-player cap comes from the madara env
+      version: defaultPresetForEnvironment(options.gameType === "eternum" ? "madara.eternum" : "madara.blitz"),
     });
     if (!summary.gameId) throw new Error(`Registrar did not return a game id for ${gameName}`);
     games.push({ gameId: summary.gameId, gameName, startAt });
@@ -276,6 +295,8 @@ async function resolveHarnessGames(
 
 function resolveSystemAddresses(manifest: WorldManifest): HarnessSystemAddresses {
   return {
+    realm: requireContract(manifest, "s2-realm_systems"),
+    registrar: requireContract(manifest, "s2-registrar_systems"),
     blitzRealm: requireContract(manifest, "s2-blitz_realm_systems"),
     prizeDistribution: requireContract(manifest, "s2-prize_distribution_systems"),
     production: requireContract(manifest, "s2-production_systems"),
@@ -374,7 +395,9 @@ async function prepareGameRun({
   }
 
   console.log(`Settling, provisioning, and creating three explorers per bot for game ${game.gameId}`);
+  if (options.gameType === "eternum" && game.startAt) await waitForGameStart(provider, game.startAt);
   const bots = await prepareHarnessBots({
+    gameType: options.gameType,
     accounts,
     beforeProvision:
       ledger && game.startAt
@@ -394,7 +417,8 @@ async function prepareGameRun({
     accounts,
     bots,
     game,
-    ledger: ledger && binding ? { binding, registration: ledger.evidence, registrations: ledger.registrations } : undefined,
+    ledger:
+      ledger && binding ? { binding, registration: ledger.evidence, registrations: ledger.registrations } : undefined,
   };
 }
 
@@ -480,7 +504,11 @@ async function finalizeValuePlaneRun({
   if (!run?.ledger || !ledgerEnvironment) return undefined;
   console.log(`Waiting for game ${run.game.gameId} to close, then publishing its competition ranking`);
   const finalization = await finalizeLedgerGame({
-    account: run.accounts[0]!.account,
+    account: new Account({
+      provider,
+      address: process.env.DOJO_ACCOUNT_ADDRESS ?? MADARA_ADMIN_ADDRESS,
+      signer: process.env.DOJO_PRIVATE_KEY ?? MADARA_ADMIN_PRIVATE_KEY,
+    }),
     concurrency: options.setupConcurrency,
     gameId: run.game.gameId,
     heraldUrl: options.heraldUrl,
@@ -488,7 +516,7 @@ async function finalizeValuePlaneRun({
     lordsAddress: ledgerEnvironment.lordsAddress,
     mainnetRpcUrl: ledgerEnvironment.mainnetRpcUrl,
     provider,
-    rankingSystemAddress: systems.prizeDistribution,
+    registrarSystemAddress: systems.registrar,
     registrations: run.ledger.registrations,
     sweepManifestPath: run.ledger.registration.sweepManifestPath,
     treasuryAddress: ledgerEnvironment.treasuryAddress,
@@ -560,11 +588,12 @@ function printUsage(): void {
 Usage: bun deploy/madara-lab/harness/run.ts [options]
 
   --bots <count>                 default: 96, maximum: 96
+  --game-type <blitz|eternum>     default: blitz
   --games <count>                default: 1; runs all games concurrently in this process
   --minutes <minutes>            default: 10
   --interval-seconds <seconds>   default: 15
   --setup-concurrency <count>    default: 6
-  --game-id <id>                 use an existing dev-mode game instead of creating one
+  --game-id <id>                 use an existing game instead of creating one
   --game-name <name>             name for a new game or report label for --game-id
   --rpc-url <url>                default: ${DEFAULT_RPC_URL}
   --herald-url <url>             default: ${DEFAULT_HERALD_URL}

--- a/deploy/madara-lab/harness/season-lifecycle.test.ts
+++ b/deploy/madara-lab/harness/season-lifecycle.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, mock, spyOn, test } from "bun:test";
+import { HeraldObserver } from "./herald-observer";
+import { closeHarnessSeason } from "./season-lifecycle";
+
+const rows = (target: number, dev = false) =>
+  new Map<string, Record<string, unknown>[]>([
+    ["GameRegistry", [{ game_id: 1, preset_id: 10, end_at: 200, dev_mode_on: dev }]],
+    [
+      "PresetConfig",
+      [
+        {
+          preset_id: 10,
+          victory_points_win_config: { points_for_win: String(target * 1_000_000) },
+          victory_points_grant_config: { hyp_points_per_second: 1_000_000 },
+        },
+      ],
+    ],
+    ["Hyperstructure", [{ game_id: 1, hyperstructure_id: 7, completed: true, points_multiplier: 1 }]],
+    [
+      "HyperstructureShareholders",
+      [{ game_id: 1, hyperstructure_id: 7, start_at: 50, shareholders: [["0x1", 10000]] }],
+    ],
+    ["PlayerRegisteredPoints", []],
+  ]);
+
+const options = () => ({
+  gameId: 1,
+  heraldUrl: "http://herald.test",
+  seasonSystemAddress: "0x7",
+  provider: { getBlock: async () => ({ timestamp: 100 }) } as never,
+  accounts: [
+    {
+      address: "0x1",
+      account: {
+        execute: mock(async () => ({ transaction_hash: "0xabc" })),
+        waitForTransaction: async () => ({ execution_status: "SUCCEEDED" }),
+      },
+    },
+  ] as never,
+});
+
+afterEach(() => mock.restore());
+
+test("an Eternum workload below the victory target does not claim lifecycle success", async () => {
+  spyOn(HeraldObserver.prototype, "readModelRows").mockResolvedValue(rows(100));
+  const result = await closeHarnessSeason(options());
+  expect(result.status).toBe("target-not-reached");
+  expect(result.highestBotPoints).toBe(50);
+});
+
+test("a bot can close using accrued shares and verifies the registered result", async () => {
+  spyOn(HeraldObserver.prototype, "readModelRows").mockResolvedValue(rows(50));
+  const final = rows(50);
+  final.set("GameRegistry", [{ end_at: 100, status: "Ended" }]);
+  final.set("PlayerRegisteredPoints", [{ address: "0x1", registered_points: "50000000" }]);
+  final.set("SeasonPrize", [{ total_registered_points: "50000000" }]);
+  final.set("HyperstructureShareholders", [{ hyperstructure_id: 7, start_at: 100 }]);
+  spyOn(HeraldObserver.prototype, "waitForModelRows").mockResolvedValue(final);
+  const result = await closeHarnessSeason(options());
+  expect(result).toMatchObject({ status: "closed", winner: "0x1", endAt: 100, transactionHash: "0xabc" });
+});
+
+test("dev mode cannot provide Eternum finalization evidence", async () => {
+  spyOn(HeraldObserver.prototype, "readModelRows").mockResolvedValue(rows(50, true));
+  expect(closeHarnessSeason(options())).rejects.toThrow("dev mode off");
+});

--- a/deploy/madara-lab/harness/season-lifecycle.ts
+++ b/deploy/madara-lab/harness/season-lifecycle.ts
@@ -1,0 +1,129 @@
+import type { RpcProvider } from "starknet";
+import { calculateUnregisteredShareholderPoints } from "../../../packages/core/src/sync/shareholder-points";
+import type { HarnessAccount } from "./account-factory";
+import { HeraldObserver } from "./herald-observer";
+import { executeMadaraAndWait } from "./transactions";
+
+export interface SeasonFinalizationEvidence {
+  gameId: number;
+  status: "closed" | "target-not-reached";
+  pointsForWin: number;
+  highestBotPoints: number;
+  winner?: string;
+  transactionHash?: string;
+  endAt?: number;
+}
+
+export async function closeHarnessSeason(options: {
+  accounts: HarnessAccount[];
+  gameId: number;
+  heraldUrl: string;
+  provider: RpcProvider;
+  seasonSystemAddress: string;
+}): Promise<SeasonFinalizationEvidence> {
+  const observer = new HeraldObserver(options.heraldUrl, "madara");
+  const { models, pointsForWin } = await readSeasonTarget(observer, options.gameId);
+  const block = await options.provider.getBlock("latest");
+  const scores = readScores(models, options.gameId, Number(block.timestamp));
+  const candidates = options.accounts
+    .map((account) => ({ account, points: scores.get(normalize(account.address)) ?? 0 }))
+    .sort((a, b) => b.points - a.points);
+  const leader = candidates[0];
+  const evidence: SeasonFinalizationEvidence = {
+    gameId: options.gameId,
+    status: "target-not-reached",
+    pointsForWin,
+    highestBotPoints: leader?.points ?? 0,
+  };
+  if (!leader || leader.points < pointsForWin) return evidence;
+
+  const transactionHash = await executeMadaraAndWait(
+    leader.account.account,
+    {
+      contractAddress: options.seasonSystemAddress,
+      entrypoint: "season_close",
+      calldata: [options.gameId.toString()],
+    },
+    `close Eternum game ${options.gameId}`,
+  );
+  const endAt = await verifyClosedSeason(observer, options.gameId);
+  return { ...evidence, status: "closed", winner: leader.account.address, transactionHash, endAt };
+}
+
+async function readSeasonTarget(observer: HeraldObserver, gameId: number) {
+  const models = await observer.readModelRows(gameId, [
+    "GameRegistry",
+    "PresetConfig",
+    "Hyperstructure",
+    "HyperstructureShareholders",
+    "PlayerRegisteredPoints",
+  ]);
+  const game = models.get("GameRegistry")![0];
+  if (!game || game.dev_mode_on !== false) throw new Error("Eternum lifecycle verification requires dev mode off");
+  const preset = models
+    .get("PresetConfig")!
+    .find((row) => BigInt(row.preset_id as string) === BigInt(game.preset_id as string));
+  const winConfig = preset?.victory_points_win_config as { points_for_win?: string } | undefined;
+  if (!winConfig?.points_for_win || BigInt(winConfig.points_for_win) <= 0n)
+    throw new Error("Eternum victory target is missing");
+  const pointsForWin = Number(BigInt(winConfig.points_for_win)) / 1_000_000;
+  return { models, pointsForWin };
+}
+
+async function verifyClosedSeason(observer: HeraldObserver, gameId: number): Promise<number> {
+  const final = await observer.waitForModelRows(
+    gameId,
+    ["GameRegistry", "PlayerRegisteredPoints", "SeasonPrize", "Hyperstructure", "HyperstructureShareholders"],
+    (rows) => rows.get("GameRegistry")!.some(isEnded),
+    120_000,
+  );
+  const endAt = Number(final.get("GameRegistry")![0].end_at);
+  const total = final
+    .get("PlayerRegisteredPoints")!
+    .reduce((sum, row) => sum + BigInt(row.registered_points as string), 0n);
+  const pool = final.get("SeasonPrize")![0];
+  if (!pool || total !== BigInt(pool.total_registered_points as string))
+    throw new Error("Final registered points do not match the season total");
+  const completed = new Set(
+    final
+      .get("Hyperstructure")!
+      .filter((row) => row.completed === true)
+      .map((row) => String(row.hyperstructure_id)),
+  );
+  if (
+    final
+      .get("HyperstructureShareholders")!
+      .some((row) => completed.has(String(row.hyperstructure_id)) && Number(row.start_at) < endAt)
+  )
+    throw new Error("Finalization left unregistered shareholder points");
+  return endAt;
+}
+
+function isEnded(row: Record<string, unknown>): boolean {
+  return row.status === "Ended" || (typeof row.status === "object" && row.status !== null && "Ended" in row.status);
+}
+
+function readScores(
+  models: Map<string, Record<string, unknown>[]>,
+  gameId: number,
+  timestamp: number,
+): Map<string, number> {
+  const pending = calculateUnregisteredShareholderPoints(
+    {
+      gameRegistry: models.get("GameRegistry")!,
+      presets: models.get("PresetConfig")!,
+      hyperstructures: models.get("Hyperstructure")!,
+      shareholders: models.get("HyperstructureShareholders")!,
+    },
+    gameId,
+    timestamp,
+  );
+  const scores = new Map(pending);
+  for (const row of models.get("PlayerRegisteredPoints")!) {
+    const address = normalize(String(row.address));
+    scores.set(address, (pending.get(address) ?? 0) + Number(BigInt(row.registered_points as string)) / 1_000_000);
+  }
+  return scores;
+}
+
+const normalize = (address: string) => `0x${BigInt(address).toString(16)}`;

--- a/deploy/madara-lab/harness/transactions.ts
+++ b/deploy/madara-lab/harness/transactions.ts
@@ -1,0 +1,15 @@
+import type { Account, Call } from "starknet";
+import { resolveGameTransactionResourceBounds } from "../../../packages/core/src/account/transaction-resource-bounds";
+
+export async function executeMadaraAndWait(account: Account, calls: Call | Call[], label: string): Promise<string> {
+  const transaction = await account.execute(calls, {
+    resourceBounds: resolveGameTransactionResourceBounds("madara"),
+    tip: 0,
+  });
+  const receipt = await account.waitForTransaction(transaction.transaction_hash, { retryInterval: 50 });
+  const status = receipt as { execution_status?: string; isSuccess?: () => boolean };
+  const succeeded =
+    typeof status.isSuccess === "function" ? status.isSuccess() : status.execution_status === "SUCCEEDED";
+  if (!succeeded) throw new Error(`${label} failed for transaction ${transaction.transaction_hash}`);
+  return transaction.transaction_hash;
+}


### PR DESCRIPTION
Accept madara.eternum in launch-service persistence and enforce the format-to-preset pairing. Build Herald live standings from folded current rows and the shared shareholder formula, with history used only for activity breakdowns.

The harness can enter Eternum, verify real dev-off season closure, and checkpoint ended-game shares before operator ranking. Report target-not-reached as a failed lifecycle gate instead of treating an ordinary movement workload as proof of victory finalization.

Validation: focused Herald, launch-service and harness tests from the implementation pass; service typechecks passed. These runtime files are unchanged by the subsequent entitlement/checkpoint review fixes. Final stack formatting and Knip pass. No deployed lifecycle or worst-case gas evidence is claimed.

Scope: depends on the contract, configuration, and client changes. Paid Eternum is not supported by the ledger harness yet. No box deployment, L2 endpoint deployment, or change to existing Blitz preset balances.

Stack 4/5. Depends on https://github.com/BibliothecaDAO/eternum/pull/4953. Review this diff against its base branch; merge and retarget in order after the existing CI PR.

The upgrade procedure and box release gates are in https://github.com/BibliothecaDAO/eternum/pull/4951.
