### PR TITLE
feat(client): render animated spires on both world-map layers

### DIFF
--- a/apps/game/src/three/managers/spire-manager.test.ts
+++ b/apps/game/src/three/managers/spire-manager.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { Group, Scene, Vector3 } from "three";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TileOccupier } from "@bibliothecadao/types";
+import type { WorldSpatialProjection } from "@bibliothecadao/eternum/game-sync";
+
+const harness = vi.hoisted(() => ({ alt: false, onLayer: () => {}, load: vi.fn(), models: [] as any[] }));
+vi.mock("@/three/map-layer", () => ({ activeMapLayer: () => harness.alt }));
+vi.mock("@/hooks/store/use-ui-store", () => ({
+  useUIStore: {
+    subscribe: (_selector: unknown, listener: () => void) => {
+      harness.onLayer = listener;
+      return vi.fn();
+    },
+  },
+}));
+vi.mock("../utils/utils", () => ({
+  gltfLoader: { loadAsync: harness.load },
+  getWorldPositionForHex: () => new Vector3(),
+}));
+vi.mock("../structures/spire-model", () => ({
+  SpireModel: class {
+    group = new Group();
+    setCount = vi.fn();
+    setMatrixAt = vi.fn();
+    needsUpdate = vi.fn();
+    dispose = vi.fn();
+    updateAnimations = vi.fn();
+    constructor() {
+      harness.models.push(this);
+    }
+  },
+}));
+import { SpireManager } from "./spire-manager";
+
+function setup(surface: boolean, ethereal: boolean) {
+  const unsubscribe = vi.fn();
+  const projection = {
+    subscribeTiles: () => unsubscribe,
+    getTiles: (alt: boolean) =>
+      (alt ? ethereal : surface)
+        ? [
+            {
+              occupierType: TileOccupier.Spire,
+              hexCoords: { alt, col: 2147483647, row: 2147483647 },
+            },
+          ]
+        : [],
+  } as unknown as WorldSpatialProjection;
+  const labels = new Group();
+  return { manager: new SpireManager(new Scene(), projection, labels), labels, unsubscribe };
+}
+
+beforeEach(() => {
+  harness.alt = false;
+  harness.models = [];
+  harness.load.mockReset();
+});
+
+describe("spire presentation lifecycle", () => {
+  it("does not request an asset when the game has no spires", () => {
+    const { manager, labels } = setup(false, false);
+    expect(harness.load).not.toHaveBeenCalled();
+    expect(labels.children).toHaveLength(0);
+    manager.destroy();
+  });
+  it("uses the current layer when loading finishes and reuses the model on return", async () => {
+    let resolve!: (value: object) => void;
+    harness.load.mockReturnValue(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const { manager, labels } = setup(true, false);
+    harness.alt = true;
+    harness.onLayer();
+    resolve({});
+    await vi.waitFor(() => expect(harness.models).toHaveLength(1));
+    expect(labels.children).toHaveLength(0);
+    expect(harness.models[0].setMatrixAt).not.toHaveBeenCalled();
+    harness.alt = false;
+    harness.onLayer();
+    expect(labels.children).toHaveLength(1);
+    expect(harness.models[0].setCount).toHaveBeenLastCalledWith(1);
+    expect(harness.load).toHaveBeenCalledTimes(1);
+    manager.destroy();
+    expect(labels.children).toHaveLength(0);
+    expect(harness.models[0].dispose).toHaveBeenCalledOnce();
+  });
+  it("does not attach a model after the scene is destroyed during loading", async () => {
+    let resolve!: (value: object) => void;
+    harness.load.mockReturnValue(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    const { manager, labels, unsubscribe } = setup(true, true);
+    manager.destroy();
+    resolve({});
+    await new Promise((done) => setTimeout(done, 0));
+    expect(harness.models).toHaveLength(0);
+    expect(labels.children).toHaveLength(0);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/game/src/three/managers/spire-manager.ts
+++ b/apps/game/src/three/managers/spire-manager.ts
@@ -1,0 +1,135 @@
+import { useUIStore } from "@/hooks/store/use-ui-store";
+import { SPIRE_MODEL_PATH } from "@/three/constants/scene-constants";
+import { activeMapLayer } from "@/three/map-layer";
+import { FELT_CENTER } from "@/ui/config";
+import { projectionChangesForLayer, type TileSpatialRenderable, type WorldSpatialProjection } from "@bibliothecadao/eternum/game-sync";
+import { TileOccupier } from "@bibliothecadao/types";
+import { Group, Object3D, Scene } from "three";
+import { CSS2DObject } from "three/addons/renderers/CSS2DRenderer.js";
+import type { SpireModel } from "../structures/spire-model";
+import { FLAT_TERRAIN_SURFACE, placePositionOnTerrain, type TerrainSurface } from "../terrain/terrain-surface";
+import { getWorldPositionForHex } from "../utils";
+import { gltfLoader } from "../utils/utils";
+
+/** Spires belong to tiles, so they never require a Structure component. */
+export class SpireManager {
+  private readonly dummy = new Object3D();
+  private readonly subscriptions: Array<() => void>;
+  private model: SpireModel | null = null;
+  private loading: Promise<void> | null = null;
+  private capacity = 0;
+  private modelVisible = true;
+  private destroyed = false;
+
+  constructor(
+    private readonly scene: Scene,
+    private readonly projection: WorldSpatialProjection,
+    private readonly labels: Group,
+    private readonly terrain: TerrainSurface = FLAT_TERRAIN_SURFACE,
+    private readonly markLabelsDirty: () => void = () => {},
+  ) {
+    this.subscriptions = [
+      projection.subscribeTiles((changes) => {
+        const relevant = projectionChangesForLayer(changes, activeMapLayer());
+        if (
+          relevant.some(
+            ({ previous, current }) =>
+              previous?.occupierType === TileOccupier.Spire || current?.occupierType === TileOccupier.Spire,
+          )
+        )
+          this.refresh();
+      }),
+      useUIStore.subscribe(
+        (state) => state.mapLayer,
+        () => this.refresh(),
+      ),
+    ];
+    this.refresh();
+  }
+
+  public setModelVisible(visible: boolean): void {
+    this.modelVisible = visible;
+    if (this.model) this.model.group.visible = visible;
+  }
+
+  public update(delta: number): void {
+    this.model?.updateAnimations(delta);
+  }
+
+  public destroy(): void {
+    this.destroyed = true;
+    this.subscriptions.forEach((unsubscribe) => unsubscribe());
+    this.clearLabels();
+    this.model?.dispose();
+    this.model = null;
+  }
+
+  private refresh(): void {
+    if (this.destroyed) return;
+    const tiles = this.getSpireTiles();
+    this.clearLabels();
+    this.model?.setCount(0);
+    if (!tiles.length) return;
+    if (!this.model || tiles.length > this.capacity) {
+      // No spire tiles means no asset request, including every Blitz game.
+      if (!this.loading) {
+        this.loading = this.loadModel(tiles.length).finally(() => {
+          this.loading = null;
+        });
+      }
+      return;
+    }
+    tiles.forEach((tile, index) => this.placeSpire(tile, index));
+    this.model.setCount(tiles.length);
+    this.model.needsUpdate();
+  }
+
+  private placeSpire(tile: TileSpatialRenderable, index: number): void {
+    const position = getWorldPositionForHex({
+      col: tile.hexCoords.col - FELT_CENTER(),
+      row: tile.hexCoords.row - FELT_CENTER(),
+    });
+    placePositionOnTerrain(position, this.terrain);
+    this.dummy.position.copy(position);
+    this.dummy.updateMatrix();
+    this.model!.setMatrixAt(index, this.dummy.matrix);
+    const element = document.createElement("div");
+    element.textContent = "Spire";
+    element.className = "rounded-md px-2 py-1 text-xs text-gold bg-dark-brown/90 border border-gold/30";
+    element.style.pointerEvents = "none";
+    const label = new CSS2DObject(element);
+    label.position.copy(position);
+    label.position.y += 2.5;
+    this.labels.add(label);
+  }
+
+  private async loadModel(capacity: number): Promise<void> {
+    try {
+      const [gltf, { SpireModel }] = await Promise.all([
+        gltfLoader.loadAsync(SPIRE_MODEL_PATH),
+        import("../structures/spire-model"),
+      ]);
+      if (this.destroyed) return;
+      this.model?.dispose();
+      this.capacity = Math.max(capacity, this.getSpireTiles().length);
+      this.model = new SpireModel(gltf, this.capacity);
+      this.model.group.visible = this.modelVisible;
+      this.scene.add(this.model.group);
+      this.refresh();
+    } catch (error) {
+      console.error("[SpireManager] Failed to load spire model", error);
+    }
+  }
+
+  private getSpireTiles() {
+    return this.projection.getTiles(activeMapLayer()).filter((tile) => tile.occupierType === TileOccupier.Spire);
+  }
+
+  private clearLabels(): void {
+    this.markLabelsDirty();
+    for (const child of [...this.labels.children]) {
+      if (child instanceof CSS2DObject) child.element.remove();
+      this.labels.remove(child);
+    }
+  }
+}

--- a/apps/game/src/three/managers/spire-manager.ts
+++ b/apps/game/src/three/managers/spire-manager.ts
@@ -2,7 +2,11 @@ import { useUIStore } from "@/hooks/store/use-ui-store";
 import { SPIRE_MODEL_PATH } from "@/three/constants/scene-constants";
 import { activeMapLayer } from "@/three/map-layer";
 import { FELT_CENTER } from "@/ui/config";
-import { projectionChangesForLayer, type TileSpatialRenderable, type WorldSpatialProjection } from "@bibliothecadao/eternum/game-sync";
+import {
+  projectionChangesForLayer,
+  type TileSpatialRenderable,
+  type WorldSpatialProjection,
+} from "@bibliothecadao/eternum/game-sync";
 import { TileOccupier } from "@bibliothecadao/types";
 import { Group, Object3D, Scene } from "three";
 import { CSS2DObject } from "three/addons/renderers/CSS2DRenderer.js";

--- a/apps/game/src/three/scenes/worldmap-ownership-lifecycle.ts
+++ b/apps/game/src/three/scenes/worldmap-ownership-lifecycle.ts
@@ -6,6 +6,7 @@ interface WorldmapOwnedManagers {
   armyManager?: Destroyable | null;
   structureManager?: Destroyable | null;
   reservedHyperstructureManager?: Destroyable | null;
+  spireManager?: Destroyable | null;
   chestManager?: Destroyable | null;
   fxManager?: Destroyable | null;
   resourceFXManager?: Destroyable | null;
@@ -15,6 +16,7 @@ export function destroyWorldmapOwnedManagers(managers: WorldmapOwnedManagers): v
   managers.armyManager?.destroy();
   managers.structureManager?.destroy();
   managers.reservedHyperstructureManager?.destroy();
+  managers.spireManager?.destroy();
   managers.chestManager?.destroy();
   managers.fxManager?.destroy();
   managers.resourceFXManager?.destroy();

--- a/apps/game/src/three/scenes/worldmap.tsx
+++ b/apps/game/src/three/scenes/worldmap.tsx
@@ -1,3 +1,5 @@
+import { TileOccupier } from "@bibliothecadao/types";
+import { SpireManager } from "../managers/spire-manager";
 import { activeMapLayer } from "@/three/map-layer";
 import type { ReactNode } from "react";
 import { isMapPreviewAction } from "./worldmap-action-preview-policy";
@@ -977,6 +979,8 @@ export default class WorldmapScene extends WarpTravel {
   private structureLabelsGroup!: Group;
   private chestLabelsGroup!: Group;
   private reservedHyperstructureManager!: ReservedHyperstructureManager;
+  private spireManager!: SpireManager;
+  private spireLabelsGroup!: Group;
 
   private storeSubscriptions: Array<() => void> = [];
 
@@ -1154,6 +1158,8 @@ export default class WorldmapScene extends WarpTravel {
     this.structureLabelsGroup.name = "StructureLabelsGroup";
     this.chestLabelsGroup = new Group();
     this.chestLabelsGroup.name = "ChestLabelsGroup";
+    this.spireLabelsGroup = new Group();
+    this.spireLabelsGroup.name = "SpireLabelsGroup";
 
     this.armyManager = new ArmyManager(
       this.scene,
@@ -1213,6 +1219,13 @@ export default class WorldmapScene extends WarpTravel {
       this.scene,
       this.worldSpatialProjection,
       this.getTerrainSurface(),
+    );
+    this.spireManager = new SpireManager(
+      this.scene,
+      this.worldSpatialProjection,
+      this.spireLabelsGroup,
+      this.getTerrainSurface(),
+      this.markLabelsDirty,
     );
     this.chestManager = new ChestManager(
       this.scene,
@@ -1587,6 +1600,7 @@ export default class WorldmapScene extends WarpTravel {
     this.resourceFXManager.setVisible(ladder.fx);
     this.combatPresentation?.setVisible(ladder.fx);
     this.reservedHyperstructureManager.setModelVisible(ladder.structureModels);
+    this.spireManager.setModelVisible(ladder.structureModels);
     this.strategicMarkers.setVisible(ladder.band === CameraView.Far);
     this.commitStrategicMarkers();
     this.refreshLabelPriorityContext();
@@ -3610,7 +3624,8 @@ export default class WorldmapScene extends WarpTravel {
       const hex = { col: contract.x, row: contract.y };
       return (
         this.worldSpatialProjection.getStructuresAtHex({ ...hex, alt: activeMapLayer() }).length > 0 ||
-        this.worldSpatialProjection.getChestsAtHex({ ...hex, alt: activeMapLayer() }).length > 0
+        this.worldSpatialProjection.getChestsAtHex({ ...hex, alt: activeMapLayer() }).length > 0 ||
+        this.worldSpatialProjection.getTileAtHex({ ...hex, alt: activeMapLayer() })?.occupierType === TileOccupier.Spire
       );
     });
   }
@@ -3671,7 +3686,7 @@ export default class WorldmapScene extends WarpTravel {
   }
 
   private getWorldmapLabelGroups(): Group[] {
-    return [this.armyLabelsGroup, this.structureLabelsGroup, this.chestLabelsGroup];
+    return [this.armyLabelsGroup, this.structureLabelsGroup, this.chestLabelsGroup, this.spireLabelsGroup];
   }
 
   private attachWorldmapLabelGroupsToScene(): void {
@@ -7426,6 +7441,7 @@ export default class WorldmapScene extends WarpTravel {
     this.syncWorldmapZoomSnapshot(deltaTime);
     super.update(deltaTime);
     this.compactEntityLabelRenderer.updateCamera(this.camera);
+    this.spireManager.update(deltaTime);
     runWithFrameWorkOwner("armies:update", () => this.armyManager.update(deltaTime, animationContext));
     this.syncTerrainMovementInteractions();
     this.proceduralTerrain.update(deltaTime);
@@ -7821,6 +7837,7 @@ export default class WorldmapScene extends WarpTravel {
       armyManager: this.armyManager,
       structureManager: this.structureManager,
       reservedHyperstructureManager: this.reservedHyperstructureManager,
+      spireManager: this.spireManager,
       chestManager: this.chestManager,
       fxManager: this.fxManager,
       resourceFXManager: this.resourceFXManager,

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-12",
+    title: "Spires on the map",
+    type: "feature",
+    description: "Find animated spires on both layers and select their tiles to inspect a crossing.",
+  },
+  {
+    date: "2026-09-12",
     title: "Refined Realms and Clear Ownership",
     description:
       "Realm masonry grows paler and finer with each tier, with hand-laid roofs, a raised kingdom drawbridge, and full-height empire gates. Settlement supplies sit beside a clear entrance. Owned realms and villages fly green banners; all others fly red. Every realm hanging displays its order emblem. Chests are 30% smaller on the map. Game entry loads entity models as the selected world needs them.",


### PR DESCRIPTION
Superseded by #4982, which combines this change with the remaining ethereal client work on next after #4975. Merge #4982 only.

Evidence

The approved SpireModel was used only by the terrain lab. Live spire tiles were selectable but had no model or map label. They cannot use StructureManager because spires have no Structure component.

Fix

Add a tile-backed SpireManager with the approved instanced model, independent animation phases, terrain placement, and labels in the world-map label group. Reload placements on layer and spire-tile changes, clear terrain props beneath spires, and dispose the manager with the scene. Model code and assets load only when spire tiles exist; Blitz requests neither.

Verification

- On the integration branch with #4975: pnpm run format, pnpm run knip, client typecheck, and pnpm test pass (707 files / 3,452 tests). Focused lifecycle tests pass after the final label-refresh adjustment.
- Live eternum-fresh-01 spectator check: approved spire and label render on both layers; selecting its coordinate opens the spire tile panel. Screenshots captured locally.
- Existing BitcoinMine mapping already supplies its model and structure label; #4975 makes its layer reachable. No mine was available in the inspected live area.

Non-goals

Merge #4975 first for world-map layer switching. This PR contains only spire integration, independently based on next. Portal transactions and layer-aware movement follow separately; the adjacent-army travel-modal and live mine gates remain to be verified with a playable army/game. No new assets, placeholders, balance changes or contract changes.
