### PR TITLE
fix(client): remove old realm models after upgrades

### DIFF
--- a/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
+++ b/apps/game/src/three/managers/structure-manager.lifecycle.test.ts
@@ -554,6 +554,11 @@ describe("StructureManager change-set driven visible pass", () => {
     }));
     subject.worldSpatialProjection = { getStructuresInBounds: vi.fn(() => []) };
     subject.previousVisibleIds = new Set([1, 2, 3]);
+    subject.structureInstanceBindings = new Map([
+      [1, []],
+      [2, []],
+      [3, []],
+    ]);
     subject.getModelForStructure = vi.fn(() => model);
     subject.preloadStructureModels = vi.fn(async () => undefined);
     subject.commitVisibleStructureDiff = vi.fn(() => true);
@@ -912,6 +917,10 @@ describe("StructureManager destroy lifecycle", () => {
     const scheduledOwners: string[] = [];
 
     subject.previousVisibleIds = new Set([1, 2]);
+    subject.structureInstanceBindings = new Map([
+      [1, []],
+      [2, []],
+    ]);
     subject.resolveVisibleStructuresForChunk = vi.fn(() => structures);
     subject.getModelForStructure = vi.fn(() => model);
     subject.preloadStructureModels = vi.fn(async () => undefined);
@@ -1052,6 +1061,43 @@ describe("StructureManager destroy lifecycle", () => {
     expect(removeInstance).not.toHaveBeenCalled();
     expect(setMatrixAt).not.toHaveBeenCalled();
     expect([...subject.structureInstanceBindings.keys()].toSorted()).toEqual([2, 3]);
+  });
+
+  it.each([true, false])("retires a partially rendered realm before the next pass (upgrade=%s)", async (upgrade) => {
+    const { subject } = createVisibleStructurePassSubject();
+    const oldModel = { removeInstance: vi.fn(), setCount: vi.fn(), setMatrixAt: vi.fn() };
+    const newModel = { removeInstance: vi.fn(), setCount: vi.fn(), setMatrixAt: vi.fn() };
+    const realm = { entityId: 7, hasWonder: false, hexCoords: { col: 0, row: 0 }, level: 0, structureType: "Realm" };
+    subject.structureModels.set(
+      "Realm",
+      new Map([
+        [0, oldModel],
+        [1, newModel],
+      ]),
+    );
+    subject.hasCosmeticSkin = vi.fn(() => false);
+
+    // A sliced pass has drawn this realm, but was interrupted before committing its visible-ID list.
+    const dirtyModels = new Set();
+    subject.addVisibleStructureInstance(realm, new Set(), dirtyModels);
+    subject.updateVisibleStructureModelCounts(dirtyModels);
+    expect(subject.previousVisibleIds.size).toBe(0);
+    expect(oldModel.setCount).toHaveBeenLastCalledWith(1);
+
+    subject.resolveVisibleStructuresForChunk = vi.fn(() => (upgrade ? [{ ...realm, level: 1 }] : []));
+    subject.preloadStructureModels = vi.fn(async () => {});
+    subject.chunkWorkScheduler = { schedule: vi.fn(async (_lane: string, work: () => void) => work()) };
+    await subject.performVisibleStructuresUpdate({ refreshEntityIds: [7] });
+
+    expect(oldModel.removeInstance).toHaveBeenCalledWith(0);
+    expect(oldModel.setCount).toHaveBeenLastCalledWith(0);
+    expect(subject.structureInstanceSlots.has(oldModel)).toBe(false);
+    if (upgrade) {
+      expect(subject.structureInstanceBindings.get(7)[0].model).toBe(newModel);
+      expect(newModel.setCount).toHaveBeenLastCalledWith(1);
+    } else {
+      expect(subject.structureInstanceBindings.has(7)).toBe(false);
+    }
   });
 
   it("clears an instanced model bucket after its last visible structure leaves", () => {

--- a/apps/game/src/three/managers/structure-manager.ts
+++ b/apps/game/src/three/managers/structure-manager.ts
@@ -1289,7 +1289,8 @@ export class StructureManager {
 
       const renderableStructures = visibleStructures.filter((structure) => this.getModelForStructure(structure));
       const visibilityDiff = createManagerVisibilityDiff({
-        currentVisibleIds: this.previousVisibleIds,
+        // A superseded sliced pass can own instances before its visible-ID list commits.
+        currentVisibleIds: this.structureInstanceBindings.keys(),
         nextVisibleEntities: renderableStructures,
         getEntityId: (structure) => structure.entityId,
         refreshEntityIds: options.refreshEntityIds,

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-12",
+    title: "Clean realm upgrades",
+    type: "fix",
+    description: "Upgrading a realm removes its previous model, including when a map refresh is interrupted.",
+  },
+  {
+    date: "2026-09-12",
     title: "Refined Realms and Clear Ownership",
     description:
       "Realm masonry grows paler and finer with each tier, with hand-laid roofs, a raised kingdom drawbridge, and full-height empire gates. Settlement supplies sit beside a clear entrance. Owned realms and villages fly green banners; all others fly red. Every realm hanging displays its order emblem. Chests are 30% smaller on the map. Game entry loads entity models as the selected world needs them.",


### PR DESCRIPTION
Superseded by #4982, which combines this change with the remaining ethereal client work on next after #4975. Merge #4982 only.

## Evidence

An interrupted, sliced structure refresh can attach a realm instance before committing its visible-ID list. The next pass used that list, missed the old instance, and left the previous realm model overlapping the upgraded one. The same gap also left instances behind when they moved out of view. Both regression cases failed before this fix.

## Fix

Build the visibility diff from the structure instances actually attached to the scene. Existing removal and slot cleanup now retire those instances before replacing them or removing them from view.

## Verification

- Both regressions pass; all 29 structure-manager lifecycle tests, pnpm run format and pnpm run knip pass on this branch.
- Integration with the ethereal client changes: pnpm run format, pnpm run knip and client typecheck passed; pnpm test in apps/game passed all 708 files / 3,459 tests.
- Live realm upgrade has not been replayed in an authenticated game.

## Non-goals

No asset, realm appearance, balance or contract changes. This fix is independent of the ethereal scene PRs.
