### PR TITLE
chore(lab): run the daily Blitz rotation at 11:00 and 20:00 UTC

### DIFF
--- a/config/deployer/clean/launch-configs/madara-blitz-daily.yaml
+++ b/config/deployer/clean/launch-configs/madara-blitz-daily.yaml
@@ -1,4 +1,4 @@
-# One daily lab game at 11:00 UTC, dev mode off: a real game on the Regular Fast
+# Two daily lab games, 11:00 and 20:00 UTC, dev mode off: a real game on the Regular Fast
 # preset. The advance window keeps the next game joinable for roughly 24 hours;
 # the worker evaluates the rotation every 30 minutes. Renamed from
 # madara-blitz-daily on 2026-09-03: its 0002 (game 20) was created dev-on and a
@@ -18,9 +18,16 @@ version: "2"
 
 weeklyCadence:
   - { weekday: monday, utcTime: "11:00" }
+  - { weekday: monday, utcTime: "20:00" }
   - { weekday: tuesday, utcTime: "11:00" }
+  - { weekday: tuesday, utcTime: "20:00" }
   - { weekday: wednesday, utcTime: "11:00" }
+  - { weekday: wednesday, utcTime: "20:00" }
   - { weekday: thursday, utcTime: "11:00" }
+  - { weekday: thursday, utcTime: "20:00" }
   - { weekday: friday, utcTime: "11:00" }
+  - { weekday: friday, utcTime: "20:00" }
   - { weekday: saturday, utcTime: "11:00" }
+  - { weekday: saturday, utcTime: "20:00" }
   - { weekday: sunday, utcTime: "11:00" }
+  - { weekday: sunday, utcTime: "20:00" }


### PR DESCRIPTION
The rotation is live again on the fresh world and created blitz-daily-0001 on its first tick. This adds the second daily slot at 20:00 UTC to every weekday. Preset 2, one-hour duration and dev mode off stay as they are.

Verification: launch-config parsing tests, launch-service tests. The box redeploys on merge and the next rotation tick enqueues from the new cadence.