### PR TITLE
HUD: tooltips above desks, no phantom production timers, larger token badges, two-row resource strip

### DIFF
--- a/apps/game/src/ui/design-system/molecules/tooltip.tsx
+++ b/apps/game/src/ui/design-system/molecules/tooltip.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import { useTooltipStore } from "@/hooks/store/use-tooltip-store";
 import { isCoarsePointer } from "@/utils/pointer";
 import clsx from "clsx";
@@ -229,28 +230,28 @@ const HoverTooltip = ({ className }: TooltipProps) => {
 
   const hiddenTransform = useMemo(() => getHiddenTransform(placement), [placement]);
 
-  return (
-    <>
-      {tooltip && tooltip.content && (
-        <div
-          id="tooltip-root"
-          ref={ref}
-          data-placement={placement}
-          role="tooltip"
-          aria-hidden={!isVisible}
-          style={{
-            ...style,
-            opacity: isVisible ? 1 : 0,
-            transform: isVisible ? "translate3d(0, 0, 0)" : hiddenTransform,
-          }}
-          className={clsx(
-            "fixed z-[250] pointer-events-none select-none inline-flex border border-gold/30 text-xs px-4 py-2 bg-[#15100a] flex-col justify-start items-center text-gold transition-all duration-150 ease-out",
-            className,
-          )}
-        >
-          {tooltip.content}
-        </div>
+  if (!tooltip || !tooltip.content) return null;
+
+  // Desks and popovers portal to the body above the HUD tree; the tooltip must live there too or it renders behind them.
+  return createPortal(
+    <div
+      id="tooltip-root"
+      ref={ref}
+      data-placement={placement}
+      role="tooltip"
+      aria-hidden={!isVisible}
+      style={{
+        ...style,
+        opacity: isVisible ? 1 : 0,
+        transform: isVisible ? "translate3d(0, 0, 0)" : hiddenTransform,
+      }}
+      className={clsx(
+        "fixed z-[250] pointer-events-none select-none inline-flex border border-gold/30 text-xs px-4 py-2 bg-[#15100a] flex-col justify-start items-center text-gold transition-all duration-150 ease-out",
+        className,
       )}
-    </>
+    >
+      {tooltip.content}
+    </div>,
+    document.body,
   );
 };

--- a/apps/game/src/ui/features/world/containers/left-facets/merged-resource-panel.tsx
+++ b/apps/game/src/ui/features/world/containers/left-facets/merged-resource-panel.tsx
@@ -286,7 +286,10 @@ export const MergedResourcePanel = memo(
           />
         )}
         {tokens.length > 0 && (
-          <div className="flex max-w-full flex-wrap justify-start gap-x-4 gap-y-4 px-2 pt-1.5">{tokens}</div>
+          // Two token rows stay visible; more scroll inside. The inner padding keeps rings and badges off the clip edge.
+          <div className="max-h-[152px] overflow-y-auto overscroll-contain">
+            <div className="flex max-w-full flex-wrap justify-start gap-x-4 gap-y-5 px-3 pb-2 pt-2.5">{tokens}</div>
+          </div>
         )}
       </div>
     );

--- a/apps/game/src/ui/shared/components/production-status-badge.tsx
+++ b/apps/game/src/ui/shared/components/production-status-badge.tsx
@@ -197,7 +197,7 @@ export const ProductionStatusBadge: FC<ProductionStatusBadgeProps> = ({
         <ResourceIcon resource={resourceLabel} size={preset.icon} tooltipText={tooltipText} withTooltip={showTooltip} />
       </div>
       {cornerTopLeft && (
-        <span className="absolute -top-1 -left-1 z-10 flex min-w-[14px] items-center justify-center rounded-full bg-black/80 px-1 text-[8px] font-semibold text-gold/90 shadow-md border border-gold/40">
+        <span className="absolute -top-1.5 -left-1.5 z-10 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-black/85 px-1.5 text-[10px] font-semibold text-gold/90 shadow-md border border-gold/40">
           {cornerTopLeft}
         </span>
       )}
@@ -211,7 +211,7 @@ export const ProductionStatusBadge: FC<ProductionStatusBadgeProps> = ({
       {cornerTopRight && (
         <span
           className={clsx(
-            "absolute -top-1 -right-1 z-10 flex min-w-[18px] items-center justify-center rounded-full bg-black/80 px-1 text-[8px] font-semibold shadow-md border border-gold/40",
+            "absolute -top-1.5 -right-1.5 z-10 flex h-5 min-w-[24px] items-center justify-center rounded-full bg-black/85 px-1.5 text-[10px] font-semibold shadow-md border border-gold/40",
             cornerTopRightClassName ?? "text-gold/90",
           )}
         >
@@ -219,12 +219,12 @@ export const ProductionStatusBadge: FC<ProductionStatusBadgeProps> = ({
         </span>
       )}
       {cornerBottomRight && (
-        <span className="absolute -bottom-1 -right-1 z-10 flex min-w-[18px] items-center justify-center rounded-full bg-black/80 px-1 text-[8px] font-semibold text-gold/80 shadow-md border border-gold/30">
+        <span className="absolute -bottom-1.5 -right-1.5 z-10 flex h-5 min-w-[24px] items-center justify-center rounded-full bg-black/85 px-1.5 text-[10px] font-semibold text-gold/80 shadow-md border border-gold/30">
           {cornerBottomRight}
         </span>
       )}
       {!cornerTopLeft && !cornerTopRight && !cornerBottomRight && totalCount > 0 && (
-        <span className="absolute -top-1 -right-1 z-10 flex h-4 w-4 items-center justify-center rounded-full bg-gold text-[9px] font-semibold text-[#2a1f14] shadow-md">
+        <span className="absolute -top-1.5 -right-1.5 z-10 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-gold px-1 text-[10px] font-semibold text-[#2a1f14] shadow-md">
           {totalCount}
         </span>
       )}

--- a/packages/core/src/managers/resource-manager.production-data.test.ts
+++ b/packages/core/src/managers/resource-manager.production-data.test.ts
@@ -1,0 +1,24 @@
+import { ResourcesIds } from "@bibliothecadao/types";
+import { describe, expect, it } from "vitest";
+import { ResourceManager } from "./resource-manager";
+
+const RATE = 1_000_000n; // one unit per tick at resource precision
+
+const productionInfo = (outputAmountLeft: bigint) => ({
+  balance: 0n,
+  production: { building_count: 2, production_rate: RATE, output_amount_left: outputAmountLeft, last_updated_at: 100 },
+});
+
+describe("ResourceManager.calculateResourceProductionData", () => {
+  it("reports no time remaining for continuous production, however little output is banked", () => {
+    const data = ResourceManager.calculateResourceProductionData(ResourcesIds.Wheat, productionInfo(RATE), 100);
+    expect(data.isProducing).toBe(true);
+    expect(data.timeRemainingSeconds).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("keeps the banked-output countdown for input-fed production", () => {
+    const data = ResourceManager.calculateResourceProductionData(ResourcesIds.Wood, productionInfo(RATE * 60n), 100);
+    expect(data.isProducing).toBe(true);
+    expect(data.timeRemainingSeconds).toBe(60);
+  });
+});

--- a/packages/core/src/managers/resource-manager.ts
+++ b/packages/core/src/managers/resource-manager.ts
@@ -735,7 +735,12 @@ export class ResourceManager {
       (isContinuousProductionResource || remainingOutput > 0n);
 
     const outputRemainingNumber = Number(remainingOutput) / RESOURCE_PRECISION;
-    const timeRemainingSeconds = productionPerSecond > 0 ? outputRemainingNumber / productionPerSecond : 0;
+    // Continuous production never runs out, so it has no time remaining; a finite value here is one tick of noise.
+    const timeRemainingSeconds = isContinuousProductionResource
+      ? Number.POSITIVE_INFINITY
+      : productionPerSecond > 0
+        ? outputRemainingNumber / productionPerSecond
+        : 0;
 
     return {
       productionPerSecond,


### PR DESCRIPTION
Eternum playtest polish, three commits.

**Tooltips rendered behind desks.** The tooltip lived inside the HUD root, a fixed stacking context at z-0, while desks portal to the body at z-130, so the build card costs and the realm upgrade requirements opened behind the Build desk. The tooltip now portals to the body like the desks do. Existing tooltip tests pass unchanged.

**"1s" on every token and a pulsing ring that overflowed the panel.** Wheat, fish and research never run out, but their banked output is one tick's worth, so the production countdown read one second everywhere, the two-minute depletion pulse fired on every tick, and its ring spilled past the panel edge. Continuous production now reports an infinite time remaining in core, which the summary already maps to no timer, no pulse and a full ring. Input-fed production keeps its countdown; a core test covers both. Automation itself was never per tick: it runs every 60 seconds.

**Badges and strip.** Corner badges on resource tokens grow to a readable size. The token grid shows two rows and scrolls inside the panel beyond that, with inner padding so rings and badges stay off the clip edge.

Verification: full client suite (717 files), core suite plus the new test, client and core typecheck, formatting, knip.