### PR TITLE
feat(client): keep both map layers in the spatial projection

### DIFF
--- a/apps/game/src/automation/exploration/map-cache.test.ts
+++ b/apps/game/src/automation/exploration/map-cache.test.ts
@@ -41,14 +41,14 @@ describe("buildExplorationSnapshot", () => {
     const worldSpatialProjection = {
       getTilesInBounds: vi.fn(() => [
         {
-          hexCoords: { col: 10, row: 10 },
+          hexCoords: { alt: false, col: 10, row: 10 },
           biome: 1,
           occupierId: 0,
           occupierType: 0,
         },
       ]),
-      getStructuresInBounds: vi.fn(() => [{ entityId: structureId, hexCoords: { col: 10, row: 11 } }]),
-      getArmiesInBounds: vi.fn(() => [{ entityId: armyId, hexCoords: { col: 11, row: 10 } }]),
+      getStructuresInBounds: vi.fn(() => [{ entityId: structureId, hexCoords: { alt: false, col: 10, row: 11 } }]),
+      getArmiesInBounds: vi.fn(() => [{ entityId: armyId, hexCoords: { alt: false, col: 11, row: 10 } }]),
     };
 
     const snapshot = await buildExplorationSnapshot({

--- a/apps/game/src/automation/exploration/map-cache.ts
+++ b/apps/game/src/automation/exploration/map-cache.ts
@@ -71,7 +71,9 @@ export const buildExplorationSnapshot = async ({
   const questHexes = new Map<number, Map<number, HexEntityInfo>>();
   const chestHexes = new Map<number, Map<number, HexEntityInfo>>();
 
-  worldSpatialProjection.getTilesInBounds(bounds).forEach((tile) => {
+  // Automation explores the surface; layer-aware exploration is the ethereal slice, item 4.
+  const surfaceBounds = { ...bounds, alt: false };
+  worldSpatialProjection.getTilesInBounds(surfaceBounds).forEach((tile) => {
     const normalized = new Position({ x: tile.hexCoords.col, y: tile.hexCoords.row }).getNormalized();
     if (tile.biome !== 0) {
       setNestedValue(exploredTiles, normalized.x, normalized.y, tile.biome as unknown as BiomeType);
@@ -86,7 +88,7 @@ export const buildExplorationSnapshot = async ({
     }
   });
 
-  worldSpatialProjection.getStructuresInBounds(bounds).forEach((structure) => {
+  worldSpatialProjection.getStructuresInBounds(surfaceBounds).forEach((structure) => {
     if (structure.entityId === null) return;
     const normalized = new Position({ x: structure.hexCoords.col, y: structure.hexCoords.row }).getNormalized();
     setNestedValue(
@@ -97,7 +99,7 @@ export const buildExplorationSnapshot = async ({
     );
   });
 
-  worldSpatialProjection.getArmiesInBounds(bounds).forEach((army) => {
+  worldSpatialProjection.getArmiesInBounds(surfaceBounds).forEach((army) => {
     const normalized = new Position({ x: army.hexCoords.col, y: army.hexCoords.row }).getNormalized();
     setNestedValue(
       armyHexes,

--- a/apps/game/src/hooks/store/use-ui-store.ts
+++ b/apps/game/src/hooks/store/use-ui-store.ts
@@ -56,6 +56,8 @@ interface UIStore {
   setShowBlurOverlay: (show: boolean) => void;
   showBlankOverlay: boolean;
   setShowBlankOverlay: (show: boolean) => void;
+  /** The map layer the scene shows: false is the surface, true the ethereal layer, as in TileOpt.alt. */
+  mapLayer: boolean;
   isSideMenuOpened: boolean;
   toggleSideMenu: () => void;
   isSoundOn: boolean;
@@ -194,6 +196,7 @@ export const useUIStore = create(
     setShowBlankOverlay: (show) => {
       set({ showBlankOverlay: show });
     },
+    mapLayer: false,
     isSideMenuOpened: true,
     toggleSideMenu: () => set((state) => ({ isSideMenuOpened: !state.isSideMenuOpened })),
     isSoundOn: readLocalBool("soundEnabled", true),

--- a/apps/game/src/hooks/use-world-spatial-tiles.ts
+++ b/apps/game/src/hooks/use-world-spatial-tiles.ts
@@ -1,5 +1,6 @@
 import { getActiveGameSyncRuntime, type TileSpatialRenderable } from "@bibliothecadao/eternum/game-sync";
 import { useEffect, useMemo, useState } from "react";
+import { useUIStore } from "@/hooks/store/use-ui-store";
 
 interface WorldSpatialTileHex {
   col: number;
@@ -8,6 +9,7 @@ interface WorldSpatialTileHex {
 
 export const useWorldSpatialTiles = (hexes: readonly WorldSpatialTileHex[]): readonly TileSpatialRenderable[] => {
   const projection = getActiveGameSyncRuntime()?.getWorldSpatialProjection();
+  const mapLayer = useUIStore((state) => state.mapLayer);
   const [revision, setRevision] = useState(0);
 
   useEffect(() => {
@@ -19,5 +21,8 @@ export const useWorldSpatialTiles = (hexes: readonly WorldSpatialTileHex[]): rea
     return projection.subscribeTiles(() => setRevision((current) => current + 1));
   }, [projection]);
 
-  return useMemo(() => hexes.flatMap((hex) => projection?.getTileAtHex(hex) ?? []), [hexes, projection, revision]);
+  return useMemo(
+    () => hexes.flatMap((hex) => projection?.getTileAtHex({ ...hex, alt: mapLayer }) ?? []),
+    [hexes, mapLayer, projection, revision],
+  );
 };

--- a/apps/game/src/three/managers/army-manager.ts
+++ b/apps/game/src/three/managers/army-manager.ts
@@ -1,3 +1,4 @@
+import { activeMapLayer } from "@/three/map-layer";
 import { arePlayersAllied } from "@/utils/entity-ownership";
 import { useAccountStore } from "@/hooks/store/use-account-store";
 import { useChainTimeStore } from "@/hooks/store/use-chain-time-store";
@@ -1596,6 +1597,7 @@ export class ArmyManager {
     const bounds = this.getChunkBounds(startRow, startCol);
     const center = FELT_CENTER();
     return this.worldSpatialProjection.getArmiesInBounds({
+      alt: activeMapLayer(),
       minCol: bounds.minCol + center,
       maxCol: bounds.maxCol + center,
       minRow: bounds.minRow + center,

--- a/apps/game/src/three/managers/chest-manager.ts
+++ b/apps/game/src/three/managers/chest-manager.ts
@@ -1,3 +1,4 @@
+import { activeMapLayer } from "@/three/map-layer";
 import { resolveChestTransition } from "../rewards/chest-transition-policy";
 import { ChestModelPath } from "@/three/constants";
 import { RewardTileModel } from "../rewards/reward-tile-model";
@@ -283,8 +284,9 @@ export class ChestManager {
     this.renderVisibleChests(this.currentChunkKey);
   }
 
-  public revealRelics(hexCoords: { col: number; row: number }, relics: readonly number[]): boolean {
+  public revealRelics(hex: { col: number; row: number }, relics: readonly number[]): boolean {
     if (!this.chestModel || !this.chestTransitions || !this.contentLadder.structureModels) return false;
+    const hexCoords = { ...hex, alt: activeMapLayer() };
     const tile = { hexCoords };
     const key = this.transitionKey(tile);
     const opened = this.chestTransitions.start(key, "open", this.chestPlacement(tile), this.chestModel.time);
@@ -365,6 +367,7 @@ export class ChestManager {
     const bounds = getRenderBounds(startRow, startCol, this.renderChunkSize, this.chunkSize);
     const center = FELT_CENTER();
     return this.worldSpatialProjection.getChestsInBounds({
+      alt: activeMapLayer(),
       minCol: bounds.minCol + center,
       maxCol: bounds.maxCol + center,
       minRow: bounds.minRow + center,

--- a/apps/game/src/three/managers/reserved-hyperstructure-manager.ts
+++ b/apps/game/src/three/managers/reserved-hyperstructure-manager.ts
@@ -1,3 +1,4 @@
+import { activeMapLayer } from "@/three/map-layer";
 import { ReservedHyperstructureModelPath } from "@/three/constants";
 import InstancedModel from "@/three/managers/instanced-model";
 import { FELT_CENTER } from "@/ui/config";
@@ -136,7 +137,7 @@ export class ReservedHyperstructureManager {
 
   private getReservedHyperstructureHexes(): HexPosition[] {
     return this.worldSpatialProjection
-      .getStructures()
+      .getStructures(activeMapLayer())
       .filter((structure) => structure.reserved)
       .map((structure) => this.normalizeHexCoords(structure.hexCoords));
   }

--- a/apps/game/src/three/managers/structure-manager.content-ladder.test.ts
+++ b/apps/game/src/three/managers/structure-manager.content-ladder.test.ts
@@ -157,7 +157,7 @@ function createStructure(entityId: number, overrides: Record<string, unknown> = 
   return {
     entityId,
     structureName: `Realm ${entityId}`,
-    hexCoords: { col: entityId, row: 0 },
+    hexCoords: { alt: false, col: entityId, row: 0 },
     structureType: "Realm",
     isMine: false,
     isAlly: false,
@@ -226,7 +226,7 @@ function createLiveManager(structures = PRIORITY_STRUCTURES) {
   manager.entityIdLabels.set(6, createHoverLabel(6));
   manager.visibleStructureWindow = {
     chunkKey: "0,0",
-    bounds: { minCol: -10, maxCol: 10, minRow: -10, maxRow: 10 },
+    bounds: { alt: false, minCol: -10, maxCol: 10, minRow: -10, maxRow: 10 },
     structures: new Map(renderables.map((renderable) => [renderable.entityId, renderable])),
   };
   structures.forEach((structure) => manager.structureInfoCache.set(structure.entityId, structure));
@@ -353,7 +353,7 @@ function createFullRefreshSubject(structureCount: number) {
   const structures = Array.from({ length: structureCount }, (_, index) => ({
     entityId: index + 1,
     hasWonder: false,
-    hexCoords: { col: index, row: 0 },
+    hexCoords: { alt: false, col: index, row: 0 },
     stage: 0,
     structureType: "Village",
   }));

--- a/apps/game/src/three/managers/structure-manager.ts
+++ b/apps/game/src/three/managers/structure-manager.ts
@@ -1,3 +1,4 @@
+import { activeMapLayer } from "@/three/map-layer";
 import type { GLTF } from "three/addons/loaders/GLTFLoader.js";
 import { getPlayerDisplayName } from "@/hooks/use-player-profile";
 import { RewardTileModel } from "../rewards/reward-tile-model";
@@ -846,7 +847,8 @@ export class StructureManager {
   }
 
   getTotalStructures() {
-    return this.worldSpatialProjection.getStructures().filter((structure) => !structure.reserved).length;
+    return this.worldSpatialProjection.getStructures(activeMapLayer()).filter((structure) => !structure.reserved)
+      .length;
   }
 
   public prewarmChunkAssets(chunkKey: string): Promise<void> {
@@ -1057,6 +1059,7 @@ export class StructureManager {
     const bounds = expandBoundsForStructurePresentation(renderBounds, this.chunkStride);
     const center = FELT_CENTER();
     return {
+      alt: activeMapLayer(),
       minCol: bounds.minCol + center,
       maxCol: bounds.maxCol + center,
       minRow: bounds.minRow + center,
@@ -1129,7 +1132,7 @@ export class StructureManager {
   getStructureByHexCoords(hexCoords: { col: number; row: number }) {
     const center = FELT_CENTER();
     const renderable = this.worldSpatialProjection
-      .getStructuresAtHex({ col: hexCoords.col + center, row: hexCoords.row + center })
+      .getStructuresAtHex({ alt: activeMapLayer(), col: hexCoords.col + center, row: hexCoords.row + center })
       .find((structure) => !structure.reserved);
     return renderable ? this.resolveStructureInfo(renderable) : undefined;
   }
@@ -1144,7 +1147,7 @@ export class StructureManager {
 
   public refreshCosmeticsForOwner(owner: string | bigint): void {
     const normalizedOwner = BigInt(owner);
-    const refreshEntityIds = this.worldSpatialProjection.getStructures().flatMap((renderable) => {
+    const refreshEntityIds = this.worldSpatialProjection.getStructures(activeMapLayer()).flatMap((renderable) => {
       if (renderable.reserved || !this.components?.Structure) return [];
       const matchesOwner =
         getComponentValue(this.components.Structure, gameEntityKey([BigInt(renderable.entityId)]))?.owner ===
@@ -2163,7 +2166,7 @@ export class StructureManager {
     const nowSeconds = useChainTimeStore.getState().getNowSeconds();
     this.incomingTroopArrivalsByStructure.clear();
 
-    this.worldSpatialProjection.getStructures().forEach((renderable) => {
+    this.worldSpatialProjection.getStructures(activeMapLayer()).forEach((renderable) => {
       if (renderable.reserved) return;
 
       const nextArrivals = arrivalsByStructure[String(renderable.entityId)];

--- a/apps/game/src/three/map-layer.ts
+++ b/apps/game/src/three/map-layer.ts
@@ -1,0 +1,4 @@
+import { useUIStore } from "@/hooks/store/use-ui-store";
+
+/** The layer the scene renders. Three.js code reads it here; React code selects `mapLayer` from the UI store. */
+export const activeMapLayer = (): boolean => useUIStore.getState().mapLayer;

--- a/apps/game/src/three/rewards/chest-transition-policy.test.ts
+++ b/apps/game/src/three/rewards/chest-transition-policy.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { ChestSpatialRenderable, GameSyncRuntimeStatus } from "@bibliothecadao/eternum/game-sync";
 import { resolveChestTransition } from "./chest-transition-policy";
 
-const chest: ChestSpatialRenderable = { kind: "chest", entityId: 7, hexCoords: { col: 10, row: 20 } };
+const chest: ChestSpatialRenderable = { kind: "chest", entityId: 7, hexCoords: { alt: false, col: 10, row: 20 } };
 const created = { kind: "chest" as const, entityId: 7, current: chest };
 
 describe("map chest transition eligibility", () => {

--- a/apps/game/src/three/scenes/worldmap-exploration-projection.test.ts
+++ b/apps/game/src/three/scenes/worldmap-exploration-projection.test.ts
@@ -13,7 +13,7 @@ describe("worldmap exploration projection", () => {
     harness.writeArmy(1, 11, 7);
     harness.projection.flush();
     const onTileChange = vi.fn();
-    subscribeWorldmapTileChanges(harness.projection, onTileChange);
+    subscribeWorldmapTileChanges(harness.projection, onTileChange, () => false);
     harness.writeTile(12, 7);
     harness.writeArmy(1, 12, 7);
     expect(onTileChange).not.toHaveBeenCalled();
@@ -21,7 +21,7 @@ describe("worldmap exploration projection", () => {
     expect(onTileChange).toHaveBeenCalledTimes(1);
     expect(onTileChange).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "tile", previous: undefined, current: expect.anything() }),
-      { col: 11, row: 7 },
+      { alt: false, col: 11, row: 7 },
     );
   });
 
@@ -31,7 +31,7 @@ describe("worldmap exploration projection", () => {
     harness.writeArmy(1, 11, 7);
     harness.projection.flush();
     const onTileChange = vi.fn();
-    subscribeWorldmapTileChanges(harness.projection, onTileChange);
+    subscribeWorldmapTileChanges(harness.projection, onTileChange, () => false);
     harness.writeTile(12, 7, 3);
     harness.writeArmy(1, 12, 7);
     harness.projection.flush();
@@ -48,7 +48,7 @@ describe("worldmap exploration projection", () => {
   it("leaves the origin unspecified for snapshot creation without a previous army position", () => {
     const harness = createHarness();
     const onTileChange = vi.fn();
-    subscribeWorldmapTileChanges(harness.projection, onTileChange);
+    subscribeWorldmapTileChanges(harness.projection, onTileChange, () => false);
     harness.writeTile(12, 7);
     harness.writeArmy(1, 12, 7);
     harness.projection.flush();
@@ -62,7 +62,7 @@ describe("worldmap exploration projection", () => {
     harness.writeArmy(2, 12, 6);
     harness.projection.flush();
     const onTileChange = vi.fn();
-    subscribeWorldmapTileChanges(harness.projection, onTileChange);
+    subscribeWorldmapTileChanges(harness.projection, onTileChange, () => false);
     harness.writeTile(12, 7);
     harness.writeArmy(1, 12, 7);
     harness.writeArmy(2, 12, 7);
@@ -74,7 +74,7 @@ describe("worldmap exploration projection", () => {
   it("stops delivering tile changes when the scene unsubscribes", () => {
     const harness = createHarness();
     const onTileChange = vi.fn();
-    const unsubscribe = subscribeWorldmapTileChanges(harness.projection, onTileChange);
+    const unsubscribe = subscribeWorldmapTileChanges(harness.projection, onTileChange, () => false);
     unsubscribe();
     harness.writeTile(12, 7);
     harness.projection.flush();

--- a/apps/game/src/three/scenes/worldmap-exploration-projection.ts
+++ b/apps/game/src/three/scenes/worldmap-exploration-projection.ts
@@ -4,13 +4,16 @@ import type {
   WorldSpatialProjection,
   WorldSpatialProjectionChange,
 } from "@bibliothecadao/eternum/game-sync";
+import { projectionChangesForLayer } from "@bibliothecadao/eternum/game-sync";
 
 /** Pair discovery with movement from the same shared update, for players and spectators alike. */
 export function subscribeWorldmapTileChanges(
   projection: Pick<WorldSpatialProjection, "subscribe">,
   onTileChange: (change: TileSpatialProjectionChange, source?: WorldSpatialHex) => void,
+  layer: () => boolean,
 ): () => void {
-  return projection.subscribe((changes) => {
+  return projection.subscribe((published) => {
+    const changes = projectionChangesForLayer(published, layer());
     if (!changes.some((change) => change.kind === "tile")) return;
     const movementSources = collectMovementSources(changes);
     for (const change of changes) {
@@ -40,5 +43,5 @@ function collectMovementSources(
 }
 
 function hexKey(hex?: WorldSpatialHex): string {
-  return hex ? `${hex.col},${hex.row}` : "";
+  return hex ? `${hex.alt ? 1 : 0},${hex.col},${hex.row}` : "";
 }

--- a/apps/game/src/three/scenes/worldmap-terrain-ecology-refresh-runtime.test.ts
+++ b/apps/game/src/three/scenes/worldmap-terrain-ecology-refresh-runtime.test.ts
@@ -168,7 +168,7 @@ function createHarness() {
     return {
       cells: cells.map((cell) => ({
         ...cell,
-        occupied: projection.getStructuresAtHex(cell).some((structure) => !structure.reserved),
+        occupied: projection.getStructuresAtHex({ ...cell, alt: false }).some((structure) => !structure.reserved),
       })),
       commitMode: "atomic",
       mapCenter: 0,
@@ -290,7 +290,7 @@ function collectCurrentAnchors(
     },
     normalizeStructureHex: ({ col, row }) => ({ col, row }),
     projection,
-    toProjectionBounds: (bounds) => bounds,
+    toProjectionBounds: (bounds) => ({ ...bounds, alt: false }),
   });
 }
 

--- a/apps/game/src/three/scenes/worldmap-terrain-ecology-refresh-runtime.ts
+++ b/apps/game/src/three/scenes/worldmap-terrain-ecology-refresh-runtime.ts
@@ -19,7 +19,7 @@ interface CollectWorldmapTerrainEcologyAnchorsInput {
   getStructureFacts: (entityId: number) => StructureTerrainEcologyFacts | undefined;
   normalizeStructureHex: (hex: WorldSpatialHex) => { col: number; row: number };
   projection: Pick<WorldSpatialProjection, "getStructuresInBounds">;
-  toProjectionBounds: (bounds: WorldSpatialBounds) => WorldSpatialBounds;
+  toProjectionBounds: (bounds: Omit<WorldSpatialBounds, "alt">) => WorldSpatialBounds;
 }
 
 interface BindWorldmapTerrainEcologyRefreshInput {

--- a/apps/game/src/three/scenes/worldmap.tsx
+++ b/apps/game/src/three/scenes/worldmap.tsx
@@ -1,3 +1,4 @@
+import { activeMapLayer } from "@/three/map-layer";
 import type { ReactNode } from "react";
 import { isMapPreviewAction } from "./worldmap-action-preview-policy";
 import { projectHexToScreen } from "@/three/utils/project-hex-to-screen";
@@ -60,6 +61,7 @@ import {
   type WorldSpatialHex,
   type TileSpatialRenderable,
   type WorldSpatialProjection,
+  projectionChangesForLayer,
 } from "@bibliothecadao/eternum/game-sync";
 import {
   gameWorkerManager,
@@ -1308,10 +1310,16 @@ export default class WorldmapScene extends WarpTravel {
 
   private bindWorldSpatialProjectionLifecycle(): void {
     this.seedStrategicMarkers();
-    const unsubscribeTiles = subscribeWorldmapTileChanges(this.worldSpatialProjection, (change, source) => {
-      this.applyProjectedTileChange(change, source);
-    });
-    const unsubscribeStructures = this.worldSpatialProjection.subscribeStructures((changes) => {
+    const unsubscribeTiles = subscribeWorldmapTileChanges(
+      this.worldSpatialProjection,
+      (change, source) => {
+        this.applyProjectedTileChange(change, source);
+      },
+      activeMapLayer,
+    );
+    const unsubscribeStructures = this.worldSpatialProjection.subscribeStructures((published) => {
+      const changes = projectionChangesForLayer(published, activeMapLayer());
+      if (changes.length === 0) return;
       this.syncProjectedStructurePathfinding(changes);
       changes.forEach(({ previous, current }) => {
         if (previous?.reserved && !current?.reserved) {
@@ -1331,7 +1339,9 @@ export default class WorldmapScene extends WarpTravel {
       requestRefresh: () => this.scheduleTerrainEcologyRefresh(),
       structureComponent: this.dojo.components.Structure,
     });
-    const unsubscribeArmies = this.worldSpatialProjection.subscribeArmies((changes) => {
+    const unsubscribeArmies = this.worldSpatialProjection.subscribeArmies((published) => {
+      const changes = projectionChangesForLayer(published, activeMapLayer());
+      if (changes.length === 0) return;
       this.syncProjectedArmyPathfinding(changes);
       this.handleProjectedArmyChanges(changes);
       this.syncArmyMarkers(changes);
@@ -1361,8 +1371,9 @@ export default class WorldmapScene extends WarpTravel {
 
   /** The far band's subjects: every structure and army in the world, coloured by owner, from the projection. */
   private seedStrategicMarkers(): void {
-    this.worldSpatialProjection.getStructures().forEach((structure) => this.writeStructureMarker(structure));
-    this.worldSpatialProjection.getArmies().forEach((army) => this.writeArmyMarker(army));
+    const layer = activeMapLayer();
+    this.worldSpatialProjection.getStructures(layer).forEach((structure) => this.writeStructureMarker(structure));
+    this.worldSpatialProjection.getArmies(layer).forEach((army) => this.writeArmyMarker(army));
     this.commitStrategicMarkers();
   }
 
@@ -1380,7 +1391,7 @@ export default class WorldmapScene extends WarpTravel {
     const structure = this.worldSpatialProjection.getStructure(entityId);
     if (!structure) return;
     this.writeStructureMarker(structure);
-    this.worldSpatialProjection.getArmies().forEach((army) => {
+    this.worldSpatialProjection.getArmies(activeMapLayer()).forEach((army) => {
       if (this.getArmyOwnerStructureId(army.entityId) === entityId) this.writeArmyMarker(army);
     });
     this.commitStrategicMarkers();
@@ -2022,7 +2033,7 @@ export default class WorldmapScene extends WarpTravel {
   private getArmyAtHex(hexCoords: HexPosition): HexEntityInfo | undefined {
     const contract = new Position({ x: hexCoords.col, y: hexCoords.row }).getContract();
     const renderable = this.worldSpatialProjection
-      .getArmiesAtHex({ col: contract.x, row: contract.y })
+      .getArmiesAtHex({ alt: activeMapLayer(), col: contract.x, row: contract.y })
       .find(({ entityId }) => {
         const pendingPosition = this.getArmyDisplayPosition(entityId);
         return pendingPosition?.col === hexCoords.col && pendingPosition.row === hexCoords.row;
@@ -2261,7 +2272,7 @@ export default class WorldmapScene extends WarpTravel {
   private isReservedHyperstructureHex(hexCoords: HexPosition): boolean {
     const contractPosition = new Position({ x: hexCoords.col, y: hexCoords.row }).getContract();
     return this.worldSpatialProjection
-      .getStructuresAtHex({ col: contractPosition.x, row: contractPosition.y })
+      .getStructuresAtHex({ alt: activeMapLayer(), col: contractPosition.x, row: contractPosition.y })
       .some((structure) => structure.reserved);
   }
 
@@ -2291,12 +2302,13 @@ export default class WorldmapScene extends WarpTravel {
     const contractHex = position.getContract();
     const army = this.getArmyAtHex({ col: hex.x, row: hex.y });
     const projectedStructure = this.worldSpatialProjection
-      .getStructuresAtHex({ col: contractHex.x, row: contractHex.y })
+      .getStructuresAtHex({ alt: activeMapLayer(), col: contractHex.x, row: contractHex.y })
       .find((candidate) => !candidate.reserved);
     const structure = projectedStructure
       ? { id: projectedStructure.entityId, owner: this.getStructureOwnerAddress(projectedStructure.entityId) ?? 0n }
       : undefined;
     const projectedChest = this.worldSpatialProjection.getChestsAtHex({
+      alt: activeMapLayer(),
       col: contractHex.x,
       row: contractHex.y,
     })[0];
@@ -3058,7 +3070,7 @@ export default class WorldmapScene extends WarpTravel {
 
     for (const [key, path] of actionPaths.getPaths()) {
       const destination = path[path.length - 1].hex;
-      const tile = this.worldSpatialProjection.getTileAtHex(destination);
+      const tile = this.worldSpatialProjection.getTileAtHex({ ...destination, alt: activeMapLayer() });
       if (ActionPaths.getActionType(path) === ActionType.CreateArmy && (!tile || Number(tile.occupierId) !== 0)) {
         actionPaths.getPaths().delete(key);
       }
@@ -3363,7 +3375,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private buildProjectedChestActionIndex(): Map<number, Map<number, HexEntityInfo>> {
     const index = new Map<number, Map<number, HexEntityInfo>>();
-    this.worldSpatialProjection.getChests().forEach((chest) => {
+    this.worldSpatialProjection.getChests(activeMapLayer()).forEach((chest) => {
       const normalized = new Position({ x: chest.hexCoords.col, y: chest.hexCoords.row }).getNormalized();
       const row = index.get(normalized.x) ?? new Map<number, HexEntityInfo>();
       row.set(normalized.y, { id: chest.entityId, owner: 0n });
@@ -3374,7 +3386,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private buildProjectedExploredTileIndex(): Map<number, Map<number, BiomeType>> {
     const index = new Map<number, Map<number, BiomeType>>();
-    this.worldSpatialProjection.getTiles().forEach((tile) => {
+    this.worldSpatialProjection.getTiles(activeMapLayer()).forEach((tile) => {
       const normalized = new Position({ x: tile.hexCoords.col, y: tile.hexCoords.row }).getNormalized();
       const row = index.get(normalized.x) ?? new Map<number, BiomeType>();
       row.set(normalized.y, requireBiomeTypeFromId(tile.biome));
@@ -3385,7 +3397,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private buildProjectedArmyActionIndex(): Map<number, Map<number, HexEntityInfo>> {
     const index = new Map<number, Map<number, HexEntityInfo>>();
-    this.worldSpatialProjection.getArmies().forEach(({ entityId }) => {
+    this.worldSpatialProjection.getArmies(activeMapLayer()).forEach(({ entityId }) => {
       const position = this.getArmyDisplayPosition(entityId);
       if (!position) return;
       const row = index.get(position.col) ?? new Map<number, HexEntityInfo>();
@@ -3397,7 +3409,7 @@ export default class WorldmapScene extends WarpTravel {
 
   private buildProjectedStructureActionIndex(): Map<number, Map<number, HexEntityInfo>> {
     const index = new Map<number, Map<number, HexEntityInfo>>();
-    this.worldSpatialProjection.getStructures().forEach((structure) => {
+    this.worldSpatialProjection.getStructures(activeMapLayer()).forEach((structure) => {
       if (structure.reserved) return;
 
       const normalized = new Position({ x: structure.hexCoords.col, y: structure.hexCoords.row }).getNormalized();
@@ -3594,15 +3606,18 @@ export default class WorldmapScene extends WarpTravel {
       const contract = new Position({ x: col, y: row }).getContract();
       const hex = { col: contract.x, row: contract.y };
       return (
-        this.worldSpatialProjection.getStructuresAtHex(hex).length > 0 ||
-        this.worldSpatialProjection.getChestsAtHex(hex).length > 0
+        this.worldSpatialProjection.getStructuresAtHex({ ...hex, alt: activeMapLayer() }).length > 0 ||
+        this.worldSpatialProjection.getChestsAtHex({ ...hex, alt: activeMapLayer() }).length > 0
       );
     });
   }
 
   private isProjectedStructureHex(col: number, row: number): boolean {
     const contract = new Position({ x: col, y: row }).getContract();
-    return this.worldSpatialProjection.getStructuresAtHex({ col: contract.x, row: contract.y }).length > 0;
+    return (
+      this.worldSpatialProjection.getStructuresAtHex({ alt: activeMapLayer(), col: contract.x, row: contract.y })
+        .length > 0
+    );
   }
 
   protected getWarpTravelLifecycleAdapter(): WarpTravelLifecycleAdapter {
@@ -5584,7 +5599,11 @@ export default class WorldmapScene extends WarpTravel {
     return this.terrainContent.capture({
       cells,
       getProjectedBiome: (col, row) => {
-        const tile = this.worldSpatialProjection.getTileAtHex({ col: col + center, row: row + center });
+        const tile = this.worldSpatialProjection.getTileAtHex({
+          alt: activeMapLayer(),
+          col: col + center,
+          row: row + center,
+        });
         return tile ? requireBiomeTypeFromId(tile.biome) : undefined;
       },
       isOccupied: (col, row) => this.isProjectedStructureHex(col, row),
@@ -6223,6 +6242,7 @@ export default class WorldmapScene extends WarpTravel {
   private toContractBounds(bounds: { minCol: number; maxCol: number; minRow: number; maxRow: number }) {
     const feltCenter = FELT_CENTER();
     return {
+      alt: activeMapLayer(),
       minCol: bounds.minCol + feltCenter,
       maxCol: bounds.maxCol + feltCenter,
       minRow: bounds.minRow + feltCenter,

--- a/apps/game/src/ui/features/military/chest/use-adjacent-own-explorer.ts
+++ b/apps/game/src/ui/features/military/chest/use-adjacent-own-explorer.ts
@@ -1,4 +1,5 @@
 import { useAccountStore } from "@/hooks/store/use-account-store";
+import { useUIStore } from "@/hooks/store/use-ui-store";
 import { getArmy } from "@bibliothecadao/eternum";
 import { getActiveGameSyncRuntime } from "@bibliothecadao/eternum/game-sync";
 import { useDojo } from "@bibliothecadao/react";
@@ -12,6 +13,7 @@ export const useAdjacentOwnExplorer = (hex: { col: number; row: number }): ID | 
   } = useDojo();
   const address = useAccountStore((state) => state.account?.address ?? null);
   const projection = getActiveGameSyncRuntime()?.getWorldSpatialProjection();
+  const mapLayer = useUIStore((state) => state.mapLayer);
   const [revision, setRevision] = useState(0);
 
   useEffect(() => projection?.subscribeArmies(() => setRevision((current) => current + 1)), [projection]);
@@ -20,11 +22,11 @@ export const useAdjacentOwnExplorer = (hex: { col: number; row: number }): ID | 
     if (!projection || !address) return null;
     const playerAddress = ContractAddress(address);
     for (const neighbor of getNeighborHexes(hex.col, hex.row)) {
-      for (const army of projection.getArmiesAtHex(neighbor)) {
+      for (const army of projection.getArmiesAtHex({ ...neighbor, alt: mapLayer })) {
         if (getArmy(army.entityId, playerAddress, components)?.isMine) return army.entityId;
       }
     }
     return null;
     // revision re-runs the scan whenever an army moves.
-  }, [address, components, hex.col, hex.row, projection, revision]);
+  }, [address, components, hex.col, hex.row, projection, revision, mapLayer]);
 };

--- a/apps/game/src/ui/features/story-events/world-event-entity-reader.ts
+++ b/apps/game/src/ui/features/story-events/world-event-entity-reader.ts
@@ -92,7 +92,7 @@ export const createWorldEventEntityReader = (
       return [];
     }
 
-    return projection.getStructures().flatMap((spatial) => {
+    return [...projection.getStructures(false), ...projection.getStructures(true)].flatMap((spatial) => {
       if (spatial.entityId === null) return [];
       const structure = getStructure(Number(spatial.entityId));
       return structure?.ownerAddress === normalizedOwner ? [structure] : [];

--- a/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
+++ b/apps/game/src/ui/features/world/components/bottom-right-panel/bottom-right-panel.tsx
@@ -766,6 +766,7 @@ export const MinimapPanel = ({ compact = false }: { compact?: boolean }) => {
 
   const focusHex = activeRealmHex ?? cameraTargetHex;
   const focusSelectedHex = activeRealmHex ?? selectedHex;
+  const mapLayer = useUIStore((state) => state.mapLayer);
 
   useEffect(() => {
     const projection = getActiveGameSyncRuntime()?.getWorldSpatialProjection();
@@ -777,7 +778,7 @@ export const MinimapPanel = ({ compact = false }: { compact?: boolean }) => {
 
     const readTiles = () => {
       setTiles(
-        projection.getTiles().map((tile) =>
+        projection.getTiles(mapLayer).map((tile) =>
           normalizeMinimapTile({
             col: tile.hexCoords.col,
             row: tile.hexCoords.row,
@@ -793,7 +794,7 @@ export const MinimapPanel = ({ compact = false }: { compact?: boolean }) => {
 
     readTiles();
     return projection.subscribeTiles(readTiles);
-  }, []);
+  }, [mapLayer]);
 
   return (
     <PanelFrame title="Minimap" height={compact ? "clamp(180px, 35dvh, 320px)" : MINIMAP_SIZE}>

--- a/packages/core/src/sync/world-spatial-projection.test.ts
+++ b/packages/core/src/sync/world-spatial-projection.test.ts
@@ -1,7 +1,11 @@
 import { TileOccupier } from "@bibliothecadao/types";
 import { Type, createWorld, defineComponent, removeComponent, setComponent } from "@dojoengine/recs";
 import { describe, expect, it, vi } from "vitest";
-import { WorldSpatialProjection } from "./world-spatial-projection";
+import {
+  WorldSpatialProjection,
+  ArmySpatialProjectionChange,
+  projectionChangesForLayer,
+} from "./world-spatial-projection";
 
 const encodeTile = (input: {
   alt?: boolean;
@@ -129,11 +133,11 @@ describe("WorldSpatialProjection", () => {
 
     projection.start();
 
-    expect(projection.getTiles()).toEqual([
+    expect(projection.getTiles(false)).toEqual([
       {
         kind: "tile",
-        spatialId: "tile:100:200",
-        hexCoords: { col: 100, row: 200 },
+        spatialId: "tile:0:100:200",
+        hexCoords: { alt: false, col: 100, row: 200 },
         biome: 4,
         occupierId: 7,
         occupierType: TileOccupier.RealmRegularLevel1,
@@ -141,8 +145,10 @@ describe("WorldSpatialProjection", () => {
         rewardExtracted: true,
       },
     ]);
-    expect(projection.getTileAtHex({ col: 100, row: 200 })?.occupierId).toBe(7);
-    expect(projection.getTilesInBounds({ minCol: 96, maxCol: 104, minRow: 196, maxRow: 204 })).toHaveLength(1);
+    expect(projection.getTileAtHex({ alt: false, col: 100, row: 200 })?.occupierId).toBe(7);
+    expect(projection.getTilesInBounds({ alt: false, minCol: 96, maxCol: 104, minRow: 196, maxRow: 204 })).toHaveLength(
+      1,
+    );
   });
 
   it("rebuilds a surface-chest index from RECS and excludes non-renderable tiles", () => {
@@ -153,11 +159,13 @@ describe("WorldSpatialProjection", () => {
 
     projection.start();
 
-    expect(projection.getChests()).toEqual([{ kind: "chest", entityId: 7, hexCoords: { col: 100, row: 200 } }]);
-    expect(projection.getChestsAtHex({ col: 100, row: 200 }).map(({ entityId }) => entityId)).toEqual([7]);
+    expect(projection.getChests(false)).toEqual([
+      { kind: "chest", entityId: 7, hexCoords: { alt: false, col: 100, row: 200 } },
+    ]);
+    expect(projection.getChestsAtHex({ alt: false, col: 100, row: 200 }).map(({ entityId }) => entityId)).toEqual([7]);
     expect(
       projection
-        .getChestsInBounds({ minCol: 96, maxCol: 100, minRow: 196, maxRow: 204 })
+        .getChestsInBounds({ alt: false, minCol: 96, maxCol: 100, minRow: 196, maxRow: 204 })
         .map(({ entityId }) => entityId),
     ).toEqual([7]);
   });
@@ -197,25 +205,25 @@ describe("WorldSpatialProjection", () => {
       spatialId: "entity:7",
       entityId: 7,
       reserved: false,
-      hexCoords: { col: 100, row: 200 },
+      hexCoords: { alt: false, col: 100, row: 200 },
       occupierType: TileOccupier.RealmWonderLevel2,
     });
-    expect(projection.getStructuresAtHex({ col: 101, row: 200 })).toEqual([
+    expect(projection.getStructuresAtHex({ alt: false, col: 101, row: 200 })).toEqual([
       {
         kind: "structure",
-        spatialId: "reserved:101:200",
+        spatialId: "reserved:0:101:200",
         entityId: null,
         reserved: true,
-        hexCoords: { col: 101, row: 200 },
+        hexCoords: { alt: false, col: 101, row: 200 },
         occupierType: TileOccupier.ReservedHyperstructure,
       },
     ]);
     expect(
       projection
-        .getStructuresInBounds({ minCol: 100, maxCol: 102, minRow: 200, maxRow: 200 })
+        .getStructuresInBounds({ alt: false, minCol: 100, maxCol: 102, minRow: 200, maxRow: 200 })
         .map(({ spatialId }) => spatialId),
-    ).toEqual(["entity:7", "reserved:101:200", "reserved:102:200"]);
-    expect(projection.getStructures()).toHaveLength(3);
+    ).toEqual(["entity:7", "reserved:0:101:200", "reserved:0:102:200"]);
+    expect(projection.getStructures(false)).toHaveLength(3);
   });
 
   it("indexes live surface armies from ExplorerTroops only", () => {
@@ -232,19 +240,19 @@ describe("WorldSpatialProjection", () => {
 
     projection.start();
 
-    expect(projection.getArmies()).toEqual([
+    expect(projection.getArmies(false)).toEqual([
       {
         kind: "army",
         entityId: 7,
-        hexCoords: { col: 100, row: 200 },
+        hexCoords: { alt: false, col: 100, row: 200 },
         troopCategory: "Paladin",
         troopTier: "T2",
       },
     ]);
-    expect(projection.getArmiesAtHex({ col: 100, row: 200 }).map(({ entityId }) => entityId)).toEqual([7]);
+    expect(projection.getArmiesAtHex({ alt: false, col: 100, row: 200 }).map(({ entityId }) => entityId)).toEqual([7]);
     expect(
       projection
-        .getArmiesInBounds({ minCol: 96, maxCol: 104, minRow: 196, maxRow: 204 })
+        .getArmiesInBounds({ alt: false, minCol: 96, maxCol: 104, minRow: 196, maxRow: 204 })
         .map(({ entityId }) => entityId),
     ).toEqual([7]);
     expect(projection.getArmy(10)).toBeUndefined();
@@ -266,11 +274,52 @@ describe("WorldSpatialProjection", () => {
         writeTile("destination", { col: 20, row: 21, occupierId: 7 });
       }
 
-      expect(projection.getChest(7)?.hexCoords).toEqual({ col: 20, row: 21 });
-      expect(projection.getChestsAtHex({ col: 10, row: 11 })).toEqual([]);
-      expect(projection.getChestsAtHex({ col: 20, row: 21 }).map(({ entityId }) => entityId)).toEqual([7]);
+      expect(projection.getChest(7)?.hexCoords).toEqual({ alt: false, col: 20, row: 21 });
+      expect(projection.getChestsAtHex({ alt: false, col: 10, row: 11 })).toEqual([]);
+      expect(projection.getChestsAtHex({ alt: false, col: 20, row: 21 }).map(({ entityId }) => entityId)).toEqual([7]);
     },
   );
+
+  it("keeps the surface and the ethereal layer apart at the same coordinate", () => {
+    const { projection, writeArmy, writeTile } = createHarness();
+    writeTile("spire-surface", { col: 100, row: 200, occupierId: 5, occupierType: TileOccupier.Spire });
+    writeTile("spire-ethereal", { alt: true, col: 100, row: 200, occupierId: 5, occupierType: TileOccupier.Spire });
+    writeArmy("ethereal-army", { explorerId: 9, col: 101, row: 200, alt: true });
+    projection.start();
+
+    expect(projection.getTileAtHex({ alt: false, col: 100, row: 200 })?.spatialId).toBe("tile:0:100:200");
+    expect(projection.getTileAtHex({ alt: true, col: 100, row: 200 })?.spatialId).toBe("tile:1:100:200");
+    expect(projection.getArmies(false)).toEqual([]);
+    expect(projection.getArmies(true).map(({ entityId }) => entityId)).toEqual([9]);
+    expect(projection.getArmy(9)?.hexCoords).toEqual({ alt: true, col: 101, row: 200 });
+    expect(projection.getArmiesInBounds({ alt: true, minCol: 96, maxCol: 104, minRow: 196, maxRow: 204 }).length).toBe(
+      1,
+    );
+    expect(projection.getArmiesInBounds({ alt: false, minCol: 96, maxCol: 104, minRow: 196, maxRow: 204 }).length).toBe(
+      0,
+    );
+  });
+
+  it("publishes a spire crossing as a removal on one layer and a creation on the other", () => {
+    const { projection, writeArmy } = createHarness();
+    writeArmy("army", { explorerId: 7, col: 100, row: 200 });
+    projection.start();
+    const changes: ArmySpatialProjectionChange[][] = [];
+    projection.subscribeArmies((published) => changes.push([...published]));
+
+    writeArmy("army", { explorerId: 7, col: 100, row: 200, alt: true });
+    projection.flush();
+
+    const [crossing] = changes;
+    expect(crossing).toHaveLength(1);
+    expect(projectionChangesForLayer(crossing!, false)).toEqual([
+      { ...crossing![0], previous: crossing![0]!.previous, current: undefined },
+    ]);
+    expect(projectionChangesForLayer(crossing!, true)).toEqual([
+      { ...crossing![0], previous: undefined, current: crossing![0]!.current },
+    ]);
+    expect(projectionChangesForLayer(crossing!, true)[0]!.current?.hexCoords.alt).toBe(true);
+  });
 
   it("restores missed updates and deletions from a full rebuild", () => {
     const { projection, tileOpt, writeTile } = createHarness();
@@ -292,7 +341,9 @@ describe("WorldSpatialProjection", () => {
 
     removeComponent(tileOpt, "offscreen-chest");
 
-    expect(projection.getChestsInBounds({ minCol: 196, maxCol: 204, minRow: 196, maxRow: 204 })).toEqual([]);
+    expect(projection.getChestsInBounds({ alt: false, minCol: 196, maxCol: 204, minRow: 196, maxRow: 204 })).toEqual(
+      [],
+    );
   });
 
   it("publishes one complete change and detaches cleanly", () => {
@@ -307,17 +358,17 @@ describe("WorldSpatialProjection", () => {
     expect(listener).toHaveBeenCalledWith([
       expect.objectContaining({
         kind: "tile",
-        spatialId: "tile:10:11",
+        spatialId: "tile:0:10:11",
         current: expect.objectContaining({
           kind: "tile",
-          spatialId: "tile:10:11",
-          hexCoords: { col: 10, row: 11 },
+          spatialId: "tile:0:10:11",
+          hexCoords: { alt: false, col: 10, row: 11 },
         }),
       }),
       expect.objectContaining({
         kind: "chest",
         entityId: 7,
-        current: { kind: "chest", entityId: 7, hexCoords: { col: 10, row: 11 } },
+        current: { kind: "chest", entityId: 7, hexCoords: { alt: false, col: 10, row: 11 } },
       }),
     ]);
 
@@ -328,7 +379,7 @@ describe("WorldSpatialProjection", () => {
 
     projection.dispose();
     writeTile("third", { col: 14, row: 15, occupierId: 9 });
-    expect(projection.getChests()).toEqual([]);
+    expect(projection.getChests(false)).toEqual([]);
   });
 
   it("publishes structure variant, move, and reserved-site removal changes", () => {
@@ -365,19 +416,19 @@ describe("WorldSpatialProjection", () => {
         spatialId: "entity:7",
         previous: expect.objectContaining({
           entityId: 7,
-          hexCoords: { col: 10, row: 11 },
+          hexCoords: { alt: false, col: 10, row: 11 },
           occupierType: TileOccupier.RealmRegularLevel1,
         }),
         current: expect.objectContaining({
           entityId: 7,
-          hexCoords: { col: 20, row: 21 },
+          hexCoords: { alt: false, col: 20, row: 21 },
           occupierType: TileOccupier.RealmWonderLevel2,
         }),
       },
       {
         kind: "structure",
-        spatialId: "reserved:12:13",
-        previous: expect.objectContaining({ reserved: true, hexCoords: { col: 12, row: 13 } }),
+        spatialId: "reserved:0:12:13",
+        previous: expect.objectContaining({ reserved: true, hexCoords: { alt: false, col: 12, row: 13 } }),
       },
     ]);
   });
@@ -399,16 +450,20 @@ describe("WorldSpatialProjection", () => {
       {
         kind: "army",
         entityId: 7,
-        current: expect.objectContaining({ hexCoords: { col: 10, row: 11 }, troopCategory: "Knight", troopTier: "T1" }),
+        current: expect.objectContaining({
+          hexCoords: { alt: false, col: 10, row: 11 },
+          troopCategory: "Knight",
+          troopTier: "T1",
+        }),
       },
     ]);
     expect(listener).toHaveBeenNthCalledWith(2, [
       {
         kind: "army",
         entityId: 7,
-        previous: expect.objectContaining({ hexCoords: { col: 10, row: 11 } }),
+        previous: expect.objectContaining({ hexCoords: { alt: false, col: 10, row: 11 } }),
         current: expect.objectContaining({
-          hexCoords: { col: 20, row: 21 },
+          hexCoords: { alt: false, col: 20, row: 21 },
           troopCategory: "Crossbowman",
           troopTier: "T3",
         }),
@@ -418,7 +473,7 @@ describe("WorldSpatialProjection", () => {
       {
         kind: "army",
         entityId: 7,
-        previous: expect.objectContaining({ hexCoords: { col: 20, row: 21 } }),
+        previous: expect.objectContaining({ hexCoords: { alt: false, col: 20, row: 21 } }),
       },
     ]);
   });
@@ -430,9 +485,9 @@ describe("WorldSpatialProjection", () => {
 
     writeArmy("army", { explorerId: 7, col: 200, row: 201 });
 
-    expect(projection.getArmiesInBounds({ minCol: 96, maxCol: 104, minRow: 96, maxRow: 104 })).toEqual([]);
-    expect(projection.getArmiesInBounds({ minCol: 196, maxCol: 204, minRow: 196, maxRow: 204 })).toEqual([
-      expect.objectContaining({ entityId: 7, hexCoords: { col: 200, row: 201 } }),
+    expect(projection.getArmiesInBounds({ alt: false, minCol: 96, maxCol: 104, minRow: 96, maxRow: 104 })).toEqual([]);
+    expect(projection.getArmiesInBounds({ alt: false, minCol: 196, maxCol: 204, minRow: 196, maxRow: 204 })).toEqual([
+      expect.objectContaining({ entityId: 7, hexCoords: { alt: false, col: 200, row: 201 } }),
     ]);
   });
 
@@ -444,7 +499,7 @@ describe("WorldSpatialProjection", () => {
     writeArmy("army", { explorerId: 8, col: 20, row: 21 });
 
     expect(projection.getArmy(7)).toBeUndefined();
-    expect(projection.getArmy(8)).toMatchObject({ entityId: 8, hexCoords: { col: 20, row: 21 } });
+    expect(projection.getArmy(8)).toMatchObject({ entityId: 8, hexCoords: { alt: false, col: 20, row: 21 } });
   });
 
   it("replaces a reserved construction site with its new hyperstructure immediately", () => {
@@ -466,12 +521,12 @@ describe("WorldSpatialProjection", () => {
       occupierType: TileOccupier.HyperstructureLevel1,
     });
 
-    expect(projection.getStructuresAtHex({ col: 12, row: 13 })).toEqual([
+    expect(projection.getStructuresAtHex({ alt: false, col: 12, row: 13 })).toEqual([
       expect.objectContaining({ spatialId: "entity:77", entityId: 77, reserved: false }),
     ]);
     projection.flush();
     expect(listener).toHaveBeenCalledWith([
-      expect.objectContaining({ spatialId: "reserved:12:13", current: undefined }),
+      expect.objectContaining({ spatialId: "reserved:0:12:13", current: undefined }),
       expect.objectContaining({ spatialId: "entity:77", previous: undefined }),
     ]);
   });
@@ -489,7 +544,7 @@ describe("WorldSpatialProjection", () => {
 
     expect(projection.getStructure(88)).toMatchObject({
       entityId: 88,
-      hexCoords: { col: 30, row: 31 },
+      hexCoords: { alt: false, col: 30, row: 31 },
       occupierType: TileOccupier.RealmRegularLevel1,
     });
   });
@@ -514,7 +569,7 @@ describe("WorldSpatialProjection", () => {
 
     expect(entitiesSpy).toHaveBeenCalledTimes(1);
     expect(projection.getStructure(7)).toMatchObject({
-      hexCoords: { col: 20, row: 21 },
+      hexCoords: { alt: false, col: 20, row: 21 },
       occupierType: TileOccupier.RealmWonderLevel2,
     });
   });
@@ -557,9 +612,9 @@ describe("WorldSpatialProjection", () => {
 
     expect(tileListener).toHaveBeenCalledOnce();
     expect(tileListener).toHaveBeenCalledWith([
-      expect.objectContaining({ spatialId: "tile:10:11" }),
-      expect.objectContaining({ spatialId: "tile:12:13" }),
-      expect.objectContaining({ spatialId: "tile:14:15" }),
+      expect.objectContaining({ spatialId: "tile:0:10:11" }),
+      expect.objectContaining({ spatialId: "tile:0:12:13" }),
+      expect.objectContaining({ spatialId: "tile:0:14:15" }),
     ]);
     expect(armyListener).toHaveBeenCalledOnce();
     expect(armyListener).toHaveBeenCalledWith([
@@ -570,9 +625,9 @@ describe("WorldSpatialProjection", () => {
     expect(structureListener).not.toHaveBeenCalled();
     expect(listener).toHaveBeenCalledOnce();
     expect(listener).toHaveBeenCalledWith([
-      expect.objectContaining({ kind: "tile", spatialId: "tile:10:11" }),
-      expect.objectContaining({ kind: "tile", spatialId: "tile:12:13" }),
-      expect.objectContaining({ kind: "tile", spatialId: "tile:14:15" }),
+      expect.objectContaining({ kind: "tile", spatialId: "tile:0:10:11" }),
+      expect.objectContaining({ kind: "tile", spatialId: "tile:0:12:13" }),
+      expect.objectContaining({ kind: "tile", spatialId: "tile:0:14:15" }),
       expect.objectContaining({ kind: "army", entityId: 7 }),
       expect.objectContaining({ kind: "army", entityId: 8 }),
     ]);
@@ -596,8 +651,8 @@ describe("WorldSpatialProjection", () => {
     projection.flush();
 
     expect(listener).not.toHaveBeenCalled();
-    expect(projection.getChests()).toEqual([]);
-    expect(projection.getArmies().map(({ entityId }) => entityId)).toEqual([9]);
+    expect(projection.getChests(false)).toEqual([]);
+    expect(projection.getArmies(false).map(({ entityId }) => entityId)).toEqual([9]);
   });
 
   it("publishes one net change for a row moved twice inside one slice", () => {
@@ -616,8 +671,8 @@ describe("WorldSpatialProjection", () => {
       {
         kind: "army",
         entityId: 7,
-        previous: expect.objectContaining({ hexCoords: { col: 10, row: 11 } }),
-        current: expect.objectContaining({ hexCoords: { col: 30, row: 31 } }),
+        previous: expect.objectContaining({ hexCoords: { alt: false, col: 10, row: 11 } }),
+        current: expect.objectContaining({ hexCoords: { alt: false, col: 30, row: 31 } }),
       },
     ]);
   });
@@ -630,11 +685,13 @@ describe("WorldSpatialProjection", () => {
     projection.subscribeArmies(listener);
 
     writeArmy("army", { explorerId: 7, col: 20, row: 21 });
-    expect(projection.getArmy(7)?.hexCoords).toEqual({ col: 20, row: 21 });
-    expect(projection.getArmiesAtHex({ col: 10, row: 11 })).toEqual([]);
+    expect(projection.getArmy(7)?.hexCoords).toEqual({ alt: false, col: 20, row: 21 });
+    expect(projection.getArmiesAtHex({ alt: false, col: 10, row: 11 })).toEqual([]);
     writeArmy("army", { explorerId: 7, col: 30, row: 31 });
     expect(
-      projection.getArmiesInBounds({ minCol: 24, maxCol: 32, minRow: 24, maxRow: 32 }).map(({ entityId }) => entityId),
+      projection
+        .getArmiesInBounds({ alt: false, minCol: 24, maxCol: 32, minRow: 24, maxRow: 32 })
+        .map(({ entityId }) => entityId),
     ).toEqual([7]);
     expect(listener).not.toHaveBeenCalled();
 
@@ -655,8 +712,14 @@ describe("WorldSpatialProjection", () => {
 
     expect(listener).toHaveBeenCalledOnce();
     expect(listener).toHaveBeenCalledWith([
-      expect.objectContaining({ entityId: 7, current: expect.objectContaining({ hexCoords: { col: 10, row: 11 } }) }),
-      expect.objectContaining({ entityId: 8, current: expect.objectContaining({ hexCoords: { col: 12, row: 13 } }) }),
+      expect.objectContaining({
+        entityId: 7,
+        current: expect.objectContaining({ hexCoords: { alt: false, col: 10, row: 11 } }),
+      }),
+      expect.objectContaining({
+        entityId: 8,
+        current: expect.objectContaining({ hexCoords: { alt: false, col: 12, row: 13 } }),
+      }),
     ]);
   });
 

--- a/packages/core/src/sync/world-spatial-projection.ts
+++ b/packages/core/src/sync/world-spatial-projection.ts
@@ -4,12 +4,15 @@ import { getComponentValue, type Component, type Metadata, type Schema } from "@
 import { isTileOccupierStructure } from "../utils/map/hex";
 import { tileOptToTile } from "../utils/tile-opt";
 
+/** A map hex on one layer: `alt` is false on the surface and true on the ethereal layer, as in TileOpt. */
 export interface WorldSpatialHex {
+  readonly alt: boolean;
   readonly col: number;
   readonly row: number;
 }
 
 export interface WorldSpatialBounds {
+  readonly alt: boolean;
   readonly minCol: number;
   readonly maxCol: number;
   readonly minRow: number;
@@ -18,7 +21,7 @@ export interface WorldSpatialBounds {
 
 export interface TileSpatialRenderable {
   readonly kind: "tile";
-  readonly spatialId: `tile:${number}:${number}`;
+  readonly spatialId: `tile:${0 | 1}:${number}:${number}`;
   /** Contract-space coordinates, matching TileOpt. */
   readonly hexCoords: WorldSpatialHex;
   readonly biome: number;
@@ -56,7 +59,7 @@ interface EntityStructureSpatialRenderable {
 
 interface ReservedHyperstructureSpatialRenderable {
   readonly kind: "structure";
-  readonly spatialId: `reserved:${number}:${number}`;
+  readonly spatialId: `reserved:${0 | 1}:${number}:${number}`;
   /** Reserved construction sites have no Structure entity until construction starts. */
   readonly entityId: null;
   readonly reserved: true;
@@ -94,6 +97,23 @@ export interface TileSpatialProjectionChange {
   readonly previous?: TileSpatialRenderable;
   readonly current?: TileSpatialRenderable;
 }
+
+/**
+ * Narrows a change list to one layer. A renderable that crossed layers (spire travel) becomes a
+ * removal on the layer it left and a creation on the layer it entered.
+ */
+export const projectionChangesForLayer = <
+  TChange extends { previous?: SpatialRenderable; current?: SpatialRenderable },
+>(
+  changes: readonly TChange[],
+  alt: boolean,
+): TChange[] =>
+  changes.flatMap((change) => {
+    const previous = change.previous?.hexCoords.alt === alt ? change.previous : undefined;
+    const current = change.current?.hexCoords.alt === alt ? change.current : undefined;
+    if (!previous && !current) return [];
+    return [{ ...change, previous, current }];
+  });
 
 export type WorldSpatialProjectionChange =
   | TileSpatialProjectionChange
@@ -139,25 +159,31 @@ interface SpatialIndexChange<TKey, TRenderable> {
 
 const DEFAULT_SPATIAL_BUCKET_SIZE = 32;
 
-const spatialHexKey = ({ col, row }: WorldSpatialHex): string => `${col}:${row}`;
+const layerIndex = (alt: boolean): 0 | 1 => (alt ? 1 : 0);
 
-const spatialBucketKey = ({ col, row }: WorldSpatialHex, bucketSize: number): string =>
-  `${Math.floor(col / bucketSize)}:${Math.floor(row / bucketSize)}`;
+const spatialHexKey = ({ alt, col, row }: WorldSpatialHex): string => `${layerIndex(alt)}:${col}:${row}`;
+
+const spatialBucketKey = (alt: boolean, bucketCol: number, bucketRow: number): string =>
+  `${layerIndex(alt)}:${bucketCol}:${bucketRow}`;
+
+const spatialBucketKeyOf = ({ alt, col, row }: WorldSpatialHex, bucketSize: number): string =>
+  spatialBucketKey(alt, Math.floor(col / bucketSize), Math.floor(row / bucketSize));
+
+const isSameHex = (left: WorldSpatialHex, right: WorldSpatialHex): boolean =>
+  left.alt === right.alt && left.col === right.col && left.row === right.row;
 
 const isSameChest = (left: ChestSpatialRenderable, right: ChestSpatialRenderable): boolean =>
-  left.hexCoords.col === right.hexCoords.col && left.hexCoords.row === right.hexCoords.row;
+  isSameHex(left.hexCoords, right.hexCoords);
 
 const isSameStructure = (left: StructureSpatialRenderable, right: StructureSpatialRenderable): boolean =>
   left.entityId === right.entityId &&
   left.occupierType === right.occupierType &&
-  left.hexCoords.col === right.hexCoords.col &&
-  left.hexCoords.row === right.hexCoords.row;
+  isSameHex(left.hexCoords, right.hexCoords);
 
 const isSameArmy = (left: ArmySpatialRenderable, right: ArmySpatialRenderable): boolean =>
   left.troopCategory === right.troopCategory &&
   left.troopTier === right.troopTier &&
-  left.hexCoords.col === right.hexCoords.col &&
-  left.hexCoords.row === right.hexCoords.row;
+  isSameHex(left.hexCoords, right.hexCoords);
 
 const isSameTile = (left: TileSpatialRenderable, right: TileSpatialRenderable): boolean =>
   left.biome === right.biome &&
@@ -170,12 +196,11 @@ const resolveTileRenderable = (tileOpt: TileOpt | undefined): TileSpatialRendera
   if (!tileOpt) return undefined;
 
   const tile = tileOptToTile(tileOpt);
-  if (tile.alt) return undefined;
 
   return Object.freeze({
     kind: "tile" as const,
-    spatialId: `tile:${tile.col}:${tile.row}` as const,
-    hexCoords: Object.freeze({ col: tile.col, row: tile.row }),
+    spatialId: `tile:${layerIndex(tile.alt)}:${tile.col}:${tile.row}` as const,
+    hexCoords: Object.freeze({ alt: tile.alt, col: tile.col, row: tile.row }),
     biome: tile.biome,
     occupierId: tile.occupier_id,
     occupierType: tile.occupier_type,
@@ -188,12 +213,12 @@ const resolveChestRenderable = (tileOpt: TileOpt | undefined): ChestSpatialRende
   if (!tileOpt) return undefined;
 
   const tile = tileOptToTile(tileOpt);
-  if (tile.alt || tile.occupier_type !== TileOccupier.Chest) return undefined;
+  if (tile.occupier_type !== TileOccupier.Chest) return undefined;
 
   return Object.freeze({
     kind: "chest" as const,
     entityId: tile.occupier_id,
-    hexCoords: Object.freeze({ col: tile.col, row: tile.row }),
+    hexCoords: Object.freeze({ alt: tile.alt, col: tile.col, row: tile.row }),
   });
 };
 
@@ -201,13 +226,13 @@ const resolveStructureRenderable = (tileOpt: TileOpt | undefined): StructureSpat
   if (!tileOpt) return undefined;
 
   const tile = tileOptToTile(tileOpt);
-  if (tile.alt || !isTileOccupierStructure(tile.occupier_type)) return undefined;
+  if (!isTileOccupierStructure(tile.occupier_type)) return undefined;
 
-  const hexCoords = Object.freeze({ col: tile.col, row: tile.row });
+  const hexCoords = Object.freeze({ alt: tile.alt, col: tile.col, row: tile.row });
   if (tile.occupier_type === TileOccupier.ReservedHyperstructure) {
     return Object.freeze({
       kind: "structure" as const,
-      spatialId: `reserved:${tile.col}:${tile.row}` as const,
+      spatialId: `reserved:${layerIndex(tile.alt)}:${tile.col}:${tile.row}` as const,
       entityId: null,
       reserved: true as const,
       hexCoords,
@@ -228,7 +253,7 @@ const resolveStructureRenderable = (tileOpt: TileOpt | undefined): StructureSpat
 const resolveArmyRenderable = (
   explorerTroops: ExplorerTroopsSpatialSource | undefined,
 ): ArmySpatialRenderable | undefined => {
-  if (!explorerTroops || explorerTroops.coord.alt || explorerTroops.troops.count <= 0n) return undefined;
+  if (!explorerTroops || explorerTroops.troops.count <= 0n) return undefined;
 
   const col = Number(explorerTroops.coord.x);
   const row = Number(explorerTroops.coord.y);
@@ -237,7 +262,7 @@ const resolveArmyRenderable = (
   return Object.freeze({
     kind: "army" as const,
     entityId: explorerTroops.explorer_id,
-    hexCoords: Object.freeze({ col, row }),
+    hexCoords: Object.freeze({ alt: explorerTroops.coord.alt, col, row }),
     troopCategory: explorerTroops.troops.category as TroopType,
     troopTier: explorerTroops.troops.tier as TroopTier,
   });
@@ -262,7 +287,7 @@ class SpatialIndex<TKey, TRenderable extends SpatialRenderable> {
     this.resolveChanges(nextByKey).forEach((change) => this.queueChange(change));
     this.byKey = nextByKey;
     this.keysByHex = this.buildIndex((renderable) => spatialHexKey(renderable.hexCoords));
-    this.keysByBucket = this.buildIndex((renderable) => spatialBucketKey(renderable.hexCoords, this.bucketSize));
+    this.keysByBucket = this.buildIndex((renderable) => spatialBucketKeyOf(renderable.hexCoords, this.bucketSize));
   }
 
   public update(key: TKey, current: TRenderable | undefined): void {
@@ -291,8 +316,8 @@ class SpatialIndex<TKey, TRenderable extends SpatialRenderable> {
     return this.byKey.get(key);
   }
 
-  public getAll(): readonly TRenderable[] {
-    return [...this.byKey.values()];
+  public getAll(alt: boolean): readonly TRenderable[] {
+    return [...this.byKey.values()].filter((renderable) => renderable.hexCoords.alt === alt);
   }
 
   public getAtHex(hexCoords: WorldSpatialHex): readonly TRenderable[] {
@@ -308,7 +333,9 @@ class SpatialIndex<TKey, TRenderable extends SpatialRenderable> {
 
     for (let bucketCol = startBucketCol; bucketCol <= endBucketCol; bucketCol += 1) {
       for (let bucketRow = startBucketRow; bucketRow <= endBucketRow; bucketRow += 1) {
-        this.keysByBucket.get(`${bucketCol}:${bucketRow}`)?.forEach((key) => candidates.add(key));
+        this.keysByBucket
+          .get(spatialBucketKey(bounds.alt, bucketCol, bucketRow))
+          ?.forEach((key) => candidates.add(key));
       }
     }
 
@@ -366,7 +393,7 @@ class SpatialIndex<TKey, TRenderable extends SpatialRenderable> {
 
   private addToSpatialIndexes(key: TKey, renderable: TRenderable): void {
     this.addToIndex(this.keysByHex, spatialHexKey(renderable.hexCoords), key);
-    this.addToIndex(this.keysByBucket, spatialBucketKey(renderable.hexCoords, this.bucketSize), key);
+    this.addToIndex(this.keysByBucket, spatialBucketKeyOf(renderable.hexCoords, this.bucketSize), key);
   }
 
   private addToIndex(index: Map<string, Set<TKey>>, spatialKey: string, key: TKey): void {
@@ -377,7 +404,7 @@ class SpatialIndex<TKey, TRenderable extends SpatialRenderable> {
 
   private removeFromSpatialIndexes(key: TKey, renderable: TRenderable): void {
     this.removeFromIndex(this.keysByHex, spatialHexKey(renderable.hexCoords), key);
-    this.removeFromIndex(this.keysByBucket, spatialBucketKey(renderable.hexCoords, this.bucketSize), key);
+    this.removeFromIndex(this.keysByBucket, spatialBucketKeyOf(renderable.hexCoords, this.bucketSize), key);
   }
 
   private removeFromIndex(index: Map<string, Set<TKey>>, spatialKey: string, key: TKey): void {
@@ -668,8 +695,8 @@ export class WorldSpatialProjection {
     return this.chestIndex.get(entityId);
   }
 
-  public getTiles(): readonly TileSpatialRenderable[] {
-    return this.tileIndex.getAll();
+  public getTiles(alt: boolean): readonly TileSpatialRenderable[] {
+    return this.tileIndex.getAll(alt);
   }
 
   public getTileAtHex(hexCoords: WorldSpatialHex): TileSpatialRenderable | undefined {
@@ -680,8 +707,8 @@ export class WorldSpatialProjection {
     return this.tileIndex.getInBounds(bounds);
   }
 
-  public getChests(): readonly ChestSpatialRenderable[] {
-    return this.chestIndex.getAll();
+  public getChests(alt: boolean): readonly ChestSpatialRenderable[] {
+    return this.chestIndex.getAll(alt);
   }
 
   public getChestsAtHex(hexCoords: WorldSpatialHex): readonly ChestSpatialRenderable[] {
@@ -697,8 +724,8 @@ export class WorldSpatialProjection {
     return structure && !structure.reserved ? structure : undefined;
   }
 
-  public getStructures(): readonly StructureSpatialRenderable[] {
-    return this.structureIndex.getAll();
+  public getStructures(alt: boolean): readonly StructureSpatialRenderable[] {
+    return this.structureIndex.getAll(alt);
   }
 
   public getStructuresAtHex(hexCoords: WorldSpatialHex): readonly StructureSpatialRenderable[] {
@@ -713,8 +740,8 @@ export class WorldSpatialProjection {
     return this.armyIndex.get(entityId);
   }
 
-  public getArmies(): readonly ArmySpatialRenderable[] {
-    return this.armyIndex.getAll();
+  public getArmies(alt: boolean): readonly ArmySpatialRenderable[] {
+    return this.armyIndex.getAll(alt);
   }
 
   public getArmiesAtHex(hexCoords: WorldSpatialHex): readonly ArmySpatialRenderable[] {


### PR DESCRIPTION
Ethereal layer slice, frontend item 1.

The world spatial projection dropped every ethereal-layer tile, chest, structure and army before anything could render them, and its tests asserted the drop. After spire travel an army vanished from the map while it stayed in every list.

Every renderable now carries its layer in its hex coordinates and spatial id, the hex and bucket keys include the layer, and queries take the layer they want. A cross-layer move publishes as a removal on one layer and a creation on the other through `projectionChangesForLayer`. The client reads one layer: a `mapLayer` field on the UI store, surface by default, read by three.js code through `activeMapLayer` and by hooks through the store. Nothing toggles it yet; the layer view is the next item. Exploration automation still reads the surface explicitly until movement becomes layer-aware (item 4). Story-event lookups read both layers so a travelled army stays resolvable.

Gate from the plan: with a spire on the map, the projection reports it on both layers and an army that has travelled on the ethereal one. Covered by two new core tests.

Verification: core suite 181 tests, full client suite 717 files / 3482 tests, client typecheck, formatting, knip. No rendering change on the surface.