### PR TITLE
feat(client): switch map layers from the header and explain spire crossings

### DIFF
--- a/apps/game/src/hooks/store/use-ui-store.ts
+++ b/apps/game/src/hooks/store/use-ui-store.ts
@@ -58,6 +58,7 @@ interface UIStore {
   setShowBlankOverlay: (show: boolean) => void;
   /** The map layer the scene shows: false is the surface, true the ethereal layer, as in TileOpt.alt. */
   mapLayer: boolean;
+  setMapLayer: (alt: boolean) => void;
   isSideMenuOpened: boolean;
   toggleSideMenu: () => void;
   isSoundOn: boolean;
@@ -197,6 +198,7 @@ export const useUIStore = create(
       set({ showBlankOverlay: show });
     },
     mapLayer: false,
+    setMapLayer: (alt) => set({ mapLayer: alt }),
     isSideMenuOpened: true,
     toggleSideMenu: () => set((state) => ({ isSideMenuOpened: !state.isSideMenuOpened })),
     isSoundOn: readLocalBool("soundEnabled", true),

--- a/apps/game/src/three/scenes/worldmap.tsx
+++ b/apps/game/src/three/scenes/worldmap.tsx
@@ -2895,7 +2895,10 @@ export default class WorldmapScene extends WarpTravel {
     this.openTargetActionSurface(targetHex, {
       id: "spire-travel",
       content: (
-        <SpireTravelModal onTravelThroughSpire={() => this.onArmyMovement(account, actionPath, selectedEntityId)} />
+        <SpireTravelModal
+          explorerId={selectedEntityId}
+          onTravelThroughSpire={() => this.onArmyMovement(account, actionPath, selectedEntityId)}
+        />
       ),
     });
   }

--- a/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
+++ b/apps/game/src/ui/features/world/components/actions/selected-worldmap-entity.tsx
@@ -33,7 +33,7 @@ import {
   isTileOccupierReservedHyperstructure,
   isTileOccupierStructure,
 } from "@bibliothecadao/eternum";
-import { useDojo, useQuery } from "@bibliothecadao/react";
+import { useDojo } from "@bibliothecadao/react";
 import { type ReactNode, useCallback, useMemo } from "react";
 import { toast } from "@/ui/features/event-feed/notify";
 
@@ -71,7 +71,6 @@ const SelectedWorldmapEntityContent = ({
   coordsLabel?: string;
   headerAction?: ReactNode;
 }) => {
-  const { handleUrlChange } = useQuery();
   const openSurface = usePopoverStore((state) => state.openSurface);
 
   const tile = useTileAt(selectedHex.col, selectedHex.row);
@@ -92,12 +91,9 @@ const SelectedWorldmapEntityContent = ({
   const isChest = isTileOccupierChest(occupierType);
   const isQuest = isTileOccupierQuest(occupierType);
   const isExplored = !!tile && Number(tile.biome) !== 0;
-  const normalizedSelectedHex = useMemo(() => {
-    return new Position({ x: selectedHex.col, y: selectedHex.row }).getNormalized();
-  }, [selectedHex.col, selectedHex.row]);
-  const handleTravelToEtherealLayer = useCallback(() => {
-    handleUrlChange(`/play/travel?col=${normalizedSelectedHex.x}&row=${normalizedSelectedHex.y}`);
-  }, [handleUrlChange, normalizedSelectedHex.x, normalizedSelectedHex.y]);
+  const mapLayer = useUIStore((state) => state.mapLayer);
+  const setMapLayer = useUIStore((state) => state.setMapLayer);
+  const lookAtOtherLayer = useCallback(() => setMapLayer(!mapLayer), [mapLayer, setMapLayer]);
 
   if (!tile || !isExplored) {
     return null;
@@ -148,7 +144,7 @@ const SelectedWorldmapEntityContent = ({
       {isSpire ? (
         <div className={occupiedEntityLayoutClass}>
           <TileChrome title={coordsLabel ?? "Spire tile"} headerAction={headerAction}>
-            <SpireTravelPanel onTravelToEtherealLayer={handleTravelToEtherealLayer} />
+            <SpireTravelPanel mapLayer={mapLayer} onLookAtOtherLayer={lookAtOtherLayer} />
           </TileChrome>
           <BiomeSummaryCard biome={biome} showSimulateAction onSimulateBattle={handleSimulateBattle} />
         </div>
@@ -360,13 +356,15 @@ const ReservedHyperstructurePanel = ({ selectedHex }: { selectedHex: HexPosition
   );
 };
 
-const SpireTravelPanel = ({ onTravelToEtherealLayer }: { onTravelToEtherealLayer: () => void }) => (
+const SpireTravelPanel = ({ mapLayer, onLookAtOtherLayer }: { mapLayer: boolean; onLookAtOtherLayer: () => void }) => (
   <div className="flex flex-col gap-2">
-    <p className={HUD_HEADLINE}>Ethereal Layer Gateway</p>
-    <p className={HUD_BODY}>Enter the Ethereal Layer here to fast-travel.</p>
+    <p className={HUD_HEADLINE}>Spire</p>
+    <p className={HUD_BODY}>
+      This spire stands on both layers. An army next to it crosses to the same hex on the other side.
+    </p>
     <div>
-      <button type="button" className={HUD_PILL_BUTTON} onClick={onTravelToEtherealLayer}>
-        Travel to Ethereal Layer
+      <button type="button" className={HUD_PILL_BUTTON} onClick={onLookAtOtherLayer}>
+        {mapLayer ? "Look at the surface" : "Look at the ethereal layer"}
       </button>
     </div>
   </div>

--- a/apps/game/src/ui/features/world/components/actions/spire-crossing.test.ts
+++ b/apps/game/src/ui/features/world/components/actions/spire-crossing.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveSpireCrossing } from "./spire-crossing";
+
+describe("resolveSpireCrossing", () => {
+  it("lets a surface army cross when its hex on the ethereal layer is free", () => {
+    expect(resolveSpireCrossing(false, { occupier_id: 0, occupier_is_structure: false })).toEqual({
+      kind: "clear",
+      toEthereal: true,
+    });
+    expect(resolveSpireCrossing(false, undefined)).toEqual({ kind: "clear", toEthereal: true });
+  });
+
+  it("names what blocks the hex on the other side", () => {
+    expect(resolveSpireCrossing(true, { occupier_id: 9, occupier_is_structure: false })).toEqual({
+      kind: "blocked",
+      toEthereal: false,
+      by: "army",
+    });
+    expect(resolveSpireCrossing(false, { occupier_id: 4n, occupier_is_structure: true })).toEqual({
+      kind: "blocked",
+      toEthereal: true,
+      by: "structure",
+    });
+  });
+});

--- a/apps/game/src/ui/features/world/components/actions/spire-crossing.ts
+++ b/apps/game/src/ui/features/world/components/actions/spire-crossing.ts
@@ -1,0 +1,21 @@
+/**
+ * The contract moves an army through a spire to its own hex on the other layer, and only if that hex is free.
+ * Mirrors `alt_movement_systems::toggle_alternate` so the modal can say why a crossing will not go through.
+ */
+interface SpireCrossingTile {
+  occupier_id: number | bigint;
+  occupier_is_structure: boolean;
+}
+
+type SpireCrossing =
+  | { kind: "clear"; toEthereal: boolean }
+  | { kind: "blocked"; toEthereal: boolean; by: "army" | "structure" };
+
+export const resolveSpireCrossing = (
+  explorerLayer: boolean,
+  destination: SpireCrossingTile | undefined,
+): SpireCrossing => {
+  const toEthereal = !explorerLayer;
+  if (!destination || Number(destination.occupier_id) === 0) return { kind: "clear", toEthereal };
+  return { kind: "blocked", toEthereal, by: destination.occupier_is_structure ? "structure" : "army" };
+};

--- a/apps/game/src/ui/features/world/components/actions/spire-travel-modal.tsx
+++ b/apps/game/src/ui/features/world/components/actions/spire-travel-modal.tsx
@@ -1,42 +1,77 @@
 import { usePopoverStore } from "@/hooks/store/use-popover-store";
-import { SurfaceFrame } from "@/ui/design-system/molecules/popover";
+import { gameEntityKey } from "@/sync/game-scope";
 import Button from "@/ui/design-system/atoms/button";
-import Sparkles from "lucide-react/dist/esm/icons/sparkles";
+import { SurfaceFrame } from "@/ui/design-system/molecules/popover";
+import { getTileAt } from "@bibliothecadao/eternum";
+import { useDojo } from "@bibliothecadao/react";
+import type { ID } from "@bibliothecadao/types";
+import { getComponentValue } from "@dojoengine/recs";
 import ArrowRightLeft from "lucide-react/dist/esm/icons/arrow-right-left";
+import ShieldAlert from "lucide-react/dist/esm/icons/shield-alert";
+import Sparkles from "lucide-react/dist/esm/icons/sparkles";
+import { resolveSpireCrossing } from "./spire-crossing";
 
-export const SpireTravelModal = ({ onTravelThroughSpire }: { onTravelThroughSpire: () => void }) => {
+export const SpireTravelModal = ({
+  explorerId,
+  onTravelThroughSpire,
+}: {
+  explorerId: ID;
+  onTravelThroughSpire: () => void;
+}) => {
+  const {
+    setup: { components },
+  } = useDojo();
   const closeSurface = usePopoverStore((state) => state.closeSurface);
-
-  const closeModal = () => {
-    closeSurface();
-  };
+  const explorer = getComponentValue(components.ExplorerTroops, gameEntityKey([BigInt(explorerId)]));
+  const explorerLayer = explorer?.coord.alt ?? false;
+  const destination = explorer
+    ? getTileAt(components, !explorerLayer, Number(explorer.coord.x), Number(explorer.coord.y))
+    : undefined;
+  const crossing = resolveSpireCrossing(explorerLayer, destination);
+  const sideName = crossing.toEthereal ? "the Ethereal Layer" : "the surface";
 
   const handleTravel = () => {
-    closeModal();
+    closeSurface();
     onTravelThroughSpire();
   };
 
   return (
-    <SurfaceFrame title="Spire Gate" icon={Sparkles} onClose={closeModal} className="w-[560px]" bodyClassName="p-5">
+    <SurfaceFrame title="Spire" icon={Sparkles} onClose={closeSurface} className="w-[560px]" bodyClassName="p-5">
       <div className="flex flex-col gap-4 text-gold/90">
-        <div className="flex items-start gap-3 rounded border border-cyan-300/25 bg-cyan-500/10 p-3">
-          <Sparkles className="mt-0.5 h-4 w-4 text-cyan-200" />
-          <div className="flex flex-col gap-1">
-            <p className="text-sm font-semibold text-cyan-100">No ethereal defenders detected</p>
-            <p className="text-xs text-gold/70">
-              This Spire is clear. Move through it to enter the Ethereal Layer from this coordinate.
-            </p>
+        {crossing.kind === "clear" ? (
+          <div className="flex items-start gap-3 rounded border border-cyan-300/25 bg-cyan-500/10 p-3">
+            <Sparkles className="mt-0.5 h-4 w-4 text-cyan-200" />
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-semibold text-cyan-100">Your hex on {sideName} is clear</p>
+              <p className="text-xs text-gold/70">
+                The army crosses to the same hex on {sideName}. It keeps its position and its stamina.
+              </p>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex items-start gap-3 rounded border border-red-400/30 bg-red-500/10 p-3">
+            <ShieldAlert className="mt-0.5 h-4 w-4 text-red-200" />
+            <div className="flex flex-col gap-1">
+              <p className="text-sm font-semibold text-red-100">
+                {crossing.by === "army" ? "An army holds your hex on " : "A structure holds your hex on "}
+                {sideName}
+              </p>
+              <p className="text-xs text-gold/70">
+                A crossing needs that hex free. Move one hex along the spire and try again, or clear it first.
+              </p>
+            </div>
+          </div>
+        )}
         <Button
           size="md"
           forceUppercase={false}
-          className="w-full border-cyan-300/50 bg-cyan-400/15 text-cyan-100 hover:bg-cyan-400/25"
+          disabled={crossing.kind !== "clear"}
+          className="w-full border-cyan-300/50 bg-cyan-400/15 text-cyan-100 hover:bg-cyan-400/25 disabled:opacity-50"
           onClick={handleTravel}
         >
           <span className="inline-flex items-center gap-2">
             <ArrowRightLeft className="h-4 w-4" />
-            Travel Through Spire
+            {crossing.toEthereal ? "Enter the Ethereal Layer" : "Return to the surface"}
           </span>
         </Button>
       </div>

--- a/apps/game/src/ui/features/world/containers/top-header/top-header.tsx
+++ b/apps/game/src/ui/features/world/containers/top-header/top-header.tsx
@@ -14,10 +14,12 @@ import { GameClock } from "./game-clock";
 import { AttentionPill } from "./attention-pill";
 import { IdentityChip } from "./identity-chip";
 import { TOP_PILL } from "./top-pill";
-import { useDojo, useQuery } from "@bibliothecadao/react";
+import { useDojo } from "@bibliothecadao/react";
 import { ContractAddress } from "@bibliothecadao/types";
 import { useComponentValue } from "@dojoengine/react";
 import EyeIcon from "lucide-react/dist/esm/icons/eye";
+import Mountain from "lucide-react/dist/esm/icons/mountain";
+import Sparkles from "lucide-react/dist/esm/icons/sparkles";
 import Swords from "lucide-react/dist/esm/icons/swords";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { gameEntityKey } from "@/sync/game-scope";
@@ -27,8 +29,6 @@ export const TopHeader = memo(() => {
     setup,
     account: { account },
   } = useDojo();
-
-  const { handleUrlChange } = useQuery();
 
   const playClick = useUISound("ui.click");
 
@@ -59,9 +59,11 @@ export const TopHeader = memo(() => {
   );
 
   const goToStructure = useGoToStructure(setup);
-  const showFastTravelLayerToggle = mode.id === "eternum";
-  const isFastTravelView = currentPathname.includes("/travel");
   const isLocalView = currentPathname.includes("/hex");
+  const mapLayer = useUIStore((state) => state.mapLayer);
+  const setMapLayer = useUIStore((state) => state.setMapLayer);
+  // Blitz presets have no spires, so their maps have one layer.
+  const showLayerSwitch = mode.id === "eternum" && !isLocalView;
 
   useEffect(() => {
     const updatePathname = () => {
@@ -78,31 +80,14 @@ export const TopHeader = memo(() => {
     };
   }, []);
 
-  const navigateToFastTravelLayer = useCallback(() => {
-    playClick();
-
-    if (isFastTravelView) {
-      goToStructure(
-        lastControlledStructureEntityId || structureEntityId,
-        new Position({ x: selectedStructurePosition.x, y: selectedStructurePosition.y }),
-        true,
-      );
-      return;
-    }
-
-    const col = selectedStructurePosition.x;
-    const row = selectedStructurePosition.y;
-    handleUrlChange(`/play/travel?col=${col}&row=${row}`);
-  }, [
-    goToStructure,
-    handleUrlChange,
-    isFastTravelView,
-    lastControlledStructureEntityId,
-    playClick,
-    selectedStructurePosition.x,
-    selectedStructurePosition.y,
-    structureEntityId,
-  ]);
+  const switchLayer = useCallback(
+    (alt: boolean) => {
+      if (alt === mapLayer) return;
+      playClick();
+      setMapLayer(alt);
+    },
+    [mapLayer, playClick, setMapLayer],
+  );
 
   const navigateToView = useCallback(
     (world: boolean) => {
@@ -127,10 +112,10 @@ export const TopHeader = memo(() => {
         viewControls={
           <MapViewControls
             isLocalView={isLocalView}
-            isFastTravelView={isFastTravelView}
-            showFastTravel={showFastTravelLayerToggle}
+            mapLayer={mapLayer}
+            showLayerSwitch={showLayerSwitch}
             onNavigate={navigateToView}
-            onFastTravel={navigateToFastTravelLayer}
+            onLayerChange={switchLayer}
           />
         }
       />
@@ -156,50 +141,70 @@ TopHeader.displayName = "TopHeader";
 
 function MapViewControls({
   isLocalView,
-  isFastTravelView,
-  showFastTravel,
+  mapLayer,
+  showLayerSwitch,
   onNavigate,
-  onFastTravel,
+  onLayerChange,
 }: {
   isLocalView: boolean;
-  isFastTravelView: boolean;
-  showFastTravel: boolean;
+  mapLayer: boolean;
+  showLayerSwitch: boolean;
   onNavigate: (world: boolean) => void;
-  onFastTravel: () => void;
+  onLayerChange: (alt: boolean) => void;
 }) {
-  const viewButton = (active: boolean) =>
+  const pillButton = (active: boolean) =>
     cn(
       HUD_LABEL_BRIGHT,
       "min-h-11 min-w-11 rounded-md px-3 font-sans transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-gold lg:min-h-7",
       active ? "bg-gold/20 text-gold" : "text-gold/65",
     );
+  const layerButton = (active: boolean) =>
+    cn(
+      HUD_LABEL_BRIGHT,
+      "inline-flex min-h-11 min-w-11 items-center gap-1.5 rounded-md px-3 font-sans transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-gold lg:min-h-7",
+      active ? "bg-cyan-400/15 text-cyan-100" : "text-gold/65",
+    );
   return (
-    <div role="group" aria-label="Map view" className={cn(TOP_PILL, "gap-0.5 px-1 max-lg:h-auto")}>
-      <button
-        type="button"
-        aria-pressed={isLocalView}
-        onClick={() => onNavigate(false)}
-        className={viewButton(isLocalView)}
-      >
-        Local
-      </button>
-      <button
-        type="button"
-        aria-pressed={!isLocalView && !isFastTravelView}
-        onClick={() => onNavigate(true)}
-        className={viewButton(!isLocalView && !isFastTravelView)}
-      >
-        World
-      </button>
-      {showFastTravel && (
+    <div className="flex items-center gap-2">
+      <div role="group" aria-label="Map view" className={cn(TOP_PILL, "gap-0.5 px-1 max-lg:h-auto")}>
         <button
           type="button"
-          aria-pressed={isFastTravelView}
-          onClick={onFastTravel}
-          className={viewButton(isFastTravelView)}
+          aria-pressed={isLocalView}
+          onClick={() => onNavigate(false)}
+          className={pillButton(isLocalView)}
         >
-          Ethereal
+          Local
         </button>
+        <button
+          type="button"
+          aria-pressed={!isLocalView}
+          onClick={() => onNavigate(true)}
+          className={pillButton(!isLocalView)}
+        >
+          World
+        </button>
+      </div>
+      {showLayerSwitch && (
+        <div role="group" aria-label="Map layer" className={cn(TOP_PILL, "gap-0.5 px-1 max-lg:h-auto")}>
+          <button
+            type="button"
+            aria-pressed={!mapLayer}
+            onClick={() => onLayerChange(false)}
+            className={layerButton(!mapLayer)}
+          >
+            <Mountain className="h-3.5 w-3.5" aria-hidden />
+            Surface
+          </button>
+          <button
+            type="button"
+            aria-pressed={mapLayer}
+            onClick={() => onLayerChange(true)}
+            className={layerButton(mapLayer)}
+          >
+            <Sparkles className="h-3.5 w-3.5" aria-hidden />
+            Ethereal
+          </button>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Ethereal layer slice, client UI. Stacked on #4960, which adds the store's `mapLayer` field this reads and writes.

**Header.** The Ethereal button that opened the fixture scene is gone. A Surface/Ethereal pill sits next to Local/World, in Eternum world view only, and writes the UI store's map layer. Blitz presets have no spires, so Blitz never shows it.

**Spire tile panel.** Says what a spire does and lets the player look at the other side of it from where they stand.

**Spire travel modal.** Reads the army's own hex on the other layer, which is the contract's destination, and says whether an army or a structure blocks it before the player commits; the button reads Enter the Ethereal Layer or Return to the surface. The rule is one pure function with its test. The scene passes the army id.

Not in this PR, by the owner's split: the scene's response to a layer change, the ethereal terrain material, the spire and mine models, and the deletion of the fast-travel scene itself. Until the scene reacts to the store, the pill switches what the projection queries and the minimap, not the terrain.

Verification: full client suite, typecheck, formatting, knip.