### PR TITLE
fix(lab): register the Blitz default preset with the Regular Fast profile

### DIFF
--- a/deploy/madara-lab/scripts/deploy-s2-world.ts
+++ b/deploy/madara-lab/scripts/deploy-s2-world.ts
@@ -109,10 +109,14 @@ async function deployS2World(): Promise<void> {
     playerRegistryAddress: requiredEnvironmentAddress("PLAYER_REGISTRY_ADDRESS"),
     dryRun,
   });
+  // The stored sheet is the raw base balance; the Blitz default preset is Regular Fast, which is the
+  // 60-minute official profile applied at registration. Registering without it would ship base balance
+  // under the Regular Fast label, and presets are immutable per world.
   await registerEnvironmentPreset({
     presetId: Number(DEFAULT_MADARA_PRESET_ID),
     environmentId,
     rpcUrl,
+    balanceProfile: environmentId === "madara.blitz" ? "official-60" : undefined,
     sponsored: false,
     dryRun,
   });


### PR DESCRIPTION
The bootstrap script registered the default Blitz preset from the raw base sheet, without the 60-minute official balance profile that the launch service and factory label as Regular Fast. On a fresh world that preset is immutable, so the first game would have shipped base balance under the wrong name, the same defect the deployer's own comment records for preset 4 of the old world.

One line: pass `balanceProfile: "official-60"` for the Blitz environment.

Verification: deployer preset tests. The fresh-world cutover in progress is the live check; the bootstrap step waits for this merge.