### PR TITLE
fix(harness): expect one settlement structure per Eternum bot

### DIFF
--- a/deploy/madara-lab/harness/driver.ts
+++ b/deploy/madara-lab/harness/driver.ts
@@ -128,7 +128,7 @@ interface ExplorerPriority {
 }
 
 interface PrepareHarnessBotsOptions {
-  gameType?: "blitz" | "eternum";
+  gameType?: HarnessGameType;
   accounts: HarnessAccount[];
   beforeProvision?: () => Promise<void>;
   gameId: number;
@@ -199,7 +199,13 @@ const PALADIN_UNFAVORED_TRAVEL_BIOMES = new Set([
   BiomeType.TropicalSeasonalForest,
   BiomeType.TropicalRainForest,
 ]);
-const EXPLORER_COUNT_PER_BOT = 3;
+export type HarnessGameType = "blitz" | "eternum";
+
+const BLITZ_STRUCTURES_PER_BOT = 3;
+const ETERNUM_STRUCTURES_PER_BOT = 1;
+
+const settlementStructureCount = (gameType: HarnessGameType) =>
+  gameType === "eternum" ? ETERNUM_STRUCTURES_PER_BOT : BLITZ_STRUCTURES_PER_BOT;
 const EXPLORER_TROOP_AMOUNT = 10_000_000_000n;
 const WOOD_RESOURCE_ID = 3;
 export const RECEIPT_POLL_INTERVAL_MS = 50;
@@ -342,7 +348,7 @@ export async function prepareHarnessBots({
   await beforeProvision?.();
 
   return mapWithConcurrency(accounts, setupConcurrency, async (harnessAccount) => {
-    const structureIds = await readSettlementStructureIds(heraldObserver, gameId, harnessAccount.address);
+    const structureIds = await readSettlementStructureIds(heraldObserver, gameId, harnessAccount.address, gameType);
     const structures = await readStructures(heraldObserver, gameId, structureIds, mapCenter);
 
     if (gameType === "blitz") {
@@ -574,7 +580,7 @@ async function settleBot({
   provider,
   systems,
 }: {
-  gameType: "blitz" | "eternum";
+  gameType: HarnessGameType;
   harnessAccount: HarnessAccount;
   gameId: number;
   provider: RpcProvider;
@@ -1125,6 +1131,7 @@ async function readSettlementStructureIds(
   observer: HeraldObserver,
   gameId: number,
   address: string,
+  gameType: HarnessGameType,
 ): Promise<string[]> {
   const rows = (
     await observer.waitForModelRows(
@@ -1137,8 +1144,9 @@ async function readSettlementStructureIds(
   const row = rows.find((candidate) => feltEquals(candidate.player, address));
   if (!row) throw new Error(`Settlement for ${address} in game ${gameId} is absent from Herald`);
   const structureIds = parseStructureIds(row.structure_ids);
-  if (structureIds.length !== EXPLORER_COUNT_PER_BOT) {
-    throw new Error(`Expected ${EXPLORER_COUNT_PER_BOT} structures for ${address}, found ${structureIds.length}`);
+  const expected = settlementStructureCount(gameType);
+  if (structureIds.length !== expected) {
+    throw new Error(`Expected ${expected} structures for ${address}, found ${structureIds.length}`);
   }
   return structureIds;
 }

--- a/deploy/madara-lab/harness/run.ts
+++ b/deploy/madara-lab/harness/run.ts
@@ -7,7 +7,13 @@ import { Account, BlockTag, logger, RpcProvider } from "starknet";
 import { assertChainId, assertProviderChain } from "../../../packages/chain/chain-guard.js";
 import { launchGame } from "../../../config/deployer/clean/launch/runner";
 import { createHarnessAccounts } from "./account-factory";
-import { prepareHarnessBots, runWorkload, type HarnessSystemAddresses, type TrackedTransaction } from "./driver";
+import {
+  prepareHarnessBots,
+  runWorkload,
+  type HarnessGameType,
+  type HarnessSystemAddresses,
+  type TrackedTransaction,
+} from "./driver";
 import {
   bindLedgerGameplayAccounts,
   finalizeLedgerGame,
@@ -24,7 +30,7 @@ import { readLedgerSweepManifest, sweepLedgerBalances, writeLedgerSweepReceipt }
 import { collectHarnessEvidenceBeforeRun, finishHarnessEvidence, writeHarnessReport } from "./report";
 
 interface HarnessCliOptions {
-  gameType: "blitz" | "eternum";
+  gameType: HarnessGameType;
   bots: number;
   gameId?: number;
   gameName?: string;


### PR DESCRIPTION
The settlement read asserted three structures per bot, which is the Blitz count. An Eternum bot settles one realm, so on the box every Eternum run failed right after settlement with "Expected 3 structures, found 1". The count now follows the game type, and one shared alias replaces three inline game-type unions.

Verification: harness tests pass. The live Eternum lifecycle run on the box is the gate and runs after merge.