### PR TITLE
fix(client): Madara Eternum config in the factory and the Eternum landing card

### DIFF
--- a/apps/game/index.html
+++ b/apps/game/index.html
@@ -25,6 +25,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Realms: Blitz</title>

--- a/apps/game/src/ui/features/landing/views/play-view.tsx
+++ b/apps/game/src/ui/features/landing/views/play-view.tsx
@@ -30,7 +30,7 @@ import {
 import { startGameEntryTimeline, markGameEntryMilestone } from "@/ui/layouts/game-entry-timeline";
 import { useLocation, useNavigate } from "react-router-dom";
 import { UnifiedGameGrid, type WorldSelection } from "../components/game-selector/game-card-grid";
-import { getWorldById } from "@/runtime/world/world-directory";
+import { getGameEnvironmentsForChain } from "@config";
 import { GameReviewModal } from "../components/game-review-modal";
 import type { LandingModeFilter, LandingEntryRouteState } from "../lib/landing-entry-state";
 import { setGameReviewDismissed } from "../lib/game-review-storage";
@@ -512,10 +512,12 @@ const ModeCoexistenceHero = ({
     setBackgroundId(bgMap[modeFilter]);
   }, [modeFilter, setBackgroundId]);
 
-  // Eternum seasons open in phase 3: the hero only offers modes whose world
-  // is actually deployed in the Herald-backed world directory.
+  // One world hosts both formats; the hero offers Eternum when the build chain has an Eternum environment.
+  const hasEternumEnvironment = getGameEnvironmentsForChain(env.VITE_PUBLIC_CHAIN).some(
+    (environment) => environment.gameType === "eternum",
+  );
   const availableModes = (Object.keys(MODE_VISUALS) as Array<LandingModeFilter>).filter(
-    (mode) => mode !== "season" || getWorldById("eternum") != null,
+    (mode) => mode !== "season" || hasEternumEnvironment,
   );
 
   return (

--- a/config/utils/utils.ts
+++ b/config/utils/utils.ts
@@ -11,6 +11,7 @@ export type { GameType };
 import blitzAppchainConfig from "../generated/blitz.appchain.json";
 import blitzMadaraConfig from "../generated/blitz.madara.json";
 import eternumAppchainConfig from "../generated/eternum.appchain.json";
+import eternumMadaraConfig from "../generated/eternum.madara.json";
 
 type NetworkConfigDocument = {
   configuration: any;
@@ -22,6 +23,7 @@ const configs: Record<GameType, Partial<Record<GameChain, NetworkConfigDocument>
     appchain: blitzAppchainConfig,
   },
   eternum: {
+    madara: eternumMadaraConfig,
     appchain: eternumAppchainConfig,
   },
 };


### PR DESCRIPTION
Two production fixes from the play.realms.party console.

**Boot crash "Invalid chain: madara".** The config resolver only knew the Eternum sheet for appchain, while the factory now offers Eternum on Madara, so opening the factory crashed the boot boundary. The generated Madara Eternum configuration is registered next to the Blitz one.

**Eternum card missing on the landing page.** The hero looked for a separate "eternum" world in the directory. One Madara world hosts both formats, so the card now follows the build chain's environment list, the same source the factory catalog uses.

Also declares the standard `mobile-web-app-capable` meta tag next to the Apple one, which Chrome flags as deprecated on its own.

Verification: landing and factory tests (36 files), client typecheck, formatting, knip.