### PR TITLE
fix(client): keep the mobile details sheet closed on tile selection

### DIFF
--- a/apps/game/src/ui/features/world/containers/compact-hud.test.tsx
+++ b/apps/game/src/ui/features/world/containers/compact-hud.test.tsx
@@ -168,12 +168,20 @@ it("opens the chat window from the Chat tab and lifts the shell above other surf
   expect(tab("Chat")?.getAttribute("aria-expanded")).toBe("false");
 });
 
-it("auto-opens Details on a new selection and keeps its navigation target when selection clears", async () => {
+it("keeps the sheet closed on a new selection so the map stays free for the next tap", async () => {
   await act(async () => store.setState({ selectedHex: { col: 4, row: 7 } }));
-  expect(tabLabels()).toContain("Details");
-  expect(sheetContent()).toBe("Map tile");
-  await tap("Map");
+  expect(sheet()).toBeNull();
   await act(async () => store.setState({ selectedHex: { col: 5, row: 7 } }));
+  expect(sheet()).toBeNull();
+  await tap("Details");
+  expect(sheetContent()).toBe("Map tile");
+});
+
+it("keeps an open sheet on its tab as the selection changes or clears", async () => {
+  await tap("Map");
+  await act(async () => store.setState({ selectedHex: { col: 4, row: 7 } }));
+  expect(tab("Map")?.getAttribute("aria-expanded")).toBe("true");
+  await tap("Details");
   expect(sheetContent()).toBe("Map tile");
   await act(async () => store.setState({ selectedHex: null }));
   expect(tabLabels()).toContain("Details");
@@ -185,6 +193,7 @@ it("follows the selected building in local view", async () => {
   await act(async () =>
     store.setState({ selectedBuildingHex: { outerCol: 1, outerRow: 1, innerCol: 2, innerRow: 3 } }),
   );
+  await tap("Details");
   expect(sheetContent()).toBe("Local tile");
 });
 

--- a/apps/game/src/ui/features/world/containers/compact-hud.tsx
+++ b/apps/game/src/ui/features/world/containers/compact-hud.tsx
@@ -85,7 +85,7 @@ export const CompactHud = memo(({ lane }: { lane: CompactLane }) => {
   const showBlankOverlay = useUIStore((state) => state.showBlankOverlay);
   const ordersAllowed = useUIStore(canIssueOrders);
   const { isMapView, selectionKey } = useTileSelection();
-  const { open, navigation, toggle, close, closeAndFocusTab, setChatOpen } = useCompactPanels(selectionKey);
+  const { open, navigation, toggle, close, closeAndFocusTab, setChatOpen } = useCompactPanels();
   const { rows, pinned } = useImportantFeed();
   const unread = useUnreadFeedCount(rows, open === "log");
   const chatUnread = useRealtimeChatSelector((state) => state.unreadWorldTotal + state.unreadDirectTotal);
@@ -253,7 +253,8 @@ const EmpireColumn = () => {
 
 /**
  * Tile details follow the same rule as the desktop `BottomRightPanel`: the selected hex in map view, the selected
- * building hex in local view. The key is null with no selection and changes with every new one.
+ * building hex in local view. The key is null with no selection. Selecting a tile never opens the sheet on its own:
+ * on a phone the sheet covers the map, and the next tap or hold is usually the order for the unit just selected.
  */
 const useTileSelection = () => {
   const { isMapView } = useQuery();
@@ -271,19 +272,7 @@ const useTileSelection = () => {
   return { isMapView, selectionKey: selectionKey ?? null };
 };
 
-const useOpenDetailsOnNewSelection = (
-  selectionKey: string | null,
-  canOpen: boolean,
-  open: (tab: CompactTab) => void,
-) => {
-  const lastSelection = useRef(selectionKey);
-  useEffect(() => {
-    if (canOpen && selectionKey !== null && selectionKey !== lastSelection.current) open("details");
-    lastSelection.current = selectionKey;
-  }, [canOpen, open, selectionKey]);
-};
-
-function useCompactPanels(selectionKey: string | null) {
+function useCompactPanels() {
   const [requested, setRequested] = useState<CompactTab | null>(null);
   const openPopoverId = usePopoverStore((state) => state.openId);
   const hasWorkspace = useUIStore(
@@ -294,7 +283,6 @@ function useCompactPanels(selectionKey: string | null) {
   const hasActionSurface = openPopoverId !== null || hasWorkspace;
   const open = hasActionSurface ? null : requested;
   const navigation = useRef<HTMLElement>(null);
-  useOpenDetailsOnNewSelection(selectionKey, !hasActionSurface, setRequested);
 
   const toggle = useCallback((tab: CompactTab) => {
     dismissActionSurfaces();

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -34,6 +34,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 // are surfaced in the What's New popup.
 const allLatestFeatures: LatestFeature[] = [
   {
+    date: "2026-09-12",
+    title: "Mobile Selection Keeps the Map Clear",
+    description:
+      "Selecting an army or structure on a phone no longer opens the details sheet over the map. Tap the next hex or hold to move straight away, and open the Details tab when you want the full view.",
+    type: "improvement",
+  },
+  {
     date: "2026-09-11",
     title: "Eternum Factory and Entry",
     description:


### PR DESCRIPTION
On phones, selecting an army or structure forced the compact HUD's Details sheet open over the map, so the next tap or hold landed on the sheet instead of the target hex and players had to close it before every move. This removes the auto-open hook: selection no longer opens the sheet in portrait or landscape, and the Details tab still shows the current selection when tapped. An already-open sheet stays on its tab as the selection changes or clears.

Tests in `compact-hud.test.tsx` were rewritten to assert the new behavior, and a What's New entry was added. Verified with the compact HUD test file (17 passing), `pnpm run format`, and `pnpm run knip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)