### PR TITLE
fix(client): follow army layers through movement and combat

### DIFF
--- a/apps/game/src/automation/exploration/map-cache.test.ts
+++ b/apps/game/src/automation/exploration/map-cache.test.ts
@@ -22,7 +22,7 @@ import { buildExplorationSnapshot } from "./map-cache";
 describe("buildExplorationSnapshot", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("builds the automation view from the projection and live RECS owners", async () => {
+  it.each([false, true])("builds the automation view on the exploring army layer (alt=%s)", async (alt) => {
     const explorerOwnerStructureId = 2001;
     const structureId = 201;
     const armyId = 301;
@@ -30,7 +30,7 @@ describe("buildExplorationSnapshot", () => {
     const armyOwner = 0x98765n;
     const components = {
       ExplorerTroops: new Map([
-        ["1", { coord: { x: 10, y: 10 } }],
+        ["1", { coord: { alt, x: 10, y: 10 } }],
         [armyId.toString(), { owner: explorerOwnerStructureId }],
       ]),
       Structure: new Map([
@@ -41,14 +41,14 @@ describe("buildExplorationSnapshot", () => {
     const worldSpatialProjection = {
       getTilesInBounds: vi.fn(() => [
         {
-          hexCoords: { alt: false, col: 10, row: 10 },
+          hexCoords: { alt, col: 10, row: 10 },
           biome: 1,
           occupierId: 0,
           occupierType: 0,
         },
       ]),
-      getStructuresInBounds: vi.fn(() => [{ entityId: structureId, hexCoords: { alt: false, col: 10, row: 11 } }]),
-      getArmiesInBounds: vi.fn(() => [{ entityId: armyId, hexCoords: { alt: false, col: 11, row: 10 } }]),
+      getStructuresInBounds: vi.fn(() => [{ entityId: structureId, hexCoords: { alt, col: 10, row: 11 } }]),
+      getArmiesInBounds: vi.fn(() => [{ entityId: armyId, hexCoords: { alt, col: 11, row: 10 } }]),
     };
 
     const snapshot = await buildExplorationSnapshot({
@@ -58,6 +58,13 @@ describe("buildExplorationSnapshot", () => {
       worldSpatialProjection: worldSpatialProjection as never,
     });
 
+    expect(snapshot?.alt).toBe(alt);
+    for (const query of [
+      worldSpatialProjection.getTilesInBounds,
+      worldSpatialProjection.getStructuresInBounds,
+      worldSpatialProjection.getArmiesInBounds,
+    ])
+      expect(query).toHaveBeenCalledWith(expect.objectContaining({ alt }));
     expect(snapshot?.structureHexes.get(10)?.get(11)?.owner).toBe(structureOwner);
     expect(snapshot?.armyHexes.get(11)?.get(10)?.owner).toBe(armyOwner);
     expect(snapshot?.exploredTiles.get(10)?.get(10)).toBe(1);

--- a/apps/game/src/automation/exploration/map-cache.ts
+++ b/apps/game/src/automation/exploration/map-cache.ts
@@ -2,7 +2,7 @@ import { gameEntityKey } from "@/sync/game-scope";
 import { Position } from "@bibliothecadao/eternum";
 import type { WorldSpatialProjection } from "@bibliothecadao/eternum/game-sync";
 import type { ClientComponents, HexEntityInfo } from "@bibliothecadao/types";
-import { BiomeType, TileOccupier } from "@bibliothecadao/types";
+import { BiomeType, ETHEREAL_STRIDE, TileOccupier } from "@bibliothecadao/types";
 import { getComponentValue } from "@dojoengine/recs";
 import type { ExplorationMapSnapshot } from "./types";
 
@@ -57,7 +57,8 @@ export const buildExplorationSnapshot = async ({
 
   const centerCol = Number(explorer.coord.x);
   const centerRow = Number(explorer.coord.y);
-  const radius = Math.max(1, Math.round(scopeRadius));
+  const alt = explorer.coord.alt;
+  const radius = Math.max(1, Math.round(scopeRadius)) * (alt ? ETHEREAL_STRIDE : 1);
   const bounds = {
     minCol: centerCol - radius,
     maxCol: centerCol + radius,
@@ -70,9 +71,8 @@ export const buildExplorationSnapshot = async ({
   const armyHexes = new Map<number, Map<number, HexEntityInfo>>();
   const chestHexes = new Map<number, Map<number, HexEntityInfo>>();
 
-  // Automation explores the surface; layer-aware exploration is the ethereal slice, item 4.
-  const surfaceBounds = { ...bounds, alt: false };
-  worldSpatialProjection.getTilesInBounds(surfaceBounds).forEach((tile) => {
+  const layerBounds = { ...bounds, alt };
+  worldSpatialProjection.getTilesInBounds(layerBounds).forEach((tile) => {
     const normalized = new Position({ x: tile.hexCoords.col, y: tile.hexCoords.row }).getNormalized();
     if (tile.biome !== 0) {
       setNestedValue(exploredTiles, normalized.x, normalized.y, tile.biome as unknown as BiomeType);
@@ -85,7 +85,7 @@ export const buildExplorationSnapshot = async ({
     }
   });
 
-  worldSpatialProjection.getStructuresInBounds(surfaceBounds).forEach((structure) => {
+  worldSpatialProjection.getStructuresInBounds(layerBounds).forEach((structure) => {
     if (structure.entityId === null) return;
     const normalized = new Position({ x: structure.hexCoords.col, y: structure.hexCoords.row }).getNormalized();
     setNestedValue(
@@ -96,7 +96,7 @@ export const buildExplorationSnapshot = async ({
     );
   });
 
-  worldSpatialProjection.getArmiesInBounds(surfaceBounds).forEach((army) => {
+  worldSpatialProjection.getArmiesInBounds(layerBounds).forEach((army) => {
     const normalized = new Position({ x: army.hexCoords.col, y: army.hexCoords.row }).getNormalized();
     setNestedValue(
       armyHexes,
@@ -107,6 +107,7 @@ export const buildExplorationSnapshot = async ({
   });
 
   return {
+    alt,
     position: { col: centerCol, row: centerRow },
     exploredTiles,
     structureHexes,

--- a/apps/game/src/automation/exploration/strategies/basic-frontier.ts
+++ b/apps/game/src/automation/exploration/strategies/basic-frontier.ts
@@ -1,5 +1,5 @@
 import { ActionPaths, ActionType, Position } from "@bibliothecadao/eternum";
-import { getNeighborHexes } from "@bibliothecadao/types";
+import { getLayerNeighborHexes } from "@bibliothecadao/types";
 import type { ActionPath } from "@bibliothecadao/eternum";
 import type { ExplorationStrategy, ExplorationStrategyContext } from "../types";
 
@@ -18,7 +18,7 @@ const comparePaths = (a: ActionPath[], b: ActionPath[]) => {
 };
 
 const isFrontierTile = (context: ExplorationStrategyContext, target: { col: number; row: number }) => {
-  const neighbors = getNeighborHexes(target.col, target.row);
+  const neighbors = getLayerNeighborHexes(target.col, target.row, context.alt);
   for (const neighbor of neighbors) {
     const normalized = new Position({ x: neighbor.col, y: neighbor.row }).getNormalized();
     const explored = context.exploredTiles.get(normalized.x)?.has(normalized.y) ?? false;

--- a/apps/game/src/automation/exploration/types.ts
+++ b/apps/game/src/automation/exploration/types.ts
@@ -4,6 +4,7 @@ import type { BiomeType, HexEntityInfo, HexPosition } from "@bibliothecadao/type
 export type ExplorationStrategyId = "basic-frontier";
 
 export type ExplorationMapSnapshot = {
+  alt: boolean;
   position: HexPosition;
   exploredTiles: Map<number, Map<number, BiomeType>>;
   structureHexes: Map<number, Map<number, HexEntityInfo>>;

--- a/apps/game/src/hooks/store/use-ui-store.ts
+++ b/apps/game/src/hooks/store/use-ui-store.ts
@@ -58,6 +58,7 @@ interface UIStore {
   setShowBlankOverlay: (show: boolean) => void;
   /** The map layer the scene shows: false is the surface, true the ethereal layer, as in TileOpt.alt. */
   mapLayer: boolean;
+  setMapLayer: (mapLayer: boolean) => void;
   isSideMenuOpened: boolean;
   toggleSideMenu: () => void;
   isSoundOn: boolean;
@@ -197,6 +198,7 @@ export const useUIStore = create(
       set({ showBlankOverlay: show });
     },
     mapLayer: false,
+    setMapLayer: (mapLayer) => set({ mapLayer }),
     isSideMenuOpened: true,
     toggleSideMenu: () => set((state) => ({ isSideMenuOpened: !state.isSideMenuOpened })),
     isSoundOn: readLocalBool("soundEnabled", true),

--- a/apps/game/src/three/scenes/worldmap-layer-follow.test.ts
+++ b/apps/game/src/three/scenes/worldmap-layer-follow.test.ts
@@ -1,0 +1,76 @@
+import type { ArmySpatialProjectionChange } from "@bibliothecadao/eternum/game-sync";
+import { describe, expect, it, vi } from "vitest";
+import { followArmyLayerChange } from "./worldmap-layer-follow";
+
+function setup() {
+  let alt = false;
+  let selectedId = 7;
+  const input = {
+    changes: [
+      {
+        entityId: 7,
+        previous: { hexCoords: { alt: false, col: 100, row: 100 } },
+        current: { entityId: 7, hexCoords: { alt: true, col: 100, row: 100 } },
+      },
+    ] as unknown as ArmySpatialProjectionChange[],
+    getSelectedId: () => selectedId,
+    getLayer: () => alt,
+    isSceneActive: () => true,
+    setLayer: vi.fn((value: boolean) => {
+      alt = value;
+    }),
+    finishMovement: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    select: vi.fn(),
+  };
+  return {
+    input,
+    selectOther: () => {
+      selectedId = 8;
+    },
+  };
+}
+
+describe("following an army through a spire", () => {
+  it("switches on the projection crossing and selects only after the new layer renders", async () => {
+    const { input } = setup();
+    let finish!: () => void;
+    input.refresh.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const pending = followArmyLayerChange(input);
+    expect(input.setLayer).toHaveBeenCalledWith(true);
+    expect(input.finishMovement).toHaveBeenCalledWith(7);
+    expect(input.select).not.toHaveBeenCalled();
+    finish();
+    await pending;
+    expect(input.select).toHaveBeenCalledWith(7);
+    input.changes = input.changes.map((change) => ({
+      ...change,
+      previous: change.current,
+      current: { ...change.current!, hexCoords: { ...change.current!.hexCoords, alt: false } },
+    }));
+    input.refresh.mockResolvedValue(undefined);
+    await followArmyLayerChange(input);
+    expect(input.setLayer).toHaveBeenLastCalledWith(false);
+  });
+
+  it("does not follow an unselected army", async () => {
+    const { input, selectOther } = setup();
+    selectOther();
+    await followArmyLayerChange(input);
+    expect(input.setLayer).not.toHaveBeenCalled();
+  });
+
+  it("preserves a manual selection made while the new layer loads", async () => {
+    const { input, selectOther } = setup();
+    input.refresh.mockImplementation(async () => {
+      selectOther();
+    });
+    await followArmyLayerChange(input);
+    expect(input.select).not.toHaveBeenCalled();
+  });
+});

--- a/apps/game/src/three/scenes/worldmap-layer-follow.ts
+++ b/apps/game/src/three/scenes/worldmap-layer-follow.ts
@@ -1,0 +1,30 @@
+import type { ArmySpatialProjectionChange } from "@bibliothecadao/eternum/game-sync";
+import type { ID } from "@bibliothecadao/types";
+
+interface FollowArmyLayerInput {
+  changes: readonly ArmySpatialProjectionChange[];
+  getSelectedId(): ID | null | undefined;
+  getLayer(): boolean;
+  isSceneActive(): boolean;
+  setLayer(alt: boolean): void;
+  finishMovement(entityId: ID): void;
+  refresh(): Promise<unknown>;
+  select(entityId: ID): void;
+}
+
+/** Follow projection state, including a rollback, without overriding a later manual selection. */
+export async function followArmyLayerChange(input: FollowArmyLayerInput): Promise<void> {
+  if (!input.isSceneActive()) return;
+  const selectedId = input.getSelectedId();
+  const crossing = input.changes.find(
+    ({ entityId, previous, current }) =>
+      entityId === selectedId && previous && current && previous.hexCoords.alt !== current.hexCoords.alt,
+  );
+  if (!crossing?.current) return;
+  const { entityId, hexCoords } = crossing.current;
+  input.finishMovement(entityId);
+  input.setLayer(hexCoords.alt);
+  await input.refresh();
+  if (!input.isSceneActive() || input.getLayer() !== hexCoords.alt || input.getSelectedId() !== entityId) return;
+  input.select(entityId);
+}

--- a/apps/game/src/three/scenes/worldmap-spire-travel-policy.test.ts
+++ b/apps/game/src/three/scenes/worldmap-spire-travel-policy.test.ts
@@ -1,36 +1,30 @@
 import { TileOccupier } from "@bibliothecadao/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveSpireTraversalAction } from "./worldmap-spire-travel-policy";
 
 describe("resolveSpireTraversalAction", () => {
-  it("returns attack when an ethereal explorer occupies the linked spire tile", () => {
-    const result = resolveSpireTraversalAction({
-      targetHex: { col: 100, row: 200 },
-      etherealTile: {
-        occupier_id: 42,
-        occupier_type: TileOccupier.ExplorerKnightT1Regular,
-        occupier_is_structure: false,
-      },
-    });
-
-    expect(result).toEqual({
+  it.each([false, true])("targets the attacker's coordinate on the other layer (attacker alt=%s)", (attackerAlt) => {
+    const getTile = vi.fn(() => ({
+      occupier_id: 42,
+      occupier_type: TileOccupier.ExplorerKnightT1Regular,
+      occupier_is_structure: false,
+    }));
+    expect(resolveSpireTraversalAction({ attackerHex: { col: 100, row: 200 }, attackerAlt, getTile })).toEqual({
       kind: "attack",
       targetArmyId: 42,
       targetHex: { col: 100, row: 200 },
+      defenderAlt: !attackerAlt,
     });
+    expect(getTile).toHaveBeenCalledWith(!attackerAlt, 100, 200);
   });
-
-  it("returns travel when no ethereal explorer occupies the linked spire tile", () => {
-    const result = resolveSpireTraversalAction({
-      targetHex: { col: 100, row: 200 },
-      etherealTile: {
-        occupier_id: 0,
-        occupier_type: TileOccupier.None,
-        occupier_is_structure: false,
-      },
-    });
-
-    expect(result).toEqual({
+  it("travels when the destination is empty", () => {
+    expect(
+      resolveSpireTraversalAction({
+        attackerHex: { col: 100, row: 200 },
+        attackerAlt: false,
+        getTile: () => undefined,
+      }),
+    ).toEqual({
       kind: "travel",
       targetHex: { col: 100, row: 200 },
     });

--- a/apps/game/src/three/scenes/worldmap-spire-travel-policy.ts
+++ b/apps/game/src/three/scenes/worldmap-spire-travel-policy.ts
@@ -1,6 +1,6 @@
 import { TileOccupier, type HexPosition, type ID } from "@bibliothecadao/types";
 
-type EtherealTileReference = {
+type DestinationTileReference = {
   occupier_id: ID;
   occupier_type: number;
   occupier_is_structure: boolean;
@@ -10,6 +10,7 @@ type SpireTraversalAction =
   | {
       kind: "attack";
       targetArmyId: ID;
+      defenderAlt: boolean;
       targetHex: HexPosition;
     }
   | {
@@ -24,26 +25,21 @@ function isExplorerTileOccupier(occupierType: number): boolean {
 }
 
 export function resolveSpireTraversalAction(input: {
-  targetHex: HexPosition;
-  etherealTile: EtherealTileReference | undefined;
+  attackerHex: HexPosition;
+  attackerAlt: boolean;
+  getTile: (alt: boolean, col: number, row: number) => DestinationTileReference | undefined;
 }): SpireTraversalAction {
-  const { targetHex, etherealTile } = input;
+  const targetHex = input.attackerHex;
+  const defenderAlt = !input.attackerAlt;
+  const destinationTile = input.getTile(defenderAlt, targetHex.col, targetHex.row);
 
   if (
-    etherealTile &&
-    Number(etherealTile.occupier_id) !== 0 &&
-    !etherealTile.occupier_is_structure &&
-    isExplorerTileOccupier(etherealTile.occupier_type)
+    destinationTile &&
+    Number(destinationTile.occupier_id) !== 0 &&
+    !destinationTile.occupier_is_structure &&
+    isExplorerTileOccupier(destinationTile.occupier_type)
   ) {
-    return {
-      kind: "attack",
-      targetArmyId: etherealTile.occupier_id,
-      targetHex,
-    };
+    return { kind: "attack", targetArmyId: destinationTile.occupier_id, targetHex, defenderAlt };
   }
-
-  return {
-    kind: "travel",
-    targetHex,
-  };
+  return { kind: "travel", targetHex };
 }

--- a/apps/game/src/three/scenes/worldmap.tsx
+++ b/apps/game/src/three/scenes/worldmap.tsx
@@ -1,3 +1,4 @@
+import { followArmyLayerChange } from "./worldmap-layer-follow";
 import { activeMapLayer } from "@/three/map-layer";
 import type { ReactNode } from "react";
 import { isMapPreviewAction } from "./worldmap-action-preview-policy";
@@ -1340,6 +1341,7 @@ export default class WorldmapScene extends WarpTravel {
       structureComponent: this.dojo.components.Structure,
     });
     const unsubscribeArmies = this.worldSpatialProjection.subscribeArmies((published) => {
+      this.followSelectedArmyLayer(published);
       const changes = projectionChangesForLayer(published, activeMapLayer());
       if (changes.length === 0) return;
       this.syncProjectedArmyPathfinding(changes);
@@ -1511,6 +1513,22 @@ export default class WorldmapScene extends WarpTravel {
         }
       }
     });
+  }
+
+  private followSelectedArmyLayer(changes: readonly ArmySpatialProjectionChange[]): void {
+    void followArmyLayerChange({
+      changes,
+      getSelectedId: () => getLiveWorldmapEntityActions().selectedEntityId,
+      getLayer: activeMapLayer,
+      isSceneActive: () => !this.isSwitchedOff,
+      setLayer: (alt) => useUIStore.getState().setMapLayer(alt),
+      finishMovement: (entityId) => {
+        this.completePendingArmyMovementVisuals(entityId);
+        this.disposePendingMovementVisualLifecycle(entityId);
+      },
+      refresh: () => this.updateVisibleChunks(true, { reason: "default", triggerReason: "spire_crossing" }),
+      select: (entityId) => this.onArmySelection(entityId, this.getArmyOwnerAddress(entityId) ?? 0n),
+    }).catch((error) => console.error("[WorldmapScene] Failed to follow army crossing", error));
   }
 
   private handleProjectedArmyChanges(changes: readonly ArmySpatialProjectionChange[]): void {
@@ -2617,7 +2635,8 @@ export default class WorldmapScene extends WarpTravel {
       playUnitCommandSoundForWorldmapAction(actionType);
 
       // Get the target position for the effect
-      const targetHex = actionPath[actionPath.length - 1].hex;
+      const targetHex =
+        actionType === ActionType.SpireTravel ? actionPath[0].hex : actionPath[actionPath.length - 1].hex;
       const exploreLatencyActionId =
         actionType === ActionType.Explore
           ? beginClientActionLatency({
@@ -2837,6 +2856,7 @@ export default class WorldmapScene extends WarpTravel {
       type: target.army ? ActorType.Explorer : ActorType.Structure,
       id: target.army?.id || target.structure?.id || 0,
       hex: new Position({ x: targetHex.col, y: targetHex.row }).getContract(),
+      alt: activeMapLayer(),
     };
 
     this.openTargetActionSurface(targetHex, {
@@ -2860,10 +2880,12 @@ export default class WorldmapScene extends WarpTravel {
     }
 
     const selected = this.getHexagonEntity(selectedHex);
-    const etherealTile = getTileAt(this.dojo.components, true, targetHex.col, targetHex.row);
+    const attacker = this.worldSpatialProjection.getArmy(selectedEntityId);
+    if (!attacker) return;
     const traversalAction = resolveSpireTraversalAction({
-      targetHex,
-      etherealTile,
+      attackerHex: { col: attacker.hexCoords.col, row: attacker.hexCoords.row },
+      attackerAlt: attacker.hexCoords.alt,
+      getTile: (alt, col, row) => getTileAt(this.dojo.components, alt, col, row),
     });
 
     if (traversalAction.kind === "attack") {
@@ -2875,8 +2897,8 @@ export default class WorldmapScene extends WarpTravel {
       const targetSummary = {
         type: ActorType.Explorer,
         id: traversalAction.targetArmyId,
-        hex: new Position({ x: traversalAction.targetHex.col, y: traversalAction.targetHex.row }).getContract(),
-        alt: true,
+        hex: { x: traversalAction.targetHex.col, y: traversalAction.targetHex.row },
+        alt: traversalAction.defenderAlt,
       };
 
       this.openTargetActionSurface(targetHex, {

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,12 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-12",
+    title: "Travel between the layers",
+    type: "feature",
+    description: "Armies keep their selection after crossing a spire, and explore and fight on their current layer.",
+  },
+  {
+    date: "2026-09-12",
     title: "Refined Realms and Clear Ownership",
     description:
       "Realm masonry grows paler and finer with each tier, with hand-laid roofs, a raised kingdom drawbridge, and full-height empire gates. Settlement supplies sit beside a clear entrance. Owned realms and villages fly green banners; all others fly red. Every realm hanging displays its order emblem. Chests are 30% smaller on the map. Game entry loads entity models as the selected world needs them.",

--- a/packages/core/src/managers/army-action-manager.test.ts
+++ b/packages/core/src/managers/army-action-manager.test.ts
@@ -1,5 +1,9 @@
 import {
   BiomeType,
+  Direction,
+  ETHEREAL_STRIDE,
+  getLayerNeighborHexes,
+  packTileSeed,
   getDirectionBetweenAdjacentHexes,
   getHexesWithinRadius,
   getNeighborHexes,
@@ -56,10 +60,12 @@ function buildTileOptData(input: {
   biome: number;
   occupierType: number;
   occupierId: number;
+  alt?: boolean;
 }): {
   data: bigint;
 } {
   const data =
+    BigInt(input.alt ?? false) |
     (BigInt(input.occupierType) << 1n) |
     (BigInt(input.occupierId) << 9n) |
     (BigInt(input.biome) << 41n) |
@@ -84,7 +90,7 @@ function createTestSetup(systemCalls: Record<string, unknown> = {}) {
         TEST_ENTITY_ID.toString(),
         {
           owner: 77,
-          coord: { x: oldFeltStart.col, y: oldFeltStart.row },
+          coord: { alt: false, x: oldFeltStart.col, y: oldFeltStart.row },
           troops: {
             category: TroopType.Knight,
             count: BigInt(RESOURCE_PRECISION),
@@ -244,6 +250,46 @@ describe("ArmyActionManager.findActionPaths origin precedence", () => {
     const spireActionPath = actionPaths.get(ActionPaths.posKey(spireHex));
     expect(spireActionPath).toBeDefined();
     expect(ActionPaths.getActionType(spireActionPath ?? [])).toBe(ActionType.SpireTravel);
+  });
+
+  it.each([false, true])("uses stride-one portal access on the army's layer (alt=%s)", (alt) => {
+    const { manager, components, structureHexes, armyHexes, exploredHexes, chestHexes, oldFeltStart } =
+      createTestSetup();
+    components.ExplorerTroops.get(TEST_ENTITY_ID.toString()).coord.alt = alt;
+    const spire = getNeighborHexes(oldFeltStart.col, oldFeltStart.row)[0];
+    components.TileOpt.set(
+      toTileEntityKey(alt, spire.col, spire.row),
+      buildTileOptData({ ...spire, alt, biome: 1, occupierType: TileOccupier.Spire, occupierId: 999 }),
+    );
+    const paths = manager.findActionPaths(structureHexes, armyHexes, exploredHexes, chestHexes, 0, 0, 0x123n as any);
+    expect(ActionPaths.getActionType(paths.get(ActionPaths.posKey(spire)) ?? [])).toBe(ActionType.SpireTravel);
+    if (alt) {
+      const step = getLayerNeighborHexes(oldFeltStart.col, oldFeltStart.row, true)[1];
+      expect(ActionPaths.getActionType(paths.get(ActionPaths.posKey(step)) ?? [])).toBe(ActionType.Explore);
+      expect(step.row - oldFeltStart.row).toBe(ETHEREAL_STRIDE);
+      const surfaceStep = getNeighborHexes(oldFeltStart.col, oldFeltStart.row)[1];
+      expect(paths.get(ActionPaths.posKey(surfaceStep))).toBeUndefined();
+    }
+  });
+
+  it("uses ethereal attack distance for mines and armies", () => {
+    const { manager, components, structureHexes, armyHexes, exploredHexes, chestHexes, oldFeltStart } =
+      createTestSetup();
+    components.ExplorerTroops.get(TEST_ENTITY_ID.toString()).coord.alt = true;
+    const mineHex = { col: oldFeltStart.col + ETHEREAL_STRIDE, row: oldFeltStart.row };
+    const tooFar = { col: mineHex.col + 1, row: mineHex.row };
+    setNestedMapValue(structureHexes, mineHex.col - TEST_FELT_CENTER, mineHex.row - TEST_FELT_CENTER, {
+      id: 21,
+      owner: 0x999n,
+    } as HexEntityInfo);
+    setNestedMapValue(armyHexes, tooFar.col - TEST_FELT_CENTER, tooFar.row - TEST_FELT_CENTER, {
+      id: 22,
+      owner: 0x999n,
+    } as HexEntityInfo);
+    vi.mocked(StaminaManager.prototype.getStamina).mockReturnValue({ amount: 5n, updated_tick: 0n } as any);
+    const paths = manager.findActionPaths(structureHexes, armyHexes, exploredHexes, chestHexes, 0, 0, 0x123n as any);
+    expect(ActionPaths.getActionType(paths.get(ActionPaths.posKey(mineHex)) ?? [])).toBe(ActionType.Attack);
+    expect(paths.get(ActionPaths.posKey(tooFar))).toBeUndefined();
   });
 
   it("omits adjacent enemy structure attack paths when attack stamina is below the required threshold", () => {
@@ -433,13 +479,14 @@ describe("ArmyActionManager.moveArmy explore position-freshness guard", () => {
 });
 
 describe("ArmyActionManager.moveArmy spire traversal", () => {
-  it("calls toggle_alternate for spire travel action paths", async () => {
+  it.each([false, true])("calls toggle_alternate at stride one on either layer (alt=%s)", async (alt) => {
     const systemCalls = {
       toggle_alternate: vi.fn().mockResolvedValue({}),
       explorer_travel: vi.fn().mockResolvedValue({}),
       explorer_explore: vi.fn().mockResolvedValue({}),
     };
-    const { manager, oldFeltStart } = createTestSetup(systemCalls);
+    const { manager, components, oldFeltStart } = createTestSetup(systemCalls);
+    components.ExplorerTroops.get(TEST_ENTITY_ID.toString()).coord.alt = alt;
     const spireHex = getNeighborHexes(oldFeltStart.col, oldFeltStart.row)[0];
     const spireDirection = getDirectionBetweenAdjacentHexes(oldFeltStart, spireHex);
 
@@ -467,5 +514,58 @@ describe("ArmyActionManager.moveArmy spire traversal", () => {
     });
     expect(systemCalls.explorer_travel).not.toHaveBeenCalled();
     expect(systemCalls.explorer_explore).not.toHaveBeenCalled();
+  });
+});
+
+describe("ArmyActionManager ethereal submissions", () => {
+  it.each([
+    [false, 100],
+    [true, 100],
+    [true, 101],
+  ] as const)("packs the layer and follows contract row parity (alt=%s, row=%s)", async (alt, row) => {
+    const explorer_explore = vi.fn().mockResolvedValue({});
+    const { manager, components, oldFeltStart } = createTestSetup({ explorer_explore });
+    oldFeltStart.row = row;
+    Object.assign(components.ExplorerTroops.get(TEST_ENTITY_ID.toString()).coord, { alt, y: row });
+    const stride = alt ? ETHEREAL_STRIDE : 1;
+    const destination = {
+      col: oldFeltStart.col + (row % 2 === 0 ? stride : 0),
+      row: row + stride,
+      direction: Direction.NORTH_EAST,
+    };
+    await manager.moveArmy(
+      {} as any,
+      [
+        { hex: oldFeltStart, actionType: ActionType.Move },
+        { hex: destination, actionType: ActionType.Explore },
+      ],
+      false,
+      0,
+    );
+    expect(explorer_explore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directions: [destination.direction],
+        vrf_source_salt: packTileSeed({ alt, col: destination.col, row: destination.row }),
+      }),
+    );
+  });
+
+  it("rejects a stale surface path after the army crosses", async () => {
+    const explorer_travel = vi.fn();
+    const { manager, components, oldFeltStart } = createTestSetup({ explorer_travel });
+    components.ExplorerTroops.get(TEST_ENTITY_ID.toString()).coord.alt = true;
+    const destination = getNeighborHexes(oldFeltStart.col, oldFeltStart.row)[0];
+    await expect(
+      manager.moveArmy(
+        {} as any,
+        [
+          { hex: oldFeltStart, actionType: ActionType.Move },
+          { hex: destination, actionType: ActionType.Move },
+        ],
+        true,
+        0,
+      ),
+    ).rejects.toThrow("Invalid travel direction");
+    expect(explorer_travel).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/managers/army-action-manager.ts
+++ b/packages/core/src/managers/army-action-manager.ts
@@ -3,8 +3,8 @@ import {
   type ClientComponents,
   type ContractAddress,
   type DojoAccount,
-  getDirectionBetweenAdjacentHexes,
-  getHexesWithinRadius,
+  getLayerNeighborHexes,
+  getLayeredAttackDistance,
   getNeighborHexes,
   getTroopAttackRange,
   type HexEntityInfo,
@@ -104,7 +104,8 @@ export class ArmyActionManager {
 
   private readonly _getCurrentPosition = () => {
     const position = getComponentValue(this.components.ExplorerTroops, this.entity)?.coord;
-    return { col: position!.x, row: position!.y };
+    if (!position) throw new Error("Explorer position is unavailable");
+    return { col: position.x, row: position.y, alt: position.alt };
   };
 
   // getFood is without precision
@@ -127,7 +128,7 @@ export class ArmyActionManager {
   }
 
   private isWorldSpireHex(position: HexPosition): boolean {
-    const tile = getTileAt(this.components, false, position.col, position.row);
+    const tile = getTileAt(this.components, this._getCurrentPosition().alt, position.col, position.row);
     return tile?.occupier_type === TileOccupier.Spire;
   }
 
@@ -145,9 +146,9 @@ export class ArmyActionManager {
     playerAddress: ContractAddress,
   ) {
     const attackStaminaCost = this.getAttackStaminaRequirement();
-    const targetHexes = getHexesWithinRadius(startPos.col, startPos.row, attackRange);
+    const targetHexes = this.getAttackHexesInRange(startPos, attackRange, armyHexes, structureHexes);
 
-    for (const { col, row } of targetHexes) {
+    for (const { col, row } of targetHexes.values()) {
       const army = armyHexes.get(col - this.FELT_CENTER)?.get(row - this.FELT_CENTER);
       const structure = structureHexes.get(col - this.FELT_CENTER)?.get(row - this.FELT_CENTER);
       const target = army ?? structure;
@@ -167,6 +168,25 @@ export class ArmyActionManager {
         },
       ]);
     }
+  }
+
+  private getAttackHexesInRange(
+    startPos: HexPosition,
+    attackRange: number,
+    ...indexes: Map<number, Map<number, HexEntityInfo>>[]
+  ): Map<string, HexPosition> {
+    const alt = this._getCurrentPosition().alt;
+    const targets = new Map<string, HexPosition>();
+    for (const index of indexes) {
+      for (const [col, rows] of index) {
+        for (const row of rows.keys()) {
+          const hex = { col: col + this.FELT_CENTER, row: row + this.FELT_CENTER };
+          const distance = getLayeredAttackDistance({ ...startPos, alt }, { ...hex, alt });
+          if (distance > 0 && distance <= attackRange) targets.set(ActionPaths.posKey(hex), hex);
+        }
+      }
+    }
+    return targets;
   }
 
   public findActionPaths(
@@ -198,7 +218,12 @@ export class ArmyActionManager {
     }> = [];
 
     // Process initial neighbors instead of start position
-    const neighbors = getNeighborHexes(startPos.col, startPos.row);
+    // Portal reach is one surface hex on either layer; ordinary moves use the army's stride.
+    const spires = getNeighborHexes(startPos.col, startPos.row).filter((hex) => this.isWorldSpireHex(hex));
+    const neighbors = [
+      ...getLayerNeighborHexes(startPos.col, startPos.row, startPos.alt).filter((hex) => !this.isWorldSpireHex(hex)),
+      ...spires,
+    ];
     for (const { col, row } of neighbors) {
       const isSpire = this.isWorldSpireHex({ col, row });
       const isExplored = exploredHexes.get(col - this.FELT_CENTER)?.has(row - this.FELT_CENTER) || false;
@@ -212,7 +237,7 @@ export class ArmyActionManager {
       const biome = exploredHexes.get(col - this.FELT_CENTER)?.get(row - this.FELT_CENTER);
 
       // Skip if hex requires exploration but army can't explore
-      if (!isExplored && !canExplore) continue;
+      if (!isSpire && !isExplored && !canExplore) continue;
 
       const isMine = isArmyMine || isStructureMine;
       const canAttack = (hasArmy || hasStructure) && !isMine;
@@ -284,7 +309,7 @@ export class ArmyActionManager {
         // cannot go through these hexes so need to stop here
         if (!isExplored || hasArmy || hasStructure || hasChest || hasSpire) continue;
 
-        const neighbors = getNeighborHexes(current.col, current.row);
+        const neighbors = getLayerNeighborHexes(current.col, current.row, startPos.alt);
         for (const { col, row } of neighbors) {
           const neighborKey = ActionPaths.posKey({ col, row });
           const nextDistance = distance + 1;
@@ -342,12 +367,14 @@ export class ArmyActionManager {
     return actionPaths;
   }
 
-  private readonly _findDirection = (path: HexPosition[]) => {
+  private readonly _findDirection = (path: HexPosition[], spire = false) => {
     if (path.length !== 2) return undefined;
 
     const startPos = { col: path[0].col, row: path[0].row };
     const endPos = { col: path[1].col, row: path[1].row };
-    return getDirectionBetweenAdjacentHexes(startPos, endPos);
+    return getLayerNeighborHexes(startPos.col, startPos.row, spire ? false : this._getCurrentPosition().alt).find(
+      (hex) => hex.col === endPos.col && hex.row === endPos.row,
+    )?.direction;
   };
 
   private readonly _exploreHex = async (signer: DojoAccount, path: ActionPath[], currentArmiesTick: number) => {
@@ -384,7 +411,11 @@ export class ArmyActionManager {
       }
     }
 
-    const vrfSourceSalt = packTileSeed({ alt: false, col: destinationHex.col, row: destinationHex.row });
+    const vrfSourceSalt = packTileSeed({
+      alt: this._getCurrentPosition().alt,
+      col: destinationHex.col,
+      row: destinationHex.row,
+    });
     return this.systemCalls.explorer_explore({
       explorer_id: this.entityId,
       directions: [direction],
@@ -398,19 +429,14 @@ export class ArmyActionManager {
     path: ActionPath[],
     currentArmiesTick: number,
   ) => {
-    const directions = path
-      .map((_, i) => {
-        if (path[i + 1] === undefined) return undefined;
-        return this._findDirection([
-          { col: path[i].hex.col, row: path[i].hex.row },
-          { col: path[i + 1].hex.col, row: path[i + 1].hex.row },
-        ]);
-      })
-      .filter((d) => d !== undefined) as number[];
+    const directions = path.slice(0, -1).map((step, index) => this._findDirection([step.hex, path[index + 1].hex]));
+    if (!directions.length || directions.some((direction) => direction === undefined)) {
+      throw new Error("Invalid travel direction for the army's layer");
+    }
     return this.systemCalls.explorer_travel({
       signer,
       explorer_id: this.entityId,
-      directions,
+      directions: directions as number[],
     });
   };
 
@@ -419,7 +445,10 @@ export class ArmyActionManager {
     path: ActionPath[],
     currentArmiesTick: number,
   ) => {
-    const direction = this._findDirection(path.map((p) => p.hex));
+    const direction = this._findDirection(
+      path.map((p) => p.hex),
+      true,
+    );
     if (direction === undefined || direction === null) {
       return Promise.reject(new Error("Invalid spire direction"));
     }

--- a/packages/types/src/constants/hex.ts
+++ b/packages/types/src/constants/hex.ts
@@ -158,6 +158,16 @@ export const getNeighborHexes = (col: number, row: number, steps: Steps = Steps.
   }
 };
 
+/** Matches Coord.neighbor: scale the row's offsets, without walking intermediate rows. */
+export function getLayerNeighborHexes(col: number, row: number, alt: boolean): NeighborHex[] {
+  const stride = alt ? ETHEREAL_STRIDE : 1;
+  return getNeighborOffsets(row).map(({ i, j, direction }) => ({
+    col: col + i * stride,
+    row: row + j * stride,
+    direction,
+  }));
+}
+
 export const getHexesWithinRadius = (col: number, row: number, radius: number): NeighborHex[] => {
   if (radius <= 0) return [];
 


### PR DESCRIPTION
Superseded by #4982, which combines this change with the remaining ethereal client work on next after #4975. Merge #4982 only.

## Evidence

Army paths, exploration seeds and automation still assumed the surface. Spire attack previews read the spire tile, although the contract places the defender at the attacker’s coordinate on the opposite layer.

## Fix

Use the army’s layer for movement, exploration and combat, with the shared ETHEREAL_STRIDE for ordinary neighbours and stride 1 for spire adjacency. Follow a selected army’s projection crossing, refresh the view and restore selection after rendering, while preserving later manual selections. Attack previews carry the defender’s layer.

Item 3 of the client scene slice; merge after #4975 and #4976. This branch targets next independently.

## Verification

- Integration with #4975, #4976 and the realm-instance fix: pnpm run format, pnpm run knip and client typecheck passed; pnpm test in apps/game passed all 708 files / 3,459 tests.
- Core army-action tests passed all 18 cases, including contract directions, layer seed packing, stale paths and ethereal attack range.
- Standalone branch: pnpm run format, pnpm run knip, client typecheck and eight focused client tests passed.
- Live travel → ethereal exploration → return remains unverified: the available browser has no signed-in playable army with portal-toll Essence. Keeping this PR in draft until that gate is exercised.

## Non-goals

No balance or contract changes, model redesign, or fixture scene. Scene switching and spire rendering belong to #4975 and #4976.
