### PR TITLE
chore(world): renumber the Madara presets for the fresh world

### DIFF
--- a/apps/game/src/ui/features/factory-v2/catalog.test.ts
+++ b/apps/game/src/ui/features/factory-v2/catalog.test.ts
@@ -62,7 +62,7 @@ describe("factory launch defaults", () => {
 
     expect(request).toMatchObject({
       environment: "madara.blitz",
-      version: "8",
+      version: "2",
       devModeOn: false,
       durationSeconds: 3600,
     });

--- a/apps/game/src/ui/features/factory-v2/catalog.ts
+++ b/apps/game/src/ui/features/factory-v2/catalog.ts
@@ -41,7 +41,7 @@ const factoryLaunchPresets: FactoryLaunchPreset[] = [
     name: "Standard world",
     description: "The usual Eternum launch.",
     defaults: {
-      version: "12",
+      version: "1",
       startRule: "next_hour",
       devMode: false,
       twoPlayerMode: false,
@@ -63,7 +63,7 @@ const factoryLaunchPresets: FactoryLaunchPreset[] = [
       devMode: false,
       twoPlayerMode: false,
       singleRealmMode: false,
-      version: "8",
+      version: "2",
     },
   },
   {
@@ -77,7 +77,7 @@ const factoryLaunchPresets: FactoryLaunchPreset[] = [
       devMode: false,
       twoPlayerMode: true,
       singleRealmMode: false,
-      version: "9",
+      version: "3",
     },
   },
   {
@@ -91,7 +91,7 @@ const factoryLaunchPresets: FactoryLaunchPreset[] = [
       devMode: true,
       twoPlayerMode: false,
       singleRealmMode: false,
-      version: "8",
+      version: "2",
     },
   },
 ];

--- a/apps/game/src/ui/features/factory-v2/map-options.test.ts
+++ b/apps/game/src/ui/features/factory-v2/map-options.test.ts
@@ -206,7 +206,7 @@ describe("Factory V2 map options", () => {
           devMode: false,
           twoPlayerMode: false,
           singleRealmMode: false,
-          version: "8",
+          version: "2",
         },
       },
       devModeOn: false,

--- a/apps/launch-service/src/app.test.ts
+++ b/apps/launch-service/src/app.test.ts
@@ -109,7 +109,7 @@ describe("launch service authorization", () => {
     expect((await app.request(invalid)).status).toBe(400);
   });
 
-  test("launches a Duel on preset 9 and stores version:9", async () => {
+  test("launches a Duel on preset 3 and stores version:3", async () => {
     const { app, store } = createApp(identity(ALLOWED_ADDRESS));
     const request = launchRequest();
     request.headers.set("content-type", "application/json");
@@ -117,7 +117,7 @@ describe("launch service authorization", () => {
       body: JSON.stringify({
         environment: "madara.blitz",
         gameName: "bltz-duel-game",
-        version: "9",
+        version: "3",
         twoPlayerMode: true,
         devModeOn: false,
       }),
@@ -125,7 +125,7 @@ describe("launch service authorization", () => {
 
     expect((await app.request(duel)).status).toBe(202);
     const run = await store.find("game", "madara.blitz", "bltz-duel-game");
-    expect(run?.request.version).toBe("9");
+    expect(run?.request.version).toBe("3");
   });
 
   test("launches a real game dev-off and stores devModeOn:false", async () => {

--- a/apps/launch-service/src/schemas.test.ts
+++ b/apps/launch-service/src/schemas.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { applyDurableLaunchDefaults, type CreateGameRequest } from "./schemas";
 
-const gameRequest = (devModeOn?: boolean, version?: "8" | "9"): CreateGameRequest => ({
+const gameRequest = (devModeOn?: boolean, version?: "2" | "3"): CreateGameRequest => ({
   environment: "madara.blitz",
   gameName: "bltz-test",
   ...(devModeOn === undefined ? {} : { devModeOn }),
@@ -19,18 +19,18 @@ describe("applyDurableLaunchDefaults", () => {
 
   it("defaults an absent version to 8 and stamps a default game start time", () => {
     const result = applyDurableLaunchDefaults("game", gameRequest(false), 0);
-    expect(result.version).toBe("8");
+    expect(result.version).toBe("2");
     expect("gameStartTime" in result && result.gameStartTime).toBeTruthy();
   });
 
   it("keeps a Duel launch version 9 instead of forcing the default", () => {
-    expect(applyDurableLaunchDefaults("game", gameRequest(false, "9")).version).toBe("9");
+    expect(applyDurableLaunchDefaults("game", gameRequest(false, "3")).version).toBe("3");
   });
 });
 
 it("selects the Eternum preset and rejects cross-mode presets", () => {
   const request: CreateGameRequest = { environment: "madara.eternum", gameName: "eternum-test", devModeOn: false };
-  expect(applyDurableLaunchDefaults("game", request).version).toBe("11");
-  expect(() => applyDurableLaunchDefaults("game", { ...request, version: "8" })).toThrow();
-  expect(() => applyDurableLaunchDefaults("game", { ...gameRequest(), version: "11" })).toThrow();
+  expect(applyDurableLaunchDefaults("game", request).version).toBe("1");
+  expect(() => applyDurableLaunchDefaults("game", { ...request, version: "2" })).toThrow();
+  expect(() => applyDurableLaunchDefaults("game", { ...gameRequest(), version: "1" })).toThrow();
 });

--- a/apps/launch-service/src/schemas.ts
+++ b/apps/launch-service/src/schemas.ts
@@ -7,8 +7,8 @@ const OptionalNumberRecord = Schema.optional(Schema.Record(Schema.String, Schema
 
 const SharedOptions = {
   environment: Schema.Literals(["madara.blitz", "madara.eternum"]),
-  // Registrar presets: 8 = Regular Fast, 9 = Duel, 10 = Eternum.
-  version: Schema.optional(Schema.Literals(["8", "9", "11"])),
+  // Registrar presets: 1 = Eternum, 2 = Regular Fast, 3 = Duel.
+  version: Schema.optional(Schema.Literals(["1", "2", "3"])),
   devModeOn: Schema.optional(Schema.Boolean),
   twoPlayerMode: Schema.optional(Schema.Boolean),
   singleRealmMode: Schema.optional(Schema.Boolean),
@@ -66,7 +66,7 @@ export const CreateRotationRequestSchema = Schema.Struct({
 
 interface SharedLaunchOptions {
   environment: "madara.blitz" | "madara.eternum";
-  version?: "8" | "9" | "11";
+  version?: "1" | "2" | "3";
   devModeOn?: boolean;
   twoPlayerMode?: boolean;
   singleRealmMode?: boolean;
@@ -120,7 +120,7 @@ export const applyDurableLaunchDefaults = (
   request: LaunchJobRequest,
   now = Date.now(),
 ): LaunchJobRequest => {
-  const version = request.version ?? (defaultPresetForEnvironment(request.environment) as "8" | "11");
+  const version = request.version ?? (defaultPresetForEnvironment(request.environment) as "1" | "2");
   if ((request.environment === "madara.eternum") !== (version === DEFAULT_ETERNUM_PRESET_ID)) {
     throw new Error("Preset does not match the requested game format");
   }

--- a/config/deployer/clean/constants.ts
+++ b/config/deployer/clean/constants.ts
@@ -2,12 +2,12 @@ import { DEFAULT_FACTORY_CONFIG_VERSION } from "../../shared/factory-defaults";
 import type { DeploymentEnvironment, DeploymentEnvironmentId } from "./types";
 
 export const DEFAULT_VERSION = DEFAULT_FACTORY_CONFIG_VERSION;
-// Madara preset 8 = Regular Fast (official-60), 9 = Duel (official-90),
-// registered 2026-09-03 from the standard-patched sheet. Retired immutable
-// presets: 2/3 local dev balance, 4/5 registered WITHOUT balance profiles,
-// 6/7 baked the base sheet's 24-tick spawn immunity — never offered again.
-export const DEFAULT_MADARA_PRESET_ID = "8";
-export const DEFAULT_ETERNUM_PRESET_ID = "12";
+// Madara world presets, registered on the fresh world of 2026-09-12:
+// 1 = Eternum, 2 = Blitz Regular Fast (official-60), 3 = Blitz Duel (official-90).
+// Dev mode and duration are per game at creation, so the Blitz sandbox is preset 2 with dev mode on.
+// Presets are immutable per world; a new balance is a new id on the next world.
+export const DEFAULT_MADARA_PRESET_ID = "2";
+export const DEFAULT_ETERNUM_PRESET_ID = "1";
 export const DEFAULT_APPCHAIN_GAME_INDEX_TIMEOUT_MS = 2 * 60 * 1_000;
 export const DEFAULT_APPCHAIN_GAME_INDEX_POLL_MS = 2_000;
 export const BLITZ_REGISTRATION_COUNT_CAP = 96;

--- a/config/deployer/clean/launch-configs/madara-blitz-daily.yaml
+++ b/config/deployer/clean/launch-configs/madara-blitz-daily.yaml
@@ -14,7 +14,7 @@ autoRetryEnabled: true
 autoRetryIntervalMinutes: 15
 durationSeconds: 3600
 devModeOn: false
-version: "8"
+version: "2"
 
 weeklyCadence:
   - { weekday: monday, utcTime: "11:00" }

--- a/contracts/l3/game/dojo_madara.toml
+++ b/contracts/l3/game/dojo_madara.toml
@@ -16,9 +16,9 @@ account_address = "0x055be462e718c4166d656d11f89e341115b8bc82389c3762a10eade04fc
 private_key = "0x077e56c6dc32d40a67f6f7e6625c8dc5e570abe49c0a24e9202e4ae906abcc07"
 
 [world]
-seed = "s2_blitz_madara_lab_1"
-name = "Realms: Blitz (Madara lab)"
-description = "Fast competitive Realms games"
+seed = "realms_madara_lab_2"
+name = "Realms (Madara lab)"
+description = "Blitz and Eternum games on the Madara lab chain"
 cover_uri = "file://assets/bg.webp"
 website = "https://alpha-eternum.realms.world/"
 


### PR DESCRIPTION
The fresh world of 12 September starts its presets at one: **1 Eternum, 2 Blitz Regular Fast, 3 Blitz Duel**. Dev mode and duration are game creation parameters, not preset fields, so the Blitz sandbox stays preset 2 launched with dev mode on rather than a fourth preset.

Changes: deployer default ids and comment, launch-service accepted versions and the format-to-preset guard, factory catalog versions, the daily rotation config, and the world seed (`realms_madara_lab_2`) so the native deployer creates a new world instead of upgrading the old one. The old world and its games are abandoned by the owner's decision.

Verification: launch-service tests and typecheck, factory catalog and map-option tests, client typecheck, deployer preset and environment tests, formatting, knip.

Cutover follows the merge: deploy the world with the native deployer, bootstrap the chain config, register presets 1, 2 and 3, reset Herald and the launch database, commit the manifest, redeploy the box services and the client.