### PR TITLE
fix(client): refresh game identity before loading config

### DIFF
--- a/apps/game/src/runtime/world/selection.profile.test.ts
+++ b/apps/game/src/runtime/world/selection.profile.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../env", () => ({ env: { VITE_PUBLIC_CHAIN: "madara" } }));
+vi.mock("@/ui/layouts/game-entry-timeline", () => ({
+  markGameEntryMilestone: vi.fn(),
+  recordGameEntryDuration: vi.fn(),
+}));
+
+const { deployment } = vi.hoisted(() => ({
+  deployment: {
+    id: "blitz",
+    chain: "madara",
+    namespace: "s2",
+    heraldBaseUrl: "https://herald.realms.test",
+    rpcUrl: "https://rpc.realms.test",
+    worldAddress: "0x222",
+    contractsBySelector: { "0x1": "0x333" },
+    playerAccountClassHash: "0x4",
+    playerRegistryAddress: "0x5",
+    bindingAuthorityAddress: "0x6",
+  },
+}));
+
+vi.mock("./world-directory", () => ({
+  getDefaultWorld: () => deployment,
+  getWorldById: () => deployment,
+  getWorldDirectory: () => [deployment],
+}));
+
+import { applyWorldSelection } from "./selection";
+import { getActiveWorldName, getWorldProfile, saveWorldProfile, setActiveWorldName } from "./store";
+
+describe("game entry profile resolution", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(async () =>
+        Response.json({
+          chain: "madara",
+          confirmed_block: 500629,
+          games: [
+            { name: "blitz-daily-0001", game_id: 3, preset_id: 2 },
+            { name: "eternum-fresh-01", game_id: 2, preset_id: 1 },
+          ],
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    { worldAddress: "0x111", gameId: 54, presetId: 4 },
+    { worldAddress: deployment.worldAddress, gameId: 54, presetId: 4 },
+    { worldAddress: deployment.worldAddress, gameId: 3, presetId: undefined },
+  ])("replaces a stale Blitz profile before bootstrap: %j", async (staleIdentity) => {
+    saveWorldProfile({
+      ...deployment,
+      chain: "madara",
+      worldId: deployment.id,
+      name: "blitz-daily-0001",
+      fetchedAt: 1,
+      contractsBySelector: { "0x1": "0x999" },
+      ...staleIdentity,
+    });
+
+    const { profile } = await applyWorldSelection({ name: "blitz-daily-0001", chain: "madara" }, "madara");
+
+    expect(profile).toMatchObject({
+      gameId: 3,
+      presetId: 2,
+      worldAddress: deployment.worldAddress,
+      contractsBySelector: deployment.contractsBySelector,
+    });
+    expect(getWorldProfile("blitz-daily-0001")).toEqual(profile);
+    expect(getActiveWorldName()).toBe("blitz-daily-0001");
+  });
+
+  it("resolves a first-time Eternum entry from the same directory", async () => {
+    const { profile } = await applyWorldSelection({ name: "eternum-fresh-01", chain: "madara" }, "madara");
+
+    expect(profile).toMatchObject({ gameId: 2, presetId: 1, worldAddress: deployment.worldAddress });
+    expect(getWorldProfile("eternum-fresh-01")).toEqual(profile);
+  });
+
+  it("does not enter a saved game when its directory is unavailable", async () => {
+    saveWorldProfile({
+      ...deployment,
+      chain: "madara",
+      name: "blitz-daily-0001",
+      gameId: 54,
+      presetId: 4,
+      fetchedAt: 1,
+    });
+    setActiveWorldName("eternum-fresh-01");
+    vi.mocked(fetch).mockRejectedValue(new Error("Herald unavailable"));
+
+    await expect(applyWorldSelection({ name: "blitz-daily-0001", chain: "madara" }, "madara")).rejects.toThrow(
+      "Herald unavailable",
+    );
+    expect(getActiveWorldName()).toBe("eternum-fresh-01");
+  });
+
+  it("rejects a saved game that no longer exists in the current world", async () => {
+    saveWorldProfile({
+      ...deployment,
+      chain: "madara",
+      name: "retired-blitz-game",
+      gameId: 54,
+      presetId: 4,
+      fetchedAt: 1,
+    });
+
+    await expect(applyWorldSelection({ name: "retired-blitz-game", chain: "madara" }, "madara")).rejects.toThrow(
+      'Game "retired-blitz-game" not found',
+    );
+    expect(getActiveWorldName()).toBeNull();
+  });
+});

--- a/apps/game/src/runtime/world/selection.test.ts
+++ b/apps/game/src/runtime/world/selection.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   buildWorldProfile: vi.fn(),
-  getWorldProfile: vi.fn(),
   resolveChain: vi.fn(),
   setSelectedChain: vi.fn(),
   setActiveWorldName: vi.fn(),
