### PR TITLE
chore(world): manifest for the fresh Madara world

### DIFF
--- a/contracts/l3/game/manifest_madara.json
+++ b/contracts/l3/game/manifest_madara.json
@@ -1,9 +1,9 @@
 {
   "world": {
+    "address": "0x2cb65776729bc6d74ccda27050937b3ae841df03c0cd1d581ea2c3189f70b12",
     "class_hash": "0x613551abceb2b37073b1149bb862ea70cf029981ce1ca47e9dd7c7ab97cb65d",
-    "address": "0x750018eb068d53531b07a5a61a2cfc9ae5b7c2965e605b8e7cb5e1063fb242b",
-    "seed": "s2_blitz_madara_lab_1",
-    "name": "Realms: Blitz (Madara lab)",
+    "seed": "realms_madara_lab_2",
+    "name": "Realms (Madara lab)",
     "entrypoints": [
       "uuid",
       "set_metadata",
@@ -1485,64 +1485,64 @@
   },
   "contracts": [
     {
-      "address": "0x3c3f98015d9d973ef0d3a1628e19ad01fb63b36d5bbbe1ccb40c152f01a08dc",
-      "class_hash": "0x544952dba4283ce79477790f43b28282807272703f25a3b560f635dabedeffd",
-      "init_calldata": [],
+      "class_hash": "0x17ab6b35c1c76ae57d1a89a4a7985004edbca0b9f15bc643ef18f15d8269c02",
       "tag": "s2-agent_discovery_systems",
       "selector": "0x7c2671ec6cf1263363a6c9bacd12a59bc15615a469f7d58d8a9096dea069a2d",
+      "address": "0x1baa88cdbb8e100f73f46cf8c29e41a1d40e5a8a30cf3aace525bfc9567d222",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x1239757ce96d0a5d15ef6d422ccd563e0839acfb49eaf9885f217abd65fa6d9",
-      "class_hash": "0x30eb57c4026f062dc862feb2b45adeab0699e14e9a6dbb402a48cff7cb2038",
-      "init_calldata": [],
+      "class_hash": "0x49eead5af62dffc40198a33f11b68bae2fb5d62eccbcc86d110c44ac268bded",
       "tag": "s2-alt_movement_systems",
       "selector": "0x7a0748f310a218b245cf8225f1c22391cff786962c85b0c0f959d4cf5042837",
+      "address": "0x80398b01de2a8e6b065640c8f055eaf3a197efccef8e0b86513392cd464ad9",
+      "init_calldata": [],
       "systems": [
         "toggle_alternate",
         "upgrade"
       ]
     },
     {
-      "address": "0x444fbe6881e97f83efa728fb3751ebbf5715f5b007d3c9ca9320131702e13ad",
-      "class_hash": "0x5f78b0730eef7e724f421c2bc36665da8762e7f3fd622553ac806f618ab0952",
-      "init_calldata": [],
+      "class_hash": "0x71b484f5f9da0fd31c8ccbe3525010bbf48e7f2476d95a763c35f9e06b55fa9",
       "tag": "s2-artificer_systems",
       "selector": "0x1c84002a713c32809fb1ed3b3646b263f8e643208fb1fe7645ed316e810536d",
+      "address": "0x11f3b18234c5daeb33600395825b7d765c65520b4fd8f1530fd76561c79a7ad",
+      "init_calldata": [],
       "systems": [
         "burn_research_for_relic",
         "upgrade"
       ]
     },
     {
-      "address": "0x507ea088e667a4b9f613c3d4b40e6fbe596f0c96c9f43cb1c321cc4d79d8303",
-      "class_hash": "0x552090f1c3ca91f629d7109bca830cbe2084a2f78eb00feff398cc8cb5d4e62",
-      "init_calldata": [],
+      "class_hash": "0x18bcb89d7a0dbf35dd33544af6056b0e0862ae570e72b016ec3506737762a71",
       "tag": "s2-bank_systems",
       "selector": "0x73e968dc553c4888fe990f7f2d677c813c7d46438b982b770d0ebfc4c5ba9e1",
+      "address": "0x73ba506b41b05ee70f54a38d0ff4023ffd672c9baf75337f00067c7aaf07a9a",
+      "init_calldata": [],
       "systems": [
         "create_banks",
         "upgrade"
       ]
     },
     {
-      "address": "0x5233bf3a77e2eaeb45941904fdf7d6ab37f563686667e018c889e983f4944d",
-      "class_hash": "0x6aad60eb4add272e5c9909d8b5ba2f4bf60b6bc6ce9a92d11448f244f7ea71a",
-      "init_calldata": [],
+      "class_hash": "0x3ee40b8b31070e7cc99034be6f3441dc72749ee049fc5272c07185547ee3b",
       "tag": "s2-bitcoin_mine_discovery_systems",
       "selector": "0x5014b4bbd6db146a2f69180267047b2033c1cc0a5b0f4c831da0bddba0531b1",
+      "address": "0x7adc85557e7754749ce3b7f79f2e83c9560482ee8aece24e5b3b60b495b80d6",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x4c55473994f031bd77593855e9e076fbce214a3ef4422a115cd828043e688f2",
-      "class_hash": "0x7a4bc3d4de2e3e6d1855b98ace958f31fdbe22da24acfa7b3c0bcd43ff5d33b",
-      "init_calldata": [],
+      "class_hash": "0x4783956b5a36297cf849565e7203ecc49a68a1b4c20906e2b51f5473059d08",
       "tag": "s2-bitcoin_mine_systems",
       "selector": "0x6b644b5ad75bac2dbcf4fc9ca9eb167bfc4986eff173d67ecf19f56046bbdf4",
+      "address": "0x372b2abf0e91538aad339b18c52654864d68a5949889fa90d85353c8feb59cc",
+      "init_calldata": [],
       "systems": [
         "contribute_labor",
         "claim_phase_reward",
@@ -1550,11 +1550,11 @@
       ]
     },
     {
-      "address": "0x24a29eca64b5968c56ea4109fc22ee791a9f9f5df641550724a95dadf1d44ce",
-      "class_hash": "0x60aadb5e32fa308157a356734014e153e904b830d7882458a9648fb8b040fc4",
-      "init_calldata": [],
+      "class_hash": "0xe4b1fff752f73a534ea395dd7296a9ba9bb6a24baf6a668c8203ed92faffbd",
       "tag": "s2-blitz_realm_systems",
       "selector": "0x2f457be35501fb088476ae8ad493f012f5b4bb4060d8a639a9b8fb45e6b8c3",
+      "address": "0x6ea531574ea6703162dc69a369c100a6ac35cc502dcc869cf9573447e156e57",
+      "init_calldata": [],
       "systems": [
         "settle",
         "provision_realm",
@@ -1562,43 +1562,43 @@
       ]
     },
     {
-      "address": "0x72390320f19ba24c0caf4bfbaac75b318682cd7ad0f46b715c2d0095af96745",
-      "class_hash": "0x575db9b1ecdd8096e18e94b0a457686c2c289aadfab26e5245846b83626077d",
-      "init_calldata": [],
+      "class_hash": "0x9608dfc534cc7788c2ed7202a1f040b3a7a9bbf0619b1d90d9adf375964afa",
       "tag": "s2-camp_discovery_systems",
       "selector": "0x4989e0a399f095799c92aea5fdf2cd57a9b13dbf358db7697a6485b1c039b6f",
+      "address": "0x45b282e2741b862c3d05276aad6e11e6635f2a84a2e5c47e6dabd3d99b234ab",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x73f631fbdcc1ceed0c9345f6bfa301687203315941e286139cb4edde9741bb6",
       "class_hash": "0x3eddab80f0e23f30705c27834908a851d68ebdd760f63cd414e63d08674280f",
-      "init_calldata": [],
       "tag": "s2-dev_resource_systems",
       "selector": "0x2fc2b48de3465e4be3f170c76fa28b81e85dfb130b16cab706753095f67950c",
+      "address": "0x77e1c1799570fabceee24cec3be53175e7747613099a3bfdd31ee696707ee34",
+      "init_calldata": [],
       "systems": [
         "mint",
         "upgrade"
       ]
     },
     {
-      "address": "0x745cd95c8a13f577fafed0422f765db09f3e87a4ee63bd4534282c22207e6e5",
       "class_hash": "0x39b7173aaac6389a8be54a91777c1557e4bd032d61d89a2c53d02f2b5749f2",
-      "init_calldata": [],
       "tag": "s2-entry_systems",
       "selector": "0x3ccb11ff6de17405c6c24b774784bd9662fef9666046f88a83ba400487b9c75",
+      "address": "0x91e0675f161cee50c72252d9865651590aded314856fd7ee2578ab63ced548",
+      "init_calldata": [],
       "systems": [
         "register_from_l2",
         "upgrade"
       ]
     },
     {
-      "address": "0x60ea0760babfeada75390c32a462dd2eef72deebd264413129fea329b792a7f",
-      "class_hash": "0x48648cef205438687258dc930eb941ff272306205ef1f8ef1a4d1ceb94398fb",
-      "init_calldata": [],
+      "class_hash": "0x139cc8d4479495ccb409da5ce1f8844182673e85a36554e4b0289c084034bbe",
       "tag": "s2-faith_prize_systems",
       "selector": "0x54e38ca25a11d71812b250fad1fef534ba27a8ed5f8063d53e31eb5b8ef2e14",
+      "address": "0x6496d4662339210255f7d3adb4261d480613212f14236129608641dc1c01af0",
+      "init_calldata": [],
       "systems": [
         "fund_prizes",
         "distribute_wonder_prizes",
@@ -1607,11 +1607,11 @@
       ]
     },
     {
-      "address": "0x5d28a9e5627d953344bcaa6d3d12c53977719add6c6a96cae528a24d6ae518",
-      "class_hash": "0x6a3466762b969be69eed99093dec48e818e4caef5b98187c25b8f30722df053",
-      "init_calldata": [],
+      "class_hash": "0x46416d677b73770ba3fd12237e1f51a1976db99a5d2a9cefe53e62255db632d",
       "tag": "s2-faith_systems",
       "selector": "0x5e232d2f0244cd5f3e181cf9d2107ec4395e638a8ee135e0e8cacc99d5d1322",
+      "address": "0x4a2ac07a5d1d294fe68b1e185f50e16365f1cfeea864ea3545fea980409f203",
+      "init_calldata": [],
       "systems": [
         "pledge_faith",
         "remove_faith",
@@ -1625,11 +1625,11 @@
       ]
     },
     {
-      "address": "0x20c78041e32a364908928457c30feea98929c4515648bff42dc8ac4cfdf7c42",
-      "class_hash": "0x7a2a38ca28247da6f9bbaba8b507b5a827810b6a6a0fad5b6bc8f52f39fb5c2",
-      "init_calldata": [],
+      "class_hash": "0x1f6948ef907ed230b0e634bea4a1a3174785454adc6d1e2a2d733e486df8ae0",
       "tag": "s2-guild_systems",
       "selector": "0x5ece639575c025f471d361a3088773e18bcd3cb514b4f68f2d055ec58cd4277",
+      "address": "0x31b157337cd9d833882e5ad546e9492ecc98216bd218a94046568772acd143",
+      "init_calldata": [],
       "systems": [
         "create_guild",
         "join_guild",
@@ -1640,21 +1640,11 @@
       ]
     },
     {
-      "address": "0x2c1b587588f3aaf0d6309661d34ec6e0e4bc7c9cc087a7f21a19cfc1e5047d3",
-      "class_hash": "0xc32f46dfdaedc6d4be613b73bcfe25c55d586cdaf397c60061391db166db9",
-      "init_calldata": [],
-      "tag": "s2-holysite_discovery_systems",
-      "selector": "0x7f86430688d179157aba39a0cea06dbb9d1499f7cfe948a1d55bd225cf5041f",
-      "systems": [
-        "upgrade"
-      ]
-    },
-    {
-      "address": "0x4fdc10f11826ae91b807f819f7f6327e38aa31092fdcd243cbb5a8236530888",
-      "class_hash": "0xa2c2ae8eeaa00e7615703a7379a743dbb027c2be5bf66981548ff659b43762",
-      "init_calldata": [],
+      "class_hash": "0x50414536b5657ff54ed1bd4e6043453ac4f83bd21338f584b67653c248efa99",
       "tag": "s2-hyperstructure_create_systems",
       "selector": "0x1696302d09890ddce3c1ea176cdd45c8d53934cbbfc493fd3c8a42496c34b82",
+      "address": "0x171719972adabca316601800af06f0d529f5c52fbcf323cce95dbd48306e70f",
+      "init_calldata": [],
       "systems": [
         "reserve_hyperstructures",
         "create_hyperstructure",
@@ -1662,21 +1652,21 @@
       ]
     },
     {
-      "address": "0x4b01b93cce6b5dbfd5f881374fd0012f8250c8daa60cb33b6112a5a0b26b87e",
-      "class_hash": "0xea5603297074537650e99a1ba14b0f52ecc2818d631e243e5c0eab7df90e74",
-      "init_calldata": [],
+      "class_hash": "0x4041c536ddfa25a09fe259a100ea655f9b9b0bbab4cc59e36eb70f31e3a837b",
       "tag": "s2-hyperstructure_discovery_systems",
       "selector": "0x1e7eb38cc340c53be39c039e55684b33e2a70ac89e8e4e46dc9cc9956be62b5",
+      "address": "0x56fd757f080ab81dd46f0d006649137b394d781ed7c412dcd74392fb7bc229d",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x39f94d1972ae1b783e1fc2f05ab3926cc0d1c7479e56b792f0da73f40263ef",
-      "class_hash": "0x672b7f36a04fd57bf5f722a6e41ea78d28bbe26b0bc794985c181419c233efb",
-      "init_calldata": [],
+      "class_hash": "0x5b4c90f7bc62d776931f449ccfbf828dec7d2165581edc1c6dbba333063bba",
       "tag": "s2-hyperstructure_systems",
       "selector": "0x6712ea3e6f0bb1ab77a969cc5c99866e1697139eb93b61fd182bceeb7413c6a",
+      "address": "0x25a6f6e6770cfa9dfdf554bb75e9b5797e1828609456afc8c4baa49d8283202",
+      "init_calldata": [],
       "systems": [
         "initialize",
         "contribute",
@@ -1686,11 +1676,11 @@
       ]
     },
     {
-      "address": "0x68722061887bda3931d9bd5480cbb51793f0aa1fecb81015cbe5d43758f15a1",
-      "class_hash": "0x636fdb3d1a1a0fe45efe8cd3d593ca16244f350bdfe91e0325596581183b835",
-      "init_calldata": [],
+      "class_hash": "0x1dba681d60ec3180c4eb89cf72bc93f21ecb3f014f50d2ba5ee211ad8588980",
       "tag": "s2-liquidity_systems",
       "selector": "0x2561a5f7a8d40bf75a6abf17ff561ded28a54414703220dbd7274161e8695e4",
+      "address": "0x4af3a530e60b70a4ec3323e71b58b9257bb2bdc6b735fd30fad268897db3837",
+      "init_calldata": [],
       "systems": [
         "add",
         "remove",
@@ -1698,32 +1688,32 @@
       ]
     },
     {
-      "address": "0x6b0765220a83062e4595b01ceb7130721b2888c8e32fb560d2b52d94387bd8a",
-      "class_hash": "0x16877f04ce1d8ec9a23ac33675bf1769b2db3d40d9c1541de7333f169f87c09",
-      "init_calldata": [],
+      "class_hash": "0x5bb7d80f5c2c009155e4672aaa37e0d3ac2040a71c5e5d5aa089ee9851da442",
       "tag": "s2-mine_discovery_systems",
       "selector": "0x52778c1c10bde296c8a455f4a75cc32672ab3e75f23ebb0db1d06d8c1cdca2f",
+      "address": "0x1c2ec8b343a05c2240b267497e152d04fdcc18ea2cdade97a9f15a3391db761",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x838241125d05667370406690c0aee6dd4bf01be761b8feca7754a042a88227",
       "class_hash": "0x66ba608aac980fd44d0c48fe52775e258abd3b7ffc9d49a7c63ca6660664133",
-      "init_calldata": [],
       "tag": "s2-name_systems",
       "selector": "0x49e6037e830e4f298ebb9680e1f9495fc0c66326c983d0b407b33c60375c29e",
+      "address": "0x414422a7f013e671c8109d4926d3c9ce9b41ca18c647dc13a31cd6a1bd17198",
+      "init_calldata": [],
       "systems": [
         "set_address_name",
         "upgrade"
       ]
     },
     {
-      "address": "0x1aaf02ca786539f4500176b518f138723cf71ea437add371ff648fc45601624",
-      "class_hash": "0x1018f3006b96e6ffd84f8ed01f76bd8f8a366290abf8dc005f90928bc681229",
-      "init_calldata": [],
+      "class_hash": "0x68d296eb35e8984ee1e8b44d4976ca2a1283252a24412a3e2f1c11db6c8bdc5",
       "tag": "s2-ownership_systems",
       "selector": "0x5b91b9dd3e18200a0d83b0052450799431a3c996a8db43ab750852f98fc9b4f",
+      "address": "0x35db55d5f2e69421f599ea07d1c9a89fe3ad21b12dd0e440205543a4e1056ad",
+      "init_calldata": [],
       "systems": [
         "transfer_structure_ownership",
         "transfer_agent_ownership",
@@ -1731,21 +1721,21 @@
       ]
     },
     {
-      "address": "0x1cb27eb4832e9e29381ae1b3ced6ddaf9d03eebadba14f40db18590f3dcb500",
       "class_hash": "0x6349d6d9d1fd989a2b15e342a071efa713a6e997d6b67d89384a841ed5c412e",
-      "init_calldata": [],
       "tag": "s2-point_systems",
       "selector": "0x1fa907303c222be3ec373269a668bdcb6b9900202b852cfe7e22fd7882cd0ad",
+      "address": "0x301a890d6ef0dc4fd04d04efcba5868b4dbd4426359d91588a3763ecaa324bd",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x362d9977c3a795d8fbabd37843efa82e2df47a7f16225648faefaecd5021052",
-      "class_hash": "0x4217a2f61fde127d72beba280416e58d3b8ee10e258db09a9f590d5244bacae",
-      "init_calldata": [],
+      "class_hash": "0x75709eba1dddbc5520d1e1c2348770f8e20fab685e78834f852600f762a5444",
       "tag": "s2-prize_distribution_systems",
       "selector": "0x12aecde0aeb831c6bd68cd5136815edd4f4db05e9a55c4b734534601718437d",
+      "address": "0x6ff50b2846afc788f4bc9c23050e6787118247c653f9de4e49042b350d29dde",
+      "init_calldata": [],
       "systems": [
         "blitz_get_or_compute_series_chest_reward_state",
         "blitz_prize_player_rank",
@@ -1755,11 +1745,11 @@
       ]
     },
     {
-      "address": "0x6cb7491ef804ad6664e2d3f02e2089ee2564b774f69f3cb55732473bee76c90",
-      "class_hash": "0x7cb2f4bdfbe2119ee5ad8887e8f08587a4d117467801d87d2b987b8baaaebe9",
-      "init_calldata": [],
+      "class_hash": "0x6a7ffc127036df91bb0a8e4057222aeccb595b03daedca54f1c22618049c201",
       "tag": "s2-production_systems",
       "selector": "0x4e7d3887a854bdfe780deea047c072c709e83e70d9c6611df26e69ce21af3aa",
+      "address": "0x7159634e05d5cb354eb0d1c6c545484b24f722063cae6c88c6094a0a53794ee",
+      "init_calldata": [],
       "systems": [
         "create_building",
         "destroy_building",
@@ -1772,28 +1762,11 @@
       ]
     },
     {
-      "address": "0x513f86a0238cf603785512b80d5e75c01ddb958f0f9b5109cc0456b828a58cb",
-      "class_hash": "0x70a7c6185e1305da772fe9db9c014729dd3c2653572bcf10f1b8d072d2e2547",
-      "init_calldata": [],
-      "tag": "s2-quest_systems",
-      "selector": "0x540595f0c6797a5aeda35fd5237d8542c354d6dcf6b150c243d3b80709438cd",
-      "systems": [
-        "add_game",
-        "remove_game",
-        "create_quest",
-        "start_quest",
-        "claim_reward",
-        "enable_quests",
-        "disable_quests",
-        "upgrade"
-      ]
-    },
-    {
-      "address": "0x15eecf15f1b470d23a8c6608db42a9e53c3b2dfd96469eb53aa9a81e2e93564",
-      "class_hash": "0x38d7efedd3e0efe44806bd418ffeffbf6f31a2e3cfe31c6f0f6b280519055c9",
-      "init_calldata": [],
+      "class_hash": "0x111ef4c0ff913ffac3ba5800579228bcf2b242fb9edc151277273112d4882fe",
       "tag": "s2-realm_internal_systems",
       "selector": "0x60a3de2b7fe2038c858e8171e21c4b75f1db9087e1e86cebd228e710d3e6afc",
+      "address": "0x1755d8a9f63ccb969ef2de34bc5fd959fe74bc95a23ac37b75e48764bbb33b9",
+      "init_calldata": [],
       "systems": [
         "create_internal",
         "provision_internal",
@@ -1801,22 +1774,22 @@
       ]
     },
     {
-      "address": "0x477eabbcf73904cb9734857241ad65d2f0f25e9f2d5dc8c70c9923f1aa82951",
-      "class_hash": "0x42c843d7ba980d39187f2dffe429f44e12a2ecaed49ac7ffe3fc00501d76e60",
-      "init_calldata": [],
+      "class_hash": "0x55a1ba866e624f0a37b3bc20bfe03e0a8a174897db506d26652a444cbbf0f1b",
       "tag": "s2-realm_systems",
       "selector": "0x15840f61f67edf5690ea72dd3e54dfe561477810b5684035e0476bef3436923",
+      "address": "0x2acf4d118796e53aa33d0c9c467b7f8f2a717fc0abe5335271acd458808b556",
+      "init_calldata": [],
       "systems": [
         "settle",
         "upgrade"
       ]
     },
     {
-      "address": "0x765e9ea6caf96b51e28c22337869615e101db8f61665750830c2bf51eb6a553",
-      "class_hash": "0x312c22e33a1c4e46bf20c2b5d49c65cf1224570cd6e50bb47ac4cdd60aa1a23",
-      "init_calldata": [],
+      "class_hash": "0x590f49ad3bc70c280717dd1962b9ba60e1188bbcdb0eff8e8bf18f5ddded40c",
       "tag": "s2-registrar_systems",
       "selector": "0x4804d037c91147634be0c5239a0c366e59e0365a3dbb5da3c4c4c5e9cfd6014",
+      "address": "0x4df99ef44ae86f19cc6bf9e4a38b486552fdea1a011d4a8c9526034380c3953",
+      "init_calldata": [],
       "systems": [
         "bootstrap_chain_config",
         "register_preset",
@@ -1833,21 +1806,21 @@
       ]
     },
     {
-      "address": "0x5d8ba4295b7bbb3baa79207c3bdb9a0e90385321a0682d93c25b4d82b7ebf87",
-      "class_hash": "0x434b34b0d0be2f27fc7f8516d65d305a3e9e8f77a3c49ef1c18e54e8988cc39",
-      "init_calldata": [],
+      "class_hash": "0x4fac5f579e2405245dccdd3624aa895a6323885db807e46850379a1d398a381",
       "tag": "s2-relic_chest_discovery_systems",
       "selector": "0x482f02f80b37fe032bf7a2525683c83b8c3c9519d4c34c4285f26d96240fdd",
+      "address": "0x249405bd14a5084d72c13259e6e6d5abd4ebeba915a2bfe1cd448703e59603c",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x6ad2cedfb88e875147fe203e05205a6dbd8faccf7faccd156b9382c9010835f",
-      "class_hash": "0x1403787d0a3b8e1f1bf8fd7b9240b1260747a2af515fb7b84efe71159cdd007",
-      "init_calldata": [],
+      "class_hash": "0x7183b8b97bbb0227cadca41a423d8febcd466b0ec8278573bb59c532c760973",
       "tag": "s2-relic_systems",
       "selector": "0x59ae849f6b5f2fb35aac5a3c8b8daee0c0083bef0717a05ab47d361b30bafc5",
+      "address": "0x4aac2b558fa69dd2c20220c0d4fa9979b86311e93b070f2116f800ac170c276",
+      "init_calldata": [],
       "systems": [
         "open_chest",
         "apply_relic",
@@ -1855,11 +1828,11 @@
       ]
     },
     {
-      "address": "0x2012bb66d44dd66ac8b0889deada91817f7ccb83e92ed5849731e61359863d7",
-      "class_hash": "0x432a4e8b24dd9f1b0a3d6d30c4477aa53b813ba90537d56c1c21b7e10a4f27e",
-      "init_calldata": [],
+      "class_hash": "0x468c7ad4ede37d9bb5bf94f4ec74136bfe7e31098f11672a03f23fac707beb7",
       "tag": "s2-resource_bridge_systems",
       "selector": "0x4157f73bc343f1c3729cb8d993e7a12c1d4bf8a4f335978df83e2d489638011",
+      "address": "0x5471529d109f6adb97e9971621a024c8eb997e3f34c7ddd51255c6da0c9108a",
+      "init_calldata": [],
       "systems": [
         "deposit",
         "withdraw",
@@ -1868,11 +1841,11 @@
       ]
     },
     {
-      "address": "0xe56a5f2516ce0578d332cb3b038ac814a01e5368b8a36d4e740680ea346d84",
-      "class_hash": "0x274da8a7d9d09df00edfad87ce1744883344d9dccb9a0f9d75fc5e12a8c708b",
-      "init_calldata": [],
+      "class_hash": "0x65171d7384466519684ff319342b94808dac15f72a738f67210123552f0e846",
       "tag": "s2-resource_systems",
       "selector": "0x7b684d925313a76f3f6b00e657b8d10247a72fce77dafb1b1e31cd7501fb52a",
+      "address": "0x1d9849d6e9e51f30012ad59713960d86906363ba86168117e07534ffdb6b54c",
+      "init_calldata": [],
       "systems": [
         "approve",
         "send",
@@ -1888,44 +1861,33 @@
       ]
     },
     {
-      "address": "0xa65cf5a57d37b86116296f58dea3a7b65814115cdeed63326294a7eb8c2b17",
-      "class_hash": "0x59500c789cc9855d5e8a3715a0c3f994f791d50a748fc1927cb1e853227fcee",
-      "init_calldata": [],
+      "class_hash": "0x2f95c69dbead4b74e5f761f6295e60d7e78c0a11a54957642d0ed4d4a39c251",
       "tag": "s2-season_systems",
       "selector": "0x647b9e1ced068c5c41511cf3851a373962bfe18fe4a1a469657f9d2c362208f",
+      "address": "0x777feb298e3e96aece35746ddc8a193909ed4e6efc926573b19d8bea9d90a41",
+      "init_calldata": [],
       "systems": [
         "season_close",
         "upgrade"
       ]
     },
     {
-      "address": "0x98a121ecd7a0e56485c38798275af785f666d3b41bcf55d91f4fd4d10bb015",
-      "class_hash": "0x271eb91be53138924f00278304dbab5cf6fe0c8b45fe7af319d547b7f2f8ba7",
-      "init_calldata": [],
-      "tag": "s2-spire_systems",
-      "selector": "0xa00423907c74d1d633a22ec1c4fb0617044b5aa02badae7d69d21be273d874",
-      "systems": [
-        "create_spires",
-        "upgrade"
-      ]
-    },
-    {
-      "address": "0x3ce159003fa421cd7e1de59bbaa4ad205a342d814228f20100c47c3f395097f",
-      "class_hash": "0x477bfd4424d0c3c9dec1dd24268775e29cc73c5bf937b712dc41a20cf8ee675",
-      "init_calldata": [],
+      "class_hash": "0x48c1e28333db78cca227bcef320d43a4d7391c10ffd24284262d434d36d39d3",
       "tag": "s2-structure_systems",
       "selector": "0x2ad85fc53b7641bd7384db9df083b2933792ca78cecd410cae0b29190ab889c",
+      "address": "0x1dc59d2964f13afd4aaaae57175b5083db17c3d0647d2509f4508ece51598bc",
+      "init_calldata": [],
       "systems": [
         "level_up",
         "upgrade"
       ]
     },
     {
-      "address": "0x707dc3ccf90e96612573c52a1e47e07d4813fa99dcab7a8ba79f80e9727cb7",
-      "class_hash": "0x1b28fb79cea2b24d8af45f3cb997e99553c1e97eb412992272166c39c76dda",
-      "init_calldata": [],
+      "class_hash": "0x5606d1b831ba0056074d01fd6349e5b37b3b6fa7b594cbd07182157827e6ec1",
       "tag": "s2-swap_systems",
       "selector": "0x7f8b75330f52d8ef715c833018ec8cc7f8ab49a72b18cc6646a317b79a68de2",
+      "address": "0x67e1a6ad15c0cf13656860038777505ce6b63cb1f1be435f051c31380cc25e6",
+      "init_calldata": [],
       "systems": [
         "buy",
         "sell",
@@ -1933,11 +1895,11 @@
       ]
     },
     {
-      "address": "0x8872006b149513f88df7daf82ce17143e854adf7d5a86b956f8606e92617a0",
-      "class_hash": "0x1c496156b731ff7db8d54829910efb929dbc2aa43371ce8f54042fcf82538d6",
-      "init_calldata": [],
+      "class_hash": "0x4b90a353cba754edf264edeeb9f3da06acbe284033dd7d5871cac60dd1157bc",
       "tag": "s2-trade_systems",
       "selector": "0x2e9d493f482cbae3686cc97204e9c9810b82ed6bf1c5c6a56c8e7f9eb373ee0",
+      "address": "0x79ee3891f0d762160e23ff361f4c2cb9068ffe3b73b472ce4257dfc164686be",
+      "init_calldata": [],
       "systems": [
         "create_order",
         "accept_order",
@@ -1946,11 +1908,11 @@
       ]
     },
     {
-      "address": "0x3e88dd57cafee0eef0264b59865a13eaf986470979892e43041dbcb8adc820",
-      "class_hash": "0x77b5852dd8a044c6bda8af2f1767b77549da2dbe56f3144009da291c80c01d",
-      "init_calldata": [],
+      "class_hash": "0x567ec5c8807c920ac9b37b826e0f55cb584ccfe5452e8543c3816c1fb0d49f1",
       "tag": "s2-troop_battle_systems",
       "selector": "0x25b78a11c862d0bda3ff8aaec76e9f1dca6de6c6fe97aed5434a606695dbff",
+      "address": "0x2ff873b644a719a5d7b85dc20ff43baa58abe094bddf81f650c89e367aee6a5",
+      "init_calldata": [],
       "systems": [
         "attack_explorer_vs_explorer",
         "attack_explorer_vs_guard",
@@ -1959,11 +1921,11 @@
       ]
     },
     {
-      "address": "0x4db549d37af331d9e872a79bebf5bf3d2c088a6e262182250a3cb5195a39451",
-      "class_hash": "0x5d222a362c0ce3f4375ca5d0b6abbd6ee184ed1b2e2fff591d85d0df0b80e70",
-      "init_calldata": [],
+      "class_hash": "0x6a1649814e0f915a2d3d8911fc9e42ef996865c10a837e73d55fce9ec080c7a",
       "tag": "s2-troop_management_systems",
       "selector": "0x6a6e0b89963cd143f8ac59715bb8703b82846a949938ed025fca425ad293739",
+      "address": "0x1a7b495b98837801d139e14a1ccd5d64618bf01c62ad2676607ef9873271c3a",
+      "init_calldata": [],
       "systems": [
         "guard_add",
         "guard_delete",
@@ -1977,11 +1939,11 @@
       ]
     },
     {
-      "address": "0xc1068e7f9d112f3e70f7869a243ab81c0bc37247799bf8c0b70fa418e38e29",
-      "class_hash": "0x1b2485ac6e1df024959a5be9f49be0b605f7e4967e64da632d33aac4ade0a67",
-      "init_calldata": [],
+      "class_hash": "0x1b85faa9ad41fcda8d3fbbada483ce43ebe34a08c2239c5c115c346eb611dd0",
       "tag": "s2-troop_movement_systems",
       "selector": "0x3660164eb20db73a2286ce100d274c9631ca84fae00bd5c45d0b763017b56b2",
+      "address": "0x68becf2f14cfe6e10edb33fb19ae8a74b0014d4ae707942bde5d196b4972dbd",
+      "init_calldata": [],
       "systems": [
         "explorer_move",
         "explorer_extract_reward",
@@ -1989,32 +1951,32 @@
       ]
     },
     {
-      "address": "0x48ac5b6ec94a7e04c9f7324d7bca942099e2c6c8c8f0fc26b9a9bd584d01f6c",
-      "class_hash": "0x1feefbccb7d16b7b5be1d3d5f450800d2b539f524731eb75aa9bdeed33c95ec",
-      "init_calldata": [],
+      "class_hash": "0x78feb864ae40ea0293466bb92aead17b6e0d3a7abc693eec8f18887371ef10f",
       "tag": "s2-troop_movement_util_systems",
       "selector": "0x55fd2d07088f7b57faa8c3c0890d78a105701bfc80784c216b249d948941f1d",
+      "address": "0x78a8173122b83e5b90e72ee703560c045ec997e95bb6c68f3aa1f1a33a81aaf",
+      "init_calldata": [],
       "systems": [
         "upgrade"
       ]
     },
     {
-      "address": "0x1c74a99f09cf98904d2f7fda73cf84778138c5833e2d25f873261702ae8297a",
-      "class_hash": "0x7617aaa472b46513736e1f9721b028f5a7c5800a395108a3cb3f460f9581005",
-      "init_calldata": [],
+      "class_hash": "0x3d7174967dd60081e658452daeada57099bd435722ed4f1c29eaf82ba911975",
       "tag": "s2-troop_raid_systems",
       "selector": "0x6a85660241b94f0f911a3e401027baecca8e3c962797e77362aa07761a19de6",
+      "address": "0x3ced23fc0e4100d13032f15b0f38cdfb37a7c527268a64a70df20f64b46a1f",
+      "init_calldata": [],
       "systems": [
         "raid_explorer_vs_guard",
         "upgrade"
       ]
     },
     {
-      "address": "0x20a8aa583cde37a57cc2c256bdaa46c37675b657e5bb9f1eace20b7e13d6e42",
-      "class_hash": "0x2ea1a81dc74139d71aa85a41aaa403a921e934d8ae35230ce09be74c66fab84",
-      "init_calldata": [],
+      "class_hash": "0x457506ea7aed53e83e63b247d19feeda2206500aeafce69f9613816bb98b874",
       "tag": "s2-village_systems",
       "selector": "0x7edd79ed540ae459d77f2b23976b0539de02ccbc8b43d723de2564369d38f8c",
+      "address": "0x15955d22726d46b227d5485c3cf08621aca3e1754d8a8fc2fbd2ecd53284e99",
+      "init_calldata": [],
       "systems": [
         "create",
         "receive_army_grant",
@@ -2024,43 +1986,46 @@
   ],
   "libraries": [
     {
-      "class_hash": "0x7da86fd5136e0cb2b7115d00aa45e8b9376ee924af69a8cfeea4c06737726ac",
+      "class_hash": "0x15804ad25e24836d6b737f22947f4c7c91a0256d752662cd9cb5a4a11df0b80",
       "tag": "s2-biome_library_v0_1_13",
       "selector": "0x3f57dacceb06626edd63d8604a5b78595644d82f8fec30b9c8b685384923ad2",
       "systems": [],
       "version": "0_1_13"
     },
     {
-      "class_hash": "0x28c7a600ace4071a9354719ce8b42a9b541419c4daf8a44ea68c598d790f7eb",
+      "class_hash": "0x7ebb1d384e4c34115d3118b762adaa1e6cb506f86adf8ef95cdcc8040ea280f",
       "tag": "s2-combat_library_v0_1_14",
       "selector": "0x6f626ba1ab6f77a7d708c231e18cf896cf2594248aa750184719e2af895fec7",
       "systems": [],
       "version": "0_1_14"
     },
     {
-      "class_hash": "0x3d7eedf57cdb2d979c55bd2ebde875fc88973785546d08ec926e5c4597e830f",
+      "class_hash": "0x69725c7baa0474e81d9115fbfaa07b8b603393830c82cb5c967fc45c5fa91a5",
       "tag": "s2-raid_library_v0_1_0",
       "selector": "0x76bde0be15faec04422cd972a10c57179534f8d7d942e320169f553e1abf529",
       "systems": [],
       "version": "0_1_0"
     },
     {
-      "class_hash": "0x2d4f363307b6d5dd15e27c7d2d67ab37f22ca7cc76c84e83a62a91a2d7760e0",
+      "class_hash": "0x758f4bd10470f8124bd679e02923b6ca1e8ae7a4f75ba4ee217d4ce6a08475c",
       "tag": "s2-rng_library_v0_1_16",
       "selector": "0x65b098fdddc3a9d5164d51571d9f0fd05cafeb62506532d54a23f543c90da13",
       "systems": [],
       "version": "0_1_16"
     },
     {
-      "class_hash": "0x3b221a5e6ddddae9b9f8fe6ae75e19c0de29eb59f4b6bb2f71afb3af6730173",
-      "tag": "s2-structure_creation_library_v0_1_19",
+      "class_hash": "0x46112e00498d245a7519193a2f3bb3a288edd4f609952eef3c363ffcbe18fe4",
+      "tag": "s2-structure_creation_library_v0_1_18",
       "selector": "0x16f1565db366652914b03f1d4a3f923e8a68907f7de2b08d94515bbdec88b00",
       "systems": [],
-      "version": "0_1_19"
+      "version": "0_1_18"
     }
   ],
   "models": [
     {
+      "class_hash": "0x6adda5cc81ce4591c13964264edb38f8dbb92f80816a632cb7bc64ee0b046e",
+      "tag": "s2-AddressName",
+      "selector": "0x2b8ca5d6f8452312ee31da463004ededfa6725208943d28a875ffd824d13f54",
       "members": [
         {
           "name": "address",
@@ -2072,12 +2037,12 @@
           "type": "core::felt252",
           "key": false
         }
-      ],
-      "class_hash": "0x6adda5cc81ce4591c13964264edb38f8dbb92f80816a632cb7bc64ee0b046e",
-      "tag": "s2-AddressName",
-      "selector": "0x2b8ca5d6f8452312ee31da463004ededfa6725208943d28a875ffd824d13f54"
+      ]
     },
     {
+      "class_hash": "0x6c6f790f7a436658862d8c200446ad96bf1a284932b2c56fc4af51d0e0e844a",
+      "tag": "s2-AgentConfig",
+      "selector": "0x34080e1fd152b300addc7ec9758c3ac1709600c2489cad907cc8e4ae35e3f9c",
       "members": [
         {
           "name": "game_id",
@@ -2104,29 +2069,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x6c6f790f7a436658862d8c200446ad96bf1a284932b2c56fc4af51d0e0e844a",
-      "tag": "s2-AgentConfig",
-      "selector": "0x34080e1fd152b300addc7ec9758c3ac1709600c2489cad907cc8e4ae35e3f9c"
+      ]
     },
     {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "count",
-          "type": "core::integer::u16",
-          "key": false
-        }
-      ],
       "class_hash": "0x68a1ae12894b85ba724bf425915e96228bdc3205f0ccb4fe80c95e6959d9f76",
       "tag": "s2-AgentCount",
-      "selector": "0x75da2616650b00245916370c9d04c741b77131dc1a87e410b26b87d70b2ad95"
-    },
-    {
+      "selector": "0x75da2616650b00245916370c9d04c741b77131dc1a87e410b26b87d70b2ad95",
       "members": [
         {
           "name": "game_id",
@@ -2138,12 +2086,29 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x253763030f183b9f7e096c483f90c0ec9c28880a7d4792d8668ab4e6a20f21",
-      "tag": "s2-AgentLifetimeCount",
-      "selector": "0x5461034a928fd1bb49ef2edf4db7fbeae594df217be3246f4df09bb54f1cf76"
+      ]
     },
     {
+      "class_hash": "0x253763030f183b9f7e096c483f90c0ec9c28880a7d4792d8668ab4e6a20f21",
+      "tag": "s2-AgentLifetimeCount",
+      "selector": "0x5461034a928fd1bb49ef2edf4db7fbeae594df217be3246f4df09bb54f1cf76",
+      "members": [
+        {
+          "name": "game_id",
+          "type": "core::integer::u32",
+          "key": true
+        },
+        {
+          "name": "count",
+          "type": "core::integer::u16",
+          "key": false
+        }
+      ]
+    },
+    {
+      "class_hash": "0x27547d59e7e86a163bd5897ed5c1dce70f7cb6291cd1c223a5d85b8f55b254d",
+      "tag": "s2-AgentLordsMinted",
+      "selector": "0x5e14ab3abd995d3956543ffc7746f13e08151874dd1568919bf7b4766bc2504",
       "members": [
         {
           "name": "game_id",
@@ -2155,12 +2120,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x27547d59e7e86a163bd5897ed5c1dce70f7cb6291cd1c223a5d85b8f55b254d",
-      "tag": "s2-AgentLordsMinted",
-      "selector": "0x5e14ab3abd995d3956543ffc7746f13e08151874dd1568919bf7b4766bc2504"
+      ]
     },
     {
+      "class_hash": "0x5d7e473b029efa453c0258becd510ae81e3e1679ad78d118675fa6fadb8f1fc",
+      "tag": "s2-AgentOwner",
+      "selector": "0x13298d7dfea1ab8cf6652cdb9e2098152fe67e6e225442bc665f27af2cbcfe6",
       "members": [
         {
           "name": "game_id",
@@ -2177,34 +2142,12 @@
           "type": "core::starknet::contract_address::ContractAddress",
           "key": false
         }
-      ],
-      "class_hash": "0x5d7e473b029efa453c0258becd510ae81e3e1679ad78d118675fa6fadb8f1fc",
-      "tag": "s2-AgentOwner",
-      "selector": "0x13298d7dfea1ab8cf6652cdb9e2098152fe67e6e225442bc665f27af2cbcfe6"
+      ]
     },
     {
-      "members": [
-        {
-          "name": "by_address",
-          "type": "core::starknet::contract_address::ContractAddress",
-          "key": true
-        },
-        {
-          "name": "biome",
-          "type": "core::integer::u8",
-          "key": true
-        },
-        {
-          "name": "discovered",
-          "type": "core::bool",
-          "key": false
-        }
-      ],
-      "class_hash": "0x2c7f9e364f5986124fbb5b72dd97dd29654a20933d9c1b6ca995031238bec02",
-      "tag": "s2-BiomeDiscovered",
-      "selector": "0x5aeb70e2f055c33dd533890cb2ab1602fcf3dde43c3bc1a5680cb4868f60bc"
-    },
-    {
+      "class_hash": "0x2ea85e08d9d0088fa0a501c643b659a743da0ff853acf2ff65f1ffcbae9141e",
+      "tag": "s2-BitcoinMinePhaseLabor",
+      "selector": "0x61cb15ceb1d8dfdfac2fa1e8cc87fc5009dc9c1dc364413857331091a0d6b8",
       "members": [
         {
           "name": "game_id",
@@ -2231,12 +2174,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x2ea85e08d9d0088fa0a501c643b659a743da0ff853acf2ff65f1ffcbae9141e",
-      "tag": "s2-BitcoinMinePhaseLabor",
-      "selector": "0x61cb15ceb1d8dfdfac2fa1e8cc87fc5009dc9c1dc364413857331091a0d6b8"
+      ]
     },
     {
+      "class_hash": "0x61634c0f6a75f8f24f39cdf02bfbc905ee7ed40aab1b07ed12d6b5bac169433",
+      "tag": "s2-BitcoinPhaseLabor",
+      "selector": "0x5039cdd977ae40615b0268316708465310075c2d4b81b7559127554a006fed5",
       "members": [
         {
           "name": "game_id",
@@ -2273,12 +2216,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x61634c0f6a75f8f24f39cdf02bfbc905ee7ed40aab1b07ed12d6b5bac169433",
-      "tag": "s2-BitcoinPhaseLabor",
-      "selector": "0x5039cdd977ae40615b0268316708465310075c2d4b81b7559127554a006fed5"
+      ]
     },
     {
+      "class_hash": "0x4a2c24811ab4ce661aa90c27f1c279232a11e8a6b8f8ae5b15431d2b8d67562",
+      "tag": "s2-BlitzCosmeticAttrsRegister",
+      "selector": "0x29880f346028e2f904bcbe095957daec66c52204f64bb85cff9214e0b1016ca",
       "members": [
         {
           "name": "game_id",
@@ -2295,12 +2238,12 @@
           "type": "core::array::Span::<core::integer::u128>",
           "key": false
         }
-      ],
-      "class_hash": "0x4a2c24811ab4ce661aa90c27f1c279232a11e8a6b8f8ae5b15431d2b8d67562",
-      "tag": "s2-BlitzCosmeticAttrsRegister",
-      "selector": "0x29880f346028e2f904bcbe095957daec66c52204f64bb85cff9214e0b1016ca"
+      ]
     },
     {
+      "class_hash": "0x2515e76ce1b450b60a918f2a841283d897982a29751b73e8c94d1c6cf872f0e",
+      "tag": "s2-BlitzSettlement",
+      "selector": "0x9928513c94768fd8112b8a0535d614fa42f55fe744a1e8ea349484d547610b",
       "members": [
         {
           "name": "game_id",
@@ -2317,12 +2260,12 @@
           "type": "core::array::Span::<core::integer::u32>",
           "key": false
         }
-      ],
-      "class_hash": "0x2515e76ce1b450b60a918f2a841283d897982a29751b73e8c94d1c6cf872f0e",
-      "tag": "s2-BlitzSettlement",
-      "selector": "0x9928513c94768fd8112b8a0535d614fa42f55fe744a1e8ea349484d547610b"
+      ]
     },
     {
+      "class_hash": "0x7825820b1f06f78015d64b022309832a94cce7975a551b0806da8f0c78f2b03",
+      "tag": "s2-BlitzSettlementPosition",
+      "selector": "0x29f2e14f3fc6a94769232cfec77d87b9c1a4d91a4825f4b5494207896ecf26f",
       "members": [
         {
           "name": "game_id",
@@ -2339,12 +2282,12 @@
           "type": "core::array::Span::<eternum::models::position::Coord>",
           "key": false
         }
-      ],
-      "class_hash": "0x7825820b1f06f78015d64b022309832a94cce7975a551b0806da8f0c78f2b03",
-      "tag": "s2-BlitzSettlementPosition",
-      "selector": "0x29f2e14f3fc6a94769232cfec77d87b9c1a4d91a4825f4b5494207896ecf26f"
+      ]
     },
     {
+      "class_hash": "0x42902af5c8bf895b5fbfa3c4a6b96c5500e3ac6f14928b08a9add9ce3cce73",
+      "tag": "s2-Building",
+      "selector": "0x765484ee46c523b2a584a88943210abaa4a76e1e25f34305001eabddb3b757d",
       "members": [
         {
           "name": "game_id",
@@ -2401,12 +2344,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x42902af5c8bf895b5fbfa3c4a6b96c5500e3ac6f14928b08a9add9ce3cce73",
-      "tag": "s2-Building",
-      "selector": "0x765484ee46c523b2a584a88943210abaa4a76e1e25f34305001eabddb3b757d"
+      ]
     },
     {
+      "class_hash": "0x7c2a64d7b656b1d379cbda37bf3ffed0ca0c236b7e47b9688d07c222ade4589",
+      "tag": "s2-BuildingCategoryConfig",
+      "selector": "0x7d944c480b136a52539e323edd08b8fb2137c7ace3b71665893aeb94306d95d",
       "members": [
         {
           "name": "preset_id",
@@ -2448,12 +2391,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x7c2a64d7b656b1d379cbda37bf3ffed0ca0c236b7e47b9688d07c222ade4589",
-      "tag": "s2-BuildingCategoryConfig",
-      "selector": "0x7d944c480b136a52539e323edd08b8fb2137c7ace3b71665893aeb94306d95d"
+      ]
     },
     {
+      "class_hash": "0x4f6ca02875602be1f1a8e279650754b8556fa57f7f4e162acd7856fb90ff154",
+      "tag": "s2-ChainConfig",
+      "selector": "0x61823304792b97c11797dcd646d3f856bd9571bc8952480d6c9ec68ab35e417",
       "members": [
         {
           "name": "config_id",
@@ -2505,12 +2448,12 @@
           "type": "core::starknet::contract_address::ContractAddress",
           "key": false
         }
-      ],
-      "class_hash": "0x4f6ca02875602be1f1a8e279650754b8556fa57f7f4e162acd7856fb90ff154",
-      "tag": "s2-ChainConfig",
-      "selector": "0x61823304792b97c11797dcd646d3f856bd9571bc8952480d6c9ec68ab35e417"
+      ]
     },
     {
+      "class_hash": "0x75a77b86688aef0c8581d61cbe44ef1bdce41840d249869703f8be3dbe69703",
+      "tag": "s2-CompletedHyperstructure",
+      "selector": "0x5250d374cb0b7593aa79fc57e664d70b0f2ebe30bd05b84cbb9bced86a50914",
       "members": [
         {
           "name": "game_id",
@@ -2527,12 +2470,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x75a77b86688aef0c8581d61cbe44ef1bdce41840d249869703f8be3dbe69703",
-      "tag": "s2-CompletedHyperstructure",
-      "selector": "0x5250d374cb0b7593aa79fc57e664d70b0f2ebe30bd05b84cbb9bced86a50914"
+      ]
     },
     {
+      "class_hash": "0x2556656798db2f56743f0405a8bfd0dcedc6b18667e89ed84b4def5bec350b8",
+      "tag": "s2-EntityName",
+      "selector": "0x3ffca4beca8c61e8bd16d380c43fa4df691b63f3c21750e86288b9b62389d57",
       "members": [
         {
           "name": "game_id",
@@ -2549,12 +2492,12 @@
           "type": "core::felt252",
           "key": false
         }
-      ],
-      "class_hash": "0x2556656798db2f56743f0405a8bfd0dcedc6b18667e89ed84b4def5bec350b8",
-      "tag": "s2-EntityName",
-      "selector": "0x3ffca4beca8c61e8bd16d380c43fa4df691b63f3c21750e86288b9b62389d57"
+      ]
     },
     {
+      "class_hash": "0x53e28f819f1bc1b8fcf5b3d8aa571de472be7881310c61cb57f997a0cf3e77c",
+      "tag": "s2-ExplorerTroops",
+      "selector": "0xbe0b28837eb913e8ed5809a4c914d3ab6ca5f409a3b048ee4334b0bdd2ca38",
       "members": [
         {
           "name": "game_id",
@@ -2581,12 +2524,12 @@
           "type": "eternum::models::position::Coord",
           "key": false
         }
-      ],
-      "class_hash": "0x53e28f819f1bc1b8fcf5b3d8aa571de472be7881310c61cb57f997a0cf3e77c",
-      "tag": "s2-ExplorerTroops",
-      "selector": "0xbe0b28837eb913e8ed5809a4c914d3ab6ca5f409a3b048ee4334b0bdd2ca38"
+      ]
     },
     {
+      "class_hash": "0x598ad6d55d784770f20396773ee75cfa48826e69cf45bf63cea479bbf0df207",
+      "tag": "s2-FaithPrizePool",
+      "selector": "0x43f6cbbc67b62a661663958972322e983f5ee448f0945b35e55b8b02bb7ddf4",
       "members": [
         {
           "name": "game_id",
@@ -2603,12 +2546,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x598ad6d55d784770f20396773ee75cfa48826e69cf45bf63cea479bbf0df207",
-      "tag": "s2-FaithPrizePool",
-      "selector": "0x43f6cbbc67b62a661663958972322e983f5ee448f0945b35e55b8b02bb7ddf4"
+      ]
     },
     {
+      "class_hash": "0x470929fda35a225f8669511413424c5e8c0c559e7ff1fbedbaf84300541aa49",
+      "tag": "s2-FaithWonders",
+      "selector": "0x24155d99584e40026a141d6fae08ebba4a084234784e7fe6f24314c78d5715d",
       "members": [
         {
           "name": "game_id",
@@ -2620,12 +2563,12 @@
           "type": "core::array::Array::<core::integer::u32>",
           "key": false
         }
-      ],
-      "class_hash": "0x470929fda35a225f8669511413424c5e8c0c559e7ff1fbedbaf84300541aa49",
-      "tag": "s2-FaithWonders",
-      "selector": "0x24155d99584e40026a141d6fae08ebba4a084234784e7fe6f24314c78d5715d"
+      ]
     },
     {
+      "class_hash": "0x30c6c11e91dfb36d522f9397e33c6e76b3a0265b4e7e4c1d8d7c14465e04795",
+      "tag": "s2-FaithfulStructure",
+      "selector": "0x264398361e8ea94a7001abf1f5d2311ccbfefd25d2a02d06e99e53b0ed4389b",
       "members": [
         {
           "name": "game_id",
@@ -2662,12 +2605,12 @@
           "type": "core::starknet::contract_address::ContractAddress",
           "key": false
         }
-      ],
-      "class_hash": "0x30c6c11e91dfb36d522f9397e33c6e76b3a0265b4e7e4c1d8d7c14465e04795",
-      "tag": "s2-FaithfulStructure",
-      "selector": "0x264398361e8ea94a7001abf1f5d2311ccbfefd25d2a02d06e99e53b0ed4389b"
+      ]
     },
     {
+      "class_hash": "0x396c9989e5d49a91c150d5fdaed67eca857c28b0595b73b33b07f73c794ce0f",
+      "tag": "s2-GameChestReward",
+      "selector": "0x5c3d7784444733b41f8d1536395ee83d457351f25f7fb8e03afe545ca894e62",
       "members": [
         {
           "name": "game_id",
@@ -2684,12 +2627,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x396c9989e5d49a91c150d5fdaed67eca857c28b0595b73b33b07f73c794ce0f",
-      "tag": "s2-GameChestReward",
-      "selector": "0x5c3d7784444733b41f8d1536395ee83d457351f25f7fb8e03afe545ca894e62"
+      ]
     },
     {
+      "class_hash": "0x6a0d68e230040bcf295707632c5ec0cfa1fc54e0c0958317b0f4291721c3e75",
+      "tag": "s2-GameCounter",
+      "selector": "0x32bf68cb725e03306146b8efdae813fa8c372592bd900c2be783cda1e90fcbf",
       "members": [
         {
           "name": "id",
@@ -2701,12 +2644,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x6a0d68e230040bcf295707632c5ec0cfa1fc54e0c0958317b0f4291721c3e75",
-      "tag": "s2-GameCounter",
-      "selector": "0x32bf68cb725e03306146b8efdae813fa8c372592bd900c2be783cda1e90fcbf"
+      ]
     },
     {
+      "class_hash": "0x5d752c97133be05b3c1eb702badd7056573fdf3d210920771fa1f3cefde35ab",
+      "tag": "s2-GameMapConfig",
+      "selector": "0x6e72a5750b7d7c7cf49e56b77e2fab8d5bb7b8e82f364b8e51a9f058b66a210",
       "members": [
         {
           "name": "game_id",
@@ -2718,12 +2661,12 @@
           "type": "eternum::models::config::MapConfig",
           "key": false
         }
-      ],
-      "class_hash": "0x5d752c97133be05b3c1eb702badd7056573fdf3d210920771fa1f3cefde35ab",
-      "tag": "s2-GameMapConfig",
-      "selector": "0x6e72a5750b7d7c7cf49e56b77e2fab8d5bb7b8e82f364b8e51a9f058b66a210"
+      ]
     },
     {
+      "class_hash": "0x7eccaa39b0ce880604e8f2711b79d0791c1efbaaacbcb42bc1a69770df2add0",
+      "tag": "s2-GameRegistry",
+      "selector": "0x42fb799cf6ef454237db3b350d6517f5d7e1d8505cf88955b2b4af830c34a34",
       "members": [
         {
           "name": "game_id",
@@ -2800,12 +2743,12 @@
           "type": "core::felt252",
           "key": false
         }
-      ],
-      "class_hash": "0x7eccaa39b0ce880604e8f2711b79d0791c1efbaaacbcb42bc1a69770df2add0",
-      "tag": "s2-GameRegistry",
-      "selector": "0x42fb799cf6ef454237db3b350d6517f5d7e1d8505cf88955b2b4af830c34a34"
+      ]
     },
     {
+      "class_hash": "0x43d192556fbc5f7fa34711962cae7b94dfcf70c48e9490008dace1493f13ea1",
+      "tag": "s2-Guild",
+      "selector": "0x272e9734c4c18684064c6693467a9d9dab5ded5dfab771919e9d417f6e0cdba",
       "members": [
         {
           "name": "game_id",
@@ -2832,12 +2775,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x43d192556fbc5f7fa34711962cae7b94dfcf70c48e9490008dace1493f13ea1",
-      "tag": "s2-Guild",
-      "selector": "0x272e9734c4c18684064c6693467a9d9dab5ded5dfab771919e9d417f6e0cdba"
+      ]
     },
     {
+      "class_hash": "0x41de906be9d5232fd47bdeb61ad9625ce72bd9010ed6ee83a8d927455f0763d",
+      "tag": "s2-GuildMember",
+      "selector": "0x6aaa78a96566f91c8de68caf40ab994f96dab8cb7f8aa11d1f510a5d62d737c",
       "members": [
         {
           "name": "game_id",
@@ -2854,12 +2797,12 @@
           "type": "core::starknet::contract_address::ContractAddress",
           "key": false
         }
-      ],
-      "class_hash": "0x41de906be9d5232fd47bdeb61ad9625ce72bd9010ed6ee83a8d927455f0763d",
-      "tag": "s2-GuildMember",
-      "selector": "0x6aaa78a96566f91c8de68caf40ab994f96dab8cb7f8aa11d1f510a5d62d737c"
+      ]
     },
     {
+      "class_hash": "0x35bcba9d06bf87f751444aa9849aba553c683e3480c54d0f0f97fb5da2dd430",
+      "tag": "s2-GuildWhitelist",
+      "selector": "0x54225109ea5547a706d02e5e2d0197050ae44c4d783f9287b2e45dfaf8aa9e0",
       "members": [
         {
           "name": "game_id",
@@ -2881,12 +2824,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x35bcba9d06bf87f751444aa9849aba553c683e3480c54d0f0f97fb5da2dd430",
-      "tag": "s2-GuildWhitelist",
-      "selector": "0x54225109ea5547a706d02e5e2d0197050ae44c4d783f9287b2e45dfaf8aa9e0"
+      ]
     },
     {
+      "class_hash": "0x6184627d5ac5dd3a7e9c3e5d305530e5562d889d1377fdba191ff170730a5b9",
+      "tag": "s2-HyperstrtConstructConfig",
+      "selector": "0x13268b3c71b49e4d98d182f301b77b1d39fb50d1528913c17ff3acc052dda6",
       "members": [
         {
           "name": "preset_id",
@@ -2913,12 +2856,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x6184627d5ac5dd3a7e9c3e5d305530e5562d889d1377fdba191ff170730a5b9",
-      "tag": "s2-HyperstrtConstructConfig",
-      "selector": "0x13268b3c71b49e4d98d182f301b77b1d39fb50d1528913c17ff3acc052dda6"
+      ]
     },
     {
+      "class_hash": "0x3ed1195b99b987f6a3d4a7b7aec7251d51d04ae5dbba283d67fe145fcba2627",
+      "tag": "s2-Hyperstructure",
+      "selector": "0x25a89c98d4cb8f08b090dda201fb3aaa62dc1372d9562c573f6e447d6d8511f",
       "members": [
         {
           "name": "game_id",
@@ -2955,12 +2898,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x3ed1195b99b987f6a3d4a7b7aec7251d51d04ae5dbba283d67fe145fcba2627",
-      "tag": "s2-Hyperstructure",
-      "selector": "0x25a89c98d4cb8f08b090dda201fb3aaa62dc1372d9562c573f6e447d6d8511f"
+      ]
     },
     {
+      "class_hash": "0x2a4d6147989b2052e4560f49d46a7c93f7417560adfae092851d523aa275d7e",
+      "tag": "s2-HyperstructureGlobals",
+      "selector": "0x36ebd328a34e1f92e88cd430f8331f1dcbeffb8b53a85756b7d899dbd3bf77b",
       "members": [
         {
           "name": "game_id",
@@ -2977,12 +2920,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x2a4d6147989b2052e4560f49d46a7c93f7417560adfae092851d523aa275d7e",
-      "tag": "s2-HyperstructureGlobals",
-      "selector": "0x36ebd328a34e1f92e88cd430f8331f1dcbeffb8b53a85756b7d899dbd3bf77b"
+      ]
     },
     {
+      "class_hash": "0x7145593b980f125ac87203684f79a10725f6bb151646efa525953f97b57ea41",
+      "tag": "s2-HyperstructureIndex",
+      "selector": "0x1b88328b3bc4a4743f5d66cdbc0e44d6e1e2fca8c8bb5e000c62733e7349a89",
       "members": [
         {
           "name": "game_id",
@@ -2999,12 +2942,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x7145593b980f125ac87203684f79a10725f6bb151646efa525953f97b57ea41",
-      "tag": "s2-HyperstructureIndex",
-      "selector": "0x1b88328b3bc4a4743f5d66cdbc0e44d6e1e2fca8c8bb5e000c62733e7349a89"
+      ]
     },
     {
+      "class_hash": "0x531008f597d58023107734f14fa4c6fa69ce7a048d26de776a97b12de53871a",
+      "tag": "s2-HyperstructureRequirements",
+      "selector": "0x2d8d13a807738399782d11f7056462a8a55ea4ad30d41757e5c73f7e271c743",
       "members": [
         {
           "name": "game_id",
@@ -3141,12 +3084,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x531008f597d58023107734f14fa4c6fa69ce7a048d26de776a97b12de53871a",
-      "tag": "s2-HyperstructureRequirements",
-      "selector": "0x2d8d13a807738399782d11f7056462a8a55ea4ad30d41757e5c73f7e271c743"
+      ]
     },
     {
+      "class_hash": "0x715edee5b5f51eedfd05ef8fd773a01a29925f7ed5cc55fcb1768bcfb1a89bc",
+      "tag": "s2-HyperstructureShareholders",
+      "selector": "0x45af61db8a61bec81c40d22ff597980ea2b08862531389341f06ea9f30461c8",
       "members": [
         {
           "name": "game_id",
@@ -3168,12 +3111,12 @@
           "type": "core::array::Span::<(core::starknet::contract_address::ContractAddress, core::integer::u16)>",
           "key": false
         }
-      ],
-      "class_hash": "0x715edee5b5f51eedfd05ef8fd773a01a29925f7ed5cc55fcb1768bcfb1a89bc",
-      "tag": "s2-HyperstructureShareholders",
-      "selector": "0x45af61db8a61bec81c40d22ff597980ea2b08862531389341f06ea9f30461c8"
+      ]
     },
     {
+      "class_hash": "0x5fad360b074057ef23d4aa2d9e64bfea6cfd919c9b654f0c27b5ae7a0b68ceb",
+      "tag": "s2-LedgerRegistration",
+      "selector": "0x4a16b0e37431221727c1c549efa45817db09dc67f4ba17525ad96069536b1ad",
       "members": [
         {
           "name": "game_id",
@@ -3205,12 +3148,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x5fad360b074057ef23d4aa2d9e64bfea6cfd919c9b654f0c27b5ae7a0b68ceb",
-      "tag": "s2-LedgerRegistration",
-      "selector": "0x4a16b0e37431221727c1c549efa45817db09dc67f4ba17525ad96069536b1ad"
+      ]
     },
     {
+      "class_hash": "0x6a27b76d18d45274952402c93dd45003eb6fb66fd1c9dd23d86b46ff9da0897",
+      "tag": "s2-Liquidity",
+      "selector": "0x2227cb9e194be1d4c70ee1f658115865da3d62a9b8fd13b1835c62c4c78b0dd",
       "members": [
         {
           "name": "game_id",
@@ -3232,12 +3175,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x6a27b76d18d45274952402c93dd45003eb6fb66fd1c9dd23d86b46ff9da0897",
-      "tag": "s2-Liquidity",
-      "selector": "0x2227cb9e194be1d4c70ee1f658115865da3d62a9b8fd13b1835c62c4c78b0dd"
+      ]
     },
     {
+      "class_hash": "0x228146e9f36e053f4a9e14cdcc36c08f70a439c28b059b238d45b949303796a",
+      "tag": "s2-Market",
+      "selector": "0x6d67a5cd0567cef4ea598909edec19d3a0e2411cd4b874f73141f01a4314825",
       "members": [
         {
           "name": "game_id",
@@ -3264,12 +3207,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x228146e9f36e053f4a9e14cdcc36c08f70a439c28b059b238d45b949303796a",
-      "tag": "s2-Market",
-      "selector": "0x6d67a5cd0567cef4ea598909edec19d3a0e2411cd4b874f73141f01a4314825"
+      ]
     },
     {
+      "class_hash": "0x35868dfbc8eab2b0f035c320322091036f089ac1d331eab9dc97efbd0cdb6d1",
+      "tag": "s2-PlayerConstructionPoints",
+      "selector": "0x5eb07e6635b394e03ceb3bbae60cab9b94e726082b63d9125e008a3e84a5fdf",
       "members": [
         {
           "name": "game_id",
@@ -3291,12 +3234,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x35868dfbc8eab2b0f035c320322091036f089ac1d331eab9dc97efbd0cdb6d1",
-      "tag": "s2-PlayerConstructionPoints",
-      "selector": "0x5eb07e6635b394e03ceb3bbae60cab9b94e726082b63d9125e008a3e84a5fdf"
+      ]
     },
     {
+      "class_hash": "0x6ecc145984621481a5b08652ec28acc83e8f04ebae5a272611951e322710d13",
+      "tag": "s2-PlayerFaithPoints",
+      "selector": "0x7fff832066e138da4eddd2989dea157125cb1ed34c412ac7d6be99b0fc1a96d",
       "members": [
         {
           "name": "game_id",
@@ -3333,12 +3276,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x6ecc145984621481a5b08652ec28acc83e8f04ebae5a272611951e322710d13",
-      "tag": "s2-PlayerFaithPoints",
-      "selector": "0x7fff832066e138da4eddd2989dea157125cb1ed34c412ac7d6be99b0fc1a96d"
+      ]
     },
     {
+      "class_hash": "0x135bc03e8ac68ff17d664f35b9bc820f5b3b6fc7cfc510b8d5ec40042d4266f",
+      "tag": "s2-PlayerFaithPrizeClaimed",
+      "selector": "0x5affd158199990c5e8cf8f3b66032ed5472c9c1d4a9d755f124c6ff2dca406b",
       "members": [
         {
           "name": "game_id",
@@ -3360,12 +3303,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x135bc03e8ac68ff17d664f35b9bc820f5b3b6fc7cfc510b8d5ec40042d4266f",
-      "tag": "s2-PlayerFaithPrizeClaimed",
-      "selector": "0x5affd158199990c5e8cf8f3b66032ed5472c9c1d4a9d755f124c6ff2dca406b"
+      ]
     },
     {
+      "class_hash": "0x18c7c523615962f66a3f459513a6566da96c70053677dd42604f7182be4fbda",
+      "tag": "s2-PlayerRank",
+      "selector": "0x305bba153d96fbda9d844d2d0d7a40234d0898db8efd47929da4803a8612edf",
       "members": [
         {
           "name": "game_id",
@@ -3387,12 +3330,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x18c7c523615962f66a3f459513a6566da96c70053677dd42604f7182be4fbda",
-      "tag": "s2-PlayerRank",
-      "selector": "0x305bba153d96fbda9d844d2d0d7a40234d0898db8efd47929da4803a8612edf"
+      ]
     },
     {
+      "class_hash": "0x79f2c0596763494181ab60d2391b5fd203cce65847f6f35cc1f6de7b20c166f",
+      "tag": "s2-PlayerRegisteredPoints",
+      "selector": "0x1ae53ffaeedb26b02aa79fa8bdc3f82c57039f564e7d0ac62591dd3a90807db",
       "members": [
         {
           "name": "game_id",
@@ -3409,12 +3352,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x79f2c0596763494181ab60d2391b5fd203cce65847f6f35cc1f6de7b20c166f",
-      "tag": "s2-PlayerRegisteredPoints",
-      "selector": "0x1ae53ffaeedb26b02aa79fa8bdc3f82c57039f564e7d0ac62591dd3a90807db"
+      ]
     },
     {
+      "class_hash": "0x42a7efe3a6931069d6672ec8d7bf316ac2667c177dbaa1377ae2ce1496dd80a",
+      "tag": "s2-PlayerSettlement",
+      "selector": "0xcd09b69ab5b4e26c09bded67df7d5bad8232db20a9760b215c67612a5fbe67",
       "members": [
         {
           "name": "game_id",
@@ -3436,12 +3379,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x42a7efe3a6931069d6672ec8d7bf316ac2667c177dbaa1377ae2ce1496dd80a",
-      "tag": "s2-PlayerSettlement",
-      "selector": "0xcd09b69ab5b4e26c09bded67df7d5bad8232db20a9760b215c67612a5fbe67"
+      ]
     },
     {
+      "class_hash": "0xdc1dea1fb973b03825700edbce0a7594417646b959560ed3e08fc7d8c34a68",
+      "tag": "s2-PlayersRankTrial",
+      "selector": "0x6a748d9b4406e8c330f08c4b47047cb80c087408c4fd0c5058506eb3b4979b3",
       "members": [
         {
           "name": "game_id",
@@ -3483,12 +3426,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0xdc1dea1fb973b03825700edbce0a7594417646b959560ed3e08fc7d8c34a68",
-      "tag": "s2-PlayersRankTrial",
-      "selector": "0x6a748d9b4406e8c330f08c4b47047cb80c087408c4fd0c5058506eb3b4979b3"
+      ]
     },
     {
+      "class_hash": "0x23677c7b9437c349ee530aacca071f6f66a0cf9484950ad22b97c42ad88393",
+      "tag": "s2-Preset",
+      "selector": "0x115df193febff852d83ad0ffc11bca8b10ca2f597cd67e213c8de88e20bfad",
       "members": [
         {
           "name": "preset_id",
@@ -3500,12 +3443,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x23677c7b9437c349ee530aacca071f6f66a0cf9484950ad22b97c42ad88393",
-      "tag": "s2-Preset",
-      "selector": "0x115df193febff852d83ad0ffc11bca8b10ca2f597cd67e213c8de88e20bfad"
+      ]
     },
     {
+      "class_hash": "0x2ddeb707a00220620b4496b62ca8f3227f245fd3d52b422a536d888679cb558",
+      "tag": "s2-PresetConfig",
+      "selector": "0x61a2c7e6edb2c94333efe3a076a799645b6fba58a8fe3efccc70c30ea987a6f",
       "members": [
         {
           "name": "preset_id",
@@ -3666,13 +3609,18 @@
           "name": "mercenaries_name",
           "type": "core::felt252",
           "key": false
+        },
+        {
+          "name": "spire_travel_essence_cost",
+          "type": "core::integer::u128",
+          "key": false
         }
-      ],
-      "class_hash": "0x5ad909a0a29552dd944ec7a8c0cb14e090d2314879ea54cc22248848acfd967",
-      "tag": "s2-PresetConfig",
-      "selector": "0x61a2c7e6edb2c94333efe3a076a799645b6fba58a8fe3efccc70c30ea987a6f"
+      ]
     },
     {
+      "class_hash": "0x50737ac0ff87fb9c741f5c3a0cf289cf4e0bc1db4d6066084f1c546d0ef6f71",
+      "tag": "s2-PresetGameConfig",
+      "selector": "0x7b0ded3a7f87aab513f6e0cd057778391f2bfdae79b995441af37dd6c1dfcd2",
       "members": [
         {
           "name": "preset_id",
@@ -3719,12 +3667,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x50737ac0ff87fb9c741f5c3a0cf289cf4e0bc1db4d6066084f1c546d0ef6f71",
-      "tag": "s2-PresetGameConfig",
-      "selector": "0x7b0ded3a7f87aab513f6e0cd057778391f2bfdae79b995441af37dd6c1dfcd2"
+      ]
     },
     {
+      "class_hash": "0x7574cb3717eb4fea57c457b974ed0734395e98fc4c4463074c714d1250efdc8",
+      "tag": "s2-ProductionBoostBonus",
+      "selector": "0x600905dc1ab9e99a4d4357c73addbc3a2014bf7262e7f71b8d32054e89e6c21",
       "members": [
         {
           "name": "game_id",
@@ -3776,12 +3724,12 @@
           "type": "eternum::models::position::Coord",
           "key": false
         }
-      ],
-      "class_hash": "0x7574cb3717eb4fea57c457b974ed0734395e98fc4c4463074c714d1250efdc8",
-      "tag": "s2-ProductionBoostBonus",
-      "selector": "0x600905dc1ab9e99a4d4357c73addbc3a2014bf7262e7f71b8d32054e89e6c21"
+      ]
     },
     {
+      "class_hash": "0x5332c387c654fe5010b7c375fe62ec6b9f74c772fc6a78c88e8199d8d9da011",
+      "tag": "s2-Quantity",
+      "selector": "0x544f6bf8c97c5eb342c920da543889bdafcf89b5eaf04c2546754eb472f3334",
       "members": [
         {
           "name": "game_id",
@@ -3798,12 +3746,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x5332c387c654fe5010b7c375fe62ec6b9f74c772fc6a78c88e8199d8d9da011",
-      "tag": "s2-Quantity",
-      "selector": "0x544f6bf8c97c5eb342c920da543889bdafcf89b5eaf04c2546754eb472f3334"
+      ]
     },
     {
+      "class_hash": "0x5ca1fc13da807c5179463e5f1fe5a6dec66d63c44d76b0c6c82811d419e3118",
+      "tag": "s2-QuantityTracker",
+      "selector": "0x4e02c97628577ddb0a35623ba9c15794fead44493eec4f9de50b490b1b1a32e",
       "members": [
         {
           "name": "game_id",
@@ -3820,194 +3768,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x5ca1fc13da807c5179463e5f1fe5a6dec66d63c44d76b0c6c82811d419e3118",
-      "tag": "s2-QuantityTracker",
-      "selector": "0x4e02c97628577ddb0a35623ba9c15794fead44493eec4f9de50b490b1b1a32e"
+      ]
     },
     {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "game_token_id",
-          "type": "core::integer::u64",
-          "key": true
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress",
-          "key": true
-        },
-        {
-          "name": "quest_tile_id",
-          "type": "core::integer::u32",
-          "key": false
-        },
-        {
-          "name": "explorer_id",
-          "type": "core::integer::u32",
-          "key": false
-        },
-        {
-          "name": "completed",
-          "type": "core::bool",
-          "key": false
-        }
-      ],
-      "class_hash": "0x30aa42645e5fa3e70bd2876d13dd51a4a0d6be6b815558a5ca44a7cef0842b3",
-      "tag": "s2-Quest",
-      "selector": "0x5a2f75d9f254d3dc026d4926a4ad6cd40415e330956a66819a9b15b17e01d9f"
-    },
-    {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "key",
-          "type": "core::felt252",
-          "key": true
-        },
-        {
-          "name": "enabled",
-          "type": "core::bool",
-          "key": false
-        }
-      ],
-      "class_hash": "0x5cd2e2d18015b6b71513b0d9ef101c02f1d7e24ba2d7423dfef20656af6d880",
-      "tag": "s2-QuestFeatureFlag",
-      "selector": "0x7a9372b72fd4a5f7c7c216781c924cfb82f1df5bd433e8307e8b8736dc1fb87"
-    },
-    {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "key",
-          "type": "core::felt252",
-          "key": true
-        },
-        {
-          "name": "games",
-          "type": "core::array::Span::<core::starknet::contract_address::ContractAddress>",
-          "key": false
-        }
-      ],
-      "class_hash": "0x1503eebafd44403502295f3d5f6aa0e415b87f11bbe45bbc53128e4b06598e7",
-      "tag": "s2-QuestGameRegistry",
-      "selector": "0xd8b24dd8b53d16f9da9c6508b185d0833973e181ff951e099a9cfdfe46eebe"
-    },
-    {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress",
-          "key": true
-        },
-        {
-          "name": "levels",
-          "type": "core::array::Span::<eternum::models::quest::Level>",
-          "key": false
-        }
-      ],
-      "class_hash": "0x3d9bdd5cdef294d3bdcbf440f9b436d43a895273fd3da5d13db408f235323fd",
-      "tag": "s2-QuestLevels",
-      "selector": "0xfebaab7d6c393079b55dc88d8e0f509e465962b5b8d40c43dd18b5a7432085"
-    },
-    {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "quest_tile_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "realm_or_village_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "game_token_id",
-          "type": "core::integer::u64",
-          "key": false
-        }
-      ],
-      "class_hash": "0x581922be60b30a63bc0ea44154135ed0336266f11caa2a02380aa53881bc57f",
-      "tag": "s2-QuestRegistrations",
-      "selector": "0x1bed9f9505922b9d850432a506053a1a47fcedb843d6d0dcb4f2347c839543"
-    },
-    {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress",
-          "key": false
-        },
-        {
-          "name": "coord",
-          "type": "eternum::models::position::Coord",
-          "key": false
-        },
-        {
-          "name": "level",
-          "type": "core::integer::u8",
-          "key": false
-        },
-        {
-          "name": "resource_type",
-          "type": "core::integer::u8",
-          "key": false
-        },
-        {
-          "name": "amount",
-          "type": "core::integer::u128",
-          "key": false
-        },
-        {
-          "name": "capacity",
-          "type": "core::integer::u16",
-          "key": false
-        },
-        {
-          "name": "participant_count",
-          "type": "core::integer::u16",
-          "key": false
-        }
-      ],
-      "class_hash": "0x1fd22f9bd0baa0c894d0d4777946851dbc3870f3c487ad8c7027cdcd8c06a2e",
-      "tag": "s2-QuestTile",
-      "selector": "0x3a90c63dc2460c4d149e0f4bb2b04c99dbb5456f93099460892dc63489f70de"
-    },
-    {
+      "class_hash": "0xc4bdb0e293902f922be3e800834f52001e15d27c9ecd0058fe17ab241db517",
+      "tag": "s2-RNG",
+      "selector": "0x3fc3821ad6b58d27e0c002bd5a5ea43395dc0746c66e375931a2226083c85a6",
       "members": [
         {
           "name": "tx_hash",
@@ -4019,12 +3785,12 @@
           "type": "core::integer::u256",
           "key": false
         }
-      ],
-      "class_hash": "0xc4bdb0e293902f922be3e800834f52001e15d27c9ecd0058fe17ab241db517",
-      "tag": "s2-RNG",
-      "selector": "0x3fc3821ad6b58d27e0c002bd5a5ea43395dc0746c66e375931a2226083c85a6"
+      ]
     },
     {
+      "class_hash": "0x50ae648c3fc636a28a73adc3bc4a82fec4b90a8c0ac7443db929a03e0f0b461",
+      "tag": "s2-RankList",
+      "selector": "0x6100d2b30dfa748cc89d09c5634e5cbb2ee563acbffece9738cad6a5e9dd85c",
       "members": [
         {
           "name": "game_id",
@@ -4046,12 +3812,12 @@
           "type": "core::starknet::contract_address::ContractAddress",
           "key": false
         }
-      ],
-      "class_hash": "0x50ae648c3fc636a28a73adc3bc4a82fec4b90a8c0ac7443db929a03e0f0b461",
-      "tag": "s2-RankList",
-      "selector": "0x6100d2b30dfa748cc89d09c5634e5cbb2ee563acbffece9738cad6a5e9dd85c"
+      ]
     },
     {
+      "class_hash": "0x532f3162932b62a579fb306905701e6b1b7c95fac27c53c2a9219848be0efb1",
+      "tag": "s2-RankPrize",
+      "selector": "0x4ccd81de11cfa27a544ef2fdb0c91ce9801817c4b658d9decd9e12fdfd08841",
       "members": [
         {
           "name": "game_id",
@@ -4073,12 +3839,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x532f3162932b62a579fb306905701e6b1b7c95fac27c53c2a9219848be0efb1",
-      "tag": "s2-RankPrize",
-      "selector": "0x4ccd81de11cfa27a544ef2fdb0c91ce9801817c4b658d9decd9e12fdfd08841"
+      ]
     },
     {
+      "class_hash": "0x1123e3b1a737a513751544d76af08dcff9f20faf0ae2395f91d3b77e09d704f",
+      "tag": "s2-RealmAllocation",
+      "selector": "0x79a4addfe0a7a10ffb8eae0b990642bc14de0631d165e38449867f8423447e0",
       "members": [
         {
           "name": "game_id",
@@ -4100,12 +3866,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x1123e3b1a737a513751544d76af08dcff9f20faf0ae2395f91d3b77e09d704f",
-      "tag": "s2-RealmAllocation",
-      "selector": "0x79a4addfe0a7a10ffb8eae0b990642bc14de0631d165e38449867f8423447e0"
+      ]
     },
     {
+      "class_hash": "0x21593d354fcf382efa95bb9dce6631d51e16b641a950ffff1da9fdc2f96fd8",
+      "tag": "s2-RealmAllocationPool",
+      "selector": "0x7ab01ba321c2b69f20dcbb8d93b0fc5ee118f434aefa66c769a7b1cf66dcbea",
       "members": [
         {
           "name": "game_id",
@@ -4122,12 +3888,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x21593d354fcf382efa95bb9dce6631d51e16b641a950ffff1da9fdc2f96fd8",
-      "tag": "s2-RealmAllocationPool",
-      "selector": "0x7ab01ba321c2b69f20dcbb8d93b0fc5ee118f434aefa66c769a7b1cf66dcbea"
+      ]
     },
     {
+      "class_hash": "0x683e1388b577b26d2e1a3c9047e3d5785b00fb2f698d6f89dcbfc813037a018",
+      "tag": "s2-RealmAllocationSlot",
+      "selector": "0x37f0c8d75886430415e511477ced907b08ebc2731741ea48a523c4aad9d3fb7",
       "members": [
         {
           "name": "game_id",
@@ -4144,12 +3910,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x683e1388b577b26d2e1a3c9047e3d5785b00fb2f698d6f89dcbfc813037a018",
-      "tag": "s2-RealmAllocationSlot",
-      "selector": "0x37f0c8d75886430415e511477ced907b08ebc2731741ea48a523c4aad9d3fb7"
+      ]
     },
     {
+      "class_hash": "0xea8e45d66b2d914ae87cdc3ea3fc1384870d1f937aada92e93462299aa6eec",
+      "tag": "s2-Resource",
+      "selector": "0x12ea8448e31b01b0d7f7d8aa1a197580a15a760e9f8321de1b5a62804621d69",
       "members": [
         {
           "name": "game_id",
@@ -4656,12 +4422,12 @@
           "type": "eternum::models::resource::production::production::Production",
           "key": false
         }
-      ],
-      "class_hash": "0xea8e45d66b2d914ae87cdc3ea3fc1384870d1f937aada92e93462299aa6eec",
-      "tag": "s2-Resource",
-      "selector": "0x12ea8448e31b01b0d7f7d8aa1a197580a15a760e9f8321de1b5a62804621d69"
+      ]
     },
     {
+      "class_hash": "0x15353441b26dfa7aac05d2b577b8bd1dee48ff91e8b22367e30f1e9542e8420",
+      "tag": "s2-ResourceAllowance",
+      "selector": "0x7aed1e68a6184c3225125832fe8a67702157f84e8fd08e2eded345157f313d9",
       "members": [
         {
           "name": "game_id",
@@ -4688,12 +4454,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x15353441b26dfa7aac05d2b577b8bd1dee48ff91e8b22367e30f1e9542e8420",
-      "tag": "s2-ResourceAllowance",
-      "selector": "0x7aed1e68a6184c3225125832fe8a67702157f84e8fd08e2eded345157f313d9"
+      ]
     },
     {
+      "class_hash": "0x763e488bdae93688097a4363addff036b3d137e6a892272d255680eb8ec720d",
+      "tag": "s2-ResourceArrival",
+      "selector": "0x1ab3ac43e04ce5ebf2fcea0f618c920f1670d75eafeab8a4111062dfc993e39",
       "members": [
         {
           "name": "game_id",
@@ -4960,12 +4726,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x763e488bdae93688097a4363addff036b3d137e6a892272d255680eb8ec720d",
-      "tag": "s2-ResourceArrival",
-      "selector": "0x1ab3ac43e04ce5ebf2fcea0f618c920f1670d75eafeab8a4111062dfc993e39"
+      ]
     },
     {
+      "class_hash": "0x6a9dfdc1071007ff21b037dd9ead5bd90154b063e6bd9685fcbef1c71621394",
+      "tag": "s2-ResourceBridgeWtlConfig",
+      "selector": "0x464b1b851f51da3adf67ef3cf8c656e2a64f58d41f97c573fa9ba930e0970a4",
       "members": [
         {
           "name": "token",
@@ -4977,12 +4743,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x6a9dfdc1071007ff21b037dd9ead5bd90154b063e6bd9685fcbef1c71621394",
-      "tag": "s2-ResourceBridgeWtlConfig",
-      "selector": "0x464b1b851f51da3adf67ef3cf8c656e2a64f58d41f97c573fa9ba930e0970a4"
+      ]
     },
     {
+      "class_hash": "0x69a98efb0da1006f496368e4db09e0856832bd2281cce8bc0fb2845ef9f5864",
+      "tag": "s2-ResourceFactoryConfig",
+      "selector": "0x68b2d9cf1eeb0106715c3974941fe39fd10d6e32da87ebbe7a474fac1c656e2",
       "members": [
         {
           "name": "preset_id",
@@ -5039,12 +4805,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x69a98efb0da1006f496368e4db09e0856832bd2281cce8bc0fb2845ef9f5864",
-      "tag": "s2-ResourceFactoryConfig",
-      "selector": "0x68b2d9cf1eeb0106715c3974941fe39fd10d6e32da87ebbe7a474fac1c656e2"
+      ]
     },
     {
+      "class_hash": "0x51c7f07f51ea6e73f51ea8f6235005ef75ae41b8f231e9a027998d771619e53",
+      "tag": "s2-ResourceList",
+      "selector": "0x3d02b0c78209352ea7031d506c3e3e110fbcb81578cfa2e1349b888971ea0db",
       "members": [
         {
           "name": "preset_id",
@@ -5071,12 +4837,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x51c7f07f51ea6e73f51ea8f6235005ef75ae41b8f231e9a027998d771619e53",
-      "tag": "s2-ResourceList",
-      "selector": "0x3d02b0c78209352ea7031d506c3e3e110fbcb81578cfa2e1349b888971ea0db"
+      ]
     },
     {
+      "class_hash": "0x980c993fe7e644609e649396dc6764fcfb907a93a4e8038710e667fe644dee",
+      "tag": "s2-ResourceMinMaxList",
+      "selector": "0x1e85bb9a6c5d99ac2747e16b7ab86ba24916758edb20419a10345396bc58a8",
       "members": [
         {
           "name": "preset_id",
@@ -5108,12 +4874,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x980c993fe7e644609e649396dc6764fcfb907a93a4e8038710e667fe644dee",
-      "tag": "s2-ResourceMinMaxList",
-      "selector": "0x1e85bb9a6c5d99ac2747e16b7ab86ba24916758edb20419a10345396bc58a8"
+      ]
     },
     {
+      "class_hash": "0x3b8e118e93c29f8bb6221f2b37f0cbae790b5d2faf7ea98c464943426ad718a",
+      "tag": "s2-ResourceRevBridgeWtlConfig",
+      "selector": "0x3344bccb4359b63390cf9e1b5c30fe6d9d104c75e6fb58456553f18178f5ce7",
       "members": [
         {
           "name": "resource_type",
@@ -5125,12 +4891,12 @@
           "type": "core::starknet::contract_address::ContractAddress",
           "key": false
         }
-      ],
-      "class_hash": "0x3b8e118e93c29f8bb6221f2b37f0cbae790b5d2faf7ea98c464943426ad718a",
-      "tag": "s2-ResourceRevBridgeWtlConfig",
-      "selector": "0x3344bccb4359b63390cf9e1b5c30fe6d9d104c75e6fb58456553f18178f5ce7"
+      ]
     },
     {
+      "class_hash": "0x470614af0bf3f4b4e2f78439fcc6b5d97491abd1e64836c7665714329ec3bfa",
+      "tag": "s2-SeasonPrize",
+      "selector": "0x2aae041775ef8f42ae07aef48aa15862c8c7ce7f9f925742c30968eb727104",
       "members": [
         {
           "name": "game_id",
@@ -5147,12 +4913,12 @@
           "type": "core::integer::u256",
           "key": false
         }
-      ],
-      "class_hash": "0x470614af0bf3f4b4e2f78439fcc6b5d97491abd1e64836c7665714329ec3bfa",
-      "tag": "s2-SeasonPrize",
-      "selector": "0x2aae041775ef8f42ae07aef48aa15862c8c7ce7f9f925742c30968eb727104"
+      ]
     },
     {
+      "class_hash": "0x35242f9379ccb25e71b5b20a71b255303ef75f010f5cba14e7ae7d8da172258",
+      "tag": "s2-Series",
+      "selector": "0x3de220b777ba6d938e5ccf03e433d8c9a5b1d77f7725f1a590623d7deeb446b",
       "members": [
         {
           "name": "series_id",
@@ -5184,12 +4950,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x35242f9379ccb25e71b5b20a71b255303ef75f010f5cba14e7ae7d8da172258",
-      "tag": "s2-Series",
-      "selector": "0x3de220b777ba6d938e5ccf03e433d8c9a5b1d77f7725f1a590623d7deeb446b"
+      ]
     },
     {
+      "class_hash": "0x2f663468bf0268e584f0dafb3ca4e92c1acbba22131712f4e1f2c8bef3c94d9",
+      "tag": "s2-SeriesChestRewardState",
+      "selector": "0x12e16001281c64150163f32e16556d9b45004ff08ad0c393a5f3bf8245cdf63",
       "members": [
         {
           "name": "series_id",
@@ -5236,12 +5002,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x2f663468bf0268e584f0dafb3ca4e92c1acbba22131712f4e1f2c8bef3c94d9",
-      "tag": "s2-SeriesChestRewardState",
-      "selector": "0x12e16001281c64150163f32e16556d9b45004ff08ad0c393a5f3bf8245cdf63"
+      ]
     },
     {
+      "class_hash": "0x6bb1f14e4a9f8527143a24bc3cb00ba0e225eb0dac69f6cff43c3da67d4ac7a",
+      "tag": "s2-SharePointsCheckpoint",
+      "selector": "0xf73657d1f49d6eda14bb017bf4d6db1aef44b0d61810efab1e28832668cb27",
       "members": [
         {
           "name": "game_id",
@@ -5258,12 +5024,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x6bb1f14e4a9f8527143a24bc3cb00ba0e225eb0dac69f6cff43c3da67d4ac7a",
-      "tag": "s2-SharePointsCheckpoint",
-      "selector": "0xf73657d1f49d6eda14bb017bf4d6db1aef44b0d61810efab1e28832668cb27"
+      ]
     },
     {
+      "class_hash": "0x3bb206e39cb1e060863680dbe70f8abbaff5990362e61b0267919e7125c0ca5",
+      "tag": "s2-Structure",
+      "selector": "0x77d1f903ad7da638ae1d7a9b19db95cd329d823d130a7f42e81a743f5d458e4",
       "members": [
         {
           "name": "game_id",
@@ -5310,12 +5076,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x3bb206e39cb1e060863680dbe70f8abbaff5990362e61b0267919e7125c0ca5",
-      "tag": "s2-Structure",
-      "selector": "0x77d1f903ad7da638ae1d7a9b19db95cd329d823d130a7f42e81a743f5d458e4"
+      ]
     },
     {
+      "class_hash": "0x641d6da9fd82e203c190dc382a925f6c96a8d18983136993e7786caf8c79a3a",
+      "tag": "s2-StructureBuildings",
+      "selector": "0x12745e1e8f5e204d09963059bf8d2f063bfe198d248c57b970356924a88e877",
       "members": [
         {
           "name": "game_id",
@@ -5352,12 +5118,12 @@
           "type": "eternum::models::position::Coord",
           "key": false
         }
-      ],
-      "class_hash": "0x641d6da9fd82e203c190dc382a925f6c96a8d18983136993e7786caf8c79a3a",
-      "tag": "s2-StructureBuildings",
-      "selector": "0x12745e1e8f5e204d09963059bf8d2f063bfe198d248c57b970356924a88e877"
+      ]
     },
     {
+      "class_hash": "0x7429662ac49e70b6941640d9f76bf2cecee9a80d8d4e579e11cbeeaffac4856",
+      "tag": "s2-StructureLevelConfig",
+      "selector": "0x59c8429eba07ceeb4773b0964f0cd8c56f0f251e2c8ac158d76f81c52990161",
       "members": [
         {
           "name": "preset_id",
@@ -5379,12 +5145,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x7429662ac49e70b6941640d9f76bf2cecee9a80d8d4e579e11cbeeaffac4856",
-      "tag": "s2-StructureLevelConfig",
-      "selector": "0x59c8429eba07ceeb4773b0964f0cd8c56f0f251e2c8ac158d76f81c52990161"
+      ]
     },
     {
+      "class_hash": "0x21dad9ac74ea02f16453ec9502b48a3813d3a75eb4e30669eaae356321b8414",
+      "tag": "s2-StructureOwnerStats",
+      "selector": "0x7421f225b353a58f1b4829abd3b8456b8c428b0c456b751c447ff886afd56ab",
       "members": [
         {
           "name": "game_id",
@@ -5401,12 +5167,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x21dad9ac74ea02f16453ec9502b48a3813d3a75eb4e30669eaae356321b8414",
-      "tag": "s2-StructureOwnerStats",
-      "selector": "0x7421f225b353a58f1b4829abd3b8456b8c428b0c456b751c447ff886afd56ab"
+      ]
     },
     {
+      "class_hash": "0x701bb33899363d215242a58472ecd78626b7941c73689bb428747463d09216a",
+      "tag": "s2-StructureReservation",
+      "selector": "0x4b965ede053858469f5a2a7948f0890592048a00c52264f877070502724ae6c",
       "members": [
         {
           "name": "game_id",
@@ -5423,12 +5189,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x701bb33899363d215242a58472ecd78626b7941c73689bb428747463d09216a",
-      "tag": "s2-StructureReservation",
-      "selector": "0x4b965ede053858469f5a2a7948f0890592048a00c52264f877070502724ae6c"
+      ]
     },
     {
+      "class_hash": "0x109394174aee46cff6bc457099c9180c96d8df0ecaf32482f0e7ee450aa7077",
+      "tag": "s2-StructureVillageSlots",
+      "selector": "0x19db93cd4e5f166164caa6a848753d2f3204855ee320aada58dfe50ab1f5828",
       "members": [
         {
           "name": "game_id",
@@ -5455,12 +5221,12 @@
           "type": "core::array::Span::<eternum::models::position::Direction>",
           "key": false
         }
-      ],
-      "class_hash": "0x109394174aee46cff6bc457099c9180c96d8df0ecaf32482f0e7ee450aa7077",
-      "tag": "s2-StructureVillageSlots",
-      "selector": "0x19db93cd4e5f166164caa6a848753d2f3204855ee320aada58dfe50ab1f5828"
+      ]
     },
     {
+      "class_hash": "0x2ea8448adfa92e00db801deb31fc747cffe5cf1344e8c36f456f89dc33705e9",
+      "tag": "s2-TileOpt",
+      "selector": "0x3342774dad77cb20dc549a5ff8254e3be590935110822f72176dd60fe6611bc",
       "members": [
         {
           "name": "game_id",
@@ -5487,12 +5253,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x2ea8448adfa92e00db801deb31fc747cffe5cf1344e8c36f456f89dc33705e9",
-      "tag": "s2-TileOpt",
-      "selector": "0x3342774dad77cb20dc549a5ff8254e3be590935110822f72176dd60fe6611bc"
+      ]
     },
     {
+      "class_hash": "0x6a4dd1134ff3cb0c36b43526da1dcfc5ca5681efad26d772e8d087653ede984",
+      "tag": "s2-Trade",
+      "selector": "0x43ac67cbf4bd6f4f243b01592b60f3e90c184e4e8e0371e74cedf4f49817d1",
       "members": [
         {
           "name": "game_id",
@@ -5544,12 +5310,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x6a4dd1134ff3cb0c36b43526da1dcfc5ca5681efad26d772e8d087653ede984",
-      "tag": "s2-Trade",
-      "selector": "0x43ac67cbf4bd6f4f243b01592b60f3e90c184e4e8e0371e74cedf4f49817d1"
+      ]
     },
     {
+      "class_hash": "0x46add3584d3f5546efcf27e49913c7aee45c18f42faba5fb90290fadfcab93e",
+      "tag": "s2-TradeCount",
+      "selector": "0x719fb79d98fafad622497098d562515653193c15b39018426eb17d0945f7013",
       "members": [
         {
           "name": "game_id",
@@ -5566,12 +5332,12 @@
           "type": "core::integer::u8",
           "key": false
         }
-      ],
-      "class_hash": "0x46add3584d3f5546efcf27e49913c7aee45c18f42faba5fb90290fadfcab93e",
-      "tag": "s2-TradeCount",
-      "selector": "0x719fb79d98fafad622497098d562515653193c15b39018426eb17d0945f7013"
+      ]
     },
     {
+      "class_hash": "0x3701ba8d12fbe1d1cd2fd57d3e66e7e57701bce93c3bed406c12969e27947c3",
+      "tag": "s2-VillageRaidImmunity",
+      "selector": "0x76276a5caf682d463124a1f62f362bd84d78a16c275b8595e77521d3f2f911a",
       "members": [
         {
           "name": "game_id",
@@ -5588,12 +5354,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x3701ba8d12fbe1d1cd2fd57d3e66e7e57701bce93c3bed406c12969e27947c3",
-      "tag": "s2-VillageRaidImmunity",
-      "selector": "0x76276a5caf682d463124a1f62f362bd84d78a16c275b8595e77521d3f2f911a"
+      ]
     },
     {
+      "class_hash": "0xcbaffe92fa94745713a5abaa01ec95e23e728080e8024d3a71b8343bd0312f",
+      "tag": "s2-VillageTroop",
+      "selector": "0x7f8e2a7997323b5cbb654c968be0459268de6b9ebde9bab3a4ce00c86d5ba5a",
       "members": [
         {
           "name": "game_id",
@@ -5610,12 +5376,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0xcbaffe92fa94745713a5abaa01ec95e23e728080e8024d3a71b8343bd0312f",
-      "tag": "s2-VillageTroop",
-      "selector": "0x7f8e2a7997323b5cbb654c968be0459268de6b9ebde9bab3a4ce00c86d5ba5a"
+      ]
     },
     {
+      "class_hash": "0xfdbb307cca55fb645ea464127092b318ecfd060d1b33a9341afe88c9e9e00b",
+      "tag": "s2-WeightConfig",
+      "selector": "0x164b82462c1c11842174496bb8e315d9d14141779448185e88e002cfce74b",
       "members": [
         {
           "name": "preset_id",
@@ -5632,12 +5398,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0xfdbb307cca55fb645ea464127092b318ecfd060d1b33a9341afe88c9e9e00b",
-      "tag": "s2-WeightConfig",
-      "selector": "0x164b82462c1c11842174496bb8e315d9d14141779448185e88e002cfce74b"
+      ]
     },
     {
+      "class_hash": "0x71a2b7d7b730eb837f45a2c5df37fde4316451addadc9b5e3a8953592c0ca00",
+      "tag": "s2-Wonder",
+      "selector": "0xbbc249063e7a895df2fedbc321f513de8277c35501835a493f2843dd8b97da",
       "members": [
         {
           "name": "game_id",
@@ -5659,12 +5425,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x71a2b7d7b730eb837f45a2c5df37fde4316451addadc9b5e3a8953592c0ca00",
-      "tag": "s2-Wonder",
-      "selector": "0xbbc249063e7a895df2fedbc321f513de8277c35501835a493f2843dd8b97da"
+      ]
     },
     {
+      "class_hash": "0x332cc9b5ea4cca9709d0f5cb51392fc96cc24a96dd2ff9e1e46383ecdb7c77c",
+      "tag": "s2-WonderFaith",
+      "selector": "0x778c0a4eb61524a1d8e4c561d8f3a7981a2137f465341b970f9ef180931f177",
       "members": [
         {
           "name": "game_id",
@@ -5706,12 +5472,12 @@
           "type": "core::integer::u32",
           "key": false
         }
-      ],
-      "class_hash": "0x332cc9b5ea4cca9709d0f5cb51392fc96cc24a96dd2ff9e1e46383ecdb7c77c",
-      "tag": "s2-WonderFaith",
-      "selector": "0x778c0a4eb61524a1d8e4c561d8f3a7981a2137f465341b970f9ef180931f177"
+      ]
     },
     {
+      "class_hash": "0x40f967bbc058ba699f081fd70260aeb9806b0045b44a50e1d866239f5924b3a",
+      "tag": "s2-WonderFaithBlacklist",
+      "selector": "0x655d7e9d74bf1ee2292162d075ed42e3f0df086e8ac154a1773958415ade748",
       "members": [
         {
           "name": "game_id",
@@ -5733,12 +5499,12 @@
           "type": "core::bool",
           "key": false
         }
-      ],
-      "class_hash": "0x40f967bbc058ba699f081fd70260aeb9806b0045b44a50e1d866239f5924b3a",
-      "tag": "s2-WonderFaithBlacklist",
-      "selector": "0x655d7e9d74bf1ee2292162d075ed42e3f0df086e8ac154a1773958415ade748"
+      ]
     },
     {
+      "class_hash": "0x3735ab37a4d7fe8f869aa717bf6ad6748c67883efecb29ac53197ce29ff0999",
+      "tag": "s2-WonderFaithPrize",
+      "selector": "0x28b9f0b6005bdb0cc2f32c07605a2253b4324582867c097cf31bf975b3b11f8",
       "members": [
         {
           "name": "game_id",
@@ -5755,12 +5521,12 @@
           "type": "core::integer::u128",
           "key": false
         }
-      ],
-      "class_hash": "0x3735ab37a4d7fe8f869aa717bf6ad6748c67883efecb29ac53197ce29ff0999",
-      "tag": "s2-WonderFaithPrize",
-      "selector": "0x28b9f0b6005bdb0cc2f32c07605a2253b4324582867c097cf31bf975b3b11f8"
+      ]
     },
     {
+      "class_hash": "0xad763ae24efd047b85fb7a121061ab3c0dc1d30a883044dd6d9f2fbc301a5c",
+      "tag": "s2-WonderFaithWinners",
+      "selector": "0x618d3239ce79629145e54cffcce0dbc94d8ea16fc6bf55fd86f869a297f260a",
       "members": [
         {
           "name": "game_id",
@@ -5777,12 +5543,12 @@
           "type": "core::array::Array::<core::integer::u32>",
           "key": false
         }
-      ],
-      "class_hash": "0xad763ae24efd047b85fb7a121061ab3c0dc1d30a883044dd6d9f2fbc301a5c",
-      "tag": "s2-WonderFaithWinners",
-      "selector": "0x618d3239ce79629145e54cffcce0dbc94d8ea16fc6bf55fd86f869a297f260a"
+      ]
     },
     {
+      "class_hash": "0x6b7bc4f6281e215c86178d38c69c0dba3ce10631c7d706f7408f8423887d0df",
+      "tag": "s2-WorldConfig",
+      "selector": "0x27f890205071c9920bc03c5768b0ef83e679583f2f43422f7c07909814edf5c",
       "members": [
         {
           "name": "game_id",
@@ -5829,12 +5595,12 @@
           "type": "eternum::models::config::RealmCountConfig",
           "key": false
         }
-      ],
-      "class_hash": "0x6b7bc4f6281e215c86178d38c69c0dba3ce10631c7d706f7408f8423887d0df",
-      "tag": "s2-WorldConfig",
-      "selector": "0x27f890205071c9920bc03c5768b0ef83e679583f2f43422f7c07909814edf5c"
+      ]
     },
     {
+      "class_hash": "0x71fa52b339fbed44213733fe3b431a44b502fa35ae5cb6cd4eb2598ac44e9f8",
+      "tag": "s2-WorldRecord",
+      "selector": "0xcd816166debe6e11c84fdfd61d1419a58a6a1b8bb11991d3b3a203ba547e55",
       "members": [
         {
           "name": "game_id",
@@ -5846,14 +5612,14 @@
           "type": "eternum::models::record::RelicRecord",
           "key": false
         }
-      ],
-      "class_hash": "0x71fa52b339fbed44213733fe3b431a44b502fa35ae5cb6cd4eb2598ac44e9f8",
-      "tag": "s2-WorldRecord",
-      "selector": "0xcd816166debe6e11c84fdfd61d1419a58a6a1b8bb11991d3b3a203ba547e55"
+      ]
     }
   ],
   "events": [
     {
+      "class_hash": "0x91999e68f9b0a5f3054bf61c9b33e43c98f102f2dc184118f776b1402f22a8",
+      "tag": "s2-AcceptOrder",
+      "selector": "0x7715fafaa3ab8ebe091eaa77b0a1b029b44b99a78d990266e1fb2035da41c75",
       "members": [
         {
           "name": "game_id",
@@ -5885,12 +5651,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x91999e68f9b0a5f3054bf61c9b33e43c98f102f2dc184118f776b1402f22a8",
-      "tag": "s2-AcceptOrder",
-      "selector": "0x7715fafaa3ab8ebe091eaa77b0a1b029b44b99a78d990266e1fb2035da41c75"
+      ]
     },
     {
+      "class_hash": "0x7b5d4a4fe31ca57dc45208dd3b002f23962d70be21ed7f67c3206e3244b908d",
+      "tag": "s2-AgentCreatedEvent",
+      "selector": "0x61013ab1ab4ae74a9109370655d205a95c5cd0468a9d6c9370802e528e7f0f0",
       "members": [
         {
           "name": "game_id",
@@ -5922,12 +5688,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x7b5d4a4fe31ca57dc45208dd3b002f23962d70be21ed7f67c3206e3244b908d",
-      "tag": "s2-AgentCreatedEvent",
-      "selector": "0x61013ab1ab4ae74a9109370655d205a95c5cd0468a9d6c9370802e528e7f0f0"
+      ]
     },
     {
+      "class_hash": "0x22991374926122fe6aaa968dce7fcb17e2f3a7140fd76fd77f4822588f93fb2",
+      "tag": "s2-BattleEvent",
+      "selector": "0x179e875aff2614970c530c44b471c44ed0e584e1e4b9ed671ddff8f5f23dbac",
       "members": [
         {
           "name": "game_id",
@@ -5974,12 +5740,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x22991374926122fe6aaa968dce7fcb17e2f3a7140fd76fd77f4822588f93fb2",
-      "tag": "s2-BattleEvent",
-      "selector": "0x179e875aff2614970c530c44b471c44ed0e584e1e4b9ed671ddff8f5f23dbac"
+      ]
     },
     {
+      "class_hash": "0x6b2019c03df74c1db40ac7daa7e9d4b4de3785806dca473bb577f20f7bca708",
+      "tag": "s2-BlitzSettlementEvent",
+      "selector": "0x191038093121876444ae38ae42c7bb5921a168700efc279c8722313ba49789",
       "members": [
         {
           "name": "game_id",
@@ -5996,12 +5762,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x6b2019c03df74c1db40ac7daa7e9d4b4de3785806dca473bb577f20f7bca708",
-      "tag": "s2-BlitzSettlementEvent",
-      "selector": "0x191038093121876444ae38ae42c7bb5921a168700efc279c8722313ba49789"
+      ]
     },
     {
+      "class_hash": "0x11a098867c3c92ae9a5dc8e0e64805170e5cf34b72383efed2e9a404129d3da",
+      "tag": "s2-BurnDonkey",
+      "selector": "0x3e93e12e914aadd09618c482c883b583feac873fc14478adc6b81cfdc889ef8",
       "members": [
         {
           "name": "game_id",
@@ -6028,12 +5794,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x11a098867c3c92ae9a5dc8e0e64805170e5cf34b72383efed2e9a404129d3da",
-      "tag": "s2-BurnDonkey",
-      "selector": "0x3e93e12e914aadd09618c482c883b583feac873fc14478adc6b81cfdc889ef8"
+      ]
     },
     {
+      "class_hash": "0xeac0e079f24ea1acc3b9b4f921f601acc39db4b96b460574d5ffb4f3ec7c4f",
+      "tag": "s2-BurnResearchForRelicEvent",
+      "selector": "0x3b6b38b7a6e5db9ebc10d7257f640af7be0ec2272cdd9d8a9a3e134932ba514",
       "members": [
         {
           "name": "game_id",
@@ -6055,44 +5821,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0xeac0e079f24ea1acc3b9b4f921f601acc39db4b96b460574d5ffb4f3ec7c4f",
-      "tag": "s2-BurnResearchForRelicEvent",
-      "selector": "0x3b6b38b7a6e5db9ebc10d7257f640af7be0ec2272cdd9d8a9a3e134932ba514"
+      ]
     },
     {
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "taker_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "maker_id",
-          "type": "core::integer::u32",
-          "key": true
-        },
-        {
-          "name": "trade_id",
-          "type": "core::integer::u32",
-          "key": false
-        },
-        {
-          "name": "timestamp",
-          "type": "core::integer::u64",
-          "key": false
-        }
-      ],
       "class_hash": "0x4cc1c3353336f63aabaa520819a77ea30ae8cbaa952154fbbeef8522f07d5ed",
       "tag": "s2-CancelOrder",
-      "selector": "0x5d4742a8575b8f8107214c18541df2cdde74a1af856605ba8621e9e1b8a774d"
-    },
-    {
+      "selector": "0x5d4742a8575b8f8107214c18541df2cdde74a1af856605ba8621e9e1b8a774d",
       "members": [
         {
           "name": "game_id",
@@ -6119,12 +5853,44 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x7339cd08ae648244d6a84decd1859346ca5bc02789eef9ebf19beec81ca6549",
-      "tag": "s2-CreateOrder",
-      "selector": "0x653ab9361baf4819a0b59fd0d70a9bec487cad177cf6f9350665200f05eb9a3"
+      ]
     },
     {
+      "class_hash": "0x7339cd08ae648244d6a84decd1859346ca5bc02789eef9ebf19beec81ca6549",
+      "tag": "s2-CreateOrder",
+      "selector": "0x653ab9361baf4819a0b59fd0d70a9bec487cad177cf6f9350665200f05eb9a3",
+      "members": [
+        {
+          "name": "game_id",
+          "type": "core::integer::u32",
+          "key": true
+        },
+        {
+          "name": "taker_id",
+          "type": "core::integer::u32",
+          "key": true
+        },
+        {
+          "name": "maker_id",
+          "type": "core::integer::u32",
+          "key": true
+        },
+        {
+          "name": "trade_id",
+          "type": "core::integer::u32",
+          "key": false
+        },
+        {
+          "name": "timestamp",
+          "type": "core::integer::u64",
+          "key": false
+        }
+      ]
+    },
+    {
+      "class_hash": "0x4892e2b9ab523494f1dc25fc9536e904a2bb58ceb717b83f3c51d42321740db",
+      "tag": "s2-ExplicitResourceBurn",
+      "selector": "0x30e26edc724e4cc2b3aa972d5e52f5caadbf33ad3bed9d106e95c6fffbdff0f",
       "members": [
         {
           "name": "game_id",
@@ -6151,12 +5917,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x4892e2b9ab523494f1dc25fc9536e904a2bb58ceb717b83f3c51d42321740db",
-      "tag": "s2-ExplicitResourceBurn",
-      "selector": "0x30e26edc724e4cc2b3aa972d5e52f5caadbf33ad3bed9d106e95c6fffbdff0f"
+      ]
     },
     {
+      "class_hash": "0x1cd22dfdf1d16d1a3232368a757fd0656cf0b54bcf1e38e5cdf9d116a765443",
+      "tag": "s2-ExplorerMoveEvent",
+      "selector": "0x35e6deee5116730049fff1398003eb92d0c8aeca26952d54048cb6a55dc086f",
       "members": [
         {
           "name": "game_id",
@@ -6188,12 +5954,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x2b0961b718c7d8636f8a046d12c6d89fcba8cce54cabee43437838c0a506bd1",
-      "tag": "s2-ExplorerMoveEvent",
-      "selector": "0x35e6deee5116730049fff1398003eb92d0c8aeca26952d54048cb6a55dc086f"
+      ]
     },
     {
+      "class_hash": "0x639eee056b47708a16363637089d497a2e434593257e99dd176c5485b66a7ec",
+      "tag": "s2-ExplorerNewRaidEvent",
+      "selector": "0x3c75e8e389d374e5b541cfc9fd632f377fc4fb6615f0a855131237186050a05",
       "members": [
         {
           "name": "game_id",
@@ -6225,12 +5991,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x639eee056b47708a16363637089d497a2e434593257e99dd176c5485b66a7ec",
-      "tag": "s2-ExplorerNewRaidEvent",
-      "selector": "0x3c75e8e389d374e5b541cfc9fd632f377fc4fb6615f0a855131237186050a05"
+      ]
     },
     {
+      "class_hash": "0x714d3ddeab5a08df1758b6a007663a26b694722ba9a433ab71bf31fa21c1f29",
+      "tag": "s2-ExplorerRaidEvent",
+      "selector": "0x4af1af66fe1e02180f8e34b722f0dd7666939abf14741d0614dd0f0c6c0e31c",
       "members": [
         {
           "name": "game_id",
@@ -6257,12 +6023,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x714d3ddeab5a08df1758b6a007663a26b694722ba9a433ab71bf31fa21c1f29",
-      "tag": "s2-ExplorerRaidEvent",
-      "selector": "0x4af1af66fe1e02180f8e34b722f0dd7666939abf14741d0614dd0f0c6c0e31c"
+      ]
     },
     {
+      "class_hash": "0x6501f5b039b1ca46d9751b9a0202c9bc56a9b874e7ddccdfae139fc9acd9f61",
+      "tag": "s2-ExplorerRewardEvent",
+      "selector": "0x2ae3a169da0ca9050e123156b18f00babde2bd0e4521cb2643720c1ff7b27c5",
       "members": [
         {
           "name": "game_id",
@@ -6304,12 +6070,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x6501f5b039b1ca46d9751b9a0202c9bc56a9b874e7ddccdfae139fc9acd9f61",
-      "tag": "s2-ExplorerRewardEvent",
-      "selector": "0x2ae3a169da0ca9050e123156b18f00babde2bd0e4521cb2643720c1ff7b27c5"
+      ]
     },
     {
+      "class_hash": "0x22c5e2a8ac74275686c95eeb1132c416d6eb9a80289a699cafa1afae3484b32",
+      "tag": "s2-GameCreated",
+      "selector": "0x7d9fb7e65b2f01a3dceecc1d862ca76e0a439addb444828b1f11edfcf19a85",
       "members": [
         {
           "name": "game_id",
@@ -6341,12 +6107,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x22c5e2a8ac74275686c95eeb1132c416d6eb9a80289a699cafa1afae3484b32",
-      "tag": "s2-GameCreated",
-      "selector": "0x7d9fb7e65b2f01a3dceecc1d862ca76e0a439addb444828b1f11edfcf19a85"
+      ]
     },
     {
+      "class_hash": "0x52ae1d68bed858768e7f33ceb66a768dfab65100c38fac7da791d385fcd200f",
+      "tag": "s2-LedgerResultRowReady",
+      "selector": "0x5181ad768e57d8e18e868df084f7314d42a17ed1dbc5cc6b3547b705428cc89",
       "members": [
         {
           "name": "game_id",
@@ -6378,12 +6144,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x52ae1d68bed858768e7f33ceb66a768dfab65100c38fac7da791d385fcd200f",
-      "tag": "s2-LedgerResultRowReady",
-      "selector": "0x5181ad768e57d8e18e868df084f7314d42a17ed1dbc5cc6b3547b705428cc89"
+      ]
     },
     {
+      "class_hash": "0x628634793c20e34247723742d889a88795f5a5b0b27e01063d2a79117c58845",
+      "tag": "s2-LedgerResultsReady",
+      "selector": "0x534600c72e902629a86bf99d736460c24d9d25401e227532df0d6a04c7a0399",
       "members": [
         {
           "name": "game_id",
@@ -6400,12 +6166,12 @@
           "type": "core::integer::u16",
           "key": false
         }
-      ],
-      "class_hash": "0x628634793c20e34247723742d889a88795f5a5b0b27e01063d2a79117c58845",
-      "tag": "s2-LedgerResultsReady",
-      "selector": "0x534600c72e902629a86bf99d736460c24d9d25401e227532df0d6a04c7a0399"
+      ]
     },
     {
+      "class_hash": "0x36ebe1433679d6631b7656e287039806fdb5beb404d0e09351f7b7c619eaaa5",
+      "tag": "s2-LiquidityEvent",
+      "selector": "0xdb12ca515a135298a331cd522125919c4b838c9e8c9a0dc71d243a61f9aad3",
       "members": [
         {
           "name": "game_id",
@@ -6452,12 +6218,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x36ebe1433679d6631b7656e287039806fdb5beb404d0e09351f7b7c619eaaa5",
-      "tag": "s2-LiquidityEvent",
-      "selector": "0xdb12ca515a135298a331cd522125919c4b838c9e8c9a0dc71d243a61f9aad3"
+      ]
     },
     {
+      "class_hash": "0x658a05b4812842ae342b1fc5324177fdab6fc84478d934489f70312372f7e8",
+      "tag": "s2-OpenRelicChestEvent",
+      "selector": "0x1190607c24f72065536de4b8a1d2fc3d8b0931a3b73cbc25f644ed70b3f8463",
       "members": [
         {
           "name": "game_id",
@@ -6484,12 +6250,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x658a05b4812842ae342b1fc5324177fdab6fc84478d934489f70312372f7e8",
-      "tag": "s2-OpenRelicChestEvent",
-      "selector": "0x1190607c24f72065536de4b8a1d2fc3d8b0931a3b73cbc25f644ed70b3f8463"
+      ]
     },
     {
+      "class_hash": "0x154292122a1f9635877a5f8ac1ef6dee51ae8a39803e2b24dd6a9307f836a4e",
+      "tag": "s2-SeasonEnded",
+      "selector": "0x12b77f4929b93f2a3ae18d04be7d4a145b05bb32011cc04017d50d0ae758b35",
       "members": [
         {
           "name": "game_id",
@@ -6506,12 +6272,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x154292122a1f9635877a5f8ac1ef6dee51ae8a39803e2b24dd6a9307f836a4e",
-      "tag": "s2-SeasonEnded",
-      "selector": "0x12b77f4929b93f2a3ae18d04be7d4a145b05bb32011cc04017d50d0ae758b35"
+      ]
     },
     {
+      "class_hash": "0x63b299196bcedf3af497a3c796f64a9de87e0ce53be6c3ecb9607f20cb69c3b",
+      "tag": "s2-StoryEvent",
+      "selector": "0x4ebc65e029374e9dd66fca7a81d5294065a636dac3651f7ac3bc67470b5e7ec",
       "members": [
         {
           "name": "game_id",
@@ -6548,12 +6314,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x4898a8368add18841027ab8c183bec1e63df644a46334ec7b441f9ecda81329",
-      "tag": "s2-StoryEvent",
-      "selector": "0x4ebc65e029374e9dd66fca7a81d5294065a636dac3651f7ac3bc67470b5e7ec"
+      ]
     },
     {
+      "class_hash": "0x4e70559fa769fcdca1db0c9a8fe15e401a34196515e38ec4b658e2bcf5c51cd",
+      "tag": "s2-SwapEvent",
+      "selector": "0x70f1f5378f8dcea24840e77909b4c392580f522c63b333ff09825c10a6ebf7f",
       "members": [
         {
           "name": "game_id",
@@ -6615,12 +6381,12 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x4e70559fa769fcdca1db0c9a8fe15e401a34196515e38ec4b658e2bcf5c51cd",
-      "tag": "s2-SwapEvent",
-      "selector": "0x70f1f5378f8dcea24840e77909b4c392580f522c63b333ff09825c10a6ebf7f"
+      ]
     },
     {
+      "class_hash": "0x126225f89bd952d3e61a2970d0ced1b269d5b968490f0646e3dc93a15efa3e1",
+      "tag": "s2-Transfer",
+      "selector": "0x41026f9d31f66889b44286d556c2b9e912aa3a4b5aba8e0e89fb65cc5599f0e",
       "members": [
         {
           "name": "game_id",
@@ -6652,278 +6418,11 @@
           "type": "core::integer::u64",
           "key": false
         }
-      ],
-      "class_hash": "0x126225f89bd952d3e61a2970d0ced1b269d5b968490f0646e3dc93a15efa3e1",
-      "tag": "s2-Transfer",
-      "selector": "0x41026f9d31f66889b44286d556c2b9e912aa3a4b5aba8e0e89fb65cc5599f0e"
-    },
-    {
-      "members": [
-        {
-          "name": "id",
-          "type": "core::felt252",
-          "key": true
-        },
-        {
-          "name": "hidden",
-          "type": "core::bool",
-          "key": false
-        },
-        {
-          "name": "index",
-          "type": "core::integer::u8",
-          "key": false
-        },
-        {
-          "name": "points",
-          "type": "core::integer::u16",
-          "key": false
-        },
-        {
-          "name": "start",
-          "type": "core::integer::u64",
-          "key": false
-        },
-        {
-          "name": "end",
-          "type": "core::integer::u64",
-          "key": false
-        },
-        {
-          "name": "group",
-          "type": "core::felt252",
-          "key": false
-        },
-        {
-          "name": "icon",
-          "type": "core::felt252",
-          "key": false
-        },
-        {
-          "name": "title",
-          "type": "core::felt252",
-          "key": false
-        },
-        {
-          "name": "description",
-          "type": "core::byte_array::ByteArray",
-          "key": false
-        },
-        {
-          "name": "tasks",
-          "type": "core::array::Span::<achievement::types::index::Task>",
-          "key": false
-        },
-        {
-          "name": "data",
-          "type": "core::byte_array::ByteArray",
-          "key": false
-        }
-      ],
-      "class_hash": "0x3c3d75546664437c554e7aff87944454f57b43d3baef047c645e6a771bf6261",
-      "tag": "s2-TrophyCreation",
-      "selector": "0x3624fb08061280216b031d3014da29513904c33aa986bceb2e5d6ba343a595e"
-    },
-    {
-      "members": [
-        {
-          "name": "player_id",
-          "type": "core::felt252",
-          "key": true
-        },
-        {
-          "name": "task_id",
-          "type": "core::felt252",
-          "key": true
-        },
-        {
-          "name": "count",
-          "type": "core::integer::u128",
-          "key": false
-        },
-        {
-          "name": "time",
-          "type": "core::integer::u64",
-          "key": false
-        }
-      ],
-      "class_hash": "0x313c566ceee5bdcaed4accfedc707b6b5a02feb96f9448a18bfa97bf43811e4",
-      "tag": "s2-TrophyProgression",
-      "selector": "0x5cdaea92a22d0616d22b3ca72947cb743cf9aaade53d7f2f91ee3707396aafb"
+      ]
     }
   ],
   "external_contracts": [],
   "abis": [
-    {
-      "type": "struct",
-      "name": "achievement::events::index::TrophyCreation",
-      "members": [
-        {
-          "name": "id",
-          "type": "core::felt252"
-        },
-        {
-          "name": "hidden",
-          "type": "core::bool"
-        },
-        {
-          "name": "index",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "points",
-          "type": "core::integer::u16"
-        },
-        {
-          "name": "start",
-          "type": "core::integer::u64"
-        },
-        {
-          "name": "end",
-          "type": "core::integer::u64"
-        },
-        {
-          "name": "group",
-          "type": "core::felt252"
-        },
-        {
-          "name": "icon",
-          "type": "core::felt252"
-        },
-        {
-          "name": "title",
-          "type": "core::felt252"
-        },
-        {
-          "name": "description",
-          "type": "core::byte_array::ByteArray"
-        },
-        {
-          "name": "tasks",
-          "type": "core::array::Span::<achievement::types::index::Task>"
-        },
-        {
-          "name": "data",
-          "type": "core::byte_array::ByteArray"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "achievement::events::index::TrophyCreationValue",
-      "members": [
-        {
-          "name": "hidden",
-          "type": "core::bool"
-        },
-        {
-          "name": "index",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "points",
-          "type": "core::integer::u16"
-        },
-        {
-          "name": "start",
-          "type": "core::integer::u64"
-        },
-        {
-          "name": "end",
-          "type": "core::integer::u64"
-        },
-        {
-          "name": "group",
-          "type": "core::felt252"
-        },
-        {
-          "name": "icon",
-          "type": "core::felt252"
-        },
-        {
-          "name": "title",
-          "type": "core::felt252"
-        },
-        {
-          "name": "description",
-          "type": "core::byte_array::ByteArray"
-        },
-        {
-          "name": "tasks",
-          "type": "core::array::Span::<achievement::types::index::Task>"
-        },
-        {
-          "name": "data",
-          "type": "core::byte_array::ByteArray"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "achievement::events::index::TrophyProgression",
-      "members": [
-        {
-          "name": "player_id",
-          "type": "core::felt252"
-        },
-        {
-          "name": "task_id",
-          "type": "core::felt252"
-        },
-        {
-          "name": "count",
-          "type": "core::integer::u128"
-        },
-        {
-          "name": "time",
-          "type": "core::integer::u64"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "achievement::events::index::TrophyProgressionValue",
-      "members": [
-        {
-          "name": "count",
-          "type": "core::integer::u128"
-        },
-        {
-          "name": "time",
-          "type": "core::integer::u64"
-        }
-      ]
-    },
-    {
-      "type": "event",
-      "name": "achievement::events::index::e_TrophyCreation::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "event",
-      "name": "achievement::events::index::e_TrophyProgression::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "struct",
-      "name": "achievement::types::index::Task",
-      "members": [
-        {
-          "name": "id",
-          "type": "core::felt252"
-        },
-        {
-          "name": "total",
-          "type": "core::integer::u128"
-        },
-        {
-          "name": "description",
-          "type": "core::byte_array::ByteArray"
-        }
-      ]
-    },
     {
       "type": "constructor",
       "name": "constructor",
@@ -6956,16 +6455,6 @@
         {
           "name": "snapshot",
           "type": "@core::array::Array::<(core::starknet::contract_address::ContractAddress, core::integer::u16)>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "core::array::Span::<achievement::types::index::Task>",
-      "members": [
-        {
-          "name": "snapshot",
-          "type": "@core::array::Array::<achievement::types::index::Task>"
         }
       ]
     },
@@ -7111,6 +6600,16 @@
     },
     {
       "type": "struct",
+      "name": "core::array::Span::<eternum::models::config::Level>",
+      "members": [
+        {
+          "name": "snapshot",
+          "type": "@core::array::Array::<eternum::models::config::Level>"
+        }
+      ]
+    },
+    {
+      "type": "struct",
       "name": "core::array::Span::<eternum::models::config::PresetQuestGame>",
       "members": [
         {
@@ -7181,16 +6680,6 @@
     },
     {
       "type": "struct",
-      "name": "core::array::Span::<eternum::models::quest::Level>",
-      "members": [
-        {
-          "name": "snapshot",
-          "type": "@core::array::Array::<eternum::models::quest::Level>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
       "name": "core::array::Span::<eternum::models::resource::resource::ResourceList>",
       "members": [
         {
@@ -7226,16 +6715,6 @@
         {
           "name": "snapshot",
           "type": "@core::array::Array::<eternum::systems::bank::contracts::bank::BankCreateParams>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "core::array::Span::<eternum::systems::spire::contracts::SpireSettlement>",
-      "members": [
-        {
-          "name": "snapshot",
-          "type": "@core::array::Array::<eternum::systems::spire::contracts::SpireSettlement>"
         }
       ]
     },
@@ -9012,7 +8491,7 @@
       "inputs": [
         {
           "name": "event",
-          "type": "achievement::events::index::TrophyProgression"
+          "type": "eternum::systems::resources::contracts::resource_systems::resource_systems::Transfer"
         }
       ],
       "outputs": [],
@@ -9031,7 +8510,7 @@
       "inputs": [
         {
           "name": "value",
-          "type": "achievement::events::index::TrophyProgressionValue"
+          "type": "eternum::systems::resources::contracts::resource_systems::resource_systems::TransferValue"
         }
       ],
       "outputs": [],
@@ -10017,6 +9496,24 @@
     },
     {
       "type": "struct",
+      "name": "eternum::models::config::Level",
+      "members": [
+        {
+          "name": "target_score",
+          "type": "core::integer::u32"
+        },
+        {
+          "name": "settings_id",
+          "type": "core::integer::u32"
+        },
+        {
+          "name": "time_limit",
+          "type": "core::integer::u64"
+        }
+      ]
+    },
+    {
+      "type": "struct",
       "name": "eternum::models::config::MapConfig",
       "members": [
         {
@@ -10224,6 +9721,10 @@
         {
           "name": "mercenaries_name",
           "type": "core::felt252"
+        },
+        {
+          "name": "spire_travel_essence_cost",
+          "type": "core::integer::u128"
         }
       ]
     },
@@ -10354,6 +9855,10 @@
         {
           "name": "mercenaries_name",
           "type": "core::felt252"
+        },
+        {
+          "name": "spire_travel_essence_cost",
+          "type": "core::integer::u128"
         }
       ]
     },
@@ -10447,7 +9952,7 @@
         },
         {
           "name": "levels",
-          "type": "core::array::Span::<eternum::models::quest::Level>"
+          "type": "core::array::Span::<eternum::models::config::Level>"
         }
       ]
     },
@@ -11372,6 +10877,14 @@
         {
           "name": "stolen_resources",
           "type": "core::array::Span::<(core::integer::u8, core::integer::u128)>"
+        },
+        {
+          "name": "attacker_roll",
+          "type": "core::integer::u8"
+        },
+        {
+          "name": "defender_roll",
+          "type": "core::integer::u8"
         }
       ]
     },
@@ -11528,15 +11041,7 @@
           "type": "()"
         },
         {
-          "name": "Quest",
-          "type": "()"
-        },
-        {
           "name": "Village",
-          "type": "()"
-        },
-        {
-          "name": "HolySite",
           "type": "()"
         },
         {
@@ -13721,34 +13226,6 @@
     },
     {
       "type": "struct",
-      "name": "eternum::models::map::BiomeDiscovered",
-      "members": [
-        {
-          "name": "by_address",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "biome",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "discovered",
-          "type": "core::bool"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::map::BiomeDiscoveredValue",
-      "members": [
-        {
-          "name": "discovered",
-          "type": "core::bool"
-        }
-      ]
-    },
-    {
-      "type": "struct",
       "name": "eternum::models::map::Tile",
       "members": [
         {
@@ -13926,19 +13403,11 @@
           "type": "()"
         },
         {
-          "name": "Quest",
-          "type": "()"
-        },
-        {
           "name": "Chest",
           "type": "()"
         },
         {
           "name": "Spire",
-          "type": "()"
-        },
-        {
-          "name": "HolySite",
           "type": "()"
         },
         {
@@ -13954,12 +13423,6 @@
           "type": "()"
         }
       ]
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::map::m_BiomeDiscovered::Event",
-      "kind": "enum",
-      "variants": []
     },
     {
       "type": "struct",
@@ -14138,330 +13601,6 @@
     {
       "type": "event",
       "name": "eternum::models::quantity::m_QuantityTracker::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::Level",
-      "members": [
-        {
-          "name": "target_score",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "settings_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "time_limit",
-          "type": "core::integer::u64"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::Quest",
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "game_token_id",
-          "type": "core::integer::u64"
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "quest_tile_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "explorer_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "completed",
-          "type": "core::bool"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestDetails",
-      "members": [
-        {
-          "name": "quest_tile_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "coord",
-          "type": "eternum::models::position::Coord"
-        },
-        {
-          "name": "target_score",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "reward_name",
-          "type": "core::byte_array::ByteArray"
-        },
-        {
-          "name": "reward_amount",
-          "type": "core::integer::u128"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestFeatureFlag",
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "key",
-          "type": "core::felt252"
-        },
-        {
-          "name": "enabled",
-          "type": "core::bool"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestFeatureFlagValue",
-      "members": [
-        {
-          "name": "enabled",
-          "type": "core::bool"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestGameRegistry",
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "key",
-          "type": "core::felt252"
-        },
-        {
-          "name": "games",
-          "type": "core::array::Span::<core::starknet::contract_address::ContractAddress>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestGameRegistryValue",
-      "members": [
-        {
-          "name": "games",
-          "type": "core::array::Span::<core::starknet::contract_address::ContractAddress>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestLevels",
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "levels",
-          "type": "core::array::Span::<eternum::models::quest::Level>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestLevelsValue",
-      "members": [
-        {
-          "name": "levels",
-          "type": "core::array::Span::<eternum::models::quest::Level>"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestRegistrations",
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "quest_tile_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "realm_or_village_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "game_token_id",
-          "type": "core::integer::u64"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestRegistrationsValue",
-      "members": [
-        {
-          "name": "game_token_id",
-          "type": "core::integer::u64"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestTile",
-      "members": [
-        {
-          "name": "game_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "coord",
-          "type": "eternum::models::position::Coord"
-        },
-        {
-          "name": "level",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "resource_type",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "amount",
-          "type": "core::integer::u128"
-        },
-        {
-          "name": "capacity",
-          "type": "core::integer::u16"
-        },
-        {
-          "name": "participant_count",
-          "type": "core::integer::u16"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestTileValue",
-      "members": [
-        {
-          "name": "game_address",
-          "type": "core::starknet::contract_address::ContractAddress"
-        },
-        {
-          "name": "coord",
-          "type": "eternum::models::position::Coord"
-        },
-        {
-          "name": "level",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "resource_type",
-          "type": "core::integer::u8"
-        },
-        {
-          "name": "amount",
-          "type": "core::integer::u128"
-        },
-        {
-          "name": "capacity",
-          "type": "core::integer::u16"
-        },
-        {
-          "name": "participant_count",
-          "type": "core::integer::u16"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::models::quest::QuestValue",
-      "members": [
-        {
-          "name": "quest_tile_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "explorer_id",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "completed",
-          "type": "core::bool"
-        }
-      ]
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::quest::m_Quest::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::quest::m_QuestFeatureFlag::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::quest::m_QuestGameRegistry::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::quest::m_QuestLevels::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::quest::m_QuestRegistrations::Event",
-      "kind": "enum",
-      "variants": []
-    },
-    {
-      "type": "event",
-      "name": "eternum::models::quest::m_QuestTile::Event",
       "kind": "enum",
       "variants": []
     },
@@ -17004,10 +16143,6 @@
           "type": "()"
         },
         {
-          "name": "HolySite",
-          "type": "()"
-        },
-        {
           "name": "Camp",
           "type": "()"
         },
@@ -17772,7 +16907,7 @@
           ],
           "outputs": [
             {
-              "type": "(eternum::models::troop::Troops, eternum::models::troop::Troops)"
+              "type": "(eternum::models::troop::Troops, eternum::models::troop::Troops, core::integer::u8, core::integer::u8)"
             }
           ],
           "state_mutability": "view"
@@ -19560,23 +18695,6 @@
     },
     {
       "type": "event",
-      "name": "eternum::systems::combat::contracts::troop_movement::holysite_discovery_systems::Event",
-      "kind": "enum",
-      "variants": [
-        {
-          "name": "UpgradeableEvent",
-          "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
-          "kind": "nested"
-        },
-        {
-          "name": "WorldProviderEvent",
-          "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
-          "kind": "nested"
-        }
-      ]
-    },
-    {
-      "type": "event",
       "name": "eternum::systems::combat::contracts::troop_movement::hyperstructure_discovery_systems::Event",
       "kind": "enum",
       "variants": [
@@ -20994,273 +20112,6 @@
     },
     {
       "type": "interface",
-      "name": "eternum::systems::quest::contracts::IQuestSystems",
-      "items": [
-        {
-          "type": "function",
-          "name": "add_game",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            },
-            {
-              "name": "levels",
-              "type": "core::array::Span::<eternum::models::quest::Level>"
-            },
-            {
-              "name": "overwrite",
-              "type": "core::bool"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "remove_game",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "create_quest",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "tile",
-              "type": "eternum::models::map::Tile"
-            },
-            {
-              "name": "vrf_seed",
-              "type": "core::integer::u256"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "start_quest",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "quest_tile_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "explorer_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "player_name",
-              "type": "core::felt252"
-            },
-            {
-              "name": "to_address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            }
-          ],
-          "outputs": [
-            {
-              "type": "core::integer::u64"
-            }
-          ],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "claim_reward",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "game_token_id",
-              "type": "core::integer::u64"
-            },
-            {
-              "name": "game_address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "enable_quests",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "disable_quests",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        },
-        {
-          "type": "function",
-          "name": "get_quest",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "game_token_id",
-              "type": "core::integer::u64"
-            },
-            {
-              "name": "game_address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            }
-          ],
-          "outputs": [
-            {
-              "type": "eternum::models::quest::Quest"
-            }
-          ],
-          "state_mutability": "view"
-        },
-        {
-          "type": "function",
-          "name": "get_quest_details",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "game_token_id",
-              "type": "core::integer::u64"
-            },
-            {
-              "name": "game_address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            }
-          ],
-          "outputs": [
-            {
-              "type": "eternum::models::quest::QuestDetails"
-            }
-          ],
-          "state_mutability": "view"
-        },
-        {
-          "type": "function",
-          "name": "get_quest_tile",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "quest_tile_id",
-              "type": "core::integer::u32"
-            }
-          ],
-          "outputs": [
-            {
-              "type": "eternum::models::quest::QuestTile"
-            }
-          ],
-          "state_mutability": "view"
-        },
-        {
-          "type": "function",
-          "name": "get_target_score",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "game_token_id",
-              "type": "core::integer::u64"
-            },
-            {
-              "name": "game_address",
-              "type": "core::starknet::contract_address::ContractAddress"
-            }
-          ],
-          "outputs": [
-            {
-              "type": "core::integer::u32"
-            }
-          ],
-          "state_mutability": "view"
-        },
-        {
-          "type": "function",
-          "name": "is_quest_feature_enabled",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            }
-          ],
-          "outputs": [
-            {
-              "type": "core::bool"
-            }
-          ],
-          "state_mutability": "view"
-        }
-      ]
-    },
-    {
-      "type": "event",
-      "name": "eternum::systems::quest::contracts::quest_systems::Event",
-      "kind": "enum",
-      "variants": [
-        {
-          "name": "UpgradeableEvent",
-          "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
-          "kind": "nested"
-        },
-        {
-          "name": "WorldProviderEvent",
-          "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
-          "kind": "nested"
-        }
-      ]
-    },
-    {
-      "type": "interface",
       "name": "eternum::systems::realm::blitz::contracts::IBlitzRealmSystems",
       "items": [
         {
@@ -22579,67 +21430,6 @@
       "name": "eternum::systems::season::contracts::season_systems::e_SeasonEnded::Event",
       "kind": "enum",
       "variants": []
-    },
-    {
-      "type": "interface",
-      "name": "eternum::systems::spire::contracts::ISpireSystems",
-      "items": [
-        {
-          "type": "function",
-          "name": "create_spires",
-          "inputs": [
-            {
-              "name": "game_id",
-              "type": "core::integer::u32"
-            },
-            {
-              "name": "is_center",
-              "type": "core::bool"
-            },
-            {
-              "name": "settlements",
-              "type": "core::array::Span::<eternum::systems::spire::contracts::SpireSettlement>"
-            }
-          ],
-          "outputs": [],
-          "state_mutability": "external"
-        }
-      ]
-    },
-    {
-      "type": "struct",
-      "name": "eternum::systems::spire::contracts::SpireSettlement",
-      "members": [
-        {
-          "name": "side",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "layer",
-          "type": "core::integer::u32"
-        },
-        {
-          "name": "point",
-          "type": "core::integer::u32"
-        }
-      ]
-    },
-    {
-      "type": "event",
-      "name": "eternum::systems::spire::contracts::spire_systems::Event",
-      "kind": "enum",
-      "variants": [
-        {
-          "name": "UpgradeableEvent",
-          "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
-          "kind": "nested"
-        },
-        {
-          "name": "WorldProviderEvent",
-          "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
-          "kind": "nested"
-        }
-      ]
     },
     {
       "type": "interface",


### PR DESCRIPTION
The native deployer created the world `realms_madara_lab_2` at `0x2cb65776729bc6d74ccda27050937b3ae841df03c0cd1d581ea2c3189f70b12` on the box chain: one namespace, 86 models, 22 events, 5 libraries, 40 contracts initialized with their writer grants, 194 transactions, no errors. Chain config is bootstrapped against the existing player registry; presets 1 Eternum, 2 Blitz Regular Fast (60-minute profile) and 3 Blitz Duel (90-minute profile) are registered. Herald and the launch service were reset and already run on this manifest from disk; this commit makes the checkout and the client build match it. The previous world and its games are abandoned.

After merge: the client deploy picks up the new addresses on its own; the box deploy needs its worktree clean first (the manifest and the bootstrap script on the box already have this content).