@@ -16,7 +15,6 @@ vi.mock("./profile-builder", () => ({
 }));
 
 vi.mock("./store", () => ({
-  getWorldProfile: mocks.getWorldProfile,
   resolveChain: mocks.resolveChain,
   setSelectedChain: mocks.setSelectedChain,
   setActiveWorldName: mocks.setActiveWorldName,
@@ -32,8 +30,6 @@ import { applyWorldSelection } from "./selection";
 describe("applyWorldSelection", () => {
   beforeEach(() => {
     mocks.buildWorldProfile.mockReset();
-    mocks.getWorldProfile.mockReset();
-    mocks.getWorldProfile.mockReturnValue(null);
     mocks.resolveChain.mockReset();
     mocks.setSelectedChain.mockReset();
     mocks.setActiveWorldName.mockReset();
@@ -60,17 +56,6 @@ describe("applyWorldSelection", () => {
 
     expect(mocks.setSelectedChain).toHaveBeenCalledTimes(1);
     expect(mocks.setSelectedChain).toHaveBeenCalledWith("madara");
-  });
-
-  it("reuses the immutable game profile when an in-game route reloads without Torii", async () => {
-    const saved = { name: "mainnet-king-1", chain: "madara", gameId: 54 };
-    mocks.resolveChain.mockReturnValue("madara");
-    mocks.getWorldProfile.mockReturnValue(saved);
-
-    const result = await applyWorldSelection({ name: "mainnet-king-1", chain: "madara" }, "madara");
-
-    expect(result.profile).toBe(saved);
-    expect(mocks.buildWorldProfile).not.toHaveBeenCalled();
   });
 
   it("records selection milestones and durations around profile building and persistence", async () => {

--- a/apps/game/src/runtime/world/selection.ts
+++ b/apps/game/src/runtime/world/selection.ts
@@ -1,7 +1,7 @@
 import type { GameChain as Chain } from "@realms-world/chain";
 import { markGameEntryMilestone, recordGameEntryDuration } from "@/ui/layouts/game-entry-timeline";
 import { buildWorldProfile } from "./profile-builder";
-import { getWorldProfile, resolveChain, setActiveWorldName, setSelectedChain } from "./store";
+import { resolveChain, setActiveWorldName, setSelectedChain } from "./store";
 import type { WorldProfile } from "./types";
 
 export interface WorldSelectionInput {
@@ -17,12 +17,6 @@ interface ApplyWorldSelectionResult {
   chainChanged: boolean;
 }
 
-const resolveWorldProfile = async (chain: Chain, name: string): Promise<WorldProfile> => {
-  const saved = getWorldProfile(name);
-  if (saved?.chain === chain && Number.isSafeInteger(saved.gameId) && (saved.gameId ?? 0) > 0) return saved;
-  return buildWorldProfile(chain, name);
-};
-
 export const applyWorldSelection = async (
   selection: WorldSelectionInput,
   fallbackChain: Chain,
@@ -36,7 +30,9 @@ export const applyWorldSelection = async (
   // even when current and target chains are already equal.
   const profileBuildStartedAt = performance.now();
   markGameEntryMilestone("world-profile-build-started");
-  const profile = await resolveWorldProfile(targetChain, selection.name);
+  // Game names can be reused after a world redeploy. Resolve their current IDs
+  // through Herald instead of bootstrapping with a persisted game's old preset.
+  const profile = await buildWorldProfile(targetChain, selection.name);
   markGameEntryMilestone("world-profile-build-completed");
   markGameEntryMilestone("world-profile-resolved");
   recordGameEntryDuration("world-profile-build", performance.now() - profileBuildStartedAt);

--- a/apps/game/src/ui/features/world/latest-features.ts
+++ b/apps/game/src/ui/features/world/latest-features.ts
@@ -35,6 +35,13 @@ const buildLatestFeaturesFeed = (features: LatestFeature[]) =>
 const allLatestFeatures: LatestFeature[] = [
   {
     date: "2026-09-12",
+    title: "Blitz Entry Config Refresh",
+    description:
+      "Rejoining a game after a world update refreshes its configuration instead of using an outdated saved game.",
+    type: "fix",
+  },
+  {
+    date: "2026-09-12",
     title: "Eternum Portals and Dev Settlement",
     description:
       "Six spires reveal their access hexes on both layers. In Eternum dev games, choose a realm number to preview its name and resources, settle additional realms, and place villages without passes.",


### PR DESCRIPTION
Previously visited game names can retain an old world address, game ID, and preset ID in `WORLD_PROFILES` after a redeploy. Entry accepted any saved profile with the same chain and a positive game ID, bypassing Herald. That can leave config lookups empty after sync and trigger the reported `Army tick duration is unavailable` crash.

Resolve the profile through the existing Herald directory and current world manifest before each new bootstrap, and replace the stored profile. A missing game or unavailable directory now fails selection instead of entering with stale IDs.

Checked #4977 and #4978 after their merges: neither fixes profile selection. A read-only live Herald check found `blitz-daily-0001` at game 3 / preset 2, with a 60-second army tick already present in its snapshot. The stale-profile regressions fail on that merged baseline; first-time Eternum entry passes.

Validation:

- 11 targeted selection and storage tests pass, covering stale deployment addresses and IDs, a missing preset ID, first-time Eternum entry, directory failure, and a removed game.
- `pnpm run format`, `pnpm run knip`, `pnpm run build:packages`, and client typecheck pass.
- CI runs the full client suite before merge.

The stale browser-profile path is reproduced in tests. The affected user's signed-in browser session has not been replayed.